### PR TITLE
feat: gesetzliche Feiertage nach Bundesland (v1.8.0)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,5 +10,5 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
-      - run: pip install pytest
+      - run: pip install pytest holidays
       - run: pytest tests/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v1.8.0
+- Gesetzliche Feiertage werden im Monats- und Wochenkalender grün markiert, sobald in den Einstellungen ein Bundesland gewählt ist — Default „— kein Bundesland —" lässt das Verhalten für Bestandsnutzer unverändert
+- Tooltip beim Hover zeigt den vollen Feiertagsnamen, sobald der Name in der Zelle truncated ist
+- Beim Anlegen eines neuen Eintrags an einem Feiertag erscheint eine Bestätigungs-Warnung mit Datum und Feiertagsname (kein Hinweis beim Bearbeiten bestehender Einträge)
+- Tag mit Eintrag und Feiertag: rote Eintragszelle bleibt visuell dominant, Tooltip zeigt zusätzlich den Feiertagsnamen
+- Datenquelle: `python-holidays` (offline gebündelt, alle 16 Bundesländer)
+
 ## v1.7.0
 - Einstellungen: neue Sektion „Gmail-Zugangsdaten" am Anfang des Dialogs mit „Ordner öffnen"-Button und Live-Status (✓/✗) für `credentials.json` — kein Suchen mehr nach `~/Library/Application Support/Zeiterfassung` oder `%LOCALAPPDATA%\Programs\Zeiterfassung`
 - Sende-Fehler bei fehlender `credentials.json`: statt der Standard-Messagebox erscheint ein Dialog im Dark-Theme mit zwei Buttons („Datenordner öffnen" / „OK") — ein Klick öffnet das richtige Verzeichnis

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ Alternative: `src/version.py` auf die nächste Patch-Version bumpen und einen ne
 python build.py
 ```
 
-`build.py` ist ein Plattform-Dispatcher und ruft PyInstaller je nach `platform.system()` unterschiedlich auf. Auf allen drei Plattformen sind `--collect-all xhtml2pdf --collect-all reportlab` zwingend — ohne sie schlägt die PDF-Erzeugung im gebauten Artefakt stumm fehl.
+`build.py` ist ein Plattform-Dispatcher und ruft PyInstaller je nach `platform.system()` unterschiedlich auf. Auf allen drei Plattformen sind `--collect-all xhtml2pdf --collect-all reportlab --collect-all holidays` zwingend — ohne sie schlagen PDF-Erzeugung bzw. Feiertags-Lookup im gebauten Artefakt stumm fehl.
 
 ## Cross-Platform Builds
 
@@ -76,7 +76,7 @@ Damit Umlaute/ß nicht als Mojibake ankommen, gelten drei Pflichten:
 
 ## Tests / CI
 
-`.github/workflows/test.yml` installiert **nur** `pytest`, nicht `requirements.txt`. Grund: `pycairo` (transitive Dep von `xhtml2pdf`) braucht Cairo-Systemheader auf Ubuntu und bricht sonst den CI-Build. Der Import von `xhtml2pdf` in `src/report.py::generate_pdf` ist lazy, daher laufen die Report-Tests ohne die Lib.
+`.github/workflows/test.yml` installiert gezielt nur die Pakete, die die Tests brauchen (`pytest`, `holidays`), **nicht** `requirements.txt`. Grund: `pycairo` (transitive Dep von `xhtml2pdf`) braucht Cairo-Systemheader auf Ubuntu und bricht sonst den CI-Build. Der Import von `xhtml2pdf` in `src/report.py::generate_pdf` ist lazy, daher laufen die Report-Tests ohne die Lib. `holidays` ist pure Python ohne C-Deps und problemlos installierbar.
 
 Lokal: `pytest` aus dem Repo-Root. Alle Tests müssen vor dem PR-Merge grün sein.
 

--- a/build.py
+++ b/build.py
@@ -20,6 +20,7 @@ def _pyinstaller_common(extra_args):
         "--add-data", add_data,
         "--collect-all", "xhtml2pdf",
         "--collect-all", "reportlab",
+        "--collect-all", "holidays",
         *extra_args,
         "src/main.py",
     ]

--- a/docs/superpowers/plans/2026-04-27-feiertage.md
+++ b/docs/superpowers/plans/2026-04-27-feiertage.md
@@ -1,0 +1,811 @@
+# Gesetzliche Feiertage Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Im Kalender zeigt die App die gesetzlichen Feiertage des in den Einstellungen gewählten Bundeslandes (DE). Feiertage werden grün markiert, der Kurzname steht in der Zelle, Tooltip beim Hover zeigt den vollen Namen, Warnung beim Anlegen eines Eintrags am Feiertag.
+
+**Architecture:** Neues Modul `src/holidays_de.py` kapselt `python-holidays` mit `lru_cache`. Neues Modul `src/tooltip.py` für ein wiederverwendbares Tk-Tooltip-Widget. UI lädt Feiertage einmal pro Refresh und rendert eine dritte Zellen-Variante (grün) zwischen den bestehenden zwei (rote Eintragszelle / leere Zelle). Eintrag-Dialog warnt nur beim **Anlegen** (nicht beim Edit).
+
+**Tech Stack:** Python 3.10, Tkinter, [python-holidays](https://pypi.org/project/holidays/), pytest.
+
+**Spec:** `docs/superpowers/specs/2026-04-27-feiertage-design.md`
+
+---
+
+## Task 1: Pip-Dependency `holidays` ergänzen
+
+Vor allem anderen, sonst können Tests die Lib nicht importieren.
+
+**Files:**
+- Modify: `requirements.txt`
+- Modify: `.github/workflows/test.yml`
+
+- [ ] **Step 1: `requirements.txt` ergänzen**
+
+Datei aktuell:
+```
+google-auth-oauthlib>=1.0.0
+google-api-python-client>=2.0.0
+xhtml2pdf>=0.2.11
+pyinstaller>=6.0.0
+```
+
+Eine Zeile hinzufügen (kein Versions-Pin, analog Bestand):
+```
+holidays
+```
+
+- [ ] **Step 2: CI-Workflow erweitert `holidays` mitinstallieren**
+
+In `.github/workflows/test.yml`, Zeile 13 (`- run: pip install pytest`) ändern zu:
+```yaml
+      - run: pip install pytest holidays
+```
+
+`holidays` hat keine C-Deps und installiert in Sekunden — kein CI-Risiko (anders als `xhtml2pdf` wegen Cairo).
+
+- [ ] **Step 3: Lokal installieren und Import-Smoke-Test**
+
+```bash
+pip install holidays
+python -c "import holidays; print(holidays.Germany(subdiv='BY', years=2026)[__import__('datetime').date(2026, 10, 3)])"
+```
+Erwartung: `Tag der Deutschen Einheit`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add requirements.txt .github/workflows/test.yml
+git commit -m "deps: add python-holidays for state-aware German holidays"
+```
+
+---
+
+## Task 2: `src/holidays_de.py` mit Tests (TDD)
+
+Helper-Modul liefert die Feiertage und kapselt das Caching.
+
+**Files:**
+- Create: `src/holidays_de.py`
+- Test: `tests/test_holidays_de.py`
+
+- [ ] **Step 1: Failing-Test schreiben**
+
+Neue Datei `tests/test_holidays_de.py`:
+```python
+from datetime import date
+
+from src.holidays_de import STATES, get_holidays
+
+
+def test_states_list_starts_with_empty_option():
+    assert STATES[0] == ("", "— kein Bundesland —")
+
+
+def test_states_list_contains_all_16_bundeslaender():
+    codes = {code for code, _ in STATES if code}
+    expected = {
+        "BW", "BY", "BE", "BB", "HB", "HH", "HE", "MV",
+        "NI", "NW", "RP", "SL", "SN", "ST", "SH", "TH",
+    }
+    assert codes == expected
+
+
+def test_empty_state_returns_empty_dict():
+    assert get_holidays("", 2026) == {}
+
+
+def test_invalid_state_returns_empty_dict():
+    assert get_holidays("XX", 2026) == {}
+
+
+def test_bayern_has_heilige_drei_koenige():
+    h = get_holidays("BY", 2026)
+    assert date(2026, 1, 6) in h
+
+
+def test_berlin_has_frauentag_but_not_heilige_drei_koenige():
+    h = get_holidays("BE", 2026)
+    assert date(2026, 3, 8) in h
+    assert date(2026, 1, 6) not in h
+
+
+def test_tag_der_deutschen_einheit_in_every_state():
+    for code, _ in STATES:
+        if not code:
+            continue
+        assert date(2026, 10, 3) in get_holidays(code, 2026)
+```
+
+- [ ] **Step 2: Tests laufen lassen — alle FAIL**
+
+```bash
+pytest tests/test_holidays_de.py -v
+```
+Erwartung: `ModuleNotFoundError: No module named 'src.holidays_de'`
+
+- [ ] **Step 3: `src/holidays_de.py` schreiben**
+
+```python
+from datetime import date
+from functools import lru_cache
+
+# Code-Label-Paare. Reihenfolge alphabetisch nach Klartext-Label.
+STATES: list[tuple[str, str]] = [
+    ("", "— kein Bundesland —"),
+    ("BW", "Baden-Württemberg"),
+    ("BY", "Bayern"),
+    ("BE", "Berlin"),
+    ("BB", "Brandenburg"),
+    ("HB", "Bremen"),
+    ("HH", "Hamburg"),
+    ("HE", "Hessen"),
+    ("MV", "Mecklenburg-Vorpommern"),
+    ("NI", "Niedersachsen"),
+    ("NW", "Nordrhein-Westfalen"),
+    ("RP", "Rheinland-Pfalz"),
+    ("SL", "Saarland"),
+    ("SN", "Sachsen"),
+    ("ST", "Sachsen-Anhalt"),
+    ("SH", "Schleswig-Holstein"),
+    ("TH", "Thüringen"),
+]
+
+_VALID_CODES = {code for code, _ in STATES if code}
+
+
+@lru_cache(maxsize=64)
+def get_holidays(state_code: str, year: int) -> dict[date, str]:
+    """Liefert {date: name} für gewähltes Bundesland und Jahr.
+
+    Leerer oder ungültiger Code → leeres Dict (silent fallback,
+    damit ein versehentlich falsch gespeicherter Code keinen Crash auslöst).
+    """
+    if state_code not in _VALID_CODES:
+        return {}
+    import holidays
+    return dict(holidays.Germany(subdiv=state_code, years=year))
+```
+
+- [ ] **Step 4: Tests laufen lassen — alle PASS**
+
+```bash
+pytest tests/test_holidays_de.py -v
+```
+Erwartung: 7 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/holidays_de.py tests/test_holidays_de.py
+git commit -m "feat(holidays): state-aware DE holidays helper with cache"
+```
+
+---
+
+## Task 3: `src/tooltip.py` Widget
+
+Tk-Tooltip — ~30 Zeilen, manuell verifiziert. Tk hat nichts Eingebautes.
+
+**Files:**
+- Create: `src/tooltip.py`
+
+- [ ] **Step 1: `src/tooltip.py` schreiben**
+
+```python
+import tkinter as tk
+
+
+class _Tooltip:
+    """Hover-Tooltip an ein beliebiges Tk-Widget binden."""
+
+    def __init__(self, widget: tk.Widget, text: str):
+        self.widget = widget
+        self.text = text
+        self.tip: tk.Toplevel | None = None
+        widget.bind("<Enter>", self._show, add="+")
+        widget.bind("<Leave>", self._hide, add="+")
+
+    def _show(self, _event):
+        if self.tip is not None or not self.text:
+            return
+        x = self.widget.winfo_rootx() + 20
+        y = self.widget.winfo_rooty() + self.widget.winfo_height() + 4
+        self.tip = tk.Toplevel(self.widget)
+        self.tip.wm_overrideredirect(True)
+        self.tip.wm_geometry(f"+{x}+{y}")
+        tk.Label(
+            self.tip,
+            text=self.text,
+            background="#1e293b",
+            foreground="#e0e0e0",
+            relief="solid",
+            borderwidth=1,
+            padx=8,
+            pady=4,
+            font=("Segoe UI", 9),
+        ).pack()
+
+    def _hide(self, _event):
+        if self.tip is not None:
+            self.tip.destroy()
+            self.tip = None
+
+
+def attach_tooltip(widget: tk.Widget, text: str) -> None:
+    """Bindet ein Tooltip an widget. Mehrfachaufruf erzeugt mehrere Tooltips — Aufrufer ist verantwortlich, das nur einmal pro Widget zu tun."""
+    _Tooltip(widget, text)
+```
+
+- [ ] **Step 2: Smoke-Importtest laufen lassen**
+
+Nur dass das Modul importierbar ist:
+```bash
+python -c "from src.tooltip import attach_tooltip; print('ok')"
+```
+Erwartung: `ok`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/tooltip.py
+git commit -m "feat(ui): tk hover tooltip widget"
+```
+
+---
+
+## Task 4: Theme-Konstanten
+
+**Files:**
+- Modify: `src/theme.py:1-31` (oben im Datei, bei den anderen Farb-Konstanten)
+
+- [ ] **Step 1: `src/theme.py` editieren**
+
+Nach Zeile 27 (`WEEKEND_ENTRY_BG_HOVER = "#223e60"`), drei neue Konstanten einfügen:
+
+```python
+
+# Holiday cell colors (green analog to red ACCENT for entries)
+HOLIDAY_BG = "#0f3a2a"
+HOLIDAY_BG_HOVER = "#15523a"
+HOLIDAY_ACCENT = "#4ade80"  # gleicher Grünton wie STATUS_OK
+```
+
+- [ ] **Step 2: Importbarkeit checken**
+
+```bash
+python -c "from src.theme import HOLIDAY_BG, HOLIDAY_BG_HOVER, HOLIDAY_ACCENT; print(HOLIDAY_ACCENT)"
+```
+Erwartung: `#4ade80`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/theme.py
+git commit -m "feat(theme): green palette for holiday cells"
+```
+
+---
+
+## Task 5: Settings-Default
+
+**Files:**
+- Modify: `src/settings.py:4-17` (DEFAULTS-Dict)
+
+- [ ] **Step 1: Default ergänzen**
+
+`DEFAULTS` um `"state": ""` ergänzen, am Ende vor der schließenden Klammer (nach `"hourly_rate"`):
+
+```python
+DEFAULTS = {
+    "email": "",
+    "default_start": "08:00",
+    "default_end": "16:00",
+    "default_pause": 30,
+    "recipient": "",
+    "autostart": False,
+    "name": "",
+    "mail_subject": "Zeiterfassung — {zeitraum}",
+    "mail_greeting": "Sehr geehrte Damen und Herren,",
+    "mail_content": "anbei erhalten Sie meine Zeiterfassung für den Zeitraum {zeitraum}.",
+    "mail_closing": "Mit freundlichen Grüßen",
+    "hourly_rate": 0.0,
+    "state": "",
+}
+```
+
+- [ ] **Step 2: Default-Verhalten verifizieren**
+
+```bash
+python -c "from src.settings import DEFAULTS; assert DEFAULTS['state'] == ''; print('ok')"
+```
+Erwartung: `ok`
+
+`Settings._load` merged geladene JSON-Werte in eine Default-Kopie — alte `settings.json`-Dateien werden also automatisch um den Key ergänzt, kein Migrations-Code nötig.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/settings.py
+git commit -m "feat(settings): add 'state' key for selected Bundesland"
+```
+
+---
+
+## Task 6: Settings-Dialog Combobox
+
+Bundesland-Auswahl in den Einstellungen.
+
+**Files:**
+- Modify: `src/dialogs/settings_dialog.py`
+
+- [ ] **Step 1: Import ergänzen**
+
+In `src/dialogs/settings_dialog.py`, am Ende der Imports (nach Zeile 14 `from src.time_utils import validate_entry`):
+
+```python
+from src.holidays_de import STATES
+```
+
+- [ ] **Step 2: Combobox einfügen, alle nachfolgenden `row=`-Indizes inkrementieren**
+
+In Zeile ~98–104 steht der Stundenlohn-Block (row=8). Direkt **nach** dem Stundenlohn-Block (also vor der Mail-Vorlage-Sektion in Zeile 106) einfügen:
+
+```python
+    label("Bundesland:", row=9)
+    state_labels = [lbl for _, lbl in STATES]
+    current_code = settings.get("state")
+    current_label = next(
+        (lbl for code, lbl in STATES if code == current_code),
+        STATES[0][1],
+    )
+    state_var = tk.StringVar(value=current_label)
+    dark_combo(dialog, state_var, state_labels).grid(row=9, column=1, padx=10, pady=8)
+```
+
+Anschließend **alle nachfolgenden `row=`-Werte um 1 erhöhen**:
+- `row=9` (Mail-Vorlage-Header) → `row=10`
+- `row=10` (Betreff) → `row=11`
+- `row=11` (Anrede) → `row=12`
+- `row=12` (Inhalt) → `row=13`
+- `row=13` (Gruß) → `row=14`
+- `row=14` (Platzhalter-Hinweis) → `row=15`
+- `row=15` (Autostart-Checkbox) → `row=16`
+- `row=16` (Buttons) → `row=17`
+
+- [ ] **Step 3: Speichern-Logik ergänzen**
+
+In `save_settings()` (nach `settings.set("hourly_rate", ...)`, vor `on_change()`):
+
+```python
+        selected_label = state_var.get()
+        selected_code = next(
+            (code for code, lbl in STATES if lbl == selected_label),
+            "",
+        )
+        settings.set("state", selected_code)
+```
+
+- [ ] **Step 4: Manuell verifizieren**
+
+```bash
+python -m src.main
+```
+Settings öffnen → „Bundesland"-Dropdown vorhanden → Auswahl „Bayern" → Speichern → Settings-Dialog erneut öffnen → „Bayern" steht weiterhin drin.
+
+Auch `settings.json` checken: enthält jetzt `"state": "BY"`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/dialogs/settings_dialog.py
+git commit -m "feat(settings): Bundesland selector in settings dialog"
+```
+
+---
+
+## Task 7: Eintrag-Dialog Feiertags-Warnung
+
+Warnung nur beim **Anlegen** eines neuen Eintrags an einem Feiertag.
+
+**Files:**
+- Modify: `src/dialogs/entry_dialog.py`
+
+- [ ] **Step 1: Imports ergänzen**
+
+Aktuelle Imports (Zeile 1–8):
+```python
+import tkinter as tk
+from tkinter import messagebox
+
+from src.theme import (
+    BG, FONT, PAUSE_VALUES, TEXT, TIME_VALUES,
+    apply_combobox_style, dark_combo, primary_button, secondary_button,
+)
+from src.time_utils import validate_entry
+```
+
+Ergänzen:
+```python
+import datetime
+
+from src.holidays_de import get_holidays
+```
+
+- [ ] **Step 2: Holiday-Check in `save()` einbauen**
+
+In `save()` (Zeile 48–55):
+```python
+    def save():
+        ok, msg = validate_entry(start_var.get(), end_var.get(), pause_minutes=int(pause_var.get()))
+        if not ok:
+            messagebox.showerror("Fehler", msg, parent=dialog)
+            return
+        storage.save(date_str, start_var.get(), end_var.get(), pause=int(pause_var.get()))
+        dialog.destroy()
+        on_change()
+```
+
+Ersetzen durch:
+```python
+    def save():
+        ok, msg = validate_entry(start_var.get(), end_var.get(), pause_minutes=int(pause_var.get()))
+        if not ok:
+            messagebox.showerror("Fehler", msg, parent=dialog)
+            return
+
+        # Feiertags-Warnung nur beim Anlegen, nicht beim Edit (entry is None)
+        if entry is None:
+            state = settings.get("state")
+            if state:
+                day = datetime.date.fromisoformat(date_str)
+                feiertage = get_holidays(state, day.year)
+                if day in feiertage:
+                    date_de = day.strftime("%d.%m.%Y")
+                    confirm = messagebox.askyesno(
+                        "Feiertag",
+                        f"Der {date_de} ist {feiertage[day]} (Feiertag).\n\n"
+                        "Trotzdem Eintrag anlegen?",
+                        parent=dialog,
+                    )
+                    if not confirm:
+                        return
+
+        storage.save(date_str, start_var.get(), end_var.get(), pause=int(pause_var.get()))
+        dialog.destroy()
+        on_change()
+```
+
+`entry` ist die Variable aus Zeile 23 (`entry = storage.get(date_str)`). `entry is None` heißt: an diesem Datum existierte kein Eintrag, das ist also ein Anlegen.
+
+- [ ] **Step 3: Manuell verifizieren**
+
+Voraussetzung: `state` ist auf `BY` gesetzt (Bayern).
+
+1. App starten (`python -m src.main`).
+2. Auf den 6.1.2026 (Heilige Drei Könige in BY) klicken — Dialog öffnet sich.
+3. „Speichern" → es erscheint Warnung „Der 06.01.2026 ist Heilige Drei Könige (Feiertag)…".
+4. „Nein" → Dialog bleibt offen, kein Eintrag in `entries.json`.
+5. Erneut „Speichern", dieses Mal „Ja" → Eintrag wird gespeichert.
+6. Erneut auf den 6.1.2026 klicken → Dialog öffnet, dieses Mal **ohne** Warnung beim erneuten Speichern (weil `entry is not None`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/dialogs/entry_dialog.py
+git commit -m "feat(entry): warn when creating entry on a public holiday"
+```
+
+---
+
+## Task 8: `ui.py` — Helper, Holiday-Cell, Monatsansicht
+
+Drei-Fall-Render in `_refresh_month`. Helper für Truncation und Holiday-Zelle. Tooltip am Eintrag, der zugleich Feiertag ist.
+
+**Files:**
+- Modify: `src/ui.py`
+
+- [ ] **Step 1: Imports ergänzen**
+
+Aktuelle Imports (Zeile 1–24). Ergänzen:
+
+In Zeile 11 nach `from src.time_utils import …`:
+```python
+from src.holidays_de import get_holidays
+from src.tooltip import attach_tooltip
+```
+
+In den Theme-Import (Zeile 18–24) ergänzen:
+- `HOLIDAY_BG`, `HOLIDAY_BG_HOVER`, `HOLIDAY_ACCENT`
+
+So:
+```python
+from src.theme import (
+    BG, CELL_BG, WEEKEND_BG, ACCENT, TEXT, TEXT_MUTED,
+    ENTRY_BG, WEEKEND_ENTRY_BG, WEEKEND_FG,
+    HOLIDAY_BG, HOLIDAY_BG_HOVER, HOLIDAY_ACCENT,
+    FONT, FONT_BOLD, FONT_HEADER, FONT_FOOTER, FONT_SMALL,
+    CELL_BG_HOVER, WEEKEND_BG_HOVER, ENTRY_BG_HOVER, WEEKEND_ENTRY_BG_HOVER,
+    icon_button, secondary_button, set_toggle_active, toggle_button,
+)
+```
+
+- [ ] **Step 2: `_truncate` Helper als Klassenmethode**
+
+Direkt vor `_cell_hover` (Zeile 400, am Ende der Klasse) einfügen:
+```python
+    @staticmethod
+    def _truncate(text: str, max_len: int) -> str:
+        if len(text) <= max_len:
+            return text
+        return text[: max_len - 1] + "…"
+```
+
+- [ ] **Step 3: `_build_holiday_cell` Helper**
+
+Direkt nach `_truncate` einfügen — analog zur Eintragszelle, nur grün und mit Feiertagsname statt Zeit-Range:
+
+```python
+    def _build_holiday_cell(self, parent, day_text, name, max_name_len, on_click):
+        """Grüne Feiertagszelle. Layout analog zur Eintragszelle."""
+        cell = tk.Frame(
+            parent, bg=HOLIDAY_BG, relief=tk.SOLID,
+            highlightbackground=HOLIDAY_ACCENT, highlightthickness=1,
+            cursor="hand2",
+        )
+        day_lbl = tk.Label(
+            cell, text=day_text, font=FONT,
+            bg=HOLIDAY_BG, fg=TEXT, cursor="hand2",
+        )
+        day_lbl.pack(pady=(4, 0))
+        name_lbl = tk.Label(
+            cell, text=self._truncate(name, max_name_len),
+            font=FONT_SMALL, bg=HOLIDAY_BG, fg=TEXT_MUTED, cursor="hand2",
+        )
+        name_lbl.pack(pady=(0, 4))
+
+        for w in (cell, day_lbl, name_lbl):
+            w.bind("<Button-1>", lambda e: on_click())
+            w.bind("<Enter>", lambda e, c=cell, dl=day_lbl, nl=name_lbl:
+                self._cell_hover(c, dl, nl, HOLIDAY_BG_HOVER))
+            w.bind("<Leave>", lambda e, c=cell, dl=day_lbl, nl=name_lbl:
+                self._cell_hover(c, dl, nl, HOLIDAY_BG))
+            attach_tooltip(w, name)
+        return cell
+```
+
+- [ ] **Step 4: `_refresh_month` erweitern**
+
+In `_refresh_month` (Zeile 220–312), am Anfang vor der Schleife (nach `total_hours = 0.0`, Zeile ~236):
+
+```python
+        state = self.settings.get("state")
+        holidays_map = get_holidays(state, self.year) if state else {}
+```
+
+Innerhalb der Schleife (Zeile 246–294) wird der Branch umgebaut. Aktuell:
+```python
+                if entry:
+                    # ... rote Zelle ...
+                else:
+                    # ... leere Zelle ...
+```
+
+Wird zu:
+```python
+                day_date = datetime.date(self.year, self.month, day)
+
+                if entry:
+                    # ... unverändert: rote Zelle ...
+                    # NEU: am Ende der Eintrags-Branch, nach den Bind-Schleifen:
+                    if day_date in holidays_map:
+                        for w in (cell, day_lbl, time_lbl):
+                            attach_tooltip(w, f"Feiertag: {holidays_map[day_date]}")
+                elif day_date in holidays_map:
+                    cell = self._build_holiday_cell(
+                        new_frame,
+                        day_text=str(day),
+                        name=holidays_map[day_date],
+                        max_name_len=12,
+                        on_click=lambda d=date_str: self._open_dialog(d),
+                    )
+                else:
+                    # ... unverändert: leere Zelle ...
+```
+
+Konkret: in der bestehenden `if entry:`-Branch (Zeilen 256–281), unmittelbar **nach** der `for w in (cell, day_lbl, time_lbl):`-Schleife einfügen:
+```python
+                    if day_date in holidays_map:
+                        for w in (cell, day_lbl, time_lbl):
+                            attach_tooltip(w, f"Feiertag: {holidays_map[day_date]}")
+```
+
+Und der `else:`-Branch (Zeile 282) wird zu `elif day_date in holidays_map:` (mit dem `_build_holiday_cell`-Aufruf), gefolgt von einem neuen `else:` für die leere Zelle.
+
+`day_date` muss am Anfang der inneren Schleife (vor dem `if entry:`) definiert werden:
+```python
+                day_date = datetime.date(self.year, self.month, day)
+```
+
+- [ ] **Step 5: Smoke-Test (Tests laufen weiterhin grün)**
+
+```bash
+pytest tests/ -v
+```
+Erwartung: alle bestehenden Tests + die 7 aus Task 2 grün.
+
+- [ ] **Step 6: Manuell verifizieren — Monat**
+
+1. Settings: BL = Bayern.
+2. April 2026 anzeigen → 3.4. (Karfreitag) und 6.4. (Ostermontag) sind grün, mit verkürztem Namen, Tooltip beim Hover zeigt vollen Namen.
+3. Auf einen grünen Tag klicken → Eintrag-Dialog öffnet, beim Speichern Warnung.
+4. Settings: BL zurück auf „— kein Bundesland —" → keine grünen Zellen mehr.
+5. Settings: BL = Berlin → 8.3. (Frauentag, fällt 2026 auf einen Sonntag — visuell überlagert mit WEEKEND_BG, das ist okay) — wechsle zu März 2026 und prüfe.
+6. Tag mit Eintrag UND Feiertag (z.B. an Karfreitag einen Eintrag erstellen): rote Zelle wie bisher, Tooltip zeigt aber „Feiertag: Karfreitag".
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/ui.py
+git commit -m "feat(ui): green holiday cells in month view with tooltip"
+```
+
+---
+
+## Task 9: `ui.py` — Wochenansicht analog
+
+`_refresh_week` (Zeile 314–398) bekommt dieselbe Drei-Fall-Logik. ISO-Wochen können zwei Jahre überspannen — deshalb beide Jahre in `holidays_map` mergen.
+
+**Files:**
+- Modify: `src/ui.py:314-398`
+
+- [ ] **Step 1: Holidays für beide Jahre laden**
+
+Am Anfang von `_refresh_week`, vor der Schleife (nach Zeile 329 `spans = week_spans_months(...)`):
+
+```python
+        state = self.settings.get("state")
+        holidays_map: dict[datetime.date, str] = {}
+        if state:
+            for y in {dates[0].year, dates[-1].year}:
+                holidays_map.update(get_holidays(state, y))
+```
+
+- [ ] **Step 2: Schleife auf Drei-Fall-Render umbauen**
+
+Innerhalb der Schleife (Zeile 331–379) — in der bestehenden `if entry:`-Branch (Zeile 341–366), nach der `for w in (cell, day_lbl, time_lbl):`-Schleife:
+```python
+                if day_date in holidays_map:
+                    for w in (cell, day_lbl, time_lbl):
+                        attach_tooltip(w, f"Feiertag: {holidays_map[day_date]}")
+```
+
+Der `else:`-Branch (Zeile 367) wird zu:
+```python
+            elif day_date in holidays_map:
+                cell = self._build_holiday_cell(
+                    new_frame,
+                    day_text=day_text,
+                    name=holidays_map[day_date],
+                    max_name_len=18,
+                    on_click=lambda d=date_str: self._open_dialog(d),
+                )
+            else:
+                # ... unverändert: leere Zelle ...
+```
+
+Hinweis: in der Wochenansicht wird `day_date` bereits aus `dates[col]` abgeleitet (Zeile 331 `for col, day_date in enumerate(dates):`) — das `day_date` heißt im Loop tatsächlich so. Reuse.
+
+- [ ] **Step 3: Smoke-Test**
+
+```bash
+pytest tests/ -v
+```
+Erwartung: alle Tests grün.
+
+- [ ] **Step 4: Manuell verifizieren — Woche**
+
+1. Settings: BL = Bayern.
+2. Wochenansicht aktivieren, Karwoche 2026 (KW 14) anzeigen → 3.4. (Karfreitag) grün.
+3. KW über Jahresgrenze testen (z.B. KW 53 von 2026, falls anwendbar — sonst KW 1 von 2027 mit Neujahr) — Feiertag wird trotzdem grün gerendert.
+4. Tooltip funktioniert.
+5. Klick auf grünen Tag öffnet Dialog mit Warnung.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ui.py
+git commit -m "feat(ui): green holiday cells in week view"
+```
+
+---
+
+## Task 10: PyInstaller — `--collect-all holidays`
+
+Damit die Lib im gefrorenen Build die mitgelieferten Daten findet.
+
+**Files:**
+- Modify: `build.py:11-25`
+
+- [ ] **Step 1: `_pyinstaller_common` ergänzen**
+
+In `build.py`, in `_pyinstaller_common`, die `--collect-all`-Liste ergänzen:
+
+```python
+        "--collect-all", "xhtml2pdf",
+        "--collect-all", "reportlab",
+        "--collect-all", "holidays",
+```
+
+- [ ] **Step 2: Lokal Build testen (Windows)**
+
+```bash
+python build.py
+```
+Erwartung: Build durchläuft. `dist/Zeiterfassung.exe` (oder Setup.exe wenn Inno Setup vorhanden) wird erzeugt.
+
+- [ ] **Step 3: Manuell — gebaute App testen**
+
+`dist/Zeiterfassung.exe` (bzw. Setup) starten → Settings → BL = Bayern → 6.1.2026 ist grün im Kalender.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add build.py
+git commit -m "build: collect-all holidays for PyInstaller bundle"
+```
+
+---
+
+## Task 11: Final-Check & PR
+
+- [ ] **Step 1: Vollständiger Testlauf**
+
+```bash
+pytest tests/ -v
+```
+Erwartung: alle grün.
+
+- [ ] **Step 2: CLAUDE.md prüfen**
+
+Lies `CLAUDE.md` durch, ob in der „Tests / CI"-Sektion Updates nötig sind (z.B. Hinweis auf `holidays`-Dep im CI-Workflow). Falls ja: ergänzen, separat committen.
+
+- [ ] **Step 3: Branch pushen, PR erstellen**
+
+```bash
+git push -u origin feature/feiertage
+gh pr create --title "feat: gesetzliche Feiertage nach Bundesland" --body "$(cat <<'EOF'
+## Summary
+- Bundesland in den Einstellungen wählbar; Default leer (opt-in)
+- Feiertage des gewählten BL erscheinen grün im Monats- und Wochenraster
+- Tooltip beim Hover zeigt den vollen Feiertagsnamen
+- Beim Anlegen eines Eintrags an einem Feiertag erscheint eine Bestätigungs-Warnung
+- PDF-/Mail-Bericht bleibt unverändert (rein lokales UI-Feature)
+
+## Test plan
+- [ ] BL = Bayern: 6.1.2026, 3.4./6.4. (Ostern), 1.5., 3.10. grün
+- [ ] BL = Berlin: 8.3.2026 grün, 6.1. nicht
+- [ ] Default „kein BL": keine Feiertage
+- [ ] Eintrag an Feiertag → Warnung beim Speichern; bei „Ja" wird gespeichert (rote Zelle, Tooltip mit Feiertagsname)
+- [ ] Edit eines bestehenden Eintrags → keine Warnung
+- [ ] Wochenansicht: Feiertage analog
+- [ ] Wechsel BL im Settings-Dialog reflektiert sofort (kein Restart)
+- [ ] Gebauter PyInstaller-Build zeigt Feiertage (Daten sind gebündelt)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Hinweis: PR-Branch sitzt aktuell auf `ci/release-fixes`. Wenn dieser PR vorher merged wurde, sollte `feature/feiertage` per `git rebase master` auf das neue master rebased werden, bevor du den PR drüber öffnest — sonst sind die Refactor-Commits doppelt.
+
+Versions-Bump (`src/version.py`) und CHANGELOG-Eintrag werden in einem separaten Release-PR gebündelt — nicht hier.
+
+---
+
+## Out of scope (siehe Spec)
+
+- Andere Länder, Bayern-Sonderfälle (Mariä Himmelfahrt / Augsburg-Friedensfest), Schulferien.
+- Feiertage in PDF-/Mail-Bericht.
+- Stundenlohn-/Soll-Stunden-Anpassung.
+- Versions-Bump und CHANGELOG.

--- a/docs/superpowers/specs/2026-04-27-feiertage-design.md
+++ b/docs/superpowers/specs/2026-04-27-feiertage-design.md
@@ -1,0 +1,332 @@
+# Gesetzliche Feiertage (Deutschland, nach Bundesland) — Design Spec
+
+## Overview
+
+Die App soll im Kalender die gesetzlichen Feiertage des vom Nutzer gewählten Bundeslandes grün markieren und beim Hover den vollen Feiertagsnamen via Tooltip anzeigen. In der Zelle steht der Name in Kurzform (truncated) analog zur bestehenden Eintrags-Darstellung mit Zeit-Range.
+
+Standardverhalten: kein Bundesland gewählt → keine Feiertage sichtbar. Erst wenn der Nutzer in den Einstellungen sein Bundesland wählt, werden Feiertage angezeigt.
+
+Beim Versuch, an einem Feiertag einen **neuen** Eintrag anzulegen, erscheint eine Bestätigungs-Dialogbox. Bei Bestätigung wird der Eintrag normal gespeichert und visuell wie alle anderen Einträge dargestellt (rote Umrandung). Beim Bearbeiten eines bereits existierenden Eintrags an einem Feiertag erscheint **keine** Warnung.
+
+PDF-Bericht und HTML-Mail bleiben unverändert — Feiertage sind ein rein lokales UI-Feature.
+
+## Scope decisions
+
+| # | Decision | Consequence |
+|---|----------|-------------|
+| 1 | Datenquelle: `python-holidays` als neue Pip-Dep | Pure-Python, offline-fähig, alle 16 BL via `subdiv=`. Kein API-Call, kein Netzwerk-Risiko, kein Auth |
+| 2 | Default `state = ""` (leer) → keine Feiertage | Bestandsnutzer sehen ohne Aktion keine Änderung; opt-in Verhalten |
+| 3 | Keine Sub-Optionen pro Bundesland (z.B. Mariä Himmelfahrt für Bayern) | Wir liefern den Default der Lib pro `subdiv=`. Gemeindeabhängige Feiertage in BY werden nicht angezeigt — bewusste YAGNI-Entscheidung |
+| 4 | Konflikt Eintrag+Feiertag: Eintrag dominiert visuell | Rote Eintragszelle wie heute; Feiertagsname wandert in den Tooltip |
+| 5 | Warnung nur beim **Anlegen** eines Eintrags, nicht beim Edit | Edit eines bestehenden Eintrags soll nicht nerven |
+| 6 | Bericht (PDF/Mail) bleibt unverändert | Feiertage sind lokal; Empfänger sieht weiterhin nur gearbeitete Stunden |
+| 7 | Wochenansicht zeigt Feiertage analog zum Monat | Gleiche Render-Logik, nur höhere Zelle → mehr Platz für Namen |
+| 8 | Versions-Bump und CHANGELOG nicht Teil dieser Spec | Wird im Release-PR gebündelt |
+
+## Architektur
+
+Neues Modul `src/holidays_de.py` kapselt sämtliche Feiertags-Logik. UI-Code (`ui.py`, `entry_dialog.py`) konsumiert nur die Public-API.
+
+```
+src/holidays_de.py     ← Public API: STATES, get_holidays(state, year)
+src/tooltip.py         ← Wiederverwendbares Tk-Tooltip-Widget
+src/theme.py           ← +HOLIDAY_BG, HOLIDAY_BG_HOVER, HOLIDAY_ACCENT
+src/settings.py        ← +DEFAULTS["state"] = ""
+src/dialogs/settings_dialog.py  ← +Bundesland-Combobox
+src/dialogs/entry_dialog.py     ← +Feiertags-Warnung beim Anlegen
+src/ui.py              ← Drei-Fall-Render: Eintrag / Feiertag / leer
+```
+
+Datenfluss beim Refresh des Kalenders:
+
+```
+App._refresh_*()
+  → settings.get("state")               -- z.B. "BY"
+  → holidays_de.get_holidays(state, y)  -- {date: name}, gecached
+  → für jede Zelle:
+      if entry: rote Zelle (+ Tooltip falls auch Feiertag)
+      elif holiday: grüne Zelle + Tooltip
+      else: leere Zelle wie heute
+```
+
+## Implementation
+
+### `src/holidays_de.py` (neu)
+
+```python
+from datetime import date
+from functools import lru_cache
+
+# Code, Klartext-Label. Reihenfolge alphabetisch nach Label.
+STATES: list[tuple[str, str]] = [
+    ("", "— kein Bundesland —"),
+    ("BW", "Baden-Württemberg"),
+    ("BY", "Bayern"),
+    ("BE", "Berlin"),
+    ("BB", "Brandenburg"),
+    ("HB", "Bremen"),
+    ("HH", "Hamburg"),
+    ("HE", "Hessen"),
+    ("MV", "Mecklenburg-Vorpommern"),
+    ("NI", "Niedersachsen"),
+    ("NW", "Nordrhein-Westfalen"),
+    ("RP", "Rheinland-Pfalz"),
+    ("SL", "Saarland"),
+    ("SN", "Sachsen"),
+    ("ST", "Sachsen-Anhalt"),
+    ("SH", "Schleswig-Holstein"),
+    ("TH", "Thüringen"),
+]
+
+_VALID_CODES = {code for code, _ in STATES if code}
+
+
+@lru_cache(maxsize=64)
+def get_holidays(state_code: str, year: int) -> dict[date, str]:
+    """Liefert {date: name} für gewähltes BL und Jahr.
+
+    Leerer / ungültiger Code → leeres Dict (kein Fehler).
+    Lazy-Import von ``holidays`` damit der Test-Workflow ohne
+    die Lib weiterhin durchläuft.
+    """
+    if state_code not in _VALID_CODES:
+        return {}
+    import holidays
+    return dict(holidays.Germany(subdiv=state_code, years=year))
+```
+
+Lazy-Import-Begründung: `tests/test_holidays_de.py` testet die Helper-Logik (leerer Code, ungültiger Code) auch ohne `holidays`-Lib im CI-Image. Tests, die echte Daten prüfen, importieren die Lib transitiv.
+
+### `src/tooltip.py` (neu)
+
+Klassisches Tk-Tooltip mit `Toplevel`. ~30 Zeilen, gebunden an `<Enter>`/`<Leave>`.
+
+```python
+import tkinter as tk
+
+class _Tooltip:
+    def __init__(self, widget, text):
+        self.widget = widget
+        self.text = text
+        self.tip = None
+        widget.bind("<Enter>", self._show)
+        widget.bind("<Leave>", self._hide)
+
+    def _show(self, _event):
+        if self.tip or not self.text:
+            return
+        x = self.widget.winfo_rootx() + 20
+        y = self.widget.winfo_rooty() + self.widget.winfo_height() + 4
+        self.tip = tk.Toplevel(self.widget)
+        self.tip.wm_overrideredirect(True)
+        self.tip.wm_geometry(f"+{x}+{y}")
+        tk.Label(
+            self.tip, text=self.text, background="#1e293b",
+            foreground="#e0e0e0", relief="solid", borderwidth=1,
+            padx=8, pady=4, font=("Segoe UI", 9),
+        ).pack()
+
+    def _hide(self, _event):
+        if self.tip:
+            self.tip.destroy()
+            self.tip = None
+
+
+def attach_tooltip(widget, text: str) -> None:
+    """Bindet ein Tooltip an widget. Mehrfach-Aufruf ersetzt nicht — also nur einmal pro Widget."""
+    _Tooltip(widget, text)
+```
+
+### `src/theme.py`
+
+```python
+HOLIDAY_BG = "#0f3a2a"
+HOLIDAY_BG_HOVER = "#15523a"
+HOLIDAY_ACCENT = "#4ade80"   # gleicher Grünton wie STATUS_OK
+```
+
+### `src/settings.py`
+
+```python
+DEFAULTS = {
+    ...
+    "hourly_rate": 0.0,
+    "state": "",
+}
+```
+
+Keine Migration nötig: der `_load`-Pfad merged geladene Daten in eine Default-Kopie, neue Keys werden automatisch befüllt.
+
+### `src/dialogs/settings_dialog.py`
+
+Neue Combobox-Zeile zwischen „Stundenlohn" (row=8) und der Mail-Vorlage-Sektion (row=9 → wird zu row=10).
+
+```python
+from src.holidays_de import STATES
+
+label("Bundesland:", row=9)
+state_var = tk.StringVar(value=settings.get("state"))
+state_labels = [label for _, label in STATES]
+state_combo = dark_combo(dialog, state_var, state_labels)
+state_combo.grid(row=9, column=1, padx=10, pady=8)
+# Initiale Auswahl auf den passenden Label-Eintrag setzen
+current = settings.get("state")
+for code, lbl in STATES:
+    if code == current:
+        state_var.set(lbl)
+        break
+```
+
+In `save_settings()`:
+
+```python
+selected_label = state_var.get()
+selected_code = next((code for code, lbl in STATES if lbl == selected_label), "")
+settings.set("state", selected_code)
+```
+
+Alle nachfolgenden `row=`-Indizes (Mail-Vorlage, Buttons) um eins inkrementieren.
+
+### `src/dialogs/entry_dialog.py`
+
+Beim Speichern, **nur wenn ein neuer Eintrag** (kein bestehender unter `date_str`):
+
+```python
+state = settings.get("state")
+if state and not _is_existing_entry:
+    year = datetime.date.fromisoformat(date_str).year
+    feiertage = get_holidays(state, year)
+    holiday_date = datetime.date.fromisoformat(date_str)
+    if holiday_date in feiertage:
+        date_de = holiday_date.strftime("%d.%m.%Y")
+        ok = messagebox.askyesno(
+            "Feiertag",
+            f"Der {date_de} ist {feiertage[holiday_date]} (Feiertag).\n\n"
+            "Trotzdem Eintrag anlegen?",
+            parent=dialog,
+        )
+        if not ok:
+            return
+```
+
+`_is_existing_entry` wird beim Öffnen des Dialogs aus `storage.get(date_str) is not None` ermittelt und im Closure gehalten.
+
+### `src/ui.py`
+
+`_refresh_month` und `_refresh_week` holen vor der Schleife einmalig die Feiertage des angezeigten Jahres:
+
+```python
+state = self.settings.get("state")
+holidays_map = get_holidays(state, self.year) if state else {}
+```
+
+In der Schleife wird der bisherige Zwei-Fall-Branch (Eintrag / kein Eintrag) zu drei Fällen erweitert:
+
+```python
+day_date = datetime.date(self.year, self.month, day)
+
+if entry:
+    # bisherige rote Eintrags-Zelle, unverändert
+    cell = build_entry_cell(...)
+    if day_date in holidays_map:
+        attach_tooltip(cell, f"Feiertag: {holidays_map[day_date]}")
+elif day_date in holidays_map:
+    name = holidays_map[day_date]
+    short = _truncate(name, 12)  # für Monatsraster
+    cell = build_holiday_cell(day_text=str(day), short_name=short, ...)
+    attach_tooltip(cell, name)
+else:
+    # bisherige leere Zelle, unverändert
+    cell = build_empty_cell(...)
+```
+
+`build_holiday_cell` erstellt analog zur Eintrags-Zelle einen `Frame` mit `highlightbackground=HOLIDAY_ACCENT`, einem Tag-Label und einem zweiten Label mit dem Kurznamen. Click-Binding wie bei der leeren Zelle (öffnet `entry_dialog`).
+
+`_truncate(name, n)`: gibt `name` zurück, falls `len(name) <= n`, sonst `name[: n - 1] + "…"`.
+
+In `_refresh_week` analog mit `n=18` (mehr Platz vorhanden) und `day_date = dates[col]`.
+
+Falls der Monat über zwei Jahre reicht (Dezember-Render zeigt Januar-Tage in der ersten Woche → tut er aber bei `firstweekday=0` nicht, da `monthdayscalendar` keine Out-of-Month-Tage zurückgibt) — kein Sonderfall. In der Wochenansicht spannt eine ISO-Woche im Übergang Dezember/Januar zwei Jahre; dort beide Jahre laden:
+
+```python
+years = {dates[0].year, dates[-1].year}
+holidays_map: dict[date, str] = {}
+if state:
+    for y in years:
+        holidays_map.update(get_holidays(state, y))
+```
+
+### `requirements.txt`
+
+```
+holidays
+```
+
+(kein Versions-Pin, analog zu den bestehenden Einträgen)
+
+### `build.py`
+
+In allen drei Plattform-Pfaden `--collect-all holidays` zu den PyInstaller-Argumenten hinzufügen, neben den bestehenden `--collect-all xhtml2pdf --collect-all reportlab`. Begründung: `holidays` lädt Locale-/Daten-Module dynamisch, ohne `--collect-all` schlägt das im gefrorenen Build still fehl.
+
+## Tests
+
+Neue Datei `tests/test_holidays_de.py`:
+
+```python
+from datetime import date
+from src.holidays_de import get_holidays, STATES
+
+
+def test_empty_state_returns_empty_dict():
+    assert get_holidays("", 2026) == {}
+
+
+def test_invalid_state_returns_empty_dict():
+    assert get_holidays("XX", 2026) == {}
+
+
+def test_bayern_has_heilige_drei_koenige():
+    h = get_holidays("BY", 2026)
+    assert date(2026, 1, 6) in h
+
+
+def test_berlin_has_frauentag_but_not_heilige_drei_koenige():
+    h = get_holidays("BE", 2026)
+    assert date(2026, 3, 8) in h
+    assert date(2026, 1, 6) not in h
+
+
+def test_tag_der_deutschen_einheit_in_every_state():
+    for code, _ in STATES:
+        if not code:
+            continue
+        h = get_holidays(code, 2026)
+        assert date(2026, 10, 3) in h
+
+
+def test_states_list_starts_with_empty_option():
+    assert STATES[0] == ("", "— kein Bundesland —")
+```
+
+`tests/test_holidays_de.py` importiert `holidays` transitiv über den Helper. Damit der CI-Workflow (`.github/workflows/test.yml`, der nur `pytest` installiert) trotzdem grün bleibt: `holidays` als pip-Dep zum CI-Step hinzufügen, **oder** Tests, die echte Daten prüfen, mit `pytest.importorskip("holidays")` skipbar machen. Vorzug: Lib im CI installieren — ist klein und ohne C-Deps, anders als `xhtml2pdf`.
+
+Manuell zu verifizieren (kein Test):
+- Bundesland-Combobox im Settings-Dialog speichert/lädt korrekt
+- Feiertag erscheint nach BL-Wechsel ohne App-Restart
+- Tooltip beim Hover am Feiertags-Tag
+- Konflikt-Tag (Eintrag + Feiertag) zeigt rote Zelle und Tooltip
+- Warnung beim Anlegen eines neuen Eintrags am Feiertag
+- Keine Warnung beim Edit eines bestehenden Eintrags am Feiertag
+- Wochenansicht zeigt Feiertag analog
+- ISO-Woche im Jahresübergang lädt Feiertage beider Jahre
+
+## Out of scope
+
+- Andere Länder (Österreich, Schweiz). Aktuell Deutschland-only.
+- Bayern-Sonderfälle Mariä Himmelfahrt / Augsburg-Friedensfest.
+- Schulferien (separates Konzept, andere Datenquelle).
+- Feiertage im PDF-/Mail-Bericht.
+- Auto-Detect des Bundeslands über Locale.
+- Versions-Bump und CHANGELOG (kommt mit dem Release-PR).
+- Stundenlohn-/Soll-Stunden-Anpassung an Feiertagen.
+- Migration alter `settings.json` (greift automatisch über DEFAULTS).

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ google-auth-oauthlib>=1.0.0
 google-api-python-client>=2.0.0
 xhtml2pdf>=0.2.11
 pyinstaller>=6.0.0
+holidays

--- a/src/dialogs/entry_dialog.py
+++ b/src/dialogs/entry_dialog.py
@@ -1,6 +1,8 @@
+import datetime
 import tkinter as tk
 from tkinter import messagebox
 
+from src.holidays_de import get_holidays
 from src.theme import (
     BG, FONT, PAUSE_VALUES, TEXT, TIME_VALUES,
     apply_combobox_style, dark_combo, primary_button, secondary_button,
@@ -50,6 +52,24 @@ def open_entry_dialog(parent, date_str, storage, settings, on_change):
         if not ok:
             messagebox.showerror("Fehler", msg, parent=dialog)
             return
+
+        # Feiertags-Warnung nur beim Anlegen, nicht beim Edit (entry is None)
+        if entry is None:
+            state = settings.get("state")
+            if state:
+                day = datetime.date.fromisoformat(date_str)
+                feiertage = get_holidays(state, day.year)
+                if day in feiertage:
+                    date_de = day.strftime("%d.%m.%Y")
+                    confirm = messagebox.askyesno(
+                        "Feiertag",
+                        f"Der {date_de} ist {feiertage[day]} (Feiertag).\n\n"
+                        "Trotzdem Eintrag anlegen?",
+                        parent=dialog,
+                    )
+                    if not confirm:
+                        return
+
         storage.save(date_str, start_var.get(), end_var.get(), pause=int(pause_var.get()))
         dialog.destroy()
         on_change()

--- a/src/dialogs/settings_dialog.py
+++ b/src/dialogs/settings_dialog.py
@@ -11,6 +11,7 @@ from src.theme import (
     apply_combobox_style, dark_combo, dark_entry, dark_text,
     primary_button, secondary_button,
 )
+from src.holidays_de import STATES
 from src.time_utils import validate_entry
 
 
@@ -103,32 +104,42 @@ def open_settings_dialog(parent, settings, base_path, on_change):
         bg=BG, fg=TEXT_MUTED,
     ).grid(row=8, column=1, padx=(120, 10), pady=8, sticky="w")
 
+    label("Bundesland:", row=9)
+    state_labels = [lbl for _, lbl in STATES]
+    current_code = settings.get("state")
+    current_label = next(
+        (lbl for code, lbl in STATES if code == current_code),
+        STATES[0][1],
+    )
+    state_var = tk.StringVar(value=current_label)
+    dark_combo(dialog, state_var, state_labels).grid(row=9, column=1, padx=10, pady=8)
+
     tk.Label(
         dialog, text="— Mail-Vorlage —", font=FONT_BOLD, bg=BG, fg=TEXT_MUTED,
-    ).grid(row=9, column=0, columnspan=2, padx=10, pady=(16, 4))
+    ).grid(row=10, column=0, columnspan=2, padx=10, pady=(16, 4))
 
-    label("Betreff:", row=10, pady=4)
+    label("Betreff:", row=11, pady=4)
     subject_var = tk.StringVar(value=settings.get("mail_subject"))
-    dark_entry(dialog, subject_var, width=35).grid(row=10, column=1, padx=10, pady=4)
+    dark_entry(dialog, subject_var, width=35).grid(row=11, column=1, padx=10, pady=4)
 
-    label("Anrede:", row=11, pady=4)
+    label("Anrede:", row=12, pady=4)
     greeting_var = tk.StringVar(value=settings.get("mail_greeting"))
-    dark_entry(dialog, greeting_var, width=35).grid(row=11, column=1, padx=10, pady=4)
+    dark_entry(dialog, greeting_var, width=35).grid(row=12, column=1, padx=10, pady=4)
 
-    label("Inhalt:", row=12, pady=4, sticky="nw")
+    label("Inhalt:", row=13, pady=4, sticky="nw")
     content_text = dark_text(dialog, 35, 3)
-    content_text.grid(row=12, column=1, padx=10, pady=4)
+    content_text.grid(row=13, column=1, padx=10, pady=4)
     content_text.insert("1.0", settings.get("mail_content"))
 
-    label("Gruß:", row=13, pady=4, sticky="nw")
+    label("Gruß:", row=14, pady=4, sticky="nw")
     closing_text = dark_text(dialog, 35, 2)
-    closing_text.grid(row=13, column=1, padx=10, pady=4)
+    closing_text.grid(row=14, column=1, padx=10, pady=4)
     closing_text.insert("1.0", settings.get("mail_closing"))
 
     tk.Label(
         dialog, text="Platzhalter: {zeitraum}, {gesamt}", font=("Segoe UI", 8),
         bg=BG, fg=TEXT_MUTED,
-    ).grid(row=14, column=0, columnspan=2, padx=10, pady=(0, 4))
+    ).grid(row=15, column=0, columnspan=2, padx=10, pady=(0, 4))
 
     autostart_var = tk.BooleanVar(value=settings.get("autostart"))
     tk.Checkbutton(
@@ -137,7 +148,7 @@ def open_settings_dialog(parent, settings, base_path, on_change):
         bg=BG, fg=TEXT, selectcolor=CELL_BG,
         activebackground=BG, activeforeground=TEXT,
         cursor="hand2",
-    ).grid(row=15, column=0, columnspan=2, padx=10, pady=8, sticky="w")
+    ).grid(row=16, column=0, columnspan=2, padx=10, pady=8, sticky="w")
 
     def save_settings():
         ok, msg = validate_entry(start_var.get(), end_var.get())
@@ -179,11 +190,17 @@ def open_settings_dialog(parent, settings, base_path, on_change):
             settings.set("hourly_rate", float(rate_str) if rate_str else 0.0)
         except ValueError:
             settings.set("hourly_rate", 0.0)
+        selected_label = state_var.get()
+        selected_code = next(
+            (code for code, lbl in STATES if lbl == selected_label),
+            "",
+        )
+        settings.set("state", selected_code)
         on_change()
         dialog.destroy()
 
     btn_frame = tk.Frame(dialog, bg=BG)
-    btn_frame.grid(row=16, column=0, columnspan=2, pady=12)
+    btn_frame.grid(row=17, column=0, columnspan=2, pady=12)
 
     primary_button(btn_frame, "Speichern", save_settings).pack(side=tk.LEFT, padx=5)
     secondary_button(btn_frame, "Abbrechen", dialog.destroy).pack(side=tk.LEFT, padx=5)

--- a/src/dialogs/settings_dialog.py
+++ b/src/dialogs/settings_dialog.py
@@ -112,7 +112,7 @@ def open_settings_dialog(parent, settings, base_path, on_change):
         STATES[0][1],
     )
     state_var = tk.StringVar(value=current_label)
-    dark_combo(dialog, state_var, state_labels).grid(row=9, column=1, padx=10, pady=8)
+    dark_combo(dialog, state_var, state_labels, width=22).grid(row=9, column=1, padx=10, pady=8)
 
     tk.Label(
         dialog, text="— Mail-Vorlage —", font=FONT_BOLD, bg=BG, fg=TEXT_MUTED,

--- a/src/holidays_de.py
+++ b/src/holidays_de.py
@@ -26,13 +26,20 @@ _VALID_CODES = {code for code, _ in STATES if code}
 
 
 @lru_cache(maxsize=64)
+def _holidays_cached(state_code: str, year: int) -> dict[date, str]:
+    import holidays
+    return dict(holidays.Germany(subdiv=state_code, years=year))
+
+
 def get_holidays(state_code: str, year: int) -> dict[date, str]:
     """Liefert {date: name} für gewähltes Bundesland und Jahr.
 
     Leerer oder ungültiger Code → leeres Dict (silent fallback,
     damit ein versehentlich falsch gespeicherter Code keinen Crash auslöst).
+
+    Rückgabe ist immer ein frisches Dict; Mutationen durch Aufrufer können
+    den internen Cache nicht vergiften.
     """
     if state_code not in _VALID_CODES:
         return {}
-    import holidays
-    return dict(holidays.Germany(subdiv=state_code, years=year))
+    return dict(_holidays_cached(state_code, year))

--- a/src/holidays_de.py
+++ b/src/holidays_de.py
@@ -1,0 +1,38 @@
+from datetime import date
+from functools import lru_cache
+
+# Code-Label-Paare. Reihenfolge alphabetisch nach Klartext-Label.
+STATES: list[tuple[str, str]] = [
+    ("", "— kein Bundesland —"),
+    ("BW", "Baden-Württemberg"),
+    ("BY", "Bayern"),
+    ("BE", "Berlin"),
+    ("BB", "Brandenburg"),
+    ("HB", "Bremen"),
+    ("HH", "Hamburg"),
+    ("HE", "Hessen"),
+    ("MV", "Mecklenburg-Vorpommern"),
+    ("NI", "Niedersachsen"),
+    ("NW", "Nordrhein-Westfalen"),
+    ("RP", "Rheinland-Pfalz"),
+    ("SL", "Saarland"),
+    ("SN", "Sachsen"),
+    ("ST", "Sachsen-Anhalt"),
+    ("SH", "Schleswig-Holstein"),
+    ("TH", "Thüringen"),
+]
+
+_VALID_CODES = {code for code, _ in STATES if code}
+
+
+@lru_cache(maxsize=64)
+def get_holidays(state_code: str, year: int) -> dict[date, str]:
+    """Liefert {date: name} für gewähltes Bundesland und Jahr.
+
+    Leerer oder ungültiger Code → leeres Dict (silent fallback,
+    damit ein versehentlich falsch gespeicherter Code keinen Crash auslöst).
+    """
+    if state_code not in _VALID_CODES:
+        return {}
+    import holidays
+    return dict(holidays.Germany(subdiv=state_code, years=year))

--- a/src/settings.py
+++ b/src/settings.py
@@ -14,6 +14,7 @@ DEFAULTS = {
     "mail_content": "anbei erhalten Sie meine Zeiterfassung für den Zeitraum {zeitraum}.",
     "mail_closing": "Mit freundlichen Grüßen",
     "hourly_rate": 0.0,
+    "state": "",
 }
 
 class Settings:

--- a/src/theme.py
+++ b/src/theme.py
@@ -26,6 +26,11 @@ WEEKEND_BG_HOVER = "#153a6e"
 ENTRY_BG_HOVER = "#224a70"
 WEEKEND_ENTRY_BG_HOVER = "#223e60"
 
+# Holiday cell colors (green analog to red ACCENT for entries)
+HOLIDAY_BG = "#0f3a2a"
+HOLIDAY_BG_HOVER = "#15523a"
+HOLIDAY_ACCENT = "#4ade80"  # gleicher Grünton wie STATUS_OK
+
 # Time dropdown values (5-min steps, 00:00 - 23:55)
 TIME_VALUES = [f"{h:02d}:{m:02d}" for h in range(24) for m in range(0, 60, 5)]
 PAUSE_VALUES = [str(m) for m in range(0, 125, 5)]

--- a/src/tooltip.py
+++ b/src/tooltip.py
@@ -1,0 +1,42 @@
+import tkinter as tk
+
+
+class _Tooltip:
+    """Hover-Tooltip an ein beliebiges Tk-Widget binden."""
+
+    def __init__(self, widget: tk.Widget, text: str):
+        self.widget = widget
+        self.text = text
+        self.tip: tk.Toplevel | None = None
+        widget.bind("<Enter>", self._show, add="+")
+        widget.bind("<Leave>", self._hide, add="+")
+
+    def _show(self, _event):
+        if self.tip is not None or not self.text:
+            return
+        x = self.widget.winfo_rootx() + 20
+        y = self.widget.winfo_rooty() + self.widget.winfo_height() + 4
+        self.tip = tk.Toplevel(self.widget)
+        self.tip.wm_overrideredirect(True)
+        self.tip.wm_geometry(f"+{x}+{y}")
+        tk.Label(
+            self.tip,
+            text=self.text,
+            background="#1e293b",
+            foreground="#e0e0e0",
+            relief="solid",
+            borderwidth=1,
+            padx=8,
+            pady=4,
+            font=("Segoe UI", 9),
+        ).pack()
+
+    def _hide(self, _event):
+        if self.tip is not None:
+            self.tip.destroy()
+            self.tip = None
+
+
+def attach_tooltip(widget: tk.Widget, text: str) -> None:
+    """Bindet ein Tooltip an widget. Mehrfachaufruf erzeugt mehrere Tooltips — Aufrufer ist verantwortlich, das nur einmal pro Widget zu tun."""
+    _Tooltip(widget, text)

--- a/src/ui.py
+++ b/src/ui.py
@@ -345,6 +345,11 @@ class App:
         entries = self.storage.get_all()
         total_hours = 0.0
         spans = week_spans_months(self.iso_year, self.current_week)
+        state = self.settings.get("state")
+        holidays_map: dict[datetime.date, str] = {}
+        if state:
+            for y in {dates[0].year, dates[-1].year}:
+                holidays_map.update(get_holidays(state, y))
 
         for col, day_date in enumerate(dates):
             date_str = day_date.isoformat()
@@ -382,6 +387,17 @@ class App:
                     w.bind("<Button-3>", lambda e, d=date_str: self._delete_entry(d))
                     w.bind("<Enter>", lambda e, c=cell, dl=day_lbl, tl=time_lbl, hb=hover_bg: self._cell_hover(c, dl, tl, hb))
                     w.bind("<Leave>", lambda e, c=cell, dl=day_lbl, tl=time_lbl, ob=bg: self._cell_hover(c, dl, tl, ob))
+                if day_date in holidays_map:
+                    for w in (cell, day_lbl, time_lbl):
+                        attach_tooltip(w, f"Feiertag: {holidays_map[day_date]}")
+            elif day_date in holidays_map:
+                cell = self._build_holiday_cell(
+                    new_frame,
+                    day_text=day_text,
+                    name=holidays_map[day_date],
+                    max_name_len=18,
+                    on_click=lambda d=date_str: self._open_dialog(d),
+                )
             else:
                 bg = WEEKEND_BG if is_weekend else CELL_BG
                 hover_bg = WEEKEND_BG_HOVER if is_weekend else CELL_BG_HOVER

--- a/src/ui.py
+++ b/src/ui.py
@@ -471,6 +471,9 @@ class App:
             cell, text=truncated,
             font=FONT_SMALL, bg=HOLIDAY_BG, fg=TEXT_MUTED, cursor="hand2",
         )
+        if cell_size is not None:
+            # Pixel-fixierte Zelle: Text bei Bedarf umbrechen, nicht horizontal überstehen.
+            name_lbl.config(wraplength=cell_size[0] - 6, justify="center")
         name_lbl.pack(pady=(0, 4))
 
         is_truncated = truncated != name

--- a/src/ui.py
+++ b/src/ui.py
@@ -9,6 +9,8 @@ import platform
 import threading
 import traceback
 from src.time_utils import calculate_hours, get_week_dates, get_week_label, week_spans_months
+from src.holidays_de import get_holidays
+from src.tooltip import attach_tooltip
 from src.mail import refresh_token_if_needed, TokenAuthError, TokenNetworkError
 from src.version import VERSION
 
@@ -18,6 +20,7 @@ from src.dialogs.settings_dialog import open_settings_dialog
 from src.theme import (
     BG, CELL_BG, WEEKEND_BG, ACCENT, TEXT, TEXT_MUTED,
     ENTRY_BG, WEEKEND_ENTRY_BG, WEEKEND_FG,
+    HOLIDAY_BG, HOLIDAY_BG_HOVER, HOLIDAY_ACCENT,
     FONT, FONT_BOLD, FONT_HEADER, FONT_FOOTER, FONT_SMALL,
     CELL_BG_HOVER, WEEKEND_BG_HOVER, ENTRY_BG_HOVER, WEEKEND_ENTRY_BG_HOVER,
     icon_button, secondary_button, set_toggle_active, toggle_button,
@@ -235,6 +238,9 @@ class App:
         entries = self.storage.get_all()
         total_hours = 0.0
 
+        state = self.settings.get("state")
+        holidays_map = get_holidays(state, self.year) if state else {}
+
         for row, week in enumerate(cal.monthdayscalendar(self.year, self.month), start=1):
             for col, day in enumerate(week):
                 if day == 0:
@@ -247,6 +253,7 @@ class App:
                 date_str = f"{self.year}-{self.month:02d}-{day:02d}"
                 entry = entries.get(date_str)
                 is_weekend = col >= 5
+                day_date = datetime.date(self.year, self.month, day)
 
                 text = str(day)
                 fg = TEXT
@@ -279,6 +286,17 @@ class App:
                         w.bind("<Button-3>", lambda e, d=date_str: self._delete_entry(d))
                         w.bind("<Enter>", lambda e, c=cell, dl=day_lbl, tl=time_lbl, hb=hover_bg: self._cell_hover(c, dl, tl, hb))
                         w.bind("<Leave>", lambda e, c=cell, dl=day_lbl, tl=time_lbl, ob=bg: self._cell_hover(c, dl, tl, ob))
+                    if day_date in holidays_map:
+                        for w in (cell, day_lbl, time_lbl):
+                            attach_tooltip(w, f"Feiertag: {holidays_map[day_date]}")
+                elif day_date in holidays_map:
+                    cell = self._build_holiday_cell(
+                        new_frame,
+                        day_text=str(day),
+                        name=holidays_map[day_date],
+                        max_name_len=12,
+                        on_click=lambda d=date_str: self._open_dialog(d),
+                    )
                 else:
                     bg = WEEKEND_BG if is_weekend else CELL_BG
                     hover_bg = WEEKEND_BG_HOVER if is_weekend else CELL_BG_HOVER
@@ -396,6 +414,39 @@ class App:
             )
         else:
             self.footer_label.config(text=f"Gesamt: {round(total_hours, 2)}h")
+
+    @staticmethod
+    def _truncate(text: str, max_len: int) -> str:
+        if len(text) <= max_len:
+            return text
+        return text[: max_len - 1] + "…"
+
+    def _build_holiday_cell(self, parent, day_text, name, max_name_len, on_click):
+        """Grüne Feiertagszelle. Layout analog zur Eintragszelle."""
+        cell = tk.Frame(
+            parent, bg=HOLIDAY_BG, relief=tk.SOLID,
+            highlightbackground=HOLIDAY_ACCENT, highlightthickness=1,
+            cursor="hand2",
+        )
+        day_lbl = tk.Label(
+            cell, text=day_text, font=FONT,
+            bg=HOLIDAY_BG, fg=TEXT, cursor="hand2",
+        )
+        day_lbl.pack(pady=(4, 0))
+        name_lbl = tk.Label(
+            cell, text=self._truncate(name, max_name_len),
+            font=FONT_SMALL, bg=HOLIDAY_BG, fg=TEXT_MUTED, cursor="hand2",
+        )
+        name_lbl.pack(pady=(0, 4))
+
+        for w in (cell, day_lbl, name_lbl):
+            w.bind("<Button-1>", lambda e: on_click())
+            w.bind("<Enter>", lambda e, c=cell, dl=day_lbl, nl=name_lbl:
+                self._cell_hover(c, dl, nl, HOLIDAY_BG_HOVER))
+            w.bind("<Leave>", lambda e, c=cell, dl=day_lbl, nl=name_lbl:
+                self._cell_hover(c, dl, nl, HOLIDAY_BG))
+            attach_tooltip(w, name)
+        return cell
 
     @staticmethod
     def _cell_hover(frame, day_lbl, time_lbl, bg):

--- a/src/ui.py
+++ b/src/ui.py
@@ -351,6 +351,14 @@ class App:
             for y in {dates[0].year, dates[-1].year}:
                 holidays_map.update(get_holidays(state, y))
 
+        # Probe-Label, um die natürliche Pixel-Größe einer Standard-Wochenzelle
+        # zu ermitteln. Holiday-Zellen werden auf diese Größe fixiert, damit
+        # längere Feiertagsnamen die Spalte nicht aufweiten.
+        probe = tk.Label(new_frame, text="", font=FONT, width=8, height=5)
+        probe.update_idletasks()
+        cell_size = (probe.winfo_reqwidth(), probe.winfo_reqheight())
+        probe.destroy()
+
         for col, day_date in enumerate(dates):
             date_str = day_date.isoformat()
             entry = entries.get(date_str)
@@ -397,6 +405,7 @@ class App:
                     name=holidays_map[day_date],
                     max_name_len=18,
                     on_click=lambda d=date_str: self._open_dialog(d),
+                    cell_size=cell_size,
                 )
             else:
                 bg = WEEKEND_BG if is_weekend else CELL_BG
@@ -437,31 +446,42 @@ class App:
             return text
         return text[: max_len - 1] + "…"
 
-    def _build_holiday_cell(self, parent, day_text, name, max_name_len, on_click):
-        """Grüne Feiertagszelle. Layout analog zur Eintragszelle."""
+    def _build_holiday_cell(self, parent, day_text, name, max_name_len, on_click, cell_size=None):
+        """Grüne Feiertagszelle. Layout analog zur Eintragszelle.
+
+        cell_size: optional (width_px, height_px). Wenn gesetzt, wird der Frame
+        auf diese Pixel-Größe fixiert (verhindert Aufweitung der Spalte durch
+        längere Namen — relevant für die Wochenansicht).
+        """
         cell = tk.Frame(
             parent, bg=HOLIDAY_BG, relief=tk.SOLID,
             highlightbackground=HOLIDAY_ACCENT, highlightthickness=1,
             cursor="hand2",
         )
+        if cell_size is not None:
+            cell.config(width=cell_size[0], height=cell_size[1])
+            cell.pack_propagate(False)
         day_lbl = tk.Label(
             cell, text=day_text, font=FONT,
             bg=HOLIDAY_BG, fg=TEXT, cursor="hand2",
         )
         day_lbl.pack(pady=(4, 0))
+        truncated = self._truncate(name, max_name_len)
         name_lbl = tk.Label(
-            cell, text=self._truncate(name, max_name_len),
+            cell, text=truncated,
             font=FONT_SMALL, bg=HOLIDAY_BG, fg=TEXT_MUTED, cursor="hand2",
         )
         name_lbl.pack(pady=(0, 4))
 
+        is_truncated = truncated != name
         for w in (cell, day_lbl, name_lbl):
             w.bind("<Button-1>", lambda e: on_click())
             w.bind("<Enter>", lambda e, c=cell, dl=day_lbl, nl=name_lbl:
                 self._cell_hover(c, dl, nl, HOLIDAY_BG_HOVER))
             w.bind("<Leave>", lambda e, c=cell, dl=day_lbl, nl=name_lbl:
                 self._cell_hover(c, dl, nl, HOLIDAY_BG))
-            attach_tooltip(w, name)
+            if is_truncated:
+                attach_tooltip(w, name)
         return cell
 
     @staticmethod

--- a/src/version.py
+++ b/src/version.py
@@ -1,1 +1,1 @@
-VERSION = "1.7.0"
+VERSION = "1.8.0"

--- a/tests/test_holidays_de.py
+++ b/tests/test_holidays_de.py
@@ -40,3 +40,10 @@ def test_tag_der_deutschen_einheit_in_every_state():
         if not code:
             continue
         assert date(2026, 10, 3) in get_holidays(code, 2026)
+
+
+def test_returned_dict_is_independent_copy():
+    h1 = get_holidays("BY", 2026)
+    h1[date(2099, 1, 1)] = "MUTATION"
+    h2 = get_holidays("BY", 2026)
+    assert date(2099, 1, 1) not in h2

--- a/tests/test_holidays_de.py
+++ b/tests/test_holidays_de.py
@@ -1,0 +1,42 @@
+from datetime import date
+
+from src.holidays_de import STATES, get_holidays
+
+
+def test_states_list_starts_with_empty_option():
+    assert STATES[0] == ("", "— kein Bundesland —")
+
+
+def test_states_list_contains_all_16_bundeslaender():
+    codes = {code for code, _ in STATES if code}
+    expected = {
+        "BW", "BY", "BE", "BB", "HB", "HH", "HE", "MV",
+        "NI", "NW", "RP", "SL", "SN", "ST", "SH", "TH",
+    }
+    assert codes == expected
+
+
+def test_empty_state_returns_empty_dict():
+    assert get_holidays("", 2026) == {}
+
+
+def test_invalid_state_returns_empty_dict():
+    assert get_holidays("XX", 2026) == {}
+
+
+def test_bayern_has_heilige_drei_koenige():
+    h = get_holidays("BY", 2026)
+    assert date(2026, 1, 6) in h
+
+
+def test_berlin_has_frauentag_but_not_heilige_drei_koenige():
+    h = get_holidays("BE", 2026)
+    assert date(2026, 3, 8) in h
+    assert date(2026, 1, 6) not in h
+
+
+def test_tag_der_deutschen_einheit_in_every_state():
+    for code, _ in STATES:
+        if not code:
+            continue
+        assert date(2026, 10, 3) in get_holidays(code, 2026)


### PR DESCRIPTION
## Summary
- Bundesland in den Einstellungen wählbar; Default leer (opt-in für Bestandsnutzer)
- Feiertage des gewählten BL erscheinen grün im Monats- und Wochenraster
- Tooltip beim Hover zeigt den vollen Feiertagsnamen, wenn der Name in der Zelle truncated ist
- Beim Anlegen eines Eintrags an einem Feiertag erscheint eine Bestätigungs-Warnung
- PDF-/Mail-Bericht bleibt unverändert (rein lokales UI-Feature)
- Datenquelle: `python-holidays` (offline gebündelt, alle 16 Bundesländer)

Implementation folgt Spec `docs/superpowers/specs/2026-04-27-feiertage-design.md` und Plan `docs/superpowers/plans/2026-04-27-feiertage.md`.

## Test plan
- [ ] BL = Bayern: 6.1., Karfreitag/Ostermontag, 1.5., 3.10. grün
- [ ] BL = Berlin: 8.3. (Frauentag) grün, 6.1. nicht
- [ ] Default „kein BL": keine Feiertage
- [ ] Eintrag an Feiertag → Warnung beim Speichern, bei „Ja" wird gespeichert (rote Zelle, Tooltip mit Feiertagsname)
- [ ] Edit eines bestehenden Eintrags → keine Warnung
- [ ] Wochenansicht: Feiertage analog, Spaltenbreite konstant (auch bei langen Namen)
- [ ] Tooltip nur wenn Name truncated
- [ ] BL-Wechsel im Settings reflektiert sofort im Kalender (kein Restart)
- [ ] Gebauter PyInstaller-Build zeigt Feiertage (Daten gebündelt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)