### PR TITLE
fix: deutsche Feiertagsnamen statt englischer Defaults (v1.8.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v1.8.1
+- Feiertagsnamen erscheinen jetzt korrekt auf Deutsch (z.B. „Tag der Deutschen Einheit" statt „German Unity Day"). `python-holidays` wird mit `language="de"` aufgerufen — vorher griff der englische Default
+
 ## v1.8.0
 - Gesetzliche Feiertage werden im Monats- und Wochenkalender grün markiert, sobald in den Einstellungen ein Bundesland gewählt ist — Default „— kein Bundesland —" lässt das Verhalten für Bestandsnutzer unverändert
 - Tooltip beim Hover zeigt den vollen Feiertagsnamen, sobald der Name in der Zelle truncated ist

--- a/src/holidays_de.py
+++ b/src/holidays_de.py
@@ -28,7 +28,7 @@ _VALID_CODES = {code for code, _ in STATES if code}
 @lru_cache(maxsize=64)
 def _holidays_cached(state_code: str, year: int) -> dict[date, str]:
     import holidays
-    return dict(holidays.Germany(subdiv=state_code, years=year))
+    return dict(holidays.Germany(subdiv=state_code, years=year, language="de"))
 
 
 def get_holidays(state_code: str, year: int) -> dict[date, str]:

--- a/src/version.py
+++ b/src/version.py
@@ -1,1 +1,1 @@
-VERSION = "1.8.0"
+VERSION = "1.8.1"

--- a/tests/test_holidays_de.py
+++ b/tests/test_holidays_de.py
@@ -42,6 +42,12 @@ def test_tag_der_deutschen_einheit_in_every_state():
         assert date(2026, 10, 3) in get_holidays(code, 2026)
 
 
+def test_holiday_names_are_german():
+    h = get_holidays("BY", 2026)
+    assert h[date(2026, 10, 3)] == "Tag der Deutschen Einheit"
+    assert h[date(2026, 1, 6)] == "Heilige Drei Könige"
+
+
 def test_returned_dict_is_independent_copy():
     h1 = get_holidays("BY", 2026)
     h1[date(2099, 1, 1)] = "MUTATION"


### PR DESCRIPTION
## Summary
- `python-holidays` wurde ohne `language=` aufgerufen und verwendete den englischen Default („German Unity Day", „Epiphany", …)
- Mit `language=\"de\"` liefert die Lib jetzt korrekt „Tag der Deutschen Einheit", „Heilige Drei Könige", „Christi Himmelfahrt" usw.
- Regressionstest `test_holiday_names_are_german` prüft die Lokalisierung explizit

## Test plan
- [ ] BL = Bayern: 3.10. heißt „Tag der Deutschen Einheit", 6.1. „Heilige Drei Könige"
- [ ] Restliche Tests grün (98 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)