### PR TITLE
Proaktiver Gmail-Token-Refresh beim App-Start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.5.0
+- Gmail-Token wird beim App-Start proaktiv im Hintergrund erneuert, damit beim Senden kein Login-Browser mehr aufpoppt
+- Differenzierte Fehlerbehandlung beim Token-Refresh: abgelaufene Anmeldung wird als Messagebox angezeigt, Netzwerkfehler beim Start werden still übergangen
+
 ## v1.4.0
 - Wochen-Gruppierung im E-Mail- und PDF-Bericht mit Wochenüberschrift und Wochensumme je KW
 - UTF-8-Fix: Umlaute und ß im E-Mail-Body und Betreff werden korrekt dargestellt

--- a/src/mail.py
+++ b/src/mail.py
@@ -9,6 +9,61 @@ from email.header import Header
 SCOPES = ["https://www.googleapis.com/auth/gmail.send"]
 
 
+class TokenAuthError(Exception):
+    """Refresh-Token ist ungültig — User muss sich neu anmelden."""
+
+
+class TokenNetworkError(Exception):
+    """Refresh fehlgeschlagen wegen Netzwerkproblem."""
+
+
+def _refresh_and_persist(creds, token_path):
+    """Refresh credentials and write them back. Translates Google exceptions."""
+    from google.auth.exceptions import RefreshError, TransportError
+    from google.auth.transport.requests import Request
+
+    try:
+        creds.refresh(Request())
+    except RefreshError as e:
+        raise TokenAuthError(str(e)) from e
+    except TransportError as e:
+        raise TokenNetworkError(str(e)) from e
+
+    with open(token_path, "w") as f:
+        f.write(creds.to_json())
+
+
+def refresh_token_if_needed(token_path="token.json"):
+    """Proactively refresh the Gmail token when it is expired.
+
+    Returns one of:
+        "no_token"  — no token file present (first use)
+        "valid"     — token is still valid, no refresh needed
+        "refreshed" — refresh succeeded and file was updated
+
+    Raises:
+        TokenAuthError    — refresh_token is invalid, user must re-authenticate
+        TokenNetworkError — network issue prevented the refresh attempt
+    """
+    from google.oauth2.credentials import Credentials
+
+    if not os.path.exists(token_path):
+        return "no_token"
+
+    creds = Credentials.from_authorized_user_file(token_path, SCOPES)
+
+    if creds.valid:
+        return "valid"
+
+    if not creds.expired or not creds.refresh_token:
+        raise TokenAuthError(
+            "Token ist ungültig und enthält kein Refresh-Token."
+        )
+
+    _refresh_and_persist(creds, token_path)
+    return "refreshed"
+
+
 def get_gmail_service(credentials_path="credentials.json", token_path="token.json"):
     """Authenticate with Gmail API and return a service object.
 
@@ -16,7 +71,6 @@ def get_gmail_service(credentials_path="credentials.json", token_path="token.jso
     """
     from google.oauth2.credentials import Credentials
     from google_auth_oauthlib.flow import InstalledAppFlow
-    from google.auth.transport.requests import Request
     from googleapiclient.discovery import build
 
     creds = None
@@ -26,8 +80,8 @@ def get_gmail_service(credentials_path="credentials.json", token_path="token.jso
 
     if creds and creds.expired and creds.refresh_token:
         try:
-            creds.refresh(Request())
-        except Exception:
+            _refresh_and_persist(creds, token_path)
+        except TokenAuthError:
             creds = None
 
     if not creds or not creds.valid:
@@ -39,9 +93,8 @@ def get_gmail_service(credentials_path="credentials.json", token_path="token.jso
             )
         flow = InstalledAppFlow.from_client_secrets_file(credentials_path, SCOPES)
         creds = flow.run_local_server(port=0)
-
-    with open(token_path, "w") as f:
-        f.write(creds.to_json())
+        with open(token_path, "w") as f:
+            f.write(creds.to_json())
 
     return build("gmail", "v1", credentials=creds)
 

--- a/src/ui.py
+++ b/src/ui.py
@@ -6,11 +6,18 @@ import ctypes
 import datetime
 import os
 import sys
+import threading
 import traceback
 from src.storage import Storage
 from src.time_utils import calculate_hours, validate_entry, get_week_dates, get_week_label, week_spans_months
 from src.report import generate_report, generate_pdf
-from src.mail import get_gmail_service, send_email
+from src.mail import (
+    get_gmail_service,
+    send_email,
+    refresh_token_if_needed,
+    TokenAuthError,
+    TokenNetworkError,
+)
 from src.autostart import enable_autostart, disable_autostart
 from src.version import VERSION
 
@@ -87,6 +94,36 @@ class App:
         self._build_grid()
         self._build_footer()
         self._refresh()
+        self._proactive_token_refresh()
+
+    def _proactive_token_refresh(self):
+        """Erneuert den Gmail-Token beim App-Start im Hintergrund.
+
+        Auth-Fehler werden als Messagebox gezeigt, Netzwerkfehler still
+        übergangen, damit ein Offline-Start nicht stört.
+        """
+        token_path = os.path.join(self.base_path, "token.json")
+
+        def worker():
+            try:
+                refresh_token_if_needed(token_path)
+            except TokenAuthError as e:
+                msg = str(e)
+                self.root.after(0, lambda: messagebox.showwarning(
+                    "Gmail-Anmeldung abgelaufen",
+                    "Der Gmail-Token konnte nicht automatisch erneuert werden:\n\n"
+                    f"{msg}\n\n"
+                    "Beim nächsten Senden wirst du zur erneuten Anmeldung aufgefordert."
+                ))
+            except TokenNetworkError:
+                pass
+            except Exception as e:
+                err = f"{type(e).__name__}: {e}\n\n{traceback.format_exc()}"
+                self.root.after(0, lambda: messagebox.showerror(
+                    "Token-Refresh fehlgeschlagen", err
+                ))
+
+        threading.Thread(target=worker, daemon=True).start()
 
     def _build_header(self):
         frame = tk.Frame(self.root, bg=BG)

--- a/src/version.py
+++ b/src/version.py
@@ -1,1 +1,1 @@
-VERSION = "1.4.0"
+VERSION = "1.5.0"

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -1,0 +1,129 @@
+# tests/test_mail.py
+import os
+import pytest
+from unittest.mock import patch, MagicMock
+
+from src.mail import (
+    refresh_token_if_needed,
+    TokenAuthError,
+    TokenNetworkError,
+)
+
+
+def test_no_token_file(tmp_path):
+    """Ohne token.json gibt die Funktion 'no_token' zurück."""
+    path = str(tmp_path / "token.json")
+    assert refresh_token_if_needed(path) == "no_token"
+
+
+def test_valid_token_is_not_refreshed(tmp_path):
+    """Gültige Credentials werden nicht erneuert."""
+    path = str(tmp_path / "token.json")
+    # Datei muss existieren, Inhalt wird aber nicht gelesen (mocked)
+    open(path, "w").close()
+
+    fake_creds = MagicMock()
+    fake_creds.valid = True
+
+    with patch("google.oauth2.credentials.Credentials.from_authorized_user_file",
+               return_value=fake_creds):
+        assert refresh_token_if_needed(path) == "valid"
+
+    fake_creds.refresh.assert_not_called()
+
+
+def test_expired_token_is_refreshed_and_persisted(tmp_path):
+    """Abgelaufene Credentials werden refreshed und die Datei neu geschrieben."""
+    path = str(tmp_path / "token.json")
+    open(path, "w").close()
+
+    fake_creds = MagicMock()
+    fake_creds.valid = False
+    fake_creds.expired = True
+    fake_creds.refresh_token = "rt"
+    fake_creds.to_json.return_value = '{"fresh": true}'
+
+    with patch("google.oauth2.credentials.Credentials.from_authorized_user_file",
+               return_value=fake_creds):
+        assert refresh_token_if_needed(path) == "refreshed"
+
+    fake_creds.refresh.assert_called_once()
+    with open(path) as f:
+        assert f.read() == '{"fresh": true}'
+
+
+def test_no_refresh_token_raises_auth_error(tmp_path):
+    """Wenn Credentials kein refresh_token haben, TokenAuthError."""
+    path = str(tmp_path / "token.json")
+    open(path, "w").close()
+
+    fake_creds = MagicMock()
+    fake_creds.valid = False
+    fake_creds.expired = True
+    fake_creds.refresh_token = None
+
+    with patch("google.oauth2.credentials.Credentials.from_authorized_user_file",
+               return_value=fake_creds):
+        with pytest.raises(TokenAuthError):
+            refresh_token_if_needed(path)
+
+
+def test_refresh_error_translates_to_auth_error(tmp_path):
+    """Google RefreshError wird in TokenAuthError übersetzt."""
+    from google.auth.exceptions import RefreshError
+
+    path = str(tmp_path / "token.json")
+    open(path, "w").close()
+
+    fake_creds = MagicMock()
+    fake_creds.valid = False
+    fake_creds.expired = True
+    fake_creds.refresh_token = "rt"
+    fake_creds.refresh.side_effect = RefreshError("invalid_grant")
+
+    with patch("google.oauth2.credentials.Credentials.from_authorized_user_file",
+               return_value=fake_creds):
+        with pytest.raises(TokenAuthError, match="invalid_grant"):
+            refresh_token_if_needed(path)
+
+
+def test_transport_error_translates_to_network_error(tmp_path):
+    """Google TransportError wird in TokenNetworkError übersetzt."""
+    from google.auth.exceptions import TransportError
+
+    path = str(tmp_path / "token.json")
+    open(path, "w").close()
+
+    fake_creds = MagicMock()
+    fake_creds.valid = False
+    fake_creds.expired = True
+    fake_creds.refresh_token = "rt"
+    fake_creds.refresh.side_effect = TransportError("connection refused")
+
+    with patch("google.oauth2.credentials.Credentials.from_authorized_user_file",
+               return_value=fake_creds):
+        with pytest.raises(TokenNetworkError, match="connection refused"):
+            refresh_token_if_needed(path)
+
+
+def test_failed_refresh_does_not_overwrite_token(tmp_path):
+    """Bei Refresh-Fehler bleibt die Token-Datei unberührt."""
+    from google.auth.exceptions import RefreshError
+
+    path = str(tmp_path / "token.json")
+    with open(path, "w") as f:
+        f.write("original-content")
+
+    fake_creds = MagicMock()
+    fake_creds.valid = False
+    fake_creds.expired = True
+    fake_creds.refresh_token = "rt"
+    fake_creds.refresh.side_effect = RefreshError("boom")
+
+    with patch("google.oauth2.credentials.Credentials.from_authorized_user_file",
+               return_value=fake_creds):
+        with pytest.raises(TokenAuthError):
+            refresh_token_if_needed(path)
+
+    with open(path) as f:
+        assert f.read() == "original-content"

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -44,6 +44,14 @@ except ImportError:
 
     _trq.Request = Request
 
+    # Parent-Attribute setzen, damit unittest.mock.patch via getattr navigieren kann
+    _google.oauth2 = _oauth2
+    _google.auth = _auth
+    _oauth2.credentials = _creds
+    _auth.exceptions = _excs
+    _auth.transport = _transport
+    _transport.requests = _trq
+
     sys.modules["google"] = _google
     sys.modules["google.oauth2"] = _oauth2
     sys.modules["google.oauth2.credentials"] = _creds

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -1,9 +1,62 @@
 # tests/test_mail.py
-import os
-import pytest
-from unittest.mock import patch, MagicMock
+import sys
+import types
 
-from src.mail import (
+# Die CI installiert google-auth nicht (s. CLAUDE.md). Damit die Tests
+# trotzdem laufen, stubben wir die Google-Module bei Bedarf.
+try:
+    import google.oauth2.credentials  # noqa: F401
+    import google.auth.exceptions  # noqa: F401
+    import google.auth.transport.requests  # noqa: F401
+except ImportError:
+    _google = types.ModuleType("google")
+    _google.__path__ = []
+    _oauth2 = types.ModuleType("google.oauth2")
+    _oauth2.__path__ = []
+    _creds = types.ModuleType("google.oauth2.credentials")
+
+    class _StubCreds:
+        @staticmethod
+        def from_authorized_user_file(path, scopes):
+            raise NotImplementedError
+
+    _creds.Credentials = _StubCreds
+
+    _auth = types.ModuleType("google.auth")
+    _auth.__path__ = []
+    _excs = types.ModuleType("google.auth.exceptions")
+
+    class RefreshError(Exception):
+        pass
+
+    class TransportError(Exception):
+        pass
+
+    _excs.RefreshError = RefreshError
+    _excs.TransportError = TransportError
+
+    _transport = types.ModuleType("google.auth.transport")
+    _transport.__path__ = []
+    _trq = types.ModuleType("google.auth.transport.requests")
+
+    class Request:  # noqa: D401
+        pass
+
+    _trq.Request = Request
+
+    sys.modules["google"] = _google
+    sys.modules["google.oauth2"] = _oauth2
+    sys.modules["google.oauth2.credentials"] = _creds
+    sys.modules["google.auth"] = _auth
+    sys.modules["google.auth.exceptions"] = _excs
+    sys.modules["google.auth.transport"] = _transport
+    sys.modules["google.auth.transport.requests"] = _trq
+
+import os  # noqa: E402
+import pytest  # noqa: E402
+from unittest.mock import patch, MagicMock  # noqa: E402
+
+from src.mail import (  # noqa: E402
     refresh_token_if_needed,
     TokenAuthError,
     TokenNetworkError,


### PR DESCRIPTION
## Summary
- Gmail-Token wird beim App-Start in einem Hintergrund-Thread proaktiv erneuert, damit beim Senden kein Browser-Popup mehr erscheint, wenn das Access-Token abgelaufen ist
- Differenzierte Fehlerbehandlung beim Refresh: `RefreshError` → Warn-Messagebox („Gmail-Anmeldung abgelaufen"), `TransportError` → still (Offline-Start soll nicht nerven)
- Bump auf v1.5.0, CHANGELOG ergänzt

## Änderungen
- `src/mail.py`: `TokenAuthError` + `TokenNetworkError`, gemeinsame `_refresh_and_persist()`-Helper, neue `refresh_token_if_needed()`-Funktion für den proaktiven Pfad
- `src/ui.py`: neuer `_proactive_token_refresh()` im Worker-Thread, wird am Ende von `App.__init__` gestartet
- `tests/test_mail.py`: 7 neue Tests für alle Return-Werte und beide Exception-Übersetzungen

## Test plan
- [x] `pytest` lokal grün (61 Tests)
- [ ] CI grün
- [ ] Manuell: App starten mit abgelaufenem Token → kein Browser-Popup beim späteren Senden
- [ ] Manuell: App offline starten → keine Fehlermeldung

🤖 Generated with [Claude Code](https://claude.com/claude-code)