### PR TITLE
ci: fix release workflow (Linux Cairo, Windows Inno, drop macOS Intel)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,13 +50,7 @@ jobs:
         run: pip install -r requirements.txt pyinstaller
       - name: Install Inno Setup
         shell: powershell
-        run: |
-          $url = "https://jrsoftware.org/download.php/is.exe"
-          Invoke-WebRequest -Uri $url -OutFile "$env:TEMP\innosetup.exe"
-          $target = "$env:LOCALAPPDATA\Programs\Inno Setup 6"
-          Start-Process -FilePath "$env:TEMP\innosetup.exe" `
-            -ArgumentList "/VERYSILENT", "/SUPPRESSMSGBOXES", "/NORESTART", "/DIR=$target" `
-            -Wait
+        run: choco install innosetup -y --no-progress
       - name: Build
         run: python build.py
       - uses: actions/upload-artifact@v4
@@ -83,25 +77,6 @@ jobs:
           name: macos-arm
           path: dist/Zeiterfassung-*-arm64.dmg
 
-  build-macos-x86:
-    needs: pre-check
-    runs-on: macos-13
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.10'
-      - name: Install dependencies
-        run: pip install -r requirements.txt pyinstaller
-      - name: Install create-dmg
-        run: brew install create-dmg
-      - name: Build
-        run: python build.py
-      - uses: actions/upload-artifact@v4
-        with:
-          name: macos-x86
-          path: dist/Zeiterfassung-*-x86_64.dmg
-
   build-linux:
     needs: pre-check
     runs-on: ubuntu-latest
@@ -113,7 +88,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libfuse2
+          sudo apt-get install -y libfuse2 libcairo2-dev pkg-config
       - name: Install appimagetool
         run: |
           curl -L -o appimagetool "https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage"
@@ -129,7 +104,7 @@ jobs:
           path: dist/Zeiterfassung-*-x86_64.AppImage
 
   publish:
-    needs: [pre-check, build-windows, build-macos-arm, build-macos-x86, build-linux]
+    needs: [pre-check, build-windows, build-macos-arm, build-linux]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -157,7 +132,6 @@ jobs:
           gh release create "v${VERSION}" \
             dist/Zeiterfassung_Setup.exe \
             dist/Zeiterfassung-${VERSION}-arm64.dmg \
-            dist/Zeiterfassung-${VERSION}-x86_64.dmg \
             dist/Zeiterfassung-${VERSION}-x86_64.AppImage \
             --title "Zeiterfassung v${VERSION}" \
             --generate-notes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ python build.py
 | Plattform | Voraussetzung | Ausgabe |
 |-----------|---------------|---------|
 | Windows | Inno Setup 6 unter `%LOCALAPPDATA%\Programs\Inno Setup 6\` | `dist/Zeiterfassung_Setup.exe` |
-| macOS | `brew install create-dmg` | `dist/Zeiterfassung-<ver>-<arch>.dmg` (arch = `arm64` oder `x86_64`) |
+| macOS | `brew install create-dmg` | `dist/Zeiterfassung-<ver>-arm64.dmg` (CI baut nur Apple Silicon; Intel-Runner `macos-13` hat de-facto unbrauchbare Queue-Zeiten) |
 | Linux | `apt install libfuse2` + `appimagetool` auf `$PATH` | `dist/Zeiterfassung-<ver>-<arch>.AppImage` |
 
 Fehlt das Pack-Tool lokal, überspringt `build.py` den Pack-Schritt mit Warnung — der PyInstaller-Build läuft trotzdem durch. Das ist für Local-Dev gewollt.

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ Vorgefertigte Installer für alle drei Plattformen gibt es unter [Releases](../.
 **Windows**
 Lade `Zeiterfassung_Setup.exe` und führe den Installer aus. App installiert nach `%LOCALAPPDATA%\Programs\Zeiterfassung\`.
 
-**macOS**
-Lade `Zeiterfassung-<ver>-arm64.dmg` (Apple Silicon) oder `Zeiterfassung-<ver>-x86_64.dmg` (Intel) herunter. Öffne das DMG und ziehe die App in den Applications-Ordner. Beim ersten Start: Rechtsklick auf die App → „Öffnen" (Gatekeeper-Warnung bestätigen), oder im Terminal:
+**macOS** (Apple Silicon)
+Lade `Zeiterfassung-<ver>-arm64.dmg` herunter. Öffne das DMG und ziehe die App in den Applications-Ordner. Beim ersten Start: Rechtsklick auf die App → „Öffnen" (Gatekeeper-Warnung bestätigen), oder im Terminal:
 
 ```bash
 xattr -dr com.apple.quarantine /Applications/Zeiterfassung.app

--- a/build.py
+++ b/build.py
@@ -25,12 +25,22 @@ def _pyinstaller_common(extra_args):
     ]
 
 
-def build_windows():
-    inno_compiler = os.path.join(
-        os.environ.get("LOCALAPPDATA", ""),
-        "Programs", "Inno Setup 6", "ISCC.exe",
-    )
+def _find_inno_compiler():
+    """Return the path to ISCC.exe, or None if Inno Setup is not installed."""
+    on_path = shutil.which("ISCC")
+    if on_path:
+        return on_path
+    for candidate in (
+        os.path.join(os.environ.get("ProgramFiles(x86)", ""), "Inno Setup 6", "ISCC.exe"),
+        os.path.join(os.environ.get("ProgramFiles", ""), "Inno Setup 6", "ISCC.exe"),
+        os.path.join(os.environ.get("LOCALAPPDATA", ""), "Programs", "Inno Setup 6", "ISCC.exe"),
+    ):
+        if candidate and os.path.exists(candidate):
+            return candidate
+    return None
 
+
+def build_windows():
     print(f"Building Zeiterfassung v{VERSION} (Windows) ...")
     cmd = _pyinstaller_common([
         "--onefile",
@@ -39,10 +49,11 @@ def build_windows():
     ])
     subprocess.run(cmd, check=True)
 
-    if not os.path.exists(inno_compiler):
-        print(f"Inno Setup not found at {inno_compiler} — skipping installer.")
+    inno_compiler = _find_inno_compiler()
+    if not inno_compiler:
+        print("Inno Setup not found on PATH or in standard locations — skipping installer.")
         return
-    print(f"Building installer v{VERSION} ...")
+    print(f"Building installer v{VERSION} with {inno_compiler} ...")
     subprocess.run([inno_compiler, f"/DAppVer={VERSION}", "installer.iss"], check=True)
     print("Installer created: dist/Zeiterfassung_Setup.exe")
 


### PR DESCRIPTION
## Summary

Behebt die drei Root-Causes, die den ersten `v1.6.0`-Release-Run nicht durchlaufen ließen:

- **Linux:** `libcairo2-dev` + `pkg-config` zusätzlich zu `libfuse2` — `pycairo` (transitive Dep von `xhtml2pdf`) fand sonst keine Cairo-Systemheader und brach `pip install -r requirements.txt` ab
- **Windows:** Inno Setup jetzt via Chocolatey (`choco install innosetup -y`). Der bisherige stumme Download von `jrsoftware.org/is.exe` hat `/DIR=` ignoriert und `ISCC.exe` landete außerhalb des von `build.py` gesuchten Pfads. `build.py::_find_inno_compiler` sucht jetzt zusätzlich PATH und Program Files (x86).
- **macOS Intel:** `build-macos-x86` entfernt. Der `macos-13`-Runner hat Queue-Zeiten jenseits von 17 h — die Apple-Silicon-DMG reicht für unseren Use-Case.

Version bleibt `1.6.0` — der Tag `v1.6.0` existiert noch nicht, weil der vorherige Run gecancelled wurde. Pre-Check sollte diesmal durchlaufen.

## Test Plan

- [x] `pytest` — 82/82 grün lokal
- [x] YAML-Lint
- [ ] `build-windows`, `build-macos-arm`, `build-linux` laufen alle durch
- [ ] `publish`-Job taggt `v1.6.0` und veröffentlicht drei Assets (EXE, arm64-DMG, AppImage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)