### PR TITLE
v1.7.0: credentials-folder discoverability + view-toggle reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.7.0
+- Einstellungen: neue Sektion „Gmail-Zugangsdaten" am Anfang des Dialogs mit „Ordner öffnen"-Button und Live-Status (✓/✗) für `credentials.json` — kein Suchen mehr nach `~/Library/Application Support/Zeiterfassung` oder `%LOCALAPPDATA%\Programs\Zeiterfassung`
+- Sende-Fehler bei fehlender `credentials.json`: statt der Standard-Messagebox erscheint ein Dialog im Dark-Theme mit zwei Buttons („Datenordner öffnen" / „OK") — ein Klick öffnet das richtige Verzeichnis
+- Status-Label aktualisiert sich live alle 500 ms, solange der Settings-Dialog offen ist (kein Neuöffnen mehr nötig nach dem Reinkopieren)
+- Monat/Woche-Toggle springt jetzt immer auf den aktuellen Monat / die aktuelle KW (vorher: behielt die zuletzt angezeigte Scroll-Position)
+
 ## v1.6.0
 - Installer für macOS (DMG, Apple Silicon und Intel) und Linux (AppImage) zusätzlich zum bestehenden Windows-Installer
 - Autostart jetzt auch unter macOS (LaunchAgent) und Linux (`.desktop`-Datei unter `~/.config/autostart/`)

--- a/docs/superpowers/plans/2026-04-24-credentials-folder-button.md
+++ b/docs/superpowers/plans/2026-04-24-credentials-folder-button.md
@@ -1,0 +1,461 @@
+# Credentials-Ordner-Button Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the user a one-click way to open the data directory where `credentials.json` belongs — both proactively (Settings dialog) and reactively (when the send fails because the file is missing).
+
+**Architecture:** A new module `src/platform_open.py` encapsulates the cross-platform "open folder in OS file manager" logic (dispatch over `platform.system()`). `src/ui.py` gains (a) a new section at the top of the Settings dialog with an "Ordner öffnen" button + status label showing whether `credentials.json` is present, and (b) a custom `Toplevel` dialog replacing the existing `messagebox.showerror` in `_send_report` when `credentials.json` is missing. `self.base_path` (already resolved by `paths.py::get_base_path`) is the directory passed to `open_folder`.
+
+**Tech Stack:** Python stdlib only — `os.startfile` (Windows), `subprocess.run` with `["open", ...]` (macOS) and `["xdg-open", ...]` (Linux). Tkinter for the UI changes. `pytest` + `monkeypatch` for the unit tests, no external deps (matches the `.github/workflows/test.yml` strategy that only installs `pytest`).
+
+**Spec reference:** `docs/superpowers/specs/2026-04-24-credentials-folder-button-design.md`
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `src/platform_open.py` | Create | Cross-platform `open_folder(path)` dispatcher |
+| `tests/test_platform_open.py` | Create | Unit tests for all four platform branches |
+| `src/ui.py` | Modify | Settings dialog: new "Gmail-Zugangsdaten" section. `_send_report`: replace `showerror` with custom dialog. New `STATUS_OK` color constant. Import `open_folder`. |
+
+No changes to `paths.py`, `mail.py`, `report.py`, `storage.py`, build, CI, or installer files.
+
+---
+
+## Chunk 1: `platform_open` module
+
+### Task 1: Create `src/platform_open.py` with TDD
+
+**Files:**
+- Create: `src/platform_open.py`
+- Test: `tests/test_platform_open.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_platform_open.py`:
+
+```python
+# tests/test_platform_open.py
+import pytest
+from unittest.mock import MagicMock
+from src.platform_open import open_folder
+
+
+def test_open_folder_windows(monkeypatch):
+    monkeypatch.setattr("src.platform_open.platform.system", lambda: "Windows")
+    mock_startfile = MagicMock()
+    monkeypatch.setattr(
+        "src.platform_open.os.startfile", mock_startfile, raising=False
+    )
+    open_folder(r"C:\Users\test\data")
+    mock_startfile.assert_called_once_with(r"C:\Users\test\data")
+
+
+def test_open_folder_macos(monkeypatch):
+    monkeypatch.setattr("src.platform_open.platform.system", lambda: "Darwin")
+    mock_run = MagicMock()
+    monkeypatch.setattr("src.platform_open.subprocess.run", mock_run)
+    open_folder("/Users/test/Library/Application Support/Zeiterfassung")
+    mock_run.assert_called_once_with(
+        ["open", "/Users/test/Library/Application Support/Zeiterfassung"],
+        check=True,
+    )
+
+
+def test_open_folder_linux(monkeypatch):
+    monkeypatch.setattr("src.platform_open.platform.system", lambda: "Linux")
+    mock_run = MagicMock()
+    monkeypatch.setattr("src.platform_open.subprocess.run", mock_run)
+    open_folder("/home/test/.local/share/Zeiterfassung")
+    mock_run.assert_called_once_with(
+        ["xdg-open", "/home/test/.local/share/Zeiterfassung"],
+        check=True,
+    )
+
+
+def test_open_folder_unsupported_platform_raises(monkeypatch):
+    monkeypatch.setattr("src.platform_open.platform.system", lambda: "FreeBSD")
+    with pytest.raises(RuntimeError, match="Unsupported platform"):
+        open_folder("/tmp/whatever")
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_platform_open.py -v`
+Expected: All four tests fail with `ModuleNotFoundError: No module named 'src.platform_open'`.
+
+- [ ] **Step 3: Create `src/platform_open.py` with minimal implementation**
+
+Create the file with this content (note: `import os` and `import subprocess` as **module imports** — not symbol imports — so the tests can patch `src.platform_open.os.startfile` and `src.platform_open.subprocess.run`):
+
+```python
+# src/platform_open.py
+import os
+import platform
+import subprocess
+
+
+def open_folder(path: str) -> None:
+    """Open the given directory in the OS file manager.
+
+    Raises:
+        RuntimeError: on unsupported platforms.
+        OSError / subprocess.CalledProcessError: on OS-level failures
+            (propagated to caller).
+    """
+    system = platform.system()
+    if system == "Windows":
+        os.startfile(path)
+    elif system == "Darwin":
+        subprocess.run(["open", path], check=True)
+    elif system == "Linux":
+        subprocess.run(["xdg-open", path], check=True)
+    else:
+        raise RuntimeError(f"Unsupported platform: {system}")
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_platform_open.py -v`
+Expected: All four tests pass.
+
+- [ ] **Step 5: Run the full test suite to confirm no regressions**
+
+Run: `pytest -v`
+Expected: All tests pass (existing + 4 new).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/platform_open.py tests/test_platform_open.py
+git commit -m "feat: add platform_open helper to open data folder cross-platform
+
+New module src/platform_open.py with open_folder(path) that dispatches
+over platform.system() to os.startfile (Windows), open (macOS), or
+xdg-open (Linux). Errors are propagated; unsupported platforms raise
+RuntimeError. Unit-tested via monkeypatch on all four branches."
+```
+
+---
+
+## Chunk 2: Settings dialog integration
+
+### Task 2: Add "Gmail-Zugangsdaten" section to settings dialog
+
+**Files:**
+- Modify: `src/ui.py` (constants block around line 31-50; `_open_settings` method around line 295-518)
+
+This task has no automated tests — Tkinter UI tests are not established in this project (per spec, Section 4). Verification is manual.
+
+- [ ] **Step 1: Add `STATUS_OK` color constant and import `open_folder`**
+
+In `src/ui.py`, find the existing color constants block (around line 31-44) and add `STATUS_OK` next to `ACCENT`:
+
+```python
+ACCENT = "#e94560"
+STATUS_OK = "#4ade80"
+TEXT = "#e0e0e0"
+```
+
+In the imports block at the top of `src/ui.py` (around line 22), add the new module import after the `autostart` import:
+
+```python
+from src.autostart import enable_autostart, disable_autostart
+from src.platform_open import open_folder
+from src.version import VERSION
+```
+
+- [ ] **Step 2: Insert new section at top of `_open_settings`**
+
+In `src/ui.py`, find `_open_settings` (starts at line 295). After `self._apply_combobox_style(dialog)` (around line 302) and **before** the existing `# Email` block (line 304), insert the new section. The first widget after `_apply_combobox_style` becomes the new header at `row=0`.
+
+Insert this block immediately after `self._apply_combobox_style(dialog)`:
+
+```python
+        # Gmail-Zugangsdaten section
+        tk.Label(
+            dialog, text="— Gmail-Zugangsdaten —", font=FONT_BOLD,
+            bg=BG, fg=TEXT_MUTED
+        ).grid(row=0, column=0, columnspan=2, padx=10, pady=(8, 4))
+
+        creds_path = os.path.join(self.base_path, "credentials.json")
+        creds_present = os.path.exists(creds_path)
+
+        tk.Label(
+            dialog, text="Datenordner:", font=FONT, bg=BG, fg=TEXT
+        ).grid(row=1, column=0, padx=10, pady=4, sticky="w")
+
+        creds_row = tk.Frame(dialog, bg=BG)
+        creds_row.grid(row=1, column=1, padx=10, pady=4, sticky="w")
+
+        def open_data_folder():
+            try:
+                open_folder(self.base_path)
+            except Exception as e:
+                messagebox.showerror(
+                    "Ordner konnte nicht geöffnet werden",
+                    f"{type(e).__name__}: {e}\n\n{traceback.format_exc()}",
+                    parent=dialog,
+                )
+
+        tk.Button(
+            creds_row, text="Ordner öffnen", command=open_data_folder,
+            font=FONT, bg=CELL_BG, fg=TEXT,
+            activebackground=ENTRY_BG, activeforeground=TEXT,
+            relief=tk.FLAT, padx=12, pady=2, cursor="hand2"
+        ).pack(side=tk.LEFT)
+
+        if creds_present:
+            status_text = "✓ credentials.json vorhanden"
+            status_fg = STATUS_OK
+        else:
+            status_text = "✗ credentials.json fehlt"
+            status_fg = ACCENT
+
+        tk.Label(
+            creds_row, text=status_text, font=FONT_SMALL,
+            bg=BG, fg=status_fg
+        ).pack(side=tk.LEFT, padx=(10, 0))
+```
+
+- [ ] **Step 3: Renumber all existing `.grid(row=N, ...)` calls in `_open_settings` by +2**
+
+Every existing `.grid(row=N, ...)` call inside `_open_settings` (originally rows 0–14) shifts to rows 2–16. Apply these mappings:
+
+| Old row | New row | What it is |
+|---------|---------|------------|
+| 0 | 2 | Absender label + Entry |
+| 1 | 3 | Standard-Start label + Combobox |
+| 2 | 4 | Standard-Ende label + Combobox |
+| 3 | 5 | Standard-Pause label + Combobox |
+| 4 | 6 | Empfänger label + Entry |
+| 5 | 7 | Name label + Entry |
+| 6 | 8 | Stundenlohn label + Entry + helper Label |
+| 7 | 9 | Mail-Vorlage section header |
+| 8 | 10 | Betreff label + Entry |
+| 9 | 11 | Anrede label + Entry |
+| 10 | 12 | Inhalt label + Text |
+| 11 | 13 | Gruß label + Text |
+| 12 | 14 | Platzhalter helper Label |
+| 13 | 15 | Autostart Checkbutton |
+| 14 | 16 | Save/Cancel `btn_frame` |
+
+Use Edit tool with `replace_all=False` for each `.grid(row=N, ...)` call. Do them in **descending order** (row=14 → row=16 first, then row=13 → row=15, …, then row=0 → row=2) to avoid temporarily creating duplicate row numbers in the file.
+
+**Important — disambiguation:** Several `.grid(row=N, column=0, padx=10, pady=8, sticky="w")` lines exist in *other* dialogs in `src/ui.py` (e.g. `_send_report` date-range dialog around line 869, `_open_dialog` around line 738) and look identical. Each `Edit` call's `old_string` must include the **preceding line** (the `tk.Label` / `tk.Entry` / `ttk.Combobox` widget that this `.grid` belongs to) to ensure Edit targets the call inside `_open_settings` and not a lookalike elsewhere. Example for the "Absender" entry:
+
+```python
+            relief=tk.FLAT, highlightbackground=TEXT_MUTED,
+            highlightcolor=ACCENT, highlightthickness=1
+        ).grid(row=0, column=1, padx=10, pady=8)
+```
+
+→ change `row=0` to `row=2`. The three preceding lines make the match unique to this widget.
+
+- [ ] **Step 4: Verify the renumbering with grep**
+
+Run:
+
+```bash
+grep -n "\.grid(row=" src/ui.py
+```
+
+Expected: inside `_open_settings` (lines around 295–520), the `.grid` calls now use rows 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 (each row used once or twice for column 0/1 pairs). No duplicates of any row except the legitimate column 0/column 1 pairings.
+
+- [ ] **Step 5: Manual UI smoke test**
+
+Run the app from the repo:
+
+```bash
+python main.py
+```
+
+Click the gear icon (top right) to open Settings. Verify:
+- New section "— Gmail-Zugangsdaten —" appears at the top.
+- "Datenordner:" label with "Ordner öffnen" button next to it.
+- Status label shows either "✓ credentials.json vorhanden" (green) or "✗ credentials.json fehlt" (red), matching the actual state of the repo root (which is `self.base_path` in script mode).
+- Click "Ordner öffnen" — the OS file manager opens the repo root directory.
+- The rest of the dialog (Absender down to Speichern/Abbrechen) renders correctly, no overlap, no missing fields.
+- Save/Cancel buttons still work.
+
+If `credentials.json` is missing in the repo root, you can create a temporary empty file to test the green status. **Safety: `credentials.json` is already in `.gitignore`** — but still delete it after the test:
+
+```bash
+touch credentials.json && python main.py   # status should now show green ✓
+rm credentials.json
+```
+
+- [ ] **Step 6: Run the full test suite to confirm no regressions**
+
+Run: `pytest -v`
+Expected: All tests pass (no UI tests added, but existing tests must still pass).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/ui.py
+git commit -m "feat: settings dialog gains Gmail-Zugangsdaten section
+
+New section at the top of the settings dialog with an 'Ordner öffnen'
+button that opens the data directory in the OS file manager, plus a
+status label showing whether credentials.json is already present
+(green check or red cross). Uses the new platform_open helper. All
+existing grid rows shifted down by 2."
+```
+
+---
+
+## Chunk 3: Send-error custom dialog
+
+### Task 3: Replace `showerror` with custom Toplevel in `_send_report`
+
+**Files:**
+- Modify: `src/ui.py` (`_send_report` method around line 809-830; new method `_show_missing_credentials_dialog`)
+
+This task has no automated tests (same reason as Task 2). Verification is manual.
+
+- [ ] **Step 1: Add `_show_missing_credentials_dialog` method on `App`**
+
+In `src/ui.py`, add this method on the `App` class. A good location is **immediately before `_send_report`** (so the helper sits right next to its sole caller). Find `def _send_report(self):` and insert the new method just above it:
+
+```python
+    def _show_missing_credentials_dialog(self):
+        dialog = tk.Toplevel(self.root)
+        dialog.title("Keine Zugangsdaten")
+        dialog.resizable(False, False)
+        dialog.grab_set()
+        dialog.configure(bg=BG)
+
+        tk.Label(
+            dialog,
+            text=(
+                "credentials.json nicht gefunden.\n\n"
+                "Bitte erstelle ein Google Cloud Projekt mit Gmail API "
+                "und lade die OAuth2 Client-ID als credentials.json in "
+                "den Datenordner."
+            ),
+            font=FONT, bg=BG, fg=TEXT,
+            wraplength=380, justify="left",
+        ).grid(row=0, column=0, columnspan=2, padx=20, pady=(20, 12))
+
+        def open_and_close():
+            try:
+                open_folder(self.base_path)
+            except Exception as e:
+                messagebox.showerror(
+                    "Ordner konnte nicht geöffnet werden",
+                    f"{type(e).__name__}: {e}\n\n{traceback.format_exc()}",
+                    parent=dialog,
+                )
+                return
+            dialog.destroy()
+
+        btn_frame = tk.Frame(dialog, bg=BG)
+        btn_frame.grid(row=1, column=0, columnspan=2, pady=(0, 16))
+
+        tk.Button(
+            btn_frame, text="Datenordner öffnen", command=open_and_close,
+            font=FONT_BOLD, bg=ACCENT, fg="#ffffff",
+            activebackground="#c73550", activeforeground="#ffffff",
+            relief=tk.FLAT, padx=16, pady=4, cursor="hand2",
+        ).pack(side=tk.LEFT, padx=5)
+
+        tk.Button(
+            btn_frame, text="OK", command=dialog.destroy,
+            font=FONT, bg=CELL_BG, fg=TEXT,
+            activebackground=ENTRY_BG, activeforeground=TEXT,
+            relief=tk.FLAT, padx=16, pady=4, cursor="hand2",
+        ).pack(side=tk.LEFT, padx=5)
+```
+
+- [ ] **Step 2: Replace the existing `messagebox.showerror` block in `_send_report`**
+
+In `src/ui.py`, find this block in `_send_report` (currently around lines 822-830):
+
+```python
+        if not os.path.exists(credentials_path):
+            messagebox.showerror(
+                "Keine Zugangsdaten",
+                "credentials.json nicht gefunden.\n\n"
+                "Bitte erstelle ein Google Cloud Projekt mit Gmail API "
+                "und lade die OAuth2 Client-ID als credentials.json herunter.",
+                parent=self.root
+            )
+            return
+```
+
+Replace with:
+
+```python
+        if not os.path.exists(credentials_path):
+            self._show_missing_credentials_dialog()
+            return
+```
+
+- [ ] **Step 3: Manual UI smoke test (file missing)**
+
+Ensure no `credentials.json` exists in the repo root:
+
+```bash
+rm -f credentials.json
+```
+
+Run the app and click "Monat senden":
+
+```bash
+python main.py
+```
+
+(You also need a recipient set in settings, otherwise the recipient-warning fires first. Set any email, e.g. `test@example.com`, in the settings dialog and save.)
+
+Verify:
+- Custom dark-themed dialog "Keine Zugangsdaten" appears (not the native messagebox).
+- Two buttons side by side: "Datenordner öffnen" (red/accent) on the left, "OK" (gray) on the right.
+- Click "Datenordner öffnen" — the OS file manager opens at the repo root, dialog closes.
+- Open the dialog again ("Monat senden") and click "OK" — dialog just closes, no folder opens.
+
+- [ ] **Step 4: Manual UI smoke test (file present)**
+
+Create a dummy credentials.json so the missing-credentials path is bypassed:
+
+```bash
+echo '{"installed":{}}' > credentials.json
+```
+
+Click "Monat senden" again — the missing-credentials dialog should NOT appear; instead you proceed to the date-range dialog (where sending will fail later because the dummy creds are invalid, but that's expected — we only care that `_show_missing_credentials_dialog` is gated correctly).
+
+Clean up: `rm credentials.json`
+
+- [ ] **Step 5: Run the full test suite to confirm no regressions**
+
+Run: `pytest -v`
+Expected: All tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/ui.py
+git commit -m "feat: custom dialog with 'Datenordner öffnen' on missing credentials
+
+Replaces the plain messagebox.showerror in _send_report with a custom
+dark-themed Toplevel that offers two actions: open the data folder
+(via platform_open) so the user can drop credentials.json in, or
+dismiss with OK. No auto-retry — user clicks 'Monat senden' again
+once the file is in place."
+```
+
+---
+
+## Verification checklist (post-implementation)
+
+Before declaring done, confirm:
+
+- [ ] `pytest -v` all green (existing tests + 4 new in `test_platform_open.py`)
+- [ ] Settings dialog opens, new section visible at top, status label correct, button opens folder
+- [ ] Clicking "Monat senden" without `credentials.json` shows the custom dialog (not the native messagebox)
+- [ ] "Datenordner öffnen" in the custom dialog opens the folder and closes the dialog
+- [ ] "OK" in the custom dialog just closes
+- [ ] No regressions in the rest of the settings dialog (all fields render, save/cancel work)
+- [ ] Three commits exist on the branch, one per chunk

--- a/docs/superpowers/plans/2026-04-24-credentials-folder-hot-reload.md
+++ b/docs/superpowers/plans/2026-04-24-credentials-folder-hot-reload.md
@@ -1,0 +1,192 @@
+# Credentials-Status Hot-Reload Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the `credentials.json` ✓/✗ status label in the Settings dialog refresh live (every 500 ms) instead of only at dialog-open time.
+
+**Architecture:** Replace the inline status-label construction in `_open_settings` with a held-reference label plus a `refresh_status` closure that updates the label and reschedules itself via `dialog.after(500, refresh_status)`. The closure self-stops via `status_label.winfo_exists()` when the dialog is destroyed. Single-file change in `src/ui.py`. No new modules, no new imports, no new tests.
+
+**Tech Stack:** Tkinter `dialog.after` for the polling timer; `widget.winfo_exists()` for the lifecycle guard. All stdlib.
+
+**Spec reference:** `docs/superpowers/specs/2026-04-24-credentials-folder-hot-reload-design.md`
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `src/ui.py` | Modify | Replace ~10 lines in `_open_settings` (the inline status-label construction + the `if creds_present` precomputation) with a held-reference label + `refresh_status` closure |
+
+No other files. No tests (UI polling, consistent with the "no Tkinter UI tests" stance of the predecessor work).
+
+---
+
+## Chunk 1: Hot-reload polling
+
+### Task 1: Replace inline status label with held-reference + refresh closure
+
+**Files:**
+- Modify: `src/ui.py` (`_open_settings`, lines 312-349)
+
+This task has no automated tests. Verification is via `pytest -v` (no regressions) plus a manual smoke test described in Step 4.
+
+- [ ] **Step 1: Apply the edit**
+
+In `src/ui.py`, find this block in `_open_settings` (currently lines 312-349):
+
+```python
+        creds_path = os.path.join(self.base_path, "credentials.json")
+        creds_present = os.path.exists(creds_path)
+
+        tk.Label(
+            dialog, text="Datenordner:", font=FONT, bg=BG, fg=TEXT
+        ).grid(row=1, column=0, padx=10, pady=4, sticky="w")
+
+        creds_row = tk.Frame(dialog, bg=BG)
+        creds_row.grid(row=1, column=1, padx=10, pady=4, sticky="w")
+
+        def open_data_folder():
+            try:
+                open_folder(self.base_path)
+            except Exception as e:
+                messagebox.showerror(
+                    "Ordner konnte nicht geöffnet werden",
+                    f"{type(e).__name__}: {e}\n\n{traceback.format_exc()}",
+                    parent=dialog,
+                )
+
+        tk.Button(
+            creds_row, text="Ordner öffnen", command=open_data_folder,
+            font=FONT, bg=CELL_BG, fg=TEXT,
+            activebackground=ENTRY_BG, activeforeground=TEXT,
+            relief=tk.FLAT, padx=12, pady=2, cursor="hand2"
+        ).pack(side=tk.LEFT)
+
+        if creds_present:
+            status_text = "✓ credentials.json vorhanden"
+            status_fg = STATUS_OK
+        else:
+            status_text = "✗ credentials.json fehlt"
+            status_fg = ACCENT
+
+        tk.Label(
+            creds_row, text=status_text, font=FONT_SMALL,
+            bg=BG, fg=status_fg
+        ).pack(side=tk.LEFT, padx=(10, 0))
+```
+
+Replace with:
+
+```python
+        creds_path = os.path.join(self.base_path, "credentials.json")
+
+        tk.Label(
+            dialog, text="Datenordner:", font=FONT, bg=BG, fg=TEXT
+        ).grid(row=1, column=0, padx=10, pady=4, sticky="w")
+
+        creds_row = tk.Frame(dialog, bg=BG)
+        creds_row.grid(row=1, column=1, padx=10, pady=4, sticky="w")
+
+        def open_data_folder():
+            try:
+                open_folder(self.base_path)
+            except Exception as e:
+                messagebox.showerror(
+                    "Ordner konnte nicht geöffnet werden",
+                    f"{type(e).__name__}: {e}\n\n{traceback.format_exc()}",
+                    parent=dialog,
+                )
+
+        tk.Button(
+            creds_row, text="Ordner öffnen", command=open_data_folder,
+            font=FONT, bg=CELL_BG, fg=TEXT,
+            activebackground=ENTRY_BG, activeforeground=TEXT,
+            relief=tk.FLAT, padx=12, pady=2, cursor="hand2"
+        ).pack(side=tk.LEFT)
+
+        status_label = tk.Label(
+            creds_row, text="", font=FONT_SMALL, bg=BG
+        )
+        status_label.pack(side=tk.LEFT, padx=(10, 0))
+
+        def refresh_status():
+            if not status_label.winfo_exists():
+                return
+            if os.path.exists(creds_path):
+                status_label.config(
+                    text="✓ credentials.json vorhanden", fg=STATUS_OK
+                )
+            else:
+                status_label.config(
+                    text="✗ credentials.json fehlt", fg=ACCENT
+                )
+            dialog.after(500, refresh_status)
+
+        refresh_status()
+```
+
+**What changed and why:**
+- Removed the `creds_present` line and the `if creds_present: ... else: ...` precomputation block — `refresh_status` handles both initial paint and live refresh.
+- The new `tk.Label` has `text=""` and no `fg` at construction; `refresh_status()` populates them on its very first synchronous call (right after `pack`).
+- `dialog.after(500, refresh_status)` reschedules at the end, creating the polling loop.
+- `status_label.winfo_exists()` at the top of the callback prevents a TclError on the last fire-after-destroy. Tkinter is single-threaded, so no race between the existence check and the `config` call within one iteration.
+
+- [ ] **Step 2: Confirm no leftover variable references**
+
+Run:
+
+```bash
+grep -n "creds_present\|status_text\|status_fg" src/ui.py
+```
+
+Expected: no matches anywhere in `src/ui.py`. The three local variables only existed inside the replaced block.
+
+- [ ] **Step 3: Run the full test suite**
+
+Run: `python -m pytest -v`
+Expected: 86 tests pass, no regressions. (No new tests; the change is UI-polling only.)
+
+- [ ] **Step 4: Manual smoke test**
+
+Run the app from the repo:
+
+```bash
+python main.py
+```
+
+Click the gear icon (top right) to open Settings.
+
+Test sequence with the dialog kept open the whole time:
+
+1. With `credentials.json` present in the repo root: status label shows `✓ credentials.json vorhanden` (green).
+2. Without closing the dialog, in another terminal/Explorer: rename or delete the file (`mv credentials.json credentials.json.bak`).
+3. Within ~1 second: the label flips to `✗ credentials.json fehlt` (red).
+4. Restore the file (`mv credentials.json.bak credentials.json`).
+5. Within ~1 second: the label flips back to `✓ credentials.json vorhanden` (green).
+6. Close the Settings dialog. (The polling stops; no Python warnings/errors in the console.)
+
+**Safety:** `credentials.json` is in `.gitignore` (verified) — your local file is not at risk of being committed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ui.py
+git commit -m "feat: settings dialog credentials-status refreshes live every 500ms
+
+Replaces the inline ✓/✗ status label in _open_settings with a held
+reference plus a refresh_status closure that polls os.path.exists
+every 500 ms via dialog.after. The loop self-stops via
+status_label.winfo_exists() when the dialog is destroyed. Reverses
+Decision #4 of the original credentials-folder-button spec — the
+once-at-open check was friction the user noticed in practice."
+```
+
+---
+
+## Verification checklist (post-implementation)
+
+- [ ] `python -m pytest -v` all green (86 tests, unchanged count)
+- [ ] Manual smoke test from Step 4 passes — status flips both directions within ~1 second
+- [ ] Closing the Settings dialog leaves no errors in the console
+- [ ] One commit on the branch with the message above

--- a/docs/superpowers/plans/2026-04-24-view-toggle-jumps-to-today.md
+++ b/docs/superpowers/plans/2026-04-24-view-toggle-jumps-to-today.md
@@ -1,0 +1,120 @@
+# View-Toggle Jumps to Today Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Monat/Woche toggle in the header always land on today's month / today's KW, instead of preserving the previously displayed scroll position via inverse-mode lookup.
+
+**Architecture:** Single-file change to `src/ui.py::_set_view`. Both branches replaced with a single `today = datetime.date.today()` lookup followed by per-mode field assignment. The early-return guard, `_update_toggle_style()` call, and `_refresh()` call stay exactly as they are. No changes to `_prev`/`_next` (arrow nav keeps its relative behaviour).
+
+**Tech Stack:** stdlib `datetime`. Already imported at the top of `src/ui.py`.
+
+**Spec reference:** `docs/superpowers/specs/2026-04-24-view-toggle-jumps-to-today-design.md`
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `src/ui.py` | Modify | Replace 11 lines inside `_set_view` (lines 252-262) with the today-based assignment |
+
+No other files. No tests (behaviour is purely state-mutation; the existing test suite must continue to pass).
+
+---
+
+## Chunk 1: Toggle resets to today
+
+### Task 1: Replace `_set_view` branches with today-based assignment
+
+**Files:**
+- Modify: `src/ui.py` (`_set_view`, lines 249-265)
+
+This task has no automated tests. Verification: `python -m pytest -v` (no regressions). Manual smoke test is the controller's job.
+
+- [ ] **Step 1: Apply the edit**
+
+In `src/ui.py`, find this exact block in `_set_view` (currently lines 249-265):
+
+```python
+    def _set_view(self, mode):
+        if mode == self.view_mode:
+            return
+        if mode == "week":
+            # Jump to first KW of current month
+            first_day = datetime.date(self.year, self.month, 1)
+            iso = first_day.isocalendar()
+            self.iso_year = iso[0]
+            self.current_week = iso[1]
+        else:
+            # Jump to month containing Monday of current week
+            monday = datetime.date.fromisocalendar(self.iso_year, self.current_week, 1)
+            self.year = monday.year
+            self.month = monday.month
+        self.view_mode = mode
+        self._update_toggle_style()
+        self._refresh()
+```
+
+Replace with:
+
+```python
+    def _set_view(self, mode):
+        if mode == self.view_mode:
+            return
+        today = datetime.date.today()
+        if mode == "week":
+            iso = today.isocalendar()
+            self.iso_year = iso[0]
+            self.current_week = iso[1]
+        else:
+            self.year = today.year
+            self.month = today.month
+        self.view_mode = mode
+        self._update_toggle_style()
+        self._refresh()
+```
+
+**Key changes:**
+- Removed: the `first_day` and `monday` intermediate variables (and their inline comments)
+- Removed: `datetime.date(self.year, self.month, 1)` and `datetime.date.fromisocalendar(self.iso_year, self.current_week, 1)` — both used the *previously displayed* state to derive the new state
+- Added: single `today = datetime.date.today()` lookup at the top of the post-guard body
+- Both branches now read from `today` instead of from `self.year`/`self.month`/`self.iso_year`/`self.current_week`
+- The early-return guard (`if mode == self.view_mode: return`), the assignment to `self.view_mode`, the `_update_toggle_style()` call, and the `_refresh()` call all stay byte-for-byte identical
+
+- [ ] **Step 2: Confirm no leftover references**
+
+Run:
+
+```bash
+grep -n "first_day\|fromisocalendar" src/ui.py
+```
+
+Expected: no matches. Both names only existed in the replaced block.
+
+- [ ] **Step 3: Run the full test suite**
+
+Run: `python -m pytest -v`
+Expected: 86 tests pass, no regressions.
+
+- [ ] **Step 4: SKIP — manual UI smoke test (controller's job)**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ui.py
+git commit -m "feat: monat/woche toggle resets to today
+
+Both directions of the view toggle now land on today's month / today's
+KW instead of preserving the previously displayed scroll position via
+inverse-mode lookup. Arrow nav (_prev/_next) keeps its relative
+behaviour. The toggle becomes a 'reset to current' gesture."
+```
+
+---
+
+## Verification checklist (post-implementation)
+
+- [ ] `python -m pytest -v` all green (86 tests, unchanged count)
+- [ ] `grep -n "first_day\|fromisocalendar" src/ui.py` returns empty
+- [ ] Manual smoke test (controller): scroll to a different month with the arrow buttons, switch to Woche → land on today's KW. Scroll to a different KW, switch to Monat → land on today's month. Click "Monat" while in Monat view (or "Woche" while in Woche) → nothing happens (early-return guard).
+- [ ] One commit on the branch with the message above

--- a/docs/superpowers/specs/2026-04-24-credentials-folder-button-design.md
+++ b/docs/superpowers/specs/2026-04-24-credentials-folder-button-design.md
@@ -56,6 +56,10 @@ Dispatch on `platform.system()`:
 
 No swallowing of errors. The caller (UI) wraps the call in try/except and shows a `messagebox.showerror` with a traceback.
 
+### Import constraint
+
+The module uses `import os` and `import subprocess` (module imports, **not** `from os import startfile` / `from subprocess import run`). This is required so the unit tests can patch the calls via `src.platform_open.os.startfile` and `src.platform_open.subprocess.run`.
+
 ---
 
 ## 2. Settings dialog — new section "Gmail-Zugangsdaten"
@@ -152,9 +156,9 @@ A new method on `App`. Builds and shows a modal `Toplevel`:
   >
   > `Bitte erstelle ein Google Cloud Projekt mit Gmail API und lade die OAuth2 Client-ID als credentials.json in den Datenordner.`
 
-- Two buttons in a `tk.Frame` at the bottom:
-  - **"Datenordner öffnen"** (ACCENT-styled, like "Speichern"): calls `open_folder(self.base_path)`, then `dialog.destroy()`. Errors → `messagebox.showerror` with traceback (parent=dialog).
-  - **"OK"** (CELL_BG-styled, like "Abbrechen"): calls `dialog.destroy()`.
+- Two buttons in a `tk.Frame` at the bottom, packed left-to-right (matching the existing `Speichern` / `Abbrechen` order in `_open_settings`):
+  - **"Datenordner öffnen"** (ACCENT-styled, like "Speichern", `pack(side=tk.LEFT, padx=5)`): calls `open_folder(self.base_path)`, then `dialog.destroy()`. Errors → `messagebox.showerror` with traceback (parent=dialog).
+  - **"OK"** (CELL_BG-styled, like "Abbrechen", `pack(side=tk.LEFT, padx=5)`): calls `dialog.destroy()`.
 
 ### No auto-retry
 

--- a/docs/superpowers/specs/2026-04-24-credentials-folder-button-design.md
+++ b/docs/superpowers/specs/2026-04-24-credentials-folder-button-design.md
@@ -1,0 +1,225 @@
+# Credentials-Ordner-Button — Design Spec
+
+## Overview
+
+Add a one-click way for the user to open the data directory where `credentials.json` belongs. Today, a new user (especially on macOS) has no obvious way to find `~/Library/Application Support/Zeiterfassung/` from inside the app. This forces them to consult docs or guess. The fix exposes the path through the UI in two places:
+
+1. **Settings dialog** — a new section "Gmail-Zugangsdaten" with an "Ordner öffnen" button and a status label showing whether `credentials.json` is already present.
+2. **Send-error dialog** — when the user clicks "Monat senden" without `credentials.json`, the existing error message is replaced by a custom dialog with two buttons: "Datenordner öffnen" and "OK".
+
+A new module `src/platform_open.py` encapsulates the cross-platform open-in-file-manager logic.
+
+## Scope decisions (settled during brainstorming)
+
+| # | Decision | Consequence |
+|---|----------|-------------|
+| 1 | Both placements (settings + send-error dialog) | Settings = default discovery path; send-error = the moment it actually matters |
+| 2 | Custom `Toplevel` for the send-error dialog (not `messagebox.askyesno`) | Consistent dark theme, two clearly labeled buttons; ~30 lines of dialog code |
+| 3 | Status label in settings (✓ vorhanden / ✗ fehlt) | Answers "am I done?" without making the user open Finder/Explorer |
+| 4 | Status checked once at dialog open (no live refresh) | Simple; user can close and reopen the dialog to re-check |
+| 5 | New module `src/platform_open.py` (not added to `paths.py`, not inlined in `ui.py`) | Matches existing module style (`mail.py`, `autostart.py`); keeps `paths.py` pure; keeps `ui.py` from growing further |
+| 6 | No UI tests | Tkinter UI tests are not established in this project; only `platform_open.py` is unit-tested |
+
+## Guiding principles
+
+1. **Discoverable, not magical.** The button opens a folder. It does not auto-download credentials, auto-validate them, or watch the filesystem. The user is in control.
+2. **Errors are visible.** Per `CLAUDE.md` ("UI-Fehler sichtbar machen"), failures from `open_folder` (missing `xdg-open`, `os.startfile` raising) are shown via `messagebox.showerror` with `traceback.format_exc()` — never swallowed.
+3. **Reuse existing infrastructure.** `self.base_path` is already the resolved data directory (via `paths.py::get_base_path`). On frozen macOS/Linux it is also guaranteed to exist (`os.makedirs(base, exist_ok=True)` in `paths.py`). No new path resolution logic needed.
+
+---
+
+## 1. New module — `src/platform_open.py`
+
+### Public API
+
+```python
+def open_folder(path: str) -> None:
+    """Open the given directory in the OS file manager.
+
+    Raises:
+        RuntimeError: on unsupported platforms.
+        OSError / subprocess.CalledProcessError: on OS-level failures
+            (propagated to caller).
+    """
+```
+
+### Implementation
+
+Dispatch on `platform.system()`:
+
+| Platform | Call |
+|----------|------|
+| `Windows` | `os.startfile(path)` |
+| `Darwin`  | `subprocess.run(["open", path], check=True)` |
+| `Linux`   | `subprocess.run(["xdg-open", path], check=True)` |
+| anything else | `raise RuntimeError(f"Unsupported platform: {system}")` |
+
+No swallowing of errors. The caller (UI) wraps the call in try/except and shows a `messagebox.showerror` with a traceback.
+
+---
+
+## 2. Settings dialog — new section "Gmail-Zugangsdaten"
+
+### Placement
+
+A new section is inserted **at the top** of the settings dialog (above "Absender"). Rationale: it's a setup precondition for sending, not a tweakable preference. Putting it first is the most discoverable spot for new users.
+
+### Layout
+
+```
+— Gmail-Zugangsdaten —
+Datenordner:  [ Ordner öffnen ]   ✓ credentials.json vorhanden
+                                  (or ✗ credentials.json fehlt)
+
+Absender:     [ ... ]
+Standard-Start: ...
+(rest of dialog unchanged)
+```
+
+### Widget details
+
+- **Section header** (`tk.Label`): `— Gmail-Zugangsdaten —` in `FONT_BOLD`, `bg=BG`, `fg=TEXT_MUTED`. Same style as the existing `— Mail-Vorlage —` header (`src/ui.py:396-397`).
+- **Label** (`tk.Label`): `Datenordner:` in `FONT`, `bg=BG`, `fg=TEXT`.
+- **Button** (`tk.Button`): text `Ordner öffnen`, styled like the "Monat senden" footer button (`bg=CELL_BG`, `fg=TEXT`, `relief=tk.FLAT`, `cursor="hand2"`).
+- **Status label** (`tk.Label`): one of two strings, color depends on state:
+  - `✓ credentials.json vorhanden` — color `#4ade80` (green; new constant `STATUS_OK` in `ui.py`)
+  - `✗ credentials.json fehlt` — color `ACCENT` (`#e94560`, existing)
+
+### Status check
+
+Computed once when the dialog opens:
+
+```python
+creds_path = os.path.join(self.base_path, "credentials.json")
+creds_present = os.path.exists(creds_path)
+```
+
+No `trace_add`, no polling. If the user copies the file in and wants visual confirmation, they close and reopen the dialog.
+
+### Button handler
+
+```python
+def open_data_folder():
+    try:
+        open_folder(self.base_path)
+    except Exception as e:
+        messagebox.showerror(
+            "Ordner konnte nicht geöffnet werden",
+            f"{type(e).__name__}: {e}\n\n{traceback.format_exc()}",
+            parent=dialog,
+        )
+```
+
+### Grid impact
+
+Existing rows in `_open_settings` (currently 0–14) shift down by 2 — one row for the section header, one row for the label/button/status row. All `.grid(row=N, ...)` calls in the method are renumbered accordingly. No layout rework beyond the renumber.
+
+---
+
+## 3. Send-error dialog — custom `Toplevel`
+
+### Replaces
+
+The current block in `_send_report` at `src/ui.py:822-830`:
+
+```python
+if not os.path.exists(credentials_path):
+    messagebox.showerror(
+        "Keine Zugangsdaten",
+        "credentials.json nicht gefunden.\n\n..."
+        parent=self.root,
+    )
+    return
+```
+
+### New flow
+
+```python
+if not os.path.exists(credentials_path):
+    self._show_missing_credentials_dialog()
+    return
+```
+
+### Dialog `_show_missing_credentials_dialog(self)`
+
+A new method on `App`. Builds and shows a modal `Toplevel`:
+
+- `title("Keine Zugangsdaten")`
+- `grab_set()`, `resizable(False, False)`, `configure(bg=BG)`
+- Body: a `tk.Label` with `wraplength=380`, `justify="left"`, containing:
+
+  > `credentials.json nicht gefunden.`
+  >
+  > `Bitte erstelle ein Google Cloud Projekt mit Gmail API und lade die OAuth2 Client-ID als credentials.json in den Datenordner.`
+
+- Two buttons in a `tk.Frame` at the bottom:
+  - **"Datenordner öffnen"** (ACCENT-styled, like "Speichern"): calls `open_folder(self.base_path)`, then `dialog.destroy()`. Errors → `messagebox.showerror` with traceback (parent=dialog).
+  - **"OK"** (CELL_BG-styled, like "Abbrechen"): calls `dialog.destroy()`.
+
+### No auto-retry
+
+Clicking "Datenordner öffnen" does not re-trigger the send. The user copies `credentials.json` into the opened folder and clicks "Monat senden" again. Keeps the control flow linear.
+
+---
+
+## 4. Tests — `tests/test_platform_open.py`
+
+Four unit tests, all using `monkeypatch`:
+
+```python
+def test_open_folder_windows(monkeypatch):
+    # platform.system() → "Windows"
+    # os.startfile mocked, asserts called with the given path
+
+def test_open_folder_macos(monkeypatch):
+    # platform.system() → "Darwin"
+    # subprocess.run mocked, asserts ["open", path], check=True
+
+def test_open_folder_linux(monkeypatch):
+    # platform.system() → "Linux"
+    # subprocess.run mocked, asserts ["xdg-open", path], check=True
+
+def test_open_folder_unsupported_platform(monkeypatch):
+    # platform.system() → "FreeBSD"
+    # asserts RuntimeError raised
+```
+
+### Cross-platform test gotcha
+
+`os.startfile` does not exist on macOS/Linux. `monkeypatch.setattr` would raise `AttributeError` when patching it on those platforms. Use `raising=False`:
+
+```python
+monkeypatch.setattr("src.platform_open.os.startfile", mock, raising=False)
+```
+
+This lets the Windows test run on the Linux CI runner (`ubuntu-latest`), matching the existing test workflow strategy.
+
+### Why no UI tests
+
+`tests/` currently contains only storage, time-utils, and report tests — no Tkinter widget tests. Adding UI tests for the settings button or the missing-credentials dialog would require introducing Tkinter test infrastructure, which is out of scope for this change. The UI wiring is small enough to verify manually on each platform during release testing.
+
+### CI fit
+
+The new tests depend only on `platform`, `os`, and `subprocess` — no third-party deps, so they run under `.github/workflows/test.yml` which only installs `pytest` (per `CLAUDE.md`).
+
+---
+
+## File touches summary
+
+| File | Change |
+|------|--------|
+| `src/platform_open.py` | **new** — `open_folder(path)` + dispatch |
+| `src/ui.py` | new section in `_open_settings`; renumber existing grid rows; new `_show_missing_credentials_dialog`; replace `messagebox.showerror` block in `_send_report`; add `STATUS_OK` color constant; import `open_folder` |
+| `tests/test_platform_open.py` | **new** — four unit tests |
+
+No changes to `paths.py`, `mail.py`, `report.py`, `storage.py`, build, CI, or installer files.
+
+---
+
+## Out of scope
+
+- Auto-creating the data directory if missing on Windows (already created by `paths.py` on macOS/Linux; on frozen Windows it's the install dir, always present).
+- Validating that `credentials.json` is a real Google OAuth2 client file (file-presence check only).
+- Watching the filesystem for `credentials.json` to appear and updating the status label live.
+- Auto-retrying the send after the user clicks "Datenordner öffnen".
+- A "credentials.json einfügen" file-picker that copies a chosen file into the data dir (could be a future addition; explicitly deferred).

--- a/docs/superpowers/specs/2026-04-24-credentials-folder-hot-reload-design.md
+++ b/docs/superpowers/specs/2026-04-24-credentials-folder-hot-reload-design.md
@@ -1,0 +1,79 @@
+# Credentials-Status Hot-Reload — Design Spec
+
+## Overview
+
+Small follow-up to `2026-04-24-credentials-folder-button-design.md`. The Settings dialog currently shows the `credentials.json` presence as ✓ / ✗ — but only at dialog-open time. After the user clicks "Ordner öffnen", drops the file into the folder, and switches back to the dialog, the status still reads "fehlt" until they close and reopen the dialog. This change adds a 500 ms polling loop that refreshes the status label live while the dialog is open.
+
+This explicitly **reverses Decision #4 of the predecessor spec** ("Status checked once at dialog open, no live refresh"). The original justification (simplicity) was correct in isolation, but in practice the missing live refresh is the most natural friction point of the feature: the user just opened the folder *to put the file in*, then comes back and the dialog still says "fehlt". The polling loop costs nothing measurable.
+
+## Scope decisions
+
+| # | Decision | Consequence |
+|---|----------|-------------|
+| 1 | Trigger: 500 ms polling loop via `dialog.after` | Simple, deterministic, fires regardless of how the user adds the file (Explorer, terminal, drag-drop) |
+| 2 | Polling interval hardcoded at 500 ms | Fast enough to feel instant; `os.path.exists` on a local path is not measurable. No setting. |
+| 3 | Loop self-stops via `status_label.winfo_exists()` check at top of callback | When the dialog is destroyed, the next scheduled `after` fires once with no live widget; the check returns early without rescheduling. No TclError, no leftover timer. |
+| 4 | Only the Settings dialog is affected — not the missing-credentials send-error dialog | The send-error dialog is transient and the user closes it to retry. Live polling there would be over-engineering. |
+| 5 | No tests | UI polling, no Tkinter test infrastructure. Manual smoke test only. |
+
+## Implementation
+
+### Changes to `src/ui.py::_open_settings`
+
+The existing Gmail-Zugangsdaten block constructs the status label inline and discards the handle:
+
+```python
+# current — handle discarded
+tk.Label(
+    creds_row, text=status_text, font=FONT_SMALL,
+    bg=BG, fg=status_fg
+).pack(side=tk.LEFT, padx=(10, 0))
+```
+
+New version: store the handle, then drive content + scheduling from a single `refresh_status` closure. The pre-computed `creds_present`, `status_text`, `status_fg` block is removed (the closure handles the initial render).
+
+```python
+status_label = tk.Label(
+    creds_row, text="", font=FONT_SMALL, bg=BG
+)
+status_label.pack(side=tk.LEFT, padx=(10, 0))
+
+def refresh_status():
+    if not status_label.winfo_exists():
+        return
+    if os.path.exists(creds_path):
+        status_label.config(
+            text="✓ credentials.json vorhanden", fg=STATUS_OK
+        )
+    else:
+        status_label.config(
+            text="✗ credentials.json fehlt", fg=ACCENT
+        )
+    dialog.after(500, refresh_status)
+
+refresh_status()
+```
+
+The initial `refresh_status()` call (no `after` wrapper) does two things at once: paints the label with the correct initial text/color, and schedules the next tick. No separate "initial render" branch needed.
+
+### What stays the same
+
+- Section header, "Datenordner:" label, "Ordner öffnen" button — unchanged.
+- `STATUS_OK` constant — unchanged.
+- Status text strings ("✓ credentials.json vorhanden" / "✗ credentials.json fehlt") — unchanged.
+- Status colors (`STATUS_OK` green / `ACCENT` red) — unchanged.
+
+### Files touched
+
+| File | Change |
+|------|--------|
+| `src/ui.py` | Replace ~10 lines in `_open_settings` (the inline status-label construction) with the held-reference + `refresh_status` closure |
+
+No new files. No new imports. No tests.
+
+## Out of scope
+
+- Hot-reload anywhere else in the UI (e.g. the missing-credentials send-error dialog, or the date-range dialog after sending fails).
+- A general-purpose file-watcher abstraction.
+- Configurable polling interval.
+- Visual transition animation when the status flips (just a snap-change is fine for a settings panel).

--- a/docs/superpowers/specs/2026-04-24-view-toggle-jumps-to-today-design.md
+++ b/docs/superpowers/specs/2026-04-24-view-toggle-jumps-to-today-design.md
@@ -1,0 +1,57 @@
+# View-Toggle Jumps to Today — Design Spec
+
+## Overview
+
+Today, switching between the Monat/Woche toggle in the header preserves "where you were": switching to Woche jumps to the first KW of the currently displayed month, switching to Monat jumps to the month containing the currently displayed week's Monday. After scrolling to a different month/KW with the arrow buttons, this means the toggle remembers your scroll position rather than resetting it.
+
+The user wants the opposite: **toggling between views should always land on today's month / today's KW**, regardless of where the navigation was scrolled to. The toggle becomes a "reset to current" gesture.
+
+## Scope decisions
+
+| # | Decision | Consequence |
+|---|----------|-------------|
+| 1 | Both directions jump to today (symmetric) | Toggle = reset, no asymmetry to remember |
+| 2 | Only `_set_view` is changed; arrow nav (`_prev`/`_next`) keeps its current behaviour | Arrow nav still moves relative to where you are; only the toggle resets |
+| 3 | `view_mode` is preserved if you click the same toggle twice (the existing `if mode == self.view_mode: return` early-return stays) | Clicking "Woche" while in week view does nothing — no surprise reset |
+| 4 | No new tests | The change replaces ~6 lines of branching logic with simpler "set to today" assignments. No unit-testable surface change. |
+
+## Implementation
+
+### `src/ui.py::_set_view` (current ~lines 247–263)
+
+Replace both branches with a single `today = datetime.date.today()` lookup, then assign per mode:
+
+```python
+def _set_view(self, mode):
+    if mode == self.view_mode:
+        return
+    today = datetime.date.today()
+    if mode == "week":
+        iso = today.isocalendar()
+        self.iso_year = iso[0]
+        self.current_week = iso[1]
+    else:
+        self.year = today.year
+        self.month = today.month
+    self.view_mode = mode
+    self._update_toggle_style()
+    self._refresh()
+```
+
+The early-return guard (`if mode == self.view_mode: return`), the `_update_toggle_style()` call, and the `_refresh()` call stay exactly as they are.
+
+### Callers
+
+`_set_view` has exactly two call sites, both inside `_build_header`:
+
+- `tk.Button(... command=lambda: self._set_view("month") ...)` (the "Monat" toggle button)
+- `tk.Button(... command=lambda: self._set_view("week") ...)` (the "Woche" toggle button)
+
+Both intentionally affected. No external callers.
+
+## Out of scope
+
+- Changing what the arrow buttons do (`_prev`/`_next`) — they keep their relative-navigation behaviour.
+- Adding a separate "Heute"-Button (the toggle now serves that purpose for the active view).
+- Persisting the view mode across app restarts.
+- Animation / visual feedback when the view jumps.

--- a/src/platform_open.py
+++ b/src/platform_open.py
@@ -1,0 +1,23 @@
+# src/platform_open.py
+import os
+import platform
+import subprocess
+
+
+def open_folder(path: str) -> None:
+    """Open the given directory in the OS file manager.
+
+    Raises:
+        RuntimeError: on unsupported platforms.
+        OSError / subprocess.CalledProcessError: on OS-level failures
+            (propagated to caller).
+    """
+    system = platform.system()
+    if system == "Windows":
+        os.startfile(path)
+    elif system == "Darwin":
+        subprocess.run(["open", path], check=True)
+    elif system == "Linux":
+        subprocess.run(["xdg-open", path], check=True)
+    else:
+        raise RuntimeError(f"Unsupported platform: {system}")

--- a/src/ui.py
+++ b/src/ui.py
@@ -20,6 +20,7 @@ from src.mail import (
     TokenNetworkError,
 )
 from src.autostart import enable_autostart, disable_autostart
+from src.platform_open import open_folder
 from src.version import VERSION
 
 DAYS_DE = ["Mo", "Di", "Mi", "Do", "Fr", "Sa", "So"]
@@ -33,6 +34,7 @@ BG = "#1a1a2e"
 CELL_BG = "#16213e"
 WEEKEND_BG = "#0f3460"
 ACCENT = "#e94560"
+STATUS_OK = "#4ade80"
 TEXT = "#e0e0e0"
 TEXT_MUTED = "#888888"
 ENTRY_BG = "#1a3a5c"
@@ -301,10 +303,55 @@ class App:
 
         self._apply_combobox_style(dialog)
 
+        # Gmail-Zugangsdaten section
+        tk.Label(
+            dialog, text="— Gmail-Zugangsdaten —", font=FONT_BOLD,
+            bg=BG, fg=TEXT_MUTED
+        ).grid(row=0, column=0, columnspan=2, padx=10, pady=(8, 4))
+
+        creds_path = os.path.join(self.base_path, "credentials.json")
+        creds_present = os.path.exists(creds_path)
+
+        tk.Label(
+            dialog, text="Datenordner:", font=FONT, bg=BG, fg=TEXT
+        ).grid(row=1, column=0, padx=10, pady=4, sticky="w")
+
+        creds_row = tk.Frame(dialog, bg=BG)
+        creds_row.grid(row=1, column=1, padx=10, pady=4, sticky="w")
+
+        def open_data_folder():
+            try:
+                open_folder(self.base_path)
+            except Exception as e:
+                messagebox.showerror(
+                    "Ordner konnte nicht geöffnet werden",
+                    f"{type(e).__name__}: {e}\n\n{traceback.format_exc()}",
+                    parent=dialog,
+                )
+
+        tk.Button(
+            creds_row, text="Ordner öffnen", command=open_data_folder,
+            font=FONT, bg=CELL_BG, fg=TEXT,
+            activebackground=ENTRY_BG, activeforeground=TEXT,
+            relief=tk.FLAT, padx=12, pady=2, cursor="hand2"
+        ).pack(side=tk.LEFT)
+
+        if creds_present:
+            status_text = "✓ credentials.json vorhanden"
+            status_fg = STATUS_OK
+        else:
+            status_text = "✗ credentials.json fehlt"
+            status_fg = ACCENT
+
+        tk.Label(
+            creds_row, text=status_text, font=FONT_SMALL,
+            bg=BG, fg=status_fg
+        ).pack(side=tk.LEFT, padx=(10, 0))
+
         # Email
         tk.Label(
             dialog, text="Absender:", font=FONT, bg=BG, fg=TEXT
-        ).grid(row=0, column=0, padx=10, pady=8, sticky="w")
+        ).grid(row=2, column=0, padx=10, pady=8, sticky="w")
 
         email_var = tk.StringVar(value=self.settings.get("email"))
         tk.Entry(
@@ -312,45 +359,45 @@ class App:
             bg=CELL_BG, fg=TEXT, insertbackground=ACCENT,
             relief=tk.FLAT, highlightbackground=TEXT_MUTED,
             highlightcolor=ACCENT, highlightthickness=1
-        ).grid(row=0, column=1, padx=10, pady=8)
+        ).grid(row=2, column=1, padx=10, pady=8)
 
         # Default start time
         tk.Label(
             dialog, text="Standard-Start:", font=FONT, bg=BG, fg=TEXT
-        ).grid(row=1, column=0, padx=10, pady=8, sticky="w")
+        ).grid(row=3, column=0, padx=10, pady=8, sticky="w")
 
         start_var = tk.StringVar(value=self.settings.get("default_start"))
         ttk.Combobox(
             dialog, textvariable=start_var, values=TIME_VALUES,
             width=8, font=FONT, style="Dark.TCombobox", state="readonly"
-        ).grid(row=1, column=1, padx=10, pady=8)
+        ).grid(row=3, column=1, padx=10, pady=8)
 
         # Default end time
         tk.Label(
             dialog, text="Standard-Ende:", font=FONT, bg=BG, fg=TEXT
-        ).grid(row=2, column=0, padx=10, pady=8, sticky="w")
+        ).grid(row=4, column=0, padx=10, pady=8, sticky="w")
 
         end_var = tk.StringVar(value=self.settings.get("default_end"))
         ttk.Combobox(
             dialog, textvariable=end_var, values=TIME_VALUES,
             width=8, font=FONT, style="Dark.TCombobox", state="readonly"
-        ).grid(row=2, column=1, padx=10, pady=8)
+        ).grid(row=4, column=1, padx=10, pady=8)
 
         # Default pause
         tk.Label(
             dialog, text="Standard-Pause (Min):", font=FONT, bg=BG, fg=TEXT
-        ).grid(row=3, column=0, padx=10, pady=8, sticky="w")
+        ).grid(row=5, column=0, padx=10, pady=8, sticky="w")
 
         pause_var = tk.StringVar(value=str(self.settings.get("default_pause")))
         ttk.Combobox(
             dialog, textvariable=pause_var, values=PAUSE_VALUES,
             width=8, font=FONT, style="Dark.TCombobox", state="readonly"
-        ).grid(row=3, column=1, padx=10, pady=8)
+        ).grid(row=5, column=1, padx=10, pady=8)
 
         # Recipient
         tk.Label(
             dialog, text="Empfänger:", font=FONT, bg=BG, fg=TEXT
-        ).grid(row=4, column=0, padx=10, pady=8, sticky="w")
+        ).grid(row=6, column=0, padx=10, pady=8, sticky="w")
 
         recipient_var = tk.StringVar(value=self.settings.get("recipient"))
         tk.Entry(
@@ -358,12 +405,12 @@ class App:
             bg=CELL_BG, fg=TEXT, insertbackground=ACCENT,
             relief=tk.FLAT, highlightbackground=TEXT_MUTED,
             highlightcolor=ACCENT, highlightthickness=1
-        ).grid(row=4, column=1, padx=10, pady=8)
+        ).grid(row=6, column=1, padx=10, pady=8)
 
         # Name
         tk.Label(
             dialog, text="Name:", font=FONT, bg=BG, fg=TEXT
-        ).grid(row=5, column=0, padx=10, pady=8, sticky="w")
+        ).grid(row=7, column=0, padx=10, pady=8, sticky="w")
 
         name_var = tk.StringVar(value=self.settings.get("name"))
         tk.Entry(
@@ -371,12 +418,12 @@ class App:
             bg=CELL_BG, fg=TEXT, insertbackground=ACCENT,
             relief=tk.FLAT, highlightbackground=TEXT_MUTED,
             highlightcolor=ACCENT, highlightthickness=1
-        ).grid(row=5, column=1, padx=10, pady=8)
+        ).grid(row=7, column=1, padx=10, pady=8)
 
         # Stundenlohn (optional)
         tk.Label(
             dialog, text="Stundenlohn (€):", font=FONT, bg=BG, fg=TEXT
-        ).grid(row=6, column=0, padx=10, pady=8, sticky="w")
+        ).grid(row=8, column=0, padx=10, pady=8, sticky="w")
 
         rate_var = tk.StringVar(value=str(self.settings.get("hourly_rate") or ""))
         tk.Entry(
@@ -384,68 +431,68 @@ class App:
             bg=CELL_BG, fg=TEXT, insertbackground=ACCENT,
             relief=tk.FLAT, highlightbackground=TEXT_MUTED,
             highlightcolor=ACCENT, highlightthickness=1
-        ).grid(row=6, column=1, padx=10, pady=8, sticky="w")
+        ).grid(row=8, column=1, padx=10, pady=8, sticky="w")
 
         tk.Label(
             dialog, text="(optional – nur für dich sichtbar)", font=FONT_SMALL,
             bg=BG, fg=TEXT_MUTED
-        ).grid(row=6, column=1, padx=(120, 10), pady=8, sticky="w")
+        ).grid(row=8, column=1, padx=(120, 10), pady=8, sticky="w")
 
         # Mail-Vorlage
         tk.Label(
             dialog, text="— Mail-Vorlage —", font=FONT_BOLD, bg=BG, fg=TEXT_MUTED
-        ).grid(row=7, column=0, columnspan=2, padx=10, pady=(16, 4))
+        ).grid(row=9, column=0, columnspan=2, padx=10, pady=(16, 4))
 
         tk.Label(
             dialog, text="Betreff:", font=FONT, bg=BG, fg=TEXT
-        ).grid(row=8, column=0, padx=10, pady=4, sticky="w")
+        ).grid(row=10, column=0, padx=10, pady=4, sticky="w")
         subject_var = tk.StringVar(value=self.settings.get("mail_subject"))
         tk.Entry(
             dialog, textvariable=subject_var, width=35, font=FONT,
             bg=CELL_BG, fg=TEXT, insertbackground=ACCENT,
             relief=tk.FLAT, highlightbackground=TEXT_MUTED,
             highlightcolor=ACCENT, highlightthickness=1
-        ).grid(row=8, column=1, padx=10, pady=4)
+        ).grid(row=10, column=1, padx=10, pady=4)
 
         tk.Label(
             dialog, text="Anrede:", font=FONT, bg=BG, fg=TEXT
-        ).grid(row=9, column=0, padx=10, pady=4, sticky="w")
+        ).grid(row=11, column=0, padx=10, pady=4, sticky="w")
         greeting_var = tk.StringVar(value=self.settings.get("mail_greeting"))
         tk.Entry(
             dialog, textvariable=greeting_var, width=35, font=FONT,
             bg=CELL_BG, fg=TEXT, insertbackground=ACCENT,
             relief=tk.FLAT, highlightbackground=TEXT_MUTED,
             highlightcolor=ACCENT, highlightthickness=1
-        ).grid(row=9, column=1, padx=10, pady=4)
+        ).grid(row=11, column=1, padx=10, pady=4)
 
         tk.Label(
             dialog, text="Inhalt:", font=FONT, bg=BG, fg=TEXT
-        ).grid(row=10, column=0, padx=10, pady=4, sticky="nw")
+        ).grid(row=12, column=0, padx=10, pady=4, sticky="nw")
         content_text = tk.Text(
             dialog, width=35, height=3, font=FONT,
             bg=CELL_BG, fg=TEXT, insertbackground=ACCENT,
             relief=tk.FLAT, highlightbackground=TEXT_MUTED,
             highlightcolor=ACCENT, highlightthickness=1, wrap=tk.WORD
         )
-        content_text.grid(row=10, column=1, padx=10, pady=4)
+        content_text.grid(row=12, column=1, padx=10, pady=4)
         content_text.insert("1.0", self.settings.get("mail_content"))
 
         tk.Label(
             dialog, text="Gruß:", font=FONT, bg=BG, fg=TEXT
-        ).grid(row=11, column=0, padx=10, pady=4, sticky="nw")
+        ).grid(row=13, column=0, padx=10, pady=4, sticky="nw")
         closing_text = tk.Text(
             dialog, width=35, height=2, font=FONT,
             bg=CELL_BG, fg=TEXT, insertbackground=ACCENT,
             relief=tk.FLAT, highlightbackground=TEXT_MUTED,
             highlightcolor=ACCENT, highlightthickness=1, wrap=tk.WORD
         )
-        closing_text.grid(row=11, column=1, padx=10, pady=4)
+        closing_text.grid(row=13, column=1, padx=10, pady=4)
         closing_text.insert("1.0", self.settings.get("mail_closing"))
 
         tk.Label(
             dialog, text="Platzhalter: {zeitraum}, {gesamt}", font=("Segoe UI", 8),
             bg=BG, fg=TEXT_MUTED
-        ).grid(row=12, column=0, columnspan=2, padx=10, pady=(0, 4))
+        ).grid(row=14, column=0, columnspan=2, padx=10, pady=(0, 4))
 
         # Autostart
         autostart_var = tk.BooleanVar(value=self.settings.get("autostart"))
@@ -455,7 +502,7 @@ class App:
             bg=BG, fg=TEXT, selectcolor=CELL_BG,
             activebackground=BG, activeforeground=TEXT,
             cursor="hand2"
-        ).grid(row=13, column=0, columnspan=2, padx=10, pady=8, sticky="w")
+        ).grid(row=15, column=0, columnspan=2, padx=10, pady=8, sticky="w")
 
         def save_settings():
             ok, msg = validate_entry(start_var.get(), end_var.get())
@@ -501,7 +548,7 @@ class App:
             dialog.destroy()
 
         btn_frame = tk.Frame(dialog, bg=BG)
-        btn_frame.grid(row=14, column=0, columnspan=2, pady=12)
+        btn_frame.grid(row=16, column=0, columnspan=2, pady=12)
 
         tk.Button(
             btn_frame, text="Speichern", command=save_settings, font=FONT_BOLD,

--- a/src/ui.py
+++ b/src/ui.py
@@ -853,6 +853,54 @@ class App:
             relief=tk.FLAT, padx=16, pady=4, cursor="hand2"
         ).pack(side=tk.LEFT, padx=5)
 
+    def _show_missing_credentials_dialog(self):
+        dialog = tk.Toplevel(self.root)
+        dialog.title("Keine Zugangsdaten")
+        dialog.resizable(False, False)
+        dialog.grab_set()
+        dialog.configure(bg=BG)
+
+        tk.Label(
+            dialog,
+            text=(
+                "credentials.json nicht gefunden.\n\n"
+                "Bitte erstelle ein Google Cloud Projekt mit Gmail API "
+                "und lade die OAuth2 Client-ID als credentials.json in "
+                "den Datenordner."
+            ),
+            font=FONT, bg=BG, fg=TEXT,
+            wraplength=380, justify="left",
+        ).grid(row=0, column=0, columnspan=2, padx=20, pady=(20, 12))
+
+        def open_and_close():
+            try:
+                open_folder(self.base_path)
+            except Exception as e:
+                messagebox.showerror(
+                    "Ordner konnte nicht geöffnet werden",
+                    f"{type(e).__name__}: {e}\n\n{traceback.format_exc()}",
+                    parent=dialog,
+                )
+                return
+            dialog.destroy()
+
+        btn_frame = tk.Frame(dialog, bg=BG)
+        btn_frame.grid(row=1, column=0, columnspan=2, pady=(0, 16))
+
+        tk.Button(
+            btn_frame, text="Datenordner öffnen", command=open_and_close,
+            font=FONT_BOLD, bg=ACCENT, fg="#ffffff",
+            activebackground="#c73550", activeforeground="#ffffff",
+            relief=tk.FLAT, padx=16, pady=4, cursor="hand2",
+        ).pack(side=tk.LEFT, padx=5)
+
+        tk.Button(
+            btn_frame, text="OK", command=dialog.destroy,
+            font=FONT, bg=CELL_BG, fg=TEXT,
+            activebackground=ENTRY_BG, activeforeground=TEXT,
+            relief=tk.FLAT, padx=16, pady=4, cursor="hand2",
+        ).pack(side=tk.LEFT, padx=5)
+
     def _send_report(self):
         recipient = self.settings.get("recipient")
         if not recipient:
@@ -867,13 +915,7 @@ class App:
         token_path = os.path.join(self.base_path, "token.json")
 
         if not os.path.exists(credentials_path):
-            messagebox.showerror(
-                "Keine Zugangsdaten",
-                "credentials.json nicht gefunden.\n\n"
-                "Bitte erstelle ein Google Cloud Projekt mit Gmail API "
-                "und lade die OAuth2 Client-ID als credentials.json herunter.",
-                parent=self.root
-            )
+            self._show_missing_credentials_dialog()
             return
 
         # Date range dialog

--- a/src/ui.py
+++ b/src/ui.py
@@ -310,7 +310,6 @@ class App:
         ).grid(row=0, column=0, columnspan=2, padx=10, pady=(8, 4))
 
         creds_path = os.path.join(self.base_path, "credentials.json")
-        creds_present = os.path.exists(creds_path)
 
         tk.Label(
             dialog, text="Datenordner:", font=FONT, bg=BG, fg=TEXT
@@ -336,17 +335,25 @@ class App:
             relief=tk.FLAT, padx=12, pady=2, cursor="hand2"
         ).pack(side=tk.LEFT)
 
-        if creds_present:
-            status_text = "✓ credentials.json vorhanden"
-            status_fg = STATUS_OK
-        else:
-            status_text = "✗ credentials.json fehlt"
-            status_fg = ACCENT
+        status_label = tk.Label(
+            creds_row, text="", font=FONT_SMALL, bg=BG
+        )
+        status_label.pack(side=tk.LEFT, padx=(10, 0))
 
-        tk.Label(
-            creds_row, text=status_text, font=FONT_SMALL,
-            bg=BG, fg=status_fg
-        ).pack(side=tk.LEFT, padx=(10, 0))
+        def refresh_status():
+            if not status_label.winfo_exists():
+                return
+            if os.path.exists(creds_path):
+                status_label.config(
+                    text="✓ credentials.json vorhanden", fg=STATUS_OK
+                )
+            else:
+                status_label.config(
+                    text="✗ credentials.json fehlt", fg=ACCENT
+                )
+            dialog.after(500, refresh_status)
+
+        refresh_status()
 
         # Email
         tk.Label(

--- a/src/ui.py
+++ b/src/ui.py
@@ -249,17 +249,14 @@ class App:
     def _set_view(self, mode):
         if mode == self.view_mode:
             return
+        today = datetime.date.today()
         if mode == "week":
-            # Jump to first KW of current month
-            first_day = datetime.date(self.year, self.month, 1)
-            iso = first_day.isocalendar()
+            iso = today.isocalendar()
             self.iso_year = iso[0]
             self.current_week = iso[1]
         else:
-            # Jump to month containing Monday of current week
-            monday = datetime.date.fromisocalendar(self.iso_year, self.current_week, 1)
-            self.year = monday.year
-            self.month = monday.month
+            self.year = today.year
+            self.month = today.month
         self.view_mode = mode
         self._update_toggle_style()
         self._refresh()

--- a/src/version.py
+++ b/src/version.py
@@ -1,1 +1,1 @@
-VERSION = "1.6.0"
+VERSION = "1.7.0"

--- a/tests/test_platform_open.py
+++ b/tests/test_platform_open.py
@@ -1,0 +1,42 @@
+# tests/test_platform_open.py
+import pytest
+from unittest.mock import MagicMock
+from src.platform_open import open_folder
+
+
+def test_open_folder_windows(monkeypatch):
+    monkeypatch.setattr("src.platform_open.platform.system", lambda: "Windows")
+    mock_startfile = MagicMock()
+    monkeypatch.setattr(
+        "src.platform_open.os.startfile", mock_startfile, raising=False
+    )
+    open_folder(r"C:\Users\test\data")
+    mock_startfile.assert_called_once_with(r"C:\Users\test\data")
+
+
+def test_open_folder_macos(monkeypatch):
+    monkeypatch.setattr("src.platform_open.platform.system", lambda: "Darwin")
+    mock_run = MagicMock()
+    monkeypatch.setattr("src.platform_open.subprocess.run", mock_run)
+    open_folder("/Users/test/Library/Application Support/Zeiterfassung")
+    mock_run.assert_called_once_with(
+        ["open", "/Users/test/Library/Application Support/Zeiterfassung"],
+        check=True,
+    )
+
+
+def test_open_folder_linux(monkeypatch):
+    monkeypatch.setattr("src.platform_open.platform.system", lambda: "Linux")
+    mock_run = MagicMock()
+    monkeypatch.setattr("src.platform_open.subprocess.run", mock_run)
+    open_folder("/home/test/.local/share/Zeiterfassung")
+    mock_run.assert_called_once_with(
+        ["xdg-open", "/home/test/.local/share/Zeiterfassung"],
+        check=True,
+    )
+
+
+def test_open_folder_unsupported_platform_raises(monkeypatch):
+    monkeypatch.setattr("src.platform_open.platform.system", lambda: "FreeBSD")
+    with pytest.raises(RuntimeError, match="Unsupported platform"):
+        open_folder("/tmp/whatever")


### PR DESCRIPTION
## Summary
- **Settings dialog: Gmail-Zugangsdaten section** — neue Sektion am Anfang mit „Ordner öffnen"-Button und Live-Status (✓/✗) für `credentials.json`. Polling alle 500 ms, also kein Neuöffnen mehr nach dem Reinkopieren.
- **Sende-Fehler: Custom-Dialog statt Messagebox** — wenn `credentials.json` beim Klick auf „Monat senden" fehlt, erscheint jetzt ein Dialog im Dark-Theme mit „Datenordner öffnen" + „OK", statt der nüchternen Standard-Messagebox.
- **Cross-Platform Open-Folder-Helper** — neues Modul `src/platform_open.py` mit Dispatch über `os.startfile` (Windows), `open` (macOS), `xdg-open` (Linux). Unit-getestet (4 Tests, alle Plattform-Branches).
- **Monat/Woche-Toggle resettet auf heute** — Toggle springt jetzt immer auf den aktuellen Monat / die aktuelle KW. Pfeilnavigation bleibt wie gehabt relativ.

## Test Plan
- [x] `pytest -v` — 86 Tests grün (4 neue für `platform_open`)
- [x] Lokaler Win11-Build via `python build.py`, manuell installiert und getestet:
  - [x] Settings: ✓ grün bei vorhandener `credentials.json`, flippt live auf ✗ rot beim Wegmoven, zurück auf ✓ beim Wiederherstellen
  - [x] „Ordner öffnen" in Settings öffnet `%LOCALAPPDATA%\Programs\Zeiterfassung\` im Explorer
  - [x] „Monat senden" ohne `credentials.json`: Custom-Dialog erscheint, „Datenordner öffnen" öffnet das Verzeichnis
  - [x] Pfeil-Nav auf anderen Monat → „Woche" toggeln → landet auf aktueller KW
  - [x] Pfeil-Nav auf andere KW → „Monat" toggeln → landet auf aktuellem Monat
- [ ] macOS-DMG (CI-Build) — manueller Smoke-Test sobald Release veröffentlicht ist
- [ ] Linux-AppImage (CI-Build) — manueller Smoke-Test sobald Release veröffentlicht ist

## Spec / Plan refs
- `docs/superpowers/specs/2026-04-24-credentials-folder-button-design.md` + `2026-04-24-credentials-folder-hot-reload-design.md` + `2026-04-24-view-toggle-jumps-to-today-design.md`
- Pläne unter `docs/superpowers/plans/` mit gleichem Datum/Topic

🤖 Generated with [Claude Code](https://claude.com/claude-code)