### PR TITLE
release: v1.6.0 (macOS + Linux installers)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.6.0
+- Installer für macOS (DMG, Apple Silicon und Intel) und Linux (AppImage) zusätzlich zum bestehenden Windows-Installer
+- Autostart jetzt auch unter macOS (LaunchAgent) und Linux (`.desktop`-Datei unter `~/.config/autostart/`)
+- Datenverzeichnisse plattformkonform: macOS unter `~/Library/Application Support/Zeiterfassung`, Linux unter `$XDG_DATA_HOME/Zeiterfassung`, Windows unverändert
+- Release-Workflow baut alle vier Artefakte parallel und taggt erst nach erfolgreichem Build aller Plattformen
+
 ## v1.5.0
 - Gmail-Token wird beim App-Start proaktiv im Hintergrund erneuert, damit beim Senden kein Login-Browser mehr aufpoppt
 - Differenzierte Fehlerbehandlung beim Token-Refresh: abgelaufene Anmeldung wird als Messagebox angezeigt, Netzwerkfehler beim Start werden still übergangen

--- a/src/version.py
+++ b/src/version.py
@@ -1,1 +1,1 @@
-VERSION = "1.5.0"
+VERSION = "1.6.0"


### PR DESCRIPTION
## Summary

Hebt die Version auf **1.6.0** und triggert damit das erste Multi-Platform-Release nach dem Merge von #3.

- `src/version.py` → `1.6.0`
- `CHANGELOG.md` mit macOS/Linux/Autostart/Release-Workflow-Einträgen aktualisiert

Der Release-Workflow baut bei Merge vier Artefakte:
- `Zeiterfassung_Setup.exe` (Windows)
- `Zeiterfassung-1.6.0-arm64.dmg` (macOS Apple Silicon)
- `Zeiterfassung-1.6.0-x86_64.dmg` (macOS Intel)
- `Zeiterfassung-1.6.0-x86_64.AppImage` (Linux)

## Test Plan

- [ ] Release-Workflow läuft grün für alle vier Build-Jobs
- [ ] `publish`-Job taggt `v1.6.0` und legt Release mit allen vier Assets an
- [ ] Manueller Smoke-Test der DMGs und AppImage nach dem Build (separat getrackt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)