### PR TITLE
refactor: storage atomic writes + ui module split + theme helpers

### DIFF
--- a/src/autostart.py
+++ b/src/autostart.py
@@ -3,11 +3,29 @@ import os
 import platform
 import plistlib
 import subprocess
+import sys
 import tempfile
 
 
 SHORTCUT_NAME = "Zeiterfassung.lnk"
 MACOS_LABEL = "com.margenheld.zeiterfassung"
+
+
+def resolve_autostart_target(base_path):
+    """Return (target, arguments) for the current runtime/platform.
+
+    Frozen Windows/macOS: the executable itself.
+    Frozen Linux: $APPIMAGE if set (persistent path), otherwise sys.executable.
+    Script mode: Python interpreter + main.py.
+    """
+    if getattr(sys, "frozen", False):
+        if platform.system() == "Linux":
+            target = os.environ.get("APPIMAGE") or sys.executable
+        else:
+            target = sys.executable
+        return target, "--minimized"
+    main_py = os.path.join(base_path, "src", "main.py")
+    return sys.executable, f"{main_py} --minimized"
 
 
 def _get_startup_folder():

--- a/src/dialogs/entry_dialog.py
+++ b/src/dialogs/entry_dialog.py
@@ -1,0 +1,91 @@
+import tkinter as tk
+from tkinter import messagebox, ttk
+
+from src.theme import (
+    ACCENT, ACCENT_HOVER, BG, CELL_BG, ENTRY_BG, FONT, FONT_BOLD,
+    PAUSE_VALUES, TEXT, TIME_VALUES, apply_combobox_style,
+)
+from src.time_utils import validate_entry
+
+
+def open_entry_dialog(parent, date_str, storage, settings, on_change):
+    """Modal dialog to edit/delete one day's time entry.
+
+    on_change is invoked after successful save or delete so the caller
+    can refresh the calendar view.
+    """
+    dialog = tk.Toplevel(parent)
+    dialog.title(date_str)
+    dialog.resizable(False, False)
+    dialog.grab_set()
+    dialog.configure(bg=BG)
+
+    entry = storage.get(date_str)
+
+    apply_combobox_style(dialog)
+
+    tk.Label(
+        dialog, text="Start:", font=FONT, bg=BG, fg=TEXT,
+    ).grid(row=0, column=0, padx=10, pady=8, sticky="w")
+
+    start_var = tk.StringVar(value=entry["start"] if entry else settings.get("default_start"))
+    ttk.Combobox(
+        dialog, textvariable=start_var, values=TIME_VALUES,
+        width=8, font=FONT, style="Dark.TCombobox", state="readonly",
+    ).grid(row=0, column=1, padx=10, pady=8)
+
+    tk.Label(
+        dialog, text="Ende:", font=FONT, bg=BG, fg=TEXT,
+    ).grid(row=1, column=0, padx=10, pady=8, sticky="w")
+
+    end_var = tk.StringVar(value=entry["end"] if entry else settings.get("default_end"))
+    ttk.Combobox(
+        dialog, textvariable=end_var, values=TIME_VALUES,
+        width=8, font=FONT, style="Dark.TCombobox", state="readonly",
+    ).grid(row=1, column=1, padx=10, pady=8)
+
+    tk.Label(
+        dialog, text="Pause (Min):", font=FONT, bg=BG, fg=TEXT,
+    ).grid(row=2, column=0, padx=10, pady=8, sticky="w")
+
+    default_pause = settings.get("default_pause")
+    if entry and "pause" in entry:
+        current_pause = str(entry["pause"])
+    else:
+        current_pause = str(default_pause) if not entry else "0"
+    pause_var = tk.StringVar(value=current_pause)
+    ttk.Combobox(
+        dialog, textvariable=pause_var, values=PAUSE_VALUES,
+        width=8, font=FONT, style="Dark.TCombobox", state="readonly",
+    ).grid(row=2, column=1, padx=10, pady=8)
+
+    def save():
+        ok, msg = validate_entry(start_var.get(), end_var.get(), pause_minutes=int(pause_var.get()))
+        if not ok:
+            messagebox.showerror("Fehler", msg, parent=dialog)
+            return
+        storage.save(date_str, start_var.get(), end_var.get(), pause=int(pause_var.get()))
+        dialog.destroy()
+        on_change()
+
+    def delete():
+        storage.delete(date_str)
+        dialog.destroy()
+        on_change()
+
+    btn_frame = tk.Frame(dialog, bg=BG)
+    btn_frame.grid(row=3, column=0, columnspan=2, pady=12)
+
+    tk.Button(
+        btn_frame, text="Speichern", command=save, font=FONT_BOLD,
+        bg=ACCENT, fg="#ffffff",
+        activebackground=ACCENT_HOVER, activeforeground="#ffffff",
+        relief=tk.FLAT, padx=16, pady=4, cursor="hand2",
+    ).pack(side=tk.LEFT, padx=5)
+
+    tk.Button(
+        btn_frame, text="Löschen", command=delete, font=FONT,
+        bg=CELL_BG, fg=TEXT,
+        activebackground=ENTRY_BG, activeforeground=TEXT,
+        relief=tk.FLAT, padx=16, pady=4, cursor="hand2",
+    ).pack(side=tk.LEFT, padx=5)

--- a/src/dialogs/entry_dialog.py
+++ b/src/dialogs/entry_dialog.py
@@ -1,9 +1,9 @@
 import tkinter as tk
-from tkinter import messagebox, ttk
+from tkinter import messagebox
 
 from src.theme import (
-    ACCENT, ACCENT_HOVER, BG, CELL_BG, ENTRY_BG, FONT, FONT_BOLD,
-    PAUSE_VALUES, TEXT, TIME_VALUES, apply_combobox_style,
+    BG, FONT, PAUSE_VALUES, TEXT, TIME_VALUES,
+    apply_combobox_style, dark_combo, primary_button, secondary_button,
 )
 from src.time_utils import validate_entry
 
@@ -24,29 +24,18 @@ def open_entry_dialog(parent, date_str, storage, settings, on_change):
 
     apply_combobox_style(dialog)
 
-    tk.Label(
-        dialog, text="Start:", font=FONT, bg=BG, fg=TEXT,
-    ).grid(row=0, column=0, padx=10, pady=8, sticky="w")
-
+    tk.Label(dialog, text="Start:", font=FONT, bg=BG, fg=TEXT).grid(
+        row=0, column=0, padx=10, pady=8, sticky="w")
     start_var = tk.StringVar(value=entry["start"] if entry else settings.get("default_start"))
-    ttk.Combobox(
-        dialog, textvariable=start_var, values=TIME_VALUES,
-        width=8, font=FONT, style="Dark.TCombobox", state="readonly",
-    ).grid(row=0, column=1, padx=10, pady=8)
+    dark_combo(dialog, start_var, TIME_VALUES).grid(row=0, column=1, padx=10, pady=8)
 
-    tk.Label(
-        dialog, text="Ende:", font=FONT, bg=BG, fg=TEXT,
-    ).grid(row=1, column=0, padx=10, pady=8, sticky="w")
-
+    tk.Label(dialog, text="Ende:", font=FONT, bg=BG, fg=TEXT).grid(
+        row=1, column=0, padx=10, pady=8, sticky="w")
     end_var = tk.StringVar(value=entry["end"] if entry else settings.get("default_end"))
-    ttk.Combobox(
-        dialog, textvariable=end_var, values=TIME_VALUES,
-        width=8, font=FONT, style="Dark.TCombobox", state="readonly",
-    ).grid(row=1, column=1, padx=10, pady=8)
+    dark_combo(dialog, end_var, TIME_VALUES).grid(row=1, column=1, padx=10, pady=8)
 
-    tk.Label(
-        dialog, text="Pause (Min):", font=FONT, bg=BG, fg=TEXT,
-    ).grid(row=2, column=0, padx=10, pady=8, sticky="w")
+    tk.Label(dialog, text="Pause (Min):", font=FONT, bg=BG, fg=TEXT).grid(
+        row=2, column=0, padx=10, pady=8, sticky="w")
 
     default_pause = settings.get("default_pause")
     if entry and "pause" in entry:
@@ -54,10 +43,7 @@ def open_entry_dialog(parent, date_str, storage, settings, on_change):
     else:
         current_pause = str(default_pause) if not entry else "0"
     pause_var = tk.StringVar(value=current_pause)
-    ttk.Combobox(
-        dialog, textvariable=pause_var, values=PAUSE_VALUES,
-        width=8, font=FONT, style="Dark.TCombobox", state="readonly",
-    ).grid(row=2, column=1, padx=10, pady=8)
+    dark_combo(dialog, pause_var, PAUSE_VALUES).grid(row=2, column=1, padx=10, pady=8)
 
     def save():
         ok, msg = validate_entry(start_var.get(), end_var.get(), pause_minutes=int(pause_var.get()))
@@ -76,16 +62,5 @@ def open_entry_dialog(parent, date_str, storage, settings, on_change):
     btn_frame = tk.Frame(dialog, bg=BG)
     btn_frame.grid(row=3, column=0, columnspan=2, pady=12)
 
-    tk.Button(
-        btn_frame, text="Speichern", command=save, font=FONT_BOLD,
-        bg=ACCENT, fg="#ffffff",
-        activebackground=ACCENT_HOVER, activeforeground="#ffffff",
-        relief=tk.FLAT, padx=16, pady=4, cursor="hand2",
-    ).pack(side=tk.LEFT, padx=5)
-
-    tk.Button(
-        btn_frame, text="Löschen", command=delete, font=FONT,
-        bg=CELL_BG, fg=TEXT,
-        activebackground=ENTRY_BG, activeforeground=TEXT,
-        relief=tk.FLAT, padx=16, pady=4, cursor="hand2",
-    ).pack(side=tk.LEFT, padx=5)
+    primary_button(btn_frame, "Speichern", save).pack(side=tk.LEFT, padx=5)
+    secondary_button(btn_frame, "Löschen", delete).pack(side=tk.LEFT, padx=5)

--- a/src/dialogs/send_dialog.py
+++ b/src/dialogs/send_dialog.py
@@ -3,14 +3,14 @@ import datetime
 import os
 import tkinter as tk
 import traceback
-from tkinter import messagebox, ttk
+from tkinter import messagebox
 
 from src.mail import get_gmail_service, send_email
 from src.platform_open import open_folder
 from src.report import generate_pdf, generate_report
 from src.theme import (
-    ACCENT, ACCENT_HOVER, BG, CELL_BG, ENTRY_BG, FONT, FONT_BOLD,
-    TEXT, apply_combobox_style,
+    BG, FONT, TEXT,
+    apply_combobox_style, dark_combo, primary_button, secondary_button,
 )
 
 
@@ -48,19 +48,8 @@ def show_missing_credentials_dialog(parent, base_path):
     btn_frame = tk.Frame(dialog, bg=BG)
     btn_frame.grid(row=1, column=0, columnspan=2, pady=(0, 16))
 
-    tk.Button(
-        btn_frame, text="Datenordner öffnen", command=open_and_close,
-        font=FONT_BOLD, bg=ACCENT, fg="#ffffff",
-        activebackground=ACCENT_HOVER, activeforeground="#ffffff",
-        relief=tk.FLAT, padx=16, pady=4, cursor="hand2",
-    ).pack(side=tk.LEFT, padx=5)
-
-    tk.Button(
-        btn_frame, text="OK", command=dialog.destroy,
-        font=FONT, bg=CELL_BG, fg=TEXT,
-        activebackground=ENTRY_BG, activeforeground=TEXT,
-        relief=tk.FLAT, padx=16, pady=4, cursor="hand2",
-    ).pack(side=tk.LEFT, padx=5)
+    primary_button(btn_frame, "Datenordner öffnen", open_and_close).pack(side=tk.LEFT, padx=5)
+    secondary_button(btn_frame, "OK", dialog.destroy).pack(side=tk.LEFT, padx=5)
 
 
 def _default_from_date(today):
@@ -112,30 +101,24 @@ def open_send_dialog(parent, storage, settings, base_path):
         if int(day_var.get()) > max_day:
             day_var.set(str(max_day))
 
-    def make_combo(textvariable, values, width):
-        return ttk.Combobox(
-            dialog, textvariable=textvariable, values=values,
-            width=width, font=FONT, style="Dark.TCombobox", state="readonly",
-        )
-
     def build_date_row(row, label_text, default_date):
         tk.Label(dialog, text=label_text, font=FONT, bg=BG, fg=TEXT).grid(
             row=row, column=0, padx=(10, 5), pady=8, sticky="w")
 
         day_var = tk.StringVar(value=str(default_date.day))
         max_day = calendar.monthrange(default_date.year, default_date.month)[1]
-        day_cb = make_combo(day_var, [str(d) for d in range(1, max_day + 1)], 3)
+        day_cb = dark_combo(dialog, day_var, [str(d) for d in range(1, max_day + 1)], width=3)
         day_cb.grid(row=row, column=1, padx=2, pady=8)
 
         tk.Label(dialog, text=".", font=FONT, bg=BG, fg=TEXT).grid(row=row, column=2)
 
         month_var = tk.StringVar(value=str(default_date.month))
-        make_combo(month_var, month_values, 3).grid(row=row, column=3, padx=2, pady=8)
+        dark_combo(dialog, month_var, month_values, width=3).grid(row=row, column=3, padx=2, pady=8)
 
         tk.Label(dialog, text=".", font=FONT, bg=BG, fg=TEXT).grid(row=row, column=4)
 
         year_var = tk.StringVar(value=str(default_date.year))
-        make_combo(year_var, year_values, 5).grid(row=row, column=5, padx=(2, 10), pady=8)
+        dark_combo(dialog, year_var, year_values, width=5).grid(row=row, column=5, padx=(2, 10), pady=8)
 
         month_var.trace_add("write", lambda *_: update_day_values(day_cb, day_var, month_var, year_var))
         year_var.trace_add("write", lambda *_: update_day_values(day_cb, day_var, month_var, year_var))
@@ -209,16 +192,5 @@ def open_send_dialog(parent, storage, settings, base_path):
     btn_frame = tk.Frame(dialog, bg=BG)
     btn_frame.grid(row=2, column=0, columnspan=6, pady=12)
 
-    tk.Button(
-        btn_frame, text="Senden", command=do_send, font=FONT_BOLD,
-        bg=ACCENT, fg="#ffffff",
-        activebackground=ACCENT_HOVER, activeforeground="#ffffff",
-        relief=tk.FLAT, padx=16, pady=4, cursor="hand2",
-    ).pack(side=tk.LEFT, padx=5)
-
-    tk.Button(
-        btn_frame, text="Abbrechen", command=dialog.destroy, font=FONT,
-        bg=CELL_BG, fg=TEXT,
-        activebackground=ENTRY_BG, activeforeground=TEXT,
-        relief=tk.FLAT, padx=16, pady=4, cursor="hand2",
-    ).pack(side=tk.LEFT, padx=5)
+    primary_button(btn_frame, "Senden", do_send).pack(side=tk.LEFT, padx=5)
+    secondary_button(btn_frame, "Abbrechen", dialog.destroy).pack(side=tk.LEFT, padx=5)

--- a/src/dialogs/send_dialog.py
+++ b/src/dialogs/send_dialog.py
@@ -1,0 +1,224 @@
+import calendar
+import datetime
+import os
+import tkinter as tk
+import traceback
+from tkinter import messagebox, ttk
+
+from src.mail import get_gmail_service, send_email
+from src.platform_open import open_folder
+from src.report import generate_pdf, generate_report
+from src.theme import (
+    ACCENT, ACCENT_HOVER, BG, CELL_BG, ENTRY_BG, FONT, FONT_BOLD,
+    TEXT, apply_combobox_style,
+)
+
+
+def show_missing_credentials_dialog(parent, base_path):
+    dialog = tk.Toplevel(parent)
+    dialog.title("Keine Zugangsdaten")
+    dialog.resizable(False, False)
+    dialog.grab_set()
+    dialog.configure(bg=BG)
+
+    tk.Label(
+        dialog,
+        text=(
+            "credentials.json nicht gefunden.\n\n"
+            "Bitte erstelle ein Google Cloud Projekt mit Gmail API "
+            "und lade die OAuth2 Client-ID als credentials.json in "
+            "den Datenordner."
+        ),
+        font=FONT, bg=BG, fg=TEXT,
+        wraplength=380, justify="left",
+    ).grid(row=0, column=0, columnspan=2, padx=20, pady=(20, 12))
+
+    def open_and_close():
+        try:
+            open_folder(base_path)
+        except Exception as e:
+            messagebox.showerror(
+                "Ordner konnte nicht geöffnet werden",
+                f"{type(e).__name__}: {e}\n\n{traceback.format_exc()}",
+                parent=dialog,
+            )
+            return
+        dialog.destroy()
+
+    btn_frame = tk.Frame(dialog, bg=BG)
+    btn_frame.grid(row=1, column=0, columnspan=2, pady=(0, 16))
+
+    tk.Button(
+        btn_frame, text="Datenordner öffnen", command=open_and_close,
+        font=FONT_BOLD, bg=ACCENT, fg="#ffffff",
+        activebackground=ACCENT_HOVER, activeforeground="#ffffff",
+        relief=tk.FLAT, padx=16, pady=4, cursor="hand2",
+    ).pack(side=tk.LEFT, padx=5)
+
+    tk.Button(
+        btn_frame, text="OK", command=dialog.destroy,
+        font=FONT, bg=CELL_BG, fg=TEXT,
+        activebackground=ENTRY_BG, activeforeground=TEXT,
+        relief=tk.FLAT, padx=16, pady=4, cursor="hand2",
+    ).pack(side=tk.LEFT, padx=5)
+
+
+def _default_from_date(today):
+    if today.month == 1:
+        return today.replace(year=today.year - 1, month=12)
+    from_month = today.month - 1
+    max_day = calendar.monthrange(today.year, from_month)[1]
+    return today.replace(month=from_month, day=min(today.day, max_day))
+
+
+def open_send_dialog(parent, storage, settings, base_path):
+    recipient = settings.get("recipient")
+    if not recipient:
+        messagebox.showwarning(
+            "Kein Empfänger",
+            "Bitte zuerst einen Empfänger in den Einstellungen angeben.",
+            parent=parent,
+        )
+        return
+
+    credentials_path = os.path.join(base_path, "credentials.json")
+    token_path = os.path.join(base_path, "token.json")
+
+    if not os.path.exists(credentials_path):
+        show_missing_credentials_dialog(parent, base_path)
+        return
+
+    dialog = tk.Toplevel(parent)
+    dialog.title("Zeitraum wählen")
+    dialog.resizable(False, False)
+    dialog.grab_set()
+    dialog.configure(bg=BG)
+
+    apply_combobox_style(dialog)
+
+    today = datetime.date.today()
+    from_default = _default_from_date(today)
+    month_values = [str(m) for m in range(1, 13)]
+    year_values = [str(y) for y in range(2020, today.year + 2)]
+
+    def update_day_values(day_cb, day_var, month_var, year_var):
+        try:
+            m = int(month_var.get())
+            y = int(year_var.get())
+            max_day = calendar.monthrange(y, m)[1]
+        except (ValueError, KeyError):
+            max_day = 31
+        day_cb["values"] = [str(d) for d in range(1, max_day + 1)]
+        if int(day_var.get()) > max_day:
+            day_var.set(str(max_day))
+
+    def make_combo(textvariable, values, width):
+        return ttk.Combobox(
+            dialog, textvariable=textvariable, values=values,
+            width=width, font=FONT, style="Dark.TCombobox", state="readonly",
+        )
+
+    def build_date_row(row, label_text, default_date):
+        tk.Label(dialog, text=label_text, font=FONT, bg=BG, fg=TEXT).grid(
+            row=row, column=0, padx=(10, 5), pady=8, sticky="w")
+
+        day_var = tk.StringVar(value=str(default_date.day))
+        max_day = calendar.monthrange(default_date.year, default_date.month)[1]
+        day_cb = make_combo(day_var, [str(d) for d in range(1, max_day + 1)], 3)
+        day_cb.grid(row=row, column=1, padx=2, pady=8)
+
+        tk.Label(dialog, text=".", font=FONT, bg=BG, fg=TEXT).grid(row=row, column=2)
+
+        month_var = tk.StringVar(value=str(default_date.month))
+        make_combo(month_var, month_values, 3).grid(row=row, column=3, padx=2, pady=8)
+
+        tk.Label(dialog, text=".", font=FONT, bg=BG, fg=TEXT).grid(row=row, column=4)
+
+        year_var = tk.StringVar(value=str(default_date.year))
+        make_combo(year_var, year_values, 5).grid(row=row, column=5, padx=(2, 10), pady=8)
+
+        month_var.trace_add("write", lambda *_: update_day_values(day_cb, day_var, month_var, year_var))
+        year_var.trace_add("write", lambda *_: update_day_values(day_cb, day_var, month_var, year_var))
+
+        return day_var, month_var, year_var
+
+    from_day, from_month, from_year = build_date_row(0, "Von:", from_default)
+    to_day, to_month, to_year = build_date_row(1, "Bis:", today)
+
+    def do_send():
+        try:
+            date_from = datetime.date(int(from_year.get()), int(from_month.get()), int(from_day.get()))
+            date_to = datetime.date(int(to_year.get()), int(to_month.get()), int(to_day.get()))
+        except ValueError:
+            messagebox.showerror("Ungültiges Datum", "Bitte ein gültiges Datum eingeben.", parent=dialog)
+            return
+
+        if date_from > date_to:
+            messagebox.showerror(
+                "Ungültiger Zeitraum",
+                "Das Von-Datum muss vor dem Bis-Datum liegen.",
+                parent=dialog,
+            )
+            return
+
+        entries = storage.get_all()
+
+        html, total = generate_report(
+            date_from, date_to, entries,
+            greeting=settings.get("mail_greeting"),
+            content=settings.get("mail_content"),
+            closing=settings.get("mail_closing"),
+        )
+
+        if html is None:
+            messagebox.showinfo(
+                "Keine Einträge",
+                f"Keine Einträge für {date_from.strftime('%d.%m.%Y')} – {date_to.strftime('%d.%m.%Y')} vorhanden.",
+                parent=dialog,
+            )
+            return
+
+        label = f"{date_from.strftime('%d.%m.%Y')} – {date_to.strftime('%d.%m.%Y')}"
+
+        try:
+            pdf_bytes = generate_pdf(date_from, date_to, entries, name=settings.get("name"))
+            service = get_gmail_service(credentials_path, token_path)
+            subject = (
+                settings.get("mail_subject")
+                .replace("{zeitraum}", label)
+                .replace("{gesamt}", f"{total}h")
+            )
+            pdf_filename = f"Zeiterfassung_{date_from.strftime('%Y%m%d')}_{date_to.strftime('%Y%m%d')}.pdf"
+            send_email(service, recipient, subject, html,
+                       pdf_bytes=pdf_bytes, pdf_filename=pdf_filename)
+            dialog.destroy()
+            messagebox.showinfo(
+                "Gesendet",
+                f"Bericht für {label} wurde an {recipient} gesendet.",
+                parent=parent,
+            )
+        except FileNotFoundError as e:
+            messagebox.showerror("Fehler", str(e), parent=dialog)
+        except Exception as e:
+            messagebox.showerror(
+                "Senden fehlgeschlagen",
+                f"{type(e).__name__}: {e}\n\n{traceback.format_exc()}",
+                parent=dialog,
+            )
+
+    btn_frame = tk.Frame(dialog, bg=BG)
+    btn_frame.grid(row=2, column=0, columnspan=6, pady=12)
+
+    tk.Button(
+        btn_frame, text="Senden", command=do_send, font=FONT_BOLD,
+        bg=ACCENT, fg="#ffffff",
+        activebackground=ACCENT_HOVER, activeforeground="#ffffff",
+        relief=tk.FLAT, padx=16, pady=4, cursor="hand2",
+    ).pack(side=tk.LEFT, padx=5)
+
+    tk.Button(
+        btn_frame, text="Abbrechen", command=dialog.destroy, font=FONT,
+        bg=CELL_BG, fg=TEXT,
+        activebackground=ENTRY_BG, activeforeground=TEXT,
+        relief=tk.FLAT, padx=16, pady=4, cursor="hand2",
+    ).pack(side=tk.LEFT, padx=5)

--- a/src/dialogs/settings_dialog.py
+++ b/src/dialogs/settings_dialog.py
@@ -1,13 +1,15 @@
 import os
 import tkinter as tk
 import traceback
-from tkinter import messagebox, ttk
+from tkinter import messagebox
 
 from src.autostart import disable_autostart, enable_autostart, resolve_autostart_target
 from src.platform_open import open_folder
 from src.theme import (
-    ACCENT, ACCENT_HOVER, BG, CELL_BG, ENTRY_BG, FONT, FONT_BOLD, FONT_SMALL,
-    PAUSE_VALUES, STATUS_OK, TEXT, TEXT_MUTED, TIME_VALUES, apply_combobox_style,
+    ACCENT, BG, CELL_BG, FONT, FONT_BOLD, FONT_SMALL,
+    PAUSE_VALUES, STATUS_OK, TEXT, TEXT_MUTED, TIME_VALUES,
+    apply_combobox_style, dark_combo, dark_entry, dark_text,
+    primary_button, secondary_button,
 )
 from src.time_utils import validate_entry
 
@@ -27,14 +29,17 @@ def open_settings_dialog(parent, settings, base_path, on_change):
 
     creds_path = os.path.join(base_path, "credentials.json")
 
+    def label(text, row, col=0, **grid_kw):
+        kw = dict(padx=10, pady=8, sticky="w")
+        kw.update(grid_kw)
+        tk.Label(dialog, text=text, font=FONT, bg=BG, fg=TEXT).grid(row=row, column=col, **kw)
+
     tk.Label(
         dialog, text="— Gmail-Zugangsdaten —", font=FONT_BOLD,
         bg=BG, fg=TEXT_MUTED,
     ).grid(row=0, column=0, columnspan=2, padx=10, pady=(8, 4))
 
-    tk.Label(
-        dialog, text="Datenordner:", font=FONT, bg=BG, fg=TEXT,
-    ).grid(row=1, column=0, padx=10, pady=4, sticky="w")
+    label("Datenordner:", row=1, pady=4)
 
     creds_row = tk.Frame(dialog, bg=BG)
     creds_row.grid(row=1, column=1, padx=10, pady=4, sticky="w")
@@ -49,12 +54,7 @@ def open_settings_dialog(parent, settings, base_path, on_change):
                 parent=dialog,
             )
 
-    tk.Button(
-        creds_row, text="Ordner öffnen", command=open_data_folder,
-        font=FONT, bg=CELL_BG, fg=TEXT,
-        activebackground=ENTRY_BG, activeforeground=TEXT,
-        relief=tk.FLAT, padx=12, pady=2, cursor="hand2",
-    ).pack(side=tk.LEFT)
+    secondary_button(creds_row, "Ordner öffnen", open_data_folder, padx=12, pady=2).pack(side=tk.LEFT)
 
     status_label = tk.Label(creds_row, text="", font=FONT_SMALL, bg=BG)
     status_label.pack(side=tk.LEFT, padx=(10, 0))
@@ -70,62 +70,33 @@ def open_settings_dialog(parent, settings, base_path, on_change):
 
     refresh_status()
 
-    def make_entry(textvariable, width):
-        return tk.Entry(
-            dialog, textvariable=textvariable, width=width, font=FONT,
-            bg=CELL_BG, fg=TEXT, insertbackground=ACCENT,
-            relief=tk.FLAT, highlightbackground=TEXT_MUTED,
-            highlightcolor=ACCENT, highlightthickness=1,
-        )
-
-    def make_text(width, height):
-        return tk.Text(
-            dialog, width=width, height=height, font=FONT,
-            bg=CELL_BG, fg=TEXT, insertbackground=ACCENT,
-            relief=tk.FLAT, highlightbackground=TEXT_MUTED,
-            highlightcolor=ACCENT, highlightthickness=1, wrap=tk.WORD,
-        )
-
-    def make_combo(textvariable, values, width):
-        return ttk.Combobox(
-            dialog, textvariable=textvariable, values=values,
-            width=width, font=FONT, style="Dark.TCombobox", state="readonly",
-        )
-
-    tk.Label(dialog, text="Absender:", font=FONT, bg=BG, fg=TEXT).grid(
-        row=2, column=0, padx=10, pady=8, sticky="w")
+    label("Absender:", row=2)
     email_var = tk.StringVar(value=settings.get("email"))
-    make_entry(email_var, 25).grid(row=2, column=1, padx=10, pady=8)
+    dark_entry(dialog, email_var, width=25).grid(row=2, column=1, padx=10, pady=8)
 
-    tk.Label(dialog, text="Standard-Start:", font=FONT, bg=BG, fg=TEXT).grid(
-        row=3, column=0, padx=10, pady=8, sticky="w")
+    label("Standard-Start:", row=3)
     start_var = tk.StringVar(value=settings.get("default_start"))
-    make_combo(start_var, TIME_VALUES, 8).grid(row=3, column=1, padx=10, pady=8)
+    dark_combo(dialog, start_var, TIME_VALUES).grid(row=3, column=1, padx=10, pady=8)
 
-    tk.Label(dialog, text="Standard-Ende:", font=FONT, bg=BG, fg=TEXT).grid(
-        row=4, column=0, padx=10, pady=8, sticky="w")
+    label("Standard-Ende:", row=4)
     end_var = tk.StringVar(value=settings.get("default_end"))
-    make_combo(end_var, TIME_VALUES, 8).grid(row=4, column=1, padx=10, pady=8)
+    dark_combo(dialog, end_var, TIME_VALUES).grid(row=4, column=1, padx=10, pady=8)
 
-    tk.Label(dialog, text="Standard-Pause (Min):", font=FONT, bg=BG, fg=TEXT).grid(
-        row=5, column=0, padx=10, pady=8, sticky="w")
+    label("Standard-Pause (Min):", row=5)
     pause_var = tk.StringVar(value=str(settings.get("default_pause")))
-    make_combo(pause_var, PAUSE_VALUES, 8).grid(row=5, column=1, padx=10, pady=8)
+    dark_combo(dialog, pause_var, PAUSE_VALUES).grid(row=5, column=1, padx=10, pady=8)
 
-    tk.Label(dialog, text="Empfänger:", font=FONT, bg=BG, fg=TEXT).grid(
-        row=6, column=0, padx=10, pady=8, sticky="w")
+    label("Empfänger:", row=6)
     recipient_var = tk.StringVar(value=settings.get("recipient"))
-    make_entry(recipient_var, 25).grid(row=6, column=1, padx=10, pady=8)
+    dark_entry(dialog, recipient_var, width=25).grid(row=6, column=1, padx=10, pady=8)
 
-    tk.Label(dialog, text="Name:", font=FONT, bg=BG, fg=TEXT).grid(
-        row=7, column=0, padx=10, pady=8, sticky="w")
+    label("Name:", row=7)
     name_var = tk.StringVar(value=settings.get("name"))
-    make_entry(name_var, 25).grid(row=7, column=1, padx=10, pady=8)
+    dark_entry(dialog, name_var, width=25).grid(row=7, column=1, padx=10, pady=8)
 
-    tk.Label(dialog, text="Stundenlohn (€):", font=FONT, bg=BG, fg=TEXT).grid(
-        row=8, column=0, padx=10, pady=8, sticky="w")
+    label("Stundenlohn (€):", row=8)
     rate_var = tk.StringVar(value=str(settings.get("hourly_rate") or ""))
-    make_entry(rate_var, 10).grid(row=8, column=1, padx=10, pady=8, sticky="w")
+    dark_entry(dialog, rate_var, width=10).grid(row=8, column=1, padx=10, pady=8, sticky="w")
 
     tk.Label(
         dialog, text="(optional – nur für dich sichtbar)", font=FONT_SMALL,
@@ -136,25 +107,21 @@ def open_settings_dialog(parent, settings, base_path, on_change):
         dialog, text="— Mail-Vorlage —", font=FONT_BOLD, bg=BG, fg=TEXT_MUTED,
     ).grid(row=9, column=0, columnspan=2, padx=10, pady=(16, 4))
 
-    tk.Label(dialog, text="Betreff:", font=FONT, bg=BG, fg=TEXT).grid(
-        row=10, column=0, padx=10, pady=4, sticky="w")
+    label("Betreff:", row=10, pady=4)
     subject_var = tk.StringVar(value=settings.get("mail_subject"))
-    make_entry(subject_var, 35).grid(row=10, column=1, padx=10, pady=4)
+    dark_entry(dialog, subject_var, width=35).grid(row=10, column=1, padx=10, pady=4)
 
-    tk.Label(dialog, text="Anrede:", font=FONT, bg=BG, fg=TEXT).grid(
-        row=11, column=0, padx=10, pady=4, sticky="w")
+    label("Anrede:", row=11, pady=4)
     greeting_var = tk.StringVar(value=settings.get("mail_greeting"))
-    make_entry(greeting_var, 35).grid(row=11, column=1, padx=10, pady=4)
+    dark_entry(dialog, greeting_var, width=35).grid(row=11, column=1, padx=10, pady=4)
 
-    tk.Label(dialog, text="Inhalt:", font=FONT, bg=BG, fg=TEXT).grid(
-        row=12, column=0, padx=10, pady=4, sticky="nw")
-    content_text = make_text(35, 3)
+    label("Inhalt:", row=12, pady=4, sticky="nw")
+    content_text = dark_text(dialog, 35, 3)
     content_text.grid(row=12, column=1, padx=10, pady=4)
     content_text.insert("1.0", settings.get("mail_content"))
 
-    tk.Label(dialog, text="Gruß:", font=FONT, bg=BG, fg=TEXT).grid(
-        row=13, column=0, padx=10, pady=4, sticky="nw")
-    closing_text = make_text(35, 2)
+    label("Gruß:", row=13, pady=4, sticky="nw")
+    closing_text = dark_text(dialog, 35, 2)
     closing_text.grid(row=13, column=1, padx=10, pady=4)
     closing_text.insert("1.0", settings.get("mail_closing"))
 
@@ -218,16 +185,5 @@ def open_settings_dialog(parent, settings, base_path, on_change):
     btn_frame = tk.Frame(dialog, bg=BG)
     btn_frame.grid(row=16, column=0, columnspan=2, pady=12)
 
-    tk.Button(
-        btn_frame, text="Speichern", command=save_settings, font=FONT_BOLD,
-        bg=ACCENT, fg="#ffffff",
-        activebackground=ACCENT_HOVER, activeforeground="#ffffff",
-        relief=tk.FLAT, padx=16, pady=4, cursor="hand2",
-    ).pack(side=tk.LEFT, padx=5)
-
-    tk.Button(
-        btn_frame, text="Abbrechen", command=dialog.destroy, font=FONT,
-        bg=CELL_BG, fg=TEXT,
-        activebackground=ENTRY_BG, activeforeground=TEXT,
-        relief=tk.FLAT, padx=16, pady=4, cursor="hand2",
-    ).pack(side=tk.LEFT, padx=5)
+    primary_button(btn_frame, "Speichern", save_settings).pack(side=tk.LEFT, padx=5)
+    secondary_button(btn_frame, "Abbrechen", dialog.destroy).pack(side=tk.LEFT, padx=5)

--- a/src/dialogs/settings_dialog.py
+++ b/src/dialogs/settings_dialog.py
@@ -1,0 +1,233 @@
+import os
+import tkinter as tk
+import traceback
+from tkinter import messagebox, ttk
+
+from src.autostart import disable_autostart, enable_autostart, resolve_autostart_target
+from src.platform_open import open_folder
+from src.theme import (
+    ACCENT, ACCENT_HOVER, BG, CELL_BG, ENTRY_BG, FONT, FONT_BOLD, FONT_SMALL,
+    PAUSE_VALUES, STATUS_OK, TEXT, TEXT_MUTED, TIME_VALUES, apply_combobox_style,
+)
+from src.time_utils import validate_entry
+
+
+def open_settings_dialog(parent, settings, base_path, on_change):
+    """Modal dialog for editing app settings.
+
+    on_change is called after a successful save so the calendar can refresh.
+    """
+    dialog = tk.Toplevel(parent)
+    dialog.title("Einstellungen")
+    dialog.resizable(False, False)
+    dialog.grab_set()
+    dialog.configure(bg=BG)
+
+    apply_combobox_style(dialog)
+
+    creds_path = os.path.join(base_path, "credentials.json")
+
+    tk.Label(
+        dialog, text="— Gmail-Zugangsdaten —", font=FONT_BOLD,
+        bg=BG, fg=TEXT_MUTED,
+    ).grid(row=0, column=0, columnspan=2, padx=10, pady=(8, 4))
+
+    tk.Label(
+        dialog, text="Datenordner:", font=FONT, bg=BG, fg=TEXT,
+    ).grid(row=1, column=0, padx=10, pady=4, sticky="w")
+
+    creds_row = tk.Frame(dialog, bg=BG)
+    creds_row.grid(row=1, column=1, padx=10, pady=4, sticky="w")
+
+    def open_data_folder():
+        try:
+            open_folder(base_path)
+        except Exception as e:
+            messagebox.showerror(
+                "Ordner konnte nicht geöffnet werden",
+                f"{type(e).__name__}: {e}\n\n{traceback.format_exc()}",
+                parent=dialog,
+            )
+
+    tk.Button(
+        creds_row, text="Ordner öffnen", command=open_data_folder,
+        font=FONT, bg=CELL_BG, fg=TEXT,
+        activebackground=ENTRY_BG, activeforeground=TEXT,
+        relief=tk.FLAT, padx=12, pady=2, cursor="hand2",
+    ).pack(side=tk.LEFT)
+
+    status_label = tk.Label(creds_row, text="", font=FONT_SMALL, bg=BG)
+    status_label.pack(side=tk.LEFT, padx=(10, 0))
+
+    def refresh_status():
+        if not status_label.winfo_exists():
+            return
+        if os.path.exists(creds_path):
+            status_label.config(text="✓ credentials.json vorhanden", fg=STATUS_OK)
+        else:
+            status_label.config(text="✗ credentials.json fehlt", fg=ACCENT)
+        dialog.after(500, refresh_status)
+
+    refresh_status()
+
+    def make_entry(textvariable, width):
+        return tk.Entry(
+            dialog, textvariable=textvariable, width=width, font=FONT,
+            bg=CELL_BG, fg=TEXT, insertbackground=ACCENT,
+            relief=tk.FLAT, highlightbackground=TEXT_MUTED,
+            highlightcolor=ACCENT, highlightthickness=1,
+        )
+
+    def make_text(width, height):
+        return tk.Text(
+            dialog, width=width, height=height, font=FONT,
+            bg=CELL_BG, fg=TEXT, insertbackground=ACCENT,
+            relief=tk.FLAT, highlightbackground=TEXT_MUTED,
+            highlightcolor=ACCENT, highlightthickness=1, wrap=tk.WORD,
+        )
+
+    def make_combo(textvariable, values, width):
+        return ttk.Combobox(
+            dialog, textvariable=textvariable, values=values,
+            width=width, font=FONT, style="Dark.TCombobox", state="readonly",
+        )
+
+    tk.Label(dialog, text="Absender:", font=FONT, bg=BG, fg=TEXT).grid(
+        row=2, column=0, padx=10, pady=8, sticky="w")
+    email_var = tk.StringVar(value=settings.get("email"))
+    make_entry(email_var, 25).grid(row=2, column=1, padx=10, pady=8)
+
+    tk.Label(dialog, text="Standard-Start:", font=FONT, bg=BG, fg=TEXT).grid(
+        row=3, column=0, padx=10, pady=8, sticky="w")
+    start_var = tk.StringVar(value=settings.get("default_start"))
+    make_combo(start_var, TIME_VALUES, 8).grid(row=3, column=1, padx=10, pady=8)
+
+    tk.Label(dialog, text="Standard-Ende:", font=FONT, bg=BG, fg=TEXT).grid(
+        row=4, column=0, padx=10, pady=8, sticky="w")
+    end_var = tk.StringVar(value=settings.get("default_end"))
+    make_combo(end_var, TIME_VALUES, 8).grid(row=4, column=1, padx=10, pady=8)
+
+    tk.Label(dialog, text="Standard-Pause (Min):", font=FONT, bg=BG, fg=TEXT).grid(
+        row=5, column=0, padx=10, pady=8, sticky="w")
+    pause_var = tk.StringVar(value=str(settings.get("default_pause")))
+    make_combo(pause_var, PAUSE_VALUES, 8).grid(row=5, column=1, padx=10, pady=8)
+
+    tk.Label(dialog, text="Empfänger:", font=FONT, bg=BG, fg=TEXT).grid(
+        row=6, column=0, padx=10, pady=8, sticky="w")
+    recipient_var = tk.StringVar(value=settings.get("recipient"))
+    make_entry(recipient_var, 25).grid(row=6, column=1, padx=10, pady=8)
+
+    tk.Label(dialog, text="Name:", font=FONT, bg=BG, fg=TEXT).grid(
+        row=7, column=0, padx=10, pady=8, sticky="w")
+    name_var = tk.StringVar(value=settings.get("name"))
+    make_entry(name_var, 25).grid(row=7, column=1, padx=10, pady=8)
+
+    tk.Label(dialog, text="Stundenlohn (€):", font=FONT, bg=BG, fg=TEXT).grid(
+        row=8, column=0, padx=10, pady=8, sticky="w")
+    rate_var = tk.StringVar(value=str(settings.get("hourly_rate") or ""))
+    make_entry(rate_var, 10).grid(row=8, column=1, padx=10, pady=8, sticky="w")
+
+    tk.Label(
+        dialog, text="(optional – nur für dich sichtbar)", font=FONT_SMALL,
+        bg=BG, fg=TEXT_MUTED,
+    ).grid(row=8, column=1, padx=(120, 10), pady=8, sticky="w")
+
+    tk.Label(
+        dialog, text="— Mail-Vorlage —", font=FONT_BOLD, bg=BG, fg=TEXT_MUTED,
+    ).grid(row=9, column=0, columnspan=2, padx=10, pady=(16, 4))
+
+    tk.Label(dialog, text="Betreff:", font=FONT, bg=BG, fg=TEXT).grid(
+        row=10, column=0, padx=10, pady=4, sticky="w")
+    subject_var = tk.StringVar(value=settings.get("mail_subject"))
+    make_entry(subject_var, 35).grid(row=10, column=1, padx=10, pady=4)
+
+    tk.Label(dialog, text="Anrede:", font=FONT, bg=BG, fg=TEXT).grid(
+        row=11, column=0, padx=10, pady=4, sticky="w")
+    greeting_var = tk.StringVar(value=settings.get("mail_greeting"))
+    make_entry(greeting_var, 35).grid(row=11, column=1, padx=10, pady=4)
+
+    tk.Label(dialog, text="Inhalt:", font=FONT, bg=BG, fg=TEXT).grid(
+        row=12, column=0, padx=10, pady=4, sticky="nw")
+    content_text = make_text(35, 3)
+    content_text.grid(row=12, column=1, padx=10, pady=4)
+    content_text.insert("1.0", settings.get("mail_content"))
+
+    tk.Label(dialog, text="Gruß:", font=FONT, bg=BG, fg=TEXT).grid(
+        row=13, column=0, padx=10, pady=4, sticky="nw")
+    closing_text = make_text(35, 2)
+    closing_text.grid(row=13, column=1, padx=10, pady=4)
+    closing_text.insert("1.0", settings.get("mail_closing"))
+
+    tk.Label(
+        dialog, text="Platzhalter: {zeitraum}, {gesamt}", font=("Segoe UI", 8),
+        bg=BG, fg=TEXT_MUTED,
+    ).grid(row=14, column=0, columnspan=2, padx=10, pady=(0, 4))
+
+    autostart_var = tk.BooleanVar(value=settings.get("autostart"))
+    tk.Checkbutton(
+        dialog, text="Autostart (minimiert bei Anmeldung)",
+        variable=autostart_var, font=FONT,
+        bg=BG, fg=TEXT, selectcolor=CELL_BG,
+        activebackground=BG, activeforeground=TEXT,
+        cursor="hand2",
+    ).grid(row=15, column=0, columnspan=2, padx=10, pady=8, sticky="w")
+
+    def save_settings():
+        ok, msg = validate_entry(start_var.get(), end_var.get())
+        if not ok:
+            messagebox.showerror("Standard-Arbeitszeit ungültig", msg, parent=dialog)
+            return
+
+        new_autostart = autostart_var.get()
+        old_autostart = settings.get("autostart")
+
+        if new_autostart != old_autostart:
+            try:
+                if new_autostart:
+                    target, arguments = resolve_autostart_target(base_path)
+                    enable_autostart(target, arguments)
+                else:
+                    disable_autostart()
+                settings.set("autostart", new_autostart)
+            except Exception as e:
+                messagebox.showerror(
+                    "Autostart-Fehler",
+                    f"Autostart konnte nicht geändert werden:\n{e}",
+                    parent=dialog,
+                )
+                return
+
+        settings.set("email", email_var.get())
+        settings.set("default_start", start_var.get())
+        settings.set("default_end", end_var.get())
+        settings.set("default_pause", int(pause_var.get()))
+        settings.set("recipient", recipient_var.get())
+        settings.set("name", name_var.get())
+        settings.set("mail_subject", subject_var.get())
+        settings.set("mail_greeting", greeting_var.get())
+        settings.set("mail_content", content_text.get("1.0", "end-1c"))
+        settings.set("mail_closing", closing_text.get("1.0", "end-1c"))
+        rate_str = rate_var.get().strip()
+        try:
+            settings.set("hourly_rate", float(rate_str) if rate_str else 0.0)
+        except ValueError:
+            settings.set("hourly_rate", 0.0)
+        on_change()
+        dialog.destroy()
+
+    btn_frame = tk.Frame(dialog, bg=BG)
+    btn_frame.grid(row=16, column=0, columnspan=2, pady=12)
+
+    tk.Button(
+        btn_frame, text="Speichern", command=save_settings, font=FONT_BOLD,
+        bg=ACCENT, fg="#ffffff",
+        activebackground=ACCENT_HOVER, activeforeground="#ffffff",
+        relief=tk.FLAT, padx=16, pady=4, cursor="hand2",
+    ).pack(side=tk.LEFT, padx=5)
+
+    tk.Button(
+        btn_frame, text="Abbrechen", command=dialog.destroy, font=FONT,
+        bg=CELL_BG, fg=TEXT,
+        activebackground=ENTRY_BG, activeforeground=TEXT,
+        relief=tk.FLAT, padx=16, pady=4, cursor="hand2",
+    ).pack(side=tk.LEFT, padx=5)

--- a/src/storage.py
+++ b/src/storage.py
@@ -1,5 +1,7 @@
+import datetime
 import json
 import os
+
 
 class Storage:
     def __init__(self, filepath="zeiterfassung.json"):
@@ -8,13 +10,30 @@ class Storage:
         self._load()
 
     def _load(self):
-        if os.path.exists(self.filepath):
+        if not os.path.exists(self.filepath):
+            return
+        try:
             with open(self.filepath, "r", encoding="utf-8") as f:
                 self._data = json.load(f)
+        except (json.JSONDecodeError, ValueError):
+            # Corrupt file: rename it so the user can recover it manually
+            # rather than silently overwriting on the next save.
+            stamp = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
+            os.replace(self.filepath, f"{self.filepath}.corrupt-{stamp}")
+            self._data = {}
 
     def _save_to_disk(self):
-        with open(self.filepath, "w", encoding="utf-8") as f:
+        # Atomic write: temp file + replace, so a crash mid-write
+        # cannot leave the data file half-written.
+        tmp = self.filepath + ".tmp"
+        with open(tmp, "w", encoding="utf-8") as f:
             json.dump(self._data, f, indent=2, ensure_ascii=False)
+        try:
+            os.replace(tmp, self.filepath)
+        except OSError:
+            if os.path.exists(tmp):
+                os.remove(tmp)
+            raise
 
     def get_all(self):
         return dict(self._data)

--- a/src/theme.py
+++ b/src/theme.py
@@ -1,3 +1,4 @@
+import tkinter as tk
 from tkinter import ttk
 
 # Dark Modern color palette
@@ -51,3 +52,90 @@ def apply_combobox_style(dialog):
     dialog.option_add("*TCombobox*Listbox.selectBackground", ACCENT)
     dialog.option_add("*TCombobox*Listbox.selectForeground", "#ffffff")
     dialog.option_add("*TCombobox*Listbox.font", FONT)
+
+
+def dark_entry(parent, textvariable, width=25, **kw):
+    return tk.Entry(
+        parent, textvariable=textvariable, width=width, font=FONT,
+        bg=CELL_BG, fg=TEXT, insertbackground=ACCENT,
+        relief=tk.FLAT, highlightbackground=TEXT_MUTED,
+        highlightcolor=ACCENT, highlightthickness=1, **kw,
+    )
+
+
+def dark_combo(parent, textvariable, values, width=8, **kw):
+    return ttk.Combobox(
+        parent, textvariable=textvariable, values=values,
+        width=width, font=FONT, style="Dark.TCombobox", state="readonly", **kw,
+    )
+
+
+def dark_text(parent, width, height, **kw):
+    return tk.Text(
+        parent, width=width, height=height, font=FONT,
+        bg=CELL_BG, fg=TEXT, insertbackground=ACCENT,
+        relief=tk.FLAT, highlightbackground=TEXT_MUTED,
+        highlightcolor=ACCENT, highlightthickness=1, wrap=tk.WORD, **kw,
+    )
+
+
+def primary_button(parent, text, command, **kw):
+    kw.setdefault("font", FONT_BOLD)
+    kw.setdefault("padx", 16)
+    kw.setdefault("pady", 4)
+    return tk.Button(
+        parent, text=text, command=command,
+        bg=ACCENT, fg="#ffffff",
+        activebackground=ACCENT_HOVER, activeforeground="#ffffff",
+        relief=tk.FLAT, cursor="hand2", **kw,
+    )
+
+
+def secondary_button(parent, text, command, **kw):
+    kw.setdefault("font", FONT)
+    kw.setdefault("padx", 16)
+    kw.setdefault("pady", 4)
+    return tk.Button(
+        parent, text=text, command=command,
+        bg=CELL_BG, fg=TEXT,
+        activebackground=ENTRY_BG, activeforeground=TEXT,
+        relief=tk.FLAT, cursor="hand2", **kw,
+    )
+
+
+def toggle_button(parent, text, command, active=False, **kw):
+    """Two-state segmented button used for the Monat/Woche switcher.
+
+    Re-style with set_toggle_active(btn, bool) when state changes.
+    """
+    btn = tk.Button(
+        parent, text=text, command=command,
+        font=FONT_SMALL, width=6, relief=tk.FLAT, cursor="hand2", **kw,
+    )
+    set_toggle_active(btn, active)
+    return btn
+
+
+def set_toggle_active(btn, active):
+    if active:
+        btn.config(
+            bg=ACCENT, fg="#ffffff",
+            activebackground=ACCENT, activeforeground="#ffffff",
+        )
+    else:
+        btn.config(
+            bg=CELL_BG, fg=TEXT_MUTED,
+            activebackground=ENTRY_BG, activeforeground=TEXT,
+        )
+
+
+def icon_button(parent, text, command, fg=ACCENT, hover_fg=None, **kw):
+    """Compact icon-style button used in the header (‹ › ⚙)."""
+    if hover_fg is None:
+        hover_fg = fg
+    return tk.Button(
+        parent, text=text, command=command, width=3,
+        font=FONT_BOLD, bg=CELL_BG, fg=fg,
+        activebackground=ENTRY_BG, activeforeground=hover_fg,
+        relief=tk.FLAT, cursor="hand2", **kw,
+    )

--- a/src/theme.py
+++ b/src/theme.py
@@ -1,0 +1,53 @@
+from tkinter import ttk
+
+# Dark Modern color palette
+BG = "#1a1a2e"
+CELL_BG = "#16213e"
+WEEKEND_BG = "#0f3460"
+ACCENT = "#e94560"
+ACCENT_HOVER = "#c73550"
+STATUS_OK = "#4ade80"
+TEXT = "#e0e0e0"
+TEXT_MUTED = "#888888"
+ENTRY_BG = "#1a3a5c"
+WEEKEND_ENTRY_BG = "#1a3050"
+WEEKEND_FG = "#6c6c80"
+
+FONT = ("Segoe UI", 10)
+FONT_SMALL = ("Segoe UI", 8)
+FONT_BOLD = ("Segoe UI", 10, "bold")
+FONT_HEADER = ("Segoe UI", 16, "bold")
+FONT_FOOTER = ("Segoe UI", 12, "bold")
+
+# Hover colors (slightly lighter variants)
+CELL_BG_HOVER = "#1e2d52"
+WEEKEND_BG_HOVER = "#153a6e"
+ENTRY_BG_HOVER = "#224a70"
+WEEKEND_ENTRY_BG_HOVER = "#223e60"
+
+# Time dropdown values (5-min steps, 00:00 - 23:55)
+TIME_VALUES = [f"{h:02d}:{m:02d}" for h in range(24) for m in range(0, 60, 5)]
+PAUSE_VALUES = [str(m) for m in range(0, 125, 5)]
+
+
+def apply_combobox_style(dialog):
+    style = ttk.Style(dialog)
+    style.theme_use("clam")
+    style.configure(
+        "Dark.TCombobox",
+        fieldbackground=CELL_BG, background=CELL_BG,
+        foreground=TEXT, arrowcolor=ACCENT,
+        bordercolor=TEXT_MUTED, lightcolor=CELL_BG, darkcolor=CELL_BG,
+        selectbackground=ENTRY_BG, selectforeground=TEXT,
+    )
+    style.map("Dark.TCombobox",
+        fieldbackground=[("readonly", CELL_BG)],
+        selectbackground=[("readonly", CELL_BG)],
+        selectforeground=[("readonly", TEXT)],
+        bordercolor=[("focus", ACCENT)],
+    )
+    dialog.option_add("*TCombobox*Listbox.background", CELL_BG)
+    dialog.option_add("*TCombobox*Listbox.foreground", TEXT)
+    dialog.option_add("*TCombobox*Listbox.selectBackground", ACCENT)
+    dialog.option_add("*TCombobox*Listbox.selectForeground", "#ffffff")
+    dialog.option_add("*TCombobox*Listbox.font", FONT)

--- a/src/ui.py
+++ b/src/ui.py
@@ -1,78 +1,32 @@
 # src/ui.py
 import tkinter as tk
-from tkinter import messagebox, ttk
+from tkinter import messagebox
 import calendar
 import ctypes
 import datetime
 import os
 import platform
-import sys
 import threading
 import traceback
-from src.storage import Storage
-from src.time_utils import calculate_hours, validate_entry, get_week_dates, get_week_label, week_spans_months
-from src.report import generate_report, generate_pdf
-from src.mail import (
-    get_gmail_service,
-    send_email,
-    refresh_token_if_needed,
-    TokenAuthError,
-    TokenNetworkError,
-)
-from src.autostart import enable_autostart, disable_autostart
-from src.platform_open import open_folder
+from src.time_utils import calculate_hours, get_week_dates, get_week_label, week_spans_months
+from src.mail import refresh_token_if_needed, TokenAuthError, TokenNetworkError
 from src.version import VERSION
+
+from src.dialogs.entry_dialog import open_entry_dialog
+from src.dialogs.send_dialog import open_send_dialog
+from src.dialogs.settings_dialog import open_settings_dialog
+from src.theme import (
+    BG, CELL_BG, WEEKEND_BG, ACCENT, TEXT, TEXT_MUTED,
+    ENTRY_BG, WEEKEND_ENTRY_BG, WEEKEND_FG,
+    FONT, FONT_SMALL, FONT_BOLD, FONT_HEADER, FONT_FOOTER,
+    CELL_BG_HOVER, WEEKEND_BG_HOVER, ENTRY_BG_HOVER, WEEKEND_ENTRY_BG_HOVER,
+)
 
 DAYS_DE = ["Mo", "Di", "Mi", "Do", "Fr", "Sa", "So"]
 MONTHS_DE = [
     "", "Januar", "Februar", "März", "April", "Mai", "Juni",
     "Juli", "August", "September", "Oktober", "November", "Dezember"
 ]
-
-# Dark Modern color palette
-BG = "#1a1a2e"
-CELL_BG = "#16213e"
-WEEKEND_BG = "#0f3460"
-ACCENT = "#e94560"
-STATUS_OK = "#4ade80"
-TEXT = "#e0e0e0"
-TEXT_MUTED = "#888888"
-ENTRY_BG = "#1a3a5c"
-WEEKEND_ENTRY_BG = "#1a3050"
-FONT = ("Segoe UI", 10)
-FONT_SMALL = ("Segoe UI", 8)
-FONT_BOLD = ("Segoe UI", 10, "bold")
-FONT_HEADER = ("Segoe UI", 16, "bold")
-FONT_FOOTER = ("Segoe UI", 12, "bold")
-
-# Hover colors (slightly lighter variants)
-CELL_BG_HOVER = "#1e2d52"
-WEEKEND_BG_HOVER = "#153a6e"
-ENTRY_BG_HOVER = "#224a70"
-WEEKEND_ENTRY_BG_HOVER = "#223e60"
-
-# Time dropdown values (5-min steps, 00:00 - 23:55)
-TIME_VALUES = [f"{h:02d}:{m:02d}" for h in range(24) for m in range(0, 60, 5)]
-
-
-PAUSE_VALUES = [str(m) for m in range(0, 125, 5)]
-
-
-def resolve_autostart_target(base_path):
-    """Return (target, arguments) for the current runtime/platform.
-
-    Frozen Windows/macOS: the executable itself.
-    Frozen Linux: $APPIMAGE if set (persistent path), otherwise sys.executable.
-    Script mode: Python interpreter + main.py.
-    """
-    if getattr(sys, "frozen", False):
-        if platform.system() == "Linux":
-            target = os.environ.get("APPIMAGE") or sys.executable
-        else:
-            target = sys.executable
-        return target, "--minimized"
-    main_py = os.path.join(base_path, "src", "main.py")
-    return sys.executable, f"{main_py} --minimized"
 
 
 class App:
@@ -150,7 +104,7 @@ class App:
         frame.pack(fill=tk.X, padx=10, pady=(10, 0))
 
         tk.Button(
-            frame, text="\u2039", command=self._prev, width=3,
+            frame, text="‹", command=self._prev, width=3,
             font=FONT_BOLD, bg=CELL_BG, fg=ACCENT,
             activebackground=ENTRY_BG, activeforeground=ACCENT,
             relief=tk.FLAT, cursor="hand2"
@@ -182,14 +136,14 @@ class App:
         self.header_label.pack(side=tk.LEFT, expand=True)
 
         tk.Button(
-            frame, text="\u2699", command=self._open_settings, width=3,
+            frame, text="⚙", command=self._open_settings, width=3,
             font=FONT_BOLD, bg=CELL_BG, fg=TEXT_MUTED,
             activebackground=ENTRY_BG, activeforeground=TEXT,
             relief=tk.FLAT, cursor="hand2"
         ).pack(side=tk.RIGHT)
 
         tk.Button(
-            frame, text="\u203a", command=self._next, width=3,
+            frame, text="›", command=self._next, width=3,
             font=FONT_BOLD, bg=CELL_BG, fg=ACCENT,
             activebackground=ENTRY_BG, activeforeground=ACCENT,
             relief=tk.FLAT, cursor="hand2"
@@ -210,7 +164,7 @@ class App:
         self.footer_label.pack(side=tk.LEFT, expand=True)
 
         tk.Button(
-            footer_frame, text="Monat senden", command=self._send_report,
+            footer_frame, text="Monat senden", command=self._send,
             font=FONT, bg=CELL_BG, fg=TEXT,
             activebackground=ENTRY_BG, activeforeground=TEXT,
             relief=tk.FLAT, padx=12, pady=4, cursor="hand2"
@@ -269,304 +223,11 @@ class App:
             self.btn_week.config(bg=ACCENT, fg="#ffffff", activebackground=ACCENT, activeforeground="#ffffff")
             self.btn_month.config(bg=CELL_BG, fg=TEXT_MUTED, activebackground=ENTRY_BG, activeforeground=TEXT)
 
-    def _apply_combobox_style(self, dialog):
-        style = ttk.Style(dialog)
-        style.theme_use("clam")
-        style.configure(
-            "Dark.TCombobox",
-            fieldbackground=CELL_BG, background=CELL_BG,
-            foreground=TEXT, arrowcolor=ACCENT,
-            bordercolor=TEXT_MUTED, lightcolor=CELL_BG, darkcolor=CELL_BG,
-            selectbackground=ENTRY_BG, selectforeground=TEXT
-        )
-        style.map("Dark.TCombobox",
-            fieldbackground=[("readonly", CELL_BG)],
-            selectbackground=[("readonly", CELL_BG)],
-            selectforeground=[("readonly", TEXT)],
-            bordercolor=[("focus", ACCENT)],
-        )
-        dialog.option_add("*TCombobox*Listbox.background", CELL_BG)
-        dialog.option_add("*TCombobox*Listbox.foreground", TEXT)
-        dialog.option_add("*TCombobox*Listbox.selectBackground", ACCENT)
-        dialog.option_add("*TCombobox*Listbox.selectForeground", "#ffffff")
-        dialog.option_add("*TCombobox*Listbox.font", FONT)
-
     def _open_settings(self):
-        dialog = tk.Toplevel(self.root)
-        dialog.title("Einstellungen")
-        dialog.resizable(False, False)
-        dialog.grab_set()
-        dialog.configure(bg=BG)
-
-        self._apply_combobox_style(dialog)
-
-        # Gmail-Zugangsdaten section
-        tk.Label(
-            dialog, text="— Gmail-Zugangsdaten —", font=FONT_BOLD,
-            bg=BG, fg=TEXT_MUTED
-        ).grid(row=0, column=0, columnspan=2, padx=10, pady=(8, 4))
-
-        creds_path = os.path.join(self.base_path, "credentials.json")
-
-        tk.Label(
-            dialog, text="Datenordner:", font=FONT, bg=BG, fg=TEXT
-        ).grid(row=1, column=0, padx=10, pady=4, sticky="w")
-
-        creds_row = tk.Frame(dialog, bg=BG)
-        creds_row.grid(row=1, column=1, padx=10, pady=4, sticky="w")
-
-        def open_data_folder():
-            try:
-                open_folder(self.base_path)
-            except Exception as e:
-                messagebox.showerror(
-                    "Ordner konnte nicht geöffnet werden",
-                    f"{type(e).__name__}: {e}\n\n{traceback.format_exc()}",
-                    parent=dialog,
-                )
-
-        tk.Button(
-            creds_row, text="Ordner öffnen", command=open_data_folder,
-            font=FONT, bg=CELL_BG, fg=TEXT,
-            activebackground=ENTRY_BG, activeforeground=TEXT,
-            relief=tk.FLAT, padx=12, pady=2, cursor="hand2"
-        ).pack(side=tk.LEFT)
-
-        status_label = tk.Label(
-            creds_row, text="", font=FONT_SMALL, bg=BG
+        open_settings_dialog(
+            self.root, self.settings, self.base_path,
+            on_change=self._refresh,
         )
-        status_label.pack(side=tk.LEFT, padx=(10, 0))
-
-        def refresh_status():
-            if not status_label.winfo_exists():
-                return
-            if os.path.exists(creds_path):
-                status_label.config(
-                    text="✓ credentials.json vorhanden", fg=STATUS_OK
-                )
-            else:
-                status_label.config(
-                    text="✗ credentials.json fehlt", fg=ACCENT
-                )
-            dialog.after(500, refresh_status)
-
-        refresh_status()
-
-        # Email
-        tk.Label(
-            dialog, text="Absender:", font=FONT, bg=BG, fg=TEXT
-        ).grid(row=2, column=0, padx=10, pady=8, sticky="w")
-
-        email_var = tk.StringVar(value=self.settings.get("email"))
-        tk.Entry(
-            dialog, textvariable=email_var, width=25, font=FONT,
-            bg=CELL_BG, fg=TEXT, insertbackground=ACCENT,
-            relief=tk.FLAT, highlightbackground=TEXT_MUTED,
-            highlightcolor=ACCENT, highlightthickness=1
-        ).grid(row=2, column=1, padx=10, pady=8)
-
-        # Default start time
-        tk.Label(
-            dialog, text="Standard-Start:", font=FONT, bg=BG, fg=TEXT
-        ).grid(row=3, column=0, padx=10, pady=8, sticky="w")
-
-        start_var = tk.StringVar(value=self.settings.get("default_start"))
-        ttk.Combobox(
-            dialog, textvariable=start_var, values=TIME_VALUES,
-            width=8, font=FONT, style="Dark.TCombobox", state="readonly"
-        ).grid(row=3, column=1, padx=10, pady=8)
-
-        # Default end time
-        tk.Label(
-            dialog, text="Standard-Ende:", font=FONT, bg=BG, fg=TEXT
-        ).grid(row=4, column=0, padx=10, pady=8, sticky="w")
-
-        end_var = tk.StringVar(value=self.settings.get("default_end"))
-        ttk.Combobox(
-            dialog, textvariable=end_var, values=TIME_VALUES,
-            width=8, font=FONT, style="Dark.TCombobox", state="readonly"
-        ).grid(row=4, column=1, padx=10, pady=8)
-
-        # Default pause
-        tk.Label(
-            dialog, text="Standard-Pause (Min):", font=FONT, bg=BG, fg=TEXT
-        ).grid(row=5, column=0, padx=10, pady=8, sticky="w")
-
-        pause_var = tk.StringVar(value=str(self.settings.get("default_pause")))
-        ttk.Combobox(
-            dialog, textvariable=pause_var, values=PAUSE_VALUES,
-            width=8, font=FONT, style="Dark.TCombobox", state="readonly"
-        ).grid(row=5, column=1, padx=10, pady=8)
-
-        # Recipient
-        tk.Label(
-            dialog, text="Empfänger:", font=FONT, bg=BG, fg=TEXT
-        ).grid(row=6, column=0, padx=10, pady=8, sticky="w")
-
-        recipient_var = tk.StringVar(value=self.settings.get("recipient"))
-        tk.Entry(
-            dialog, textvariable=recipient_var, width=25, font=FONT,
-            bg=CELL_BG, fg=TEXT, insertbackground=ACCENT,
-            relief=tk.FLAT, highlightbackground=TEXT_MUTED,
-            highlightcolor=ACCENT, highlightthickness=1
-        ).grid(row=6, column=1, padx=10, pady=8)
-
-        # Name
-        tk.Label(
-            dialog, text="Name:", font=FONT, bg=BG, fg=TEXT
-        ).grid(row=7, column=0, padx=10, pady=8, sticky="w")
-
-        name_var = tk.StringVar(value=self.settings.get("name"))
-        tk.Entry(
-            dialog, textvariable=name_var, width=25, font=FONT,
-            bg=CELL_BG, fg=TEXT, insertbackground=ACCENT,
-            relief=tk.FLAT, highlightbackground=TEXT_MUTED,
-            highlightcolor=ACCENT, highlightthickness=1
-        ).grid(row=7, column=1, padx=10, pady=8)
-
-        # Stundenlohn (optional)
-        tk.Label(
-            dialog, text="Stundenlohn (€):", font=FONT, bg=BG, fg=TEXT
-        ).grid(row=8, column=0, padx=10, pady=8, sticky="w")
-
-        rate_var = tk.StringVar(value=str(self.settings.get("hourly_rate") or ""))
-        tk.Entry(
-            dialog, textvariable=rate_var, width=10, font=FONT,
-            bg=CELL_BG, fg=TEXT, insertbackground=ACCENT,
-            relief=tk.FLAT, highlightbackground=TEXT_MUTED,
-            highlightcolor=ACCENT, highlightthickness=1
-        ).grid(row=8, column=1, padx=10, pady=8, sticky="w")
-
-        tk.Label(
-            dialog, text="(optional – nur für dich sichtbar)", font=FONT_SMALL,
-            bg=BG, fg=TEXT_MUTED
-        ).grid(row=8, column=1, padx=(120, 10), pady=8, sticky="w")
-
-        # Mail-Vorlage
-        tk.Label(
-            dialog, text="— Mail-Vorlage —", font=FONT_BOLD, bg=BG, fg=TEXT_MUTED
-        ).grid(row=9, column=0, columnspan=2, padx=10, pady=(16, 4))
-
-        tk.Label(
-            dialog, text="Betreff:", font=FONT, bg=BG, fg=TEXT
-        ).grid(row=10, column=0, padx=10, pady=4, sticky="w")
-        subject_var = tk.StringVar(value=self.settings.get("mail_subject"))
-        tk.Entry(
-            dialog, textvariable=subject_var, width=35, font=FONT,
-            bg=CELL_BG, fg=TEXT, insertbackground=ACCENT,
-            relief=tk.FLAT, highlightbackground=TEXT_MUTED,
-            highlightcolor=ACCENT, highlightthickness=1
-        ).grid(row=10, column=1, padx=10, pady=4)
-
-        tk.Label(
-            dialog, text="Anrede:", font=FONT, bg=BG, fg=TEXT
-        ).grid(row=11, column=0, padx=10, pady=4, sticky="w")
-        greeting_var = tk.StringVar(value=self.settings.get("mail_greeting"))
-        tk.Entry(
-            dialog, textvariable=greeting_var, width=35, font=FONT,
-            bg=CELL_BG, fg=TEXT, insertbackground=ACCENT,
-            relief=tk.FLAT, highlightbackground=TEXT_MUTED,
-            highlightcolor=ACCENT, highlightthickness=1
-        ).grid(row=11, column=1, padx=10, pady=4)
-
-        tk.Label(
-            dialog, text="Inhalt:", font=FONT, bg=BG, fg=TEXT
-        ).grid(row=12, column=0, padx=10, pady=4, sticky="nw")
-        content_text = tk.Text(
-            dialog, width=35, height=3, font=FONT,
-            bg=CELL_BG, fg=TEXT, insertbackground=ACCENT,
-            relief=tk.FLAT, highlightbackground=TEXT_MUTED,
-            highlightcolor=ACCENT, highlightthickness=1, wrap=tk.WORD
-        )
-        content_text.grid(row=12, column=1, padx=10, pady=4)
-        content_text.insert("1.0", self.settings.get("mail_content"))
-
-        tk.Label(
-            dialog, text="Gruß:", font=FONT, bg=BG, fg=TEXT
-        ).grid(row=13, column=0, padx=10, pady=4, sticky="nw")
-        closing_text = tk.Text(
-            dialog, width=35, height=2, font=FONT,
-            bg=CELL_BG, fg=TEXT, insertbackground=ACCENT,
-            relief=tk.FLAT, highlightbackground=TEXT_MUTED,
-            highlightcolor=ACCENT, highlightthickness=1, wrap=tk.WORD
-        )
-        closing_text.grid(row=13, column=1, padx=10, pady=4)
-        closing_text.insert("1.0", self.settings.get("mail_closing"))
-
-        tk.Label(
-            dialog, text="Platzhalter: {zeitraum}, {gesamt}", font=("Segoe UI", 8),
-            bg=BG, fg=TEXT_MUTED
-        ).grid(row=14, column=0, columnspan=2, padx=10, pady=(0, 4))
-
-        # Autostart
-        autostart_var = tk.BooleanVar(value=self.settings.get("autostart"))
-        tk.Checkbutton(
-            dialog, text="Autostart (minimiert bei Anmeldung)",
-            variable=autostart_var, font=FONT,
-            bg=BG, fg=TEXT, selectcolor=CELL_BG,
-            activebackground=BG, activeforeground=TEXT,
-            cursor="hand2"
-        ).grid(row=15, column=0, columnspan=2, padx=10, pady=8, sticky="w")
-
-        def save_settings():
-            ok, msg = validate_entry(start_var.get(), end_var.get())
-            if not ok:
-                messagebox.showerror("Standard-Arbeitszeit ungültig", msg, parent=dialog)
-                return
-
-            new_autostart = autostart_var.get()
-            old_autostart = self.settings.get("autostart")
-
-            if new_autostart != old_autostart:
-                try:
-                    if new_autostart:
-                        target, arguments = resolve_autostart_target(self.base_path)
-                        enable_autostart(target, arguments)
-                    else:
-                        disable_autostart()
-                    self.settings.set("autostart", new_autostart)
-                except Exception as e:
-                    messagebox.showerror(
-                        "Autostart-Fehler",
-                        f"Autostart konnte nicht geändert werden:\n{e}",
-                        parent=dialog,
-                    )
-                    return
-
-            self.settings.set("email", email_var.get())
-            self.settings.set("default_start", start_var.get())
-            self.settings.set("default_end", end_var.get())
-            self.settings.set("default_pause", int(pause_var.get()))
-            self.settings.set("recipient", recipient_var.get())
-            self.settings.set("name", name_var.get())
-            self.settings.set("mail_subject", subject_var.get())
-            self.settings.set("mail_greeting", greeting_var.get())
-            self.settings.set("mail_content", content_text.get("1.0", "end-1c"))
-            self.settings.set("mail_closing", closing_text.get("1.0", "end-1c"))
-            rate_str = rate_var.get().strip()
-            try:
-                self.settings.set("hourly_rate", float(rate_str) if rate_str else 0.0)
-            except ValueError:
-                self.settings.set("hourly_rate", 0.0)
-            self._refresh()
-            dialog.destroy()
-
-        btn_frame = tk.Frame(dialog, bg=BG)
-        btn_frame.grid(row=16, column=0, columnspan=2, pady=12)
-
-        tk.Button(
-            btn_frame, text="Speichern", command=save_settings, font=FONT_BOLD,
-            bg=ACCENT, fg="#ffffff",
-            activebackground="#c73550", activeforeground="#ffffff",
-            relief=tk.FLAT, padx=16, pady=4, cursor="hand2"
-        ).pack(side=tk.LEFT, padx=5)
-
-        tk.Button(
-            btn_frame, text="Abbrechen", command=dialog.destroy, font=FONT,
-            bg=CELL_BG, fg=TEXT,
-            activebackground=ENTRY_BG, activeforeground=TEXT,
-            relief=tk.FLAT, padx=16, pady=4, cursor="hand2"
-        ).pack(side=tk.LEFT, padx=5)
 
     def _refresh(self):
         if self.view_mode == "month":
@@ -587,7 +248,7 @@ class App:
 
         # Column headers
         for col, day_name in enumerate(DAYS_DE):
-            fg = TEXT_MUTED if col < 5 else "#6c6c80"
+            fg = TEXT_MUTED if col < 5 else WEEKEND_FG
             lbl = tk.Label(
                 new_frame, text=day_name, font=FONT_BOLD,
                 bg=BG, fg=fg
@@ -615,7 +276,7 @@ class App:
                 text = str(day)
                 fg = TEXT
                 if is_weekend and not entry:
-                    fg = "#6c6c80"
+                    fg = WEEKEND_FG
 
                 if entry:
                     pause = entry.get("pause", 0)
@@ -680,7 +341,7 @@ class App:
 
         # Column headers
         for col, day_name in enumerate(DAYS_DE):
-            fg = TEXT_MUTED if col < 5 else "#6c6c80"
+            fg = TEXT_MUTED if col < 5 else WEEKEND_FG
             lbl = tk.Label(
                 new_frame, text=day_name, font=FONT_BOLD,
                 bg=BG, fg=fg
@@ -700,7 +361,7 @@ class App:
 
             fg = TEXT
             if is_weekend and not entry:
-                fg = "#6c6c80"
+                fg = WEEKEND_FG
 
             if entry:
                 pause = entry.get("pause", 0)
@@ -773,332 +434,10 @@ class App:
             self._refresh()
 
     def _open_dialog(self, date_str):
-        dialog = tk.Toplevel(self.root)
-        dialog.title(date_str)
-        dialog.resizable(False, False)
-        dialog.grab_set()
-        dialog.configure(bg=BG)
-
-        entry = self.storage.get(date_str)
-
-        self._apply_combobox_style(dialog)
-
-        tk.Label(
-            dialog, text="Start:", font=FONT,
-            bg=BG, fg=TEXT
-        ).grid(row=0, column=0, padx=10, pady=8, sticky="w")
-
-        start_var = tk.StringVar(value=entry["start"] if entry else self.settings.get("default_start"))
-        start_cb = ttk.Combobox(
-            dialog, textvariable=start_var, values=TIME_VALUES,
-            width=8, font=FONT, style="Dark.TCombobox", state="readonly"
+        open_entry_dialog(
+            self.root, date_str, self.storage, self.settings,
+            on_change=self._refresh,
         )
-        start_cb.grid(row=0, column=1, padx=10, pady=8)
 
-        tk.Label(
-            dialog, text="Ende:", font=FONT,
-            bg=BG, fg=TEXT
-        ).grid(row=1, column=0, padx=10, pady=8, sticky="w")
-
-        end_var = tk.StringVar(value=entry["end"] if entry else self.settings.get("default_end"))
-        end_cb = ttk.Combobox(
-            dialog, textvariable=end_var, values=TIME_VALUES,
-            width=8, font=FONT, style="Dark.TCombobox", state="readonly"
-        )
-        end_cb.grid(row=1, column=1, padx=10, pady=8)
-
-        # Pause dropdown
-        tk.Label(
-            dialog, text="Pause (Min):", font=FONT,
-            bg=BG, fg=TEXT
-        ).grid(row=2, column=0, padx=10, pady=8, sticky="w")
-
-        default_pause = self.settings.get("default_pause")
-        if entry and "pause" in entry:
-            current_pause = str(entry["pause"])
-        else:
-            current_pause = str(default_pause) if not entry else "0"
-        pause_var = tk.StringVar(value=current_pause)
-
-        pause_cb = ttk.Combobox(
-            dialog, textvariable=pause_var, values=PAUSE_VALUES,
-            width=8, font=FONT, style="Dark.TCombobox", state="readonly"
-        )
-        pause_cb.grid(row=2, column=1, padx=10, pady=8)
-
-        def save():
-            ok, msg = validate_entry(start_var.get(), end_var.get(), pause_minutes=int(pause_var.get()))
-            if not ok:
-                messagebox.showerror("Fehler", msg, parent=dialog)
-                return
-            self.storage.save(date_str, start_var.get(), end_var.get(), pause=int(pause_var.get()))
-            dialog.destroy()
-            self._refresh()
-
-        def delete():
-            self.storage.delete(date_str)
-            dialog.destroy()
-            self._refresh()
-
-        btn_frame = tk.Frame(dialog, bg=BG)
-        btn_frame.grid(row=3, column=0, columnspan=2, pady=12)
-
-        tk.Button(
-            btn_frame, text="Speichern", command=save, font=FONT_BOLD,
-            bg=ACCENT, fg="#ffffff",
-            activebackground="#c73550", activeforeground="#ffffff",
-            relief=tk.FLAT, padx=16, pady=4, cursor="hand2"
-        ).pack(side=tk.LEFT, padx=5)
-
-        tk.Button(
-            btn_frame, text="Löschen", command=delete, font=FONT,
-            bg=CELL_BG, fg=TEXT,
-            activebackground=ENTRY_BG, activeforeground=TEXT,
-            relief=tk.FLAT, padx=16, pady=4, cursor="hand2"
-        ).pack(side=tk.LEFT, padx=5)
-
-    def _show_missing_credentials_dialog(self):
-        dialog = tk.Toplevel(self.root)
-        dialog.title("Keine Zugangsdaten")
-        dialog.resizable(False, False)
-        dialog.grab_set()
-        dialog.configure(bg=BG)
-
-        tk.Label(
-            dialog,
-            text=(
-                "credentials.json nicht gefunden.\n\n"
-                "Bitte erstelle ein Google Cloud Projekt mit Gmail API "
-                "und lade die OAuth2 Client-ID als credentials.json in "
-                "den Datenordner."
-            ),
-            font=FONT, bg=BG, fg=TEXT,
-            wraplength=380, justify="left",
-        ).grid(row=0, column=0, columnspan=2, padx=20, pady=(20, 12))
-
-        def open_and_close():
-            try:
-                open_folder(self.base_path)
-            except Exception as e:
-                messagebox.showerror(
-                    "Ordner konnte nicht geöffnet werden",
-                    f"{type(e).__name__}: {e}\n\n{traceback.format_exc()}",
-                    parent=dialog,
-                )
-                return
-            dialog.destroy()
-
-        btn_frame = tk.Frame(dialog, bg=BG)
-        btn_frame.grid(row=1, column=0, columnspan=2, pady=(0, 16))
-
-        tk.Button(
-            btn_frame, text="Datenordner öffnen", command=open_and_close,
-            font=FONT_BOLD, bg=ACCENT, fg="#ffffff",
-            activebackground="#c73550", activeforeground="#ffffff",
-            relief=tk.FLAT, padx=16, pady=4, cursor="hand2",
-        ).pack(side=tk.LEFT, padx=5)
-
-        tk.Button(
-            btn_frame, text="OK", command=dialog.destroy,
-            font=FONT, bg=CELL_BG, fg=TEXT,
-            activebackground=ENTRY_BG, activeforeground=TEXT,
-            relief=tk.FLAT, padx=16, pady=4, cursor="hand2",
-        ).pack(side=tk.LEFT, padx=5)
-
-    def _send_report(self):
-        recipient = self.settings.get("recipient")
-        if not recipient:
-            messagebox.showwarning(
-                "Kein Empfänger",
-                "Bitte zuerst einen Empfänger in den Einstellungen angeben.",
-                parent=self.root
-            )
-            return
-
-        credentials_path = os.path.join(self.base_path, "credentials.json")
-        token_path = os.path.join(self.base_path, "token.json")
-
-        if not os.path.exists(credentials_path):
-            self._show_missing_credentials_dialog()
-            return
-
-        # Date range dialog
-        dialog = tk.Toplevel(self.root)
-        dialog.title("Zeitraum wählen")
-        dialog.resizable(False, False)
-        dialog.grab_set()
-        dialog.configure(bg=BG)
-
-        self._apply_combobox_style(dialog)
-
-        today = datetime.date.today()
-        # Default: one month ago to today
-        if today.month == 1:
-            from_default = today.replace(year=today.year - 1, month=12)
-        else:
-            from_month = today.month - 1
-            from_year = today.year
-            max_day = calendar.monthrange(from_year, from_month)[1]
-            from_default = today.replace(month=from_month, day=min(today.day, max_day))
-        month_values = [str(m) for m in range(1, 13)]
-        year_values = [str(y) for y in range(2020, today.year + 2)]
-
-        def update_day_values(day_cb, day_var, month_var, year_var):
-            """Update day combobox values based on selected month/year."""
-            try:
-                m = int(month_var.get())
-                y = int(year_var.get())
-                max_day = calendar.monthrange(y, m)[1]
-            except (ValueError, KeyError):
-                max_day = 31
-            new_values = [str(d) for d in range(1, max_day + 1)]
-            day_cb["values"] = new_values
-            if int(day_var.get()) > max_day:
-                day_var.set(str(max_day))
-
-        # Von
-        tk.Label(
-            dialog, text="Von:", font=FONT, bg=BG, fg=TEXT
-        ).grid(row=0, column=0, padx=(10, 5), pady=8, sticky="w")
-
-        from_day_var = tk.StringVar(value=str(from_default.day))
-        from_max = calendar.monthrange(from_default.year, from_default.month)[1]
-        from_day_cb = ttk.Combobox(
-            dialog, textvariable=from_day_var,
-            values=[str(d) for d in range(1, from_max + 1)],
-            width=3, font=FONT, style="Dark.TCombobox", state="readonly"
-        )
-        from_day_cb.grid(row=0, column=1, padx=2, pady=8)
-
-        tk.Label(dialog, text=".", font=FONT, bg=BG, fg=TEXT).grid(row=0, column=2)
-
-        from_month_var = tk.StringVar(value=str(from_default.month))
-        from_month_cb = ttk.Combobox(
-            dialog, textvariable=from_month_var, values=month_values,
-            width=3, font=FONT, style="Dark.TCombobox", state="readonly"
-        )
-        from_month_cb.grid(row=0, column=3, padx=2, pady=8)
-
-        tk.Label(dialog, text=".", font=FONT, bg=BG, fg=TEXT).grid(row=0, column=4)
-
-        from_year_var = tk.StringVar(value=str(from_default.year))
-        from_year_cb = ttk.Combobox(
-            dialog, textvariable=from_year_var, values=year_values,
-            width=5, font=FONT, style="Dark.TCombobox", state="readonly"
-        )
-        from_year_cb.grid(row=0, column=5, padx=(2, 10), pady=8)
-
-        from_month_var.trace_add("write", lambda *_: update_day_values(from_day_cb, from_day_var, from_month_var, from_year_var))
-        from_year_var.trace_add("write", lambda *_: update_day_values(from_day_cb, from_day_var, from_month_var, from_year_var))
-
-        # Bis
-        tk.Label(
-            dialog, text="Bis:", font=FONT, bg=BG, fg=TEXT
-        ).grid(row=1, column=0, padx=(10, 5), pady=8, sticky="w")
-
-        to_day_var = tk.StringVar(value=str(today.day))
-        to_max = calendar.monthrange(today.year, today.month)[1]
-        to_day_cb = ttk.Combobox(
-            dialog, textvariable=to_day_var,
-            values=[str(d) for d in range(1, to_max + 1)],
-            width=3, font=FONT, style="Dark.TCombobox", state="readonly"
-        )
-        to_day_cb.grid(row=1, column=1, padx=2, pady=8)
-
-        tk.Label(dialog, text=".", font=FONT, bg=BG, fg=TEXT).grid(row=1, column=2)
-
-        to_month_var = tk.StringVar(value=str(today.month))
-        to_month_cb = ttk.Combobox(
-            dialog, textvariable=to_month_var, values=month_values,
-            width=3, font=FONT, style="Dark.TCombobox", state="readonly"
-        )
-        to_month_cb.grid(row=1, column=3, padx=2, pady=8)
-
-        tk.Label(dialog, text=".", font=FONT, bg=BG, fg=TEXT).grid(row=1, column=4)
-
-        to_year_var = tk.StringVar(value=str(today.year))
-        to_year_cb = ttk.Combobox(
-            dialog, textvariable=to_year_var, values=year_values,
-            width=5, font=FONT, style="Dark.TCombobox", state="readonly"
-        )
-        to_year_cb.grid(row=1, column=5, padx=(2, 10), pady=8)
-
-        to_month_var.trace_add("write", lambda *_: update_day_values(to_day_cb, to_day_var, to_month_var, to_year_var))
-        to_year_var.trace_add("write", lambda *_: update_day_values(to_day_cb, to_day_var, to_month_var, to_year_var))
-
-        def do_send():
-            try:
-                date_from = datetime.date(
-                    int(from_year_var.get()), int(from_month_var.get()), int(from_day_var.get())
-                )
-                date_to = datetime.date(
-                    int(to_year_var.get()), int(to_month_var.get()), int(to_day_var.get())
-                )
-            except ValueError:
-                messagebox.showerror("Ungültiges Datum", "Bitte ein gültiges Datum eingeben.", parent=dialog)
-                return
-
-            if date_from > date_to:
-                messagebox.showerror("Ungültiger Zeitraum", "Das Von-Datum muss vor dem Bis-Datum liegen.", parent=dialog)
-                return
-
-            entries = self.storage.get_all()
-
-            greeting = self.settings.get("mail_greeting")
-            content = self.settings.get("mail_content")
-            closing = self.settings.get("mail_closing")
-
-            html, total = generate_report(
-                date_from, date_to, entries,
-                greeting=greeting, content=content, closing=closing
-            )
-
-            if html is None:
-                messagebox.showinfo(
-                    "Keine Einträge",
-                    f"Keine Einträge für {date_from.strftime('%d.%m.%Y')} – {date_to.strftime('%d.%m.%Y')} vorhanden.",
-                    parent=dialog
-                )
-                return
-
-            label = f"{date_from.strftime('%d.%m.%Y')} – {date_to.strftime('%d.%m.%Y')}"
-
-            try:
-                pdf_bytes = generate_pdf(date_from, date_to, entries, name=self.settings.get("name"))
-                service = get_gmail_service(credentials_path, token_path)
-                subject_template = self.settings.get("mail_subject")
-                subject = subject_template.replace("{zeitraum}", label).replace("{gesamt}", f"{total}h")
-                pdf_filename = f"Zeiterfassung_{date_from.strftime('%Y%m%d')}_{date_to.strftime('%Y%m%d')}.pdf"
-                send_email(service, recipient, subject, html,
-                           pdf_bytes=pdf_bytes, pdf_filename=pdf_filename)
-                dialog.destroy()
-                messagebox.showinfo(
-                    "Gesendet",
-                    f"Bericht für {date_from.strftime('%d.%m.%Y')} – {date_to.strftime('%d.%m.%Y')} wurde an {recipient} gesendet.",
-                    parent=self.root
-                )
-            except FileNotFoundError as e:
-                messagebox.showerror("Fehler", str(e), parent=dialog)
-            except Exception as e:
-                messagebox.showerror(
-                    "Senden fehlgeschlagen",
-                    f"{type(e).__name__}: {e}\n\n{traceback.format_exc()}",
-                    parent=dialog
-                )
-
-        btn_frame = tk.Frame(dialog, bg=BG)
-        btn_frame.grid(row=2, column=0, columnspan=6, pady=12)
-
-        tk.Button(
-            btn_frame, text="Senden", command=do_send, font=FONT_BOLD,
-            bg=ACCENT, fg="#ffffff",
-            activebackground="#c73550", activeforeground="#ffffff",
-            relief=tk.FLAT, padx=16, pady=4, cursor="hand2"
-        ).pack(side=tk.LEFT, padx=5)
-
-        tk.Button(
-            btn_frame, text="Abbrechen", command=dialog.destroy, font=FONT,
-            bg=CELL_BG, fg=TEXT,
-            activebackground=ENTRY_BG, activeforeground=TEXT,
-            relief=tk.FLAT, padx=16, pady=4, cursor="hand2"
-        ).pack(side=tk.LEFT, padx=5)
+    def _send(self):
+        open_send_dialog(self.root, self.storage, self.settings, self.base_path)

--- a/src/ui.py
+++ b/src/ui.py
@@ -18,8 +18,9 @@ from src.dialogs.settings_dialog import open_settings_dialog
 from src.theme import (
     BG, CELL_BG, WEEKEND_BG, ACCENT, TEXT, TEXT_MUTED,
     ENTRY_BG, WEEKEND_ENTRY_BG, WEEKEND_FG,
-    FONT, FONT_SMALL, FONT_BOLD, FONT_HEADER, FONT_FOOTER,
+    FONT, FONT_BOLD, FONT_HEADER, FONT_FOOTER, FONT_SMALL,
     CELL_BG_HOVER, WEEKEND_BG_HOVER, ENTRY_BG_HOVER, WEEKEND_ENTRY_BG_HOVER,
+    icon_button, secondary_button, set_toggle_active, toggle_button,
 )
 
 DAYS_DE = ["Mo", "Di", "Mi", "Do", "Fr", "Sa", "So"]
@@ -103,51 +104,32 @@ class App:
         frame = tk.Frame(self.root, bg=BG)
         frame.pack(fill=tk.X, padx=10, pady=(10, 0))
 
-        tk.Button(
-            frame, text="‹", command=self._prev, width=3,
-            font=FONT_BOLD, bg=CELL_BG, fg=ACCENT,
-            activebackground=ENTRY_BG, activeforeground=ACCENT,
-            relief=tk.FLAT, cursor="hand2"
-        ).pack(side=tk.LEFT)
+        icon_button(frame, "\u2039", self._prev).pack(side=tk.LEFT)
 
-        # Toggle switch frame
         toggle_frame = tk.Frame(frame, bg=BG)
         toggle_frame.pack(side=tk.LEFT, padx=10)
 
-        self.btn_month = tk.Button(
-            toggle_frame, text="Monat", command=lambda: self._set_view("month"),
-            font=FONT_SMALL, width=6, relief=tk.FLAT, cursor="hand2",
-            bg=ACCENT, fg="#ffffff",
-            activebackground=ACCENT, activeforeground="#ffffff"
+        self.btn_month = toggle_button(
+            toggle_frame, "Monat", lambda: self._set_view("month"), active=True,
         )
         self.btn_month.pack(side=tk.LEFT, padx=(0, 1))
 
-        self.btn_week = tk.Button(
-            toggle_frame, text="Woche", command=lambda: self._set_view("week"),
-            font=FONT_SMALL, width=6, relief=tk.FLAT, cursor="hand2",
-            bg=CELL_BG, fg=TEXT_MUTED,
-            activebackground=ENTRY_BG, activeforeground=TEXT
+        self.btn_week = toggle_button(
+            toggle_frame, "Woche", lambda: self._set_view("week"), active=False,
         )
         self.btn_week.pack(side=tk.LEFT)
 
         self.header_label = tk.Label(
-            frame, text="", font=FONT_HEADER, bg=BG, fg="#ffffff"
+            frame, text="", font=FONT_HEADER, bg=BG, fg="#ffffff",
         )
         self.header_label.pack(side=tk.LEFT, expand=True)
 
-        tk.Button(
-            frame, text="⚙", command=self._open_settings, width=3,
-            font=FONT_BOLD, bg=CELL_BG, fg=TEXT_MUTED,
-            activebackground=ENTRY_BG, activeforeground=TEXT,
-            relief=tk.FLAT, cursor="hand2"
+        icon_button(
+            frame, "\u2699", self._open_settings,
+            fg=TEXT_MUTED, hover_fg=TEXT,
         ).pack(side=tk.RIGHT)
 
-        tk.Button(
-            frame, text="›", command=self._next, width=3,
-            font=FONT_BOLD, bg=CELL_BG, fg=ACCENT,
-            activebackground=ENTRY_BG, activeforeground=ACCENT,
-            relief=tk.FLAT, cursor="hand2"
-        ).pack(side=tk.RIGHT, padx=(0, 5))
+        icon_button(frame, "\u203a", self._next).pack(side=tk.RIGHT, padx=(0, 5))
 
     def _build_grid(self):
         self.grid_frame = tk.Frame(self.root, bg=BG)
@@ -163,11 +145,8 @@ class App:
         )
         self.footer_label.pack(side=tk.LEFT, expand=True)
 
-        tk.Button(
-            footer_frame, text="Monat senden", command=self._send,
-            font=FONT, bg=CELL_BG, fg=TEXT,
-            activebackground=ENTRY_BG, activeforeground=TEXT,
-            relief=tk.FLAT, padx=12, pady=4, cursor="hand2"
+        secondary_button(
+            footer_frame, "Monat senden", self._send, padx=12,
         ).pack(side=tk.RIGHT)
 
     def _prev(self):
@@ -216,12 +195,8 @@ class App:
         self._refresh()
 
     def _update_toggle_style(self):
-        if self.view_mode == "month":
-            self.btn_month.config(bg=ACCENT, fg="#ffffff", activebackground=ACCENT, activeforeground="#ffffff")
-            self.btn_week.config(bg=CELL_BG, fg=TEXT_MUTED, activebackground=ENTRY_BG, activeforeground=TEXT)
-        else:
-            self.btn_week.config(bg=ACCENT, fg="#ffffff", activebackground=ACCENT, activeforeground="#ffffff")
-            self.btn_month.config(bg=CELL_BG, fg=TEXT_MUTED, activebackground=ENTRY_BG, activeforeground=TEXT)
+        set_toggle_active(self.btn_month, self.view_mode == "month")
+        set_toggle_active(self.btn_week, self.view_mode == "week")
 
     def _open_settings(self):
         open_settings_dialog(

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,3 +1,6 @@
+import os
+from unittest import mock
+
 import pytest
 from src.storage import Storage
 
@@ -37,3 +40,40 @@ def test_save_default_pause_zero(tmp_storage):
     tmp_storage.save("2026-03-23", "08:00", "16:30")
     entry = tmp_storage.get("2026-03-23")
     assert entry == {"start": "08:00", "end": "16:30", "pause": 0}
+
+
+def test_corrupt_json_is_quarantined_and_starts_empty(tmp_path):
+    path = tmp_path / "test.json"
+    path.write_text("{not valid json", encoding="utf-8")
+
+    storage = Storage(str(path))
+
+    assert storage.get_all() == {}
+    quarantined = list(tmp_path.glob("test.json.corrupt-*"))
+    assert len(quarantined) == 1
+    assert quarantined[0].read_text(encoding="utf-8") == "{not valid json"
+
+
+def test_save_failure_keeps_original_file_intact(tmp_path):
+    path = tmp_path / "test.json"
+    storage = Storage(str(path))
+    storage.save("2026-03-23", "08:00", "16:30")
+    original_bytes = path.read_bytes()
+
+    with mock.patch("os.replace", side_effect=OSError("disk full")):
+        with pytest.raises(OSError):
+            storage.save("2026-03-24", "09:00", "17:00")
+
+    assert path.read_bytes() == original_bytes
+    leftovers = [p for p in tmp_path.iterdir() if p.suffix == ".tmp"]
+    assert leftovers == []
+
+
+def test_save_does_not_leave_tmp_files(tmp_path):
+    path = tmp_path / "test.json"
+    storage = Storage(str(path))
+    storage.save("2026-03-23", "08:00", "16:30")
+    storage.save("2026-03-24", "09:00", "17:00")
+
+    leftovers = [p.name for p in tmp_path.iterdir() if p.name.endswith(".tmp")]
+    assert leftovers == []

--- a/tests/test_ui_autostart_target.py
+++ b/tests/test_ui_autostart_target.py
@@ -1,7 +1,7 @@
 # tests/test_ui_autostart_target.py
 import sys
 import pytest
-from src.ui import resolve_autostart_target
+from src.autostart import resolve_autostart_target
 
 
 def test_repo_mode_returns_python_interpreter(monkeypatch):
@@ -15,7 +15,7 @@ def test_repo_mode_returns_python_interpreter(monkeypatch):
 def test_frozen_windows_uses_sys_executable(monkeypatch, tmp_path):
     monkeypatch.setattr(sys, "frozen", True, raising=False)
     monkeypatch.setattr(sys, "executable", str(tmp_path / "Zeiterfassung.exe"))
-    monkeypatch.setattr("src.ui.platform.system", lambda: "Windows")
+    monkeypatch.setattr("src.autostart.platform.system", lambda: "Windows")
     target, args = resolve_autostart_target("/ignored")
     assert target == str(tmp_path / "Zeiterfassung.exe")
     assert args == "--minimized"
@@ -24,7 +24,7 @@ def test_frozen_windows_uses_sys_executable(monkeypatch, tmp_path):
 def test_frozen_macos_uses_sys_executable(monkeypatch, tmp_path):
     monkeypatch.setattr(sys, "frozen", True, raising=False)
     monkeypatch.setattr(sys, "executable", str(tmp_path / "Zeiterfassung"))
-    monkeypatch.setattr("src.ui.platform.system", lambda: "Darwin")
+    monkeypatch.setattr("src.autostart.platform.system", lambda: "Darwin")
     target, args = resolve_autostart_target("/ignored")
     assert target == str(tmp_path / "Zeiterfassung")
     assert args == "--minimized"
@@ -33,7 +33,7 @@ def test_frozen_macos_uses_sys_executable(monkeypatch, tmp_path):
 def test_frozen_linux_prefers_appimage_env(monkeypatch):
     monkeypatch.setattr(sys, "frozen", True, raising=False)
     monkeypatch.setattr(sys, "executable", "/tmp/_MEIxxx/Zeiterfassung")
-    monkeypatch.setattr("src.ui.platform.system", lambda: "Linux")
+    monkeypatch.setattr("src.autostart.platform.system", lambda: "Linux")
     monkeypatch.setenv("APPIMAGE", "/home/u/Apps/Zeiterfassung.AppImage")
     target, args = resolve_autostart_target("/ignored")
     assert target == "/home/u/Apps/Zeiterfassung.AppImage"
@@ -43,7 +43,7 @@ def test_frozen_linux_prefers_appimage_env(monkeypatch):
 def test_frozen_linux_falls_back_to_sys_executable(monkeypatch, tmp_path):
     monkeypatch.setattr(sys, "frozen", True, raising=False)
     monkeypatch.setattr(sys, "executable", str(tmp_path / "Zeiterfassung"))
-    monkeypatch.setattr("src.ui.platform.system", lambda: "Linux")
+    monkeypatch.setattr("src.autostart.platform.system", lambda: "Linux")
     monkeypatch.delenv("APPIMAGE", raising=False)
     target, args = resolve_autostart_target("/ignored")
     assert target == str(tmp_path / "Zeiterfassung")


### PR DESCRIPTION
## Summary
- Atomic writes für `storage.py` mit Quarantäne-Pfad bei korrupten JSON-Dateien
- Aufspaltung der monolithischen `ui.py` in dedizierte Dialog-Module unter `src/dialogs/`
- Theme-Helper (`dark_combo`, `dark_entry`, `primary_button`, …) ersetzen per-Dialog-Style-Boilerplate

## Test plan
- [ ] Bestehende Tests grün
- [ ] Eintrag anlegen / bearbeiten / löschen funktioniert wie vorher
- [ ] Settings speichern und Mail-Versand funktionieren wie vorher
- [ ] Kein Versions-Bump, kein Release-Trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)