### PR TITLE
fix: doppelter Tooltip an Holiday-Zellen (v1.8.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v1.8.2
+- Doppelter Tooltip an Feiertags-/Eintragszellen behoben: `attach_tooltip` wird jetzt nur am äußersten Frame gebunden und erkennt beim Pointer-Übergang in Child-Widgets, dass die Maus weiterhin im Cluster ist (keine Re-Open-Stacking)
+
 ## v1.8.1
 - Feiertagsnamen erscheinen jetzt korrekt auf Deutsch (z.B. „Tag der Deutschen Einheit" statt „German Unity Day"). `python-holidays` wird mit `language="de"` aufgerufen — vorher griff der englische Default
 

--- a/src/tooltip.py
+++ b/src/tooltip.py
@@ -2,16 +2,28 @@ import tkinter as tk
 
 
 class _Tooltip:
-    """Hover-Tooltip an ein beliebiges Tk-Widget binden."""
+    """Hover-Tooltip an ein beliebiges Tk-Widget binden.
+
+    Tk feuert ``<Leave>`` auch dann, wenn der Pointer in ein Child-Widget
+    wandert. Damit der Tooltip in dem Fall nicht aufflackert, wird das
+    Schließen kurz verzögert und nur ausgeführt, wenn der Pointer
+    tatsächlich außerhalb des Bind-Widgets steht.
+    """
+
+    _CLOSE_DELAY_MS = 80
 
     def __init__(self, widget: tk.Widget, text: str):
         self.widget = widget
         self.text = text
         self.tip: tk.Toplevel | None = None
+        self._close_after_id: str | None = None
         widget.bind("<Enter>", self._show, add="+")
-        widget.bind("<Leave>", self._hide, add="+")
+        widget.bind("<Leave>", self._on_leave, add="+")
 
     def _show(self, _event):
+        if self._close_after_id is not None:
+            self.widget.after_cancel(self._close_after_id)
+            self._close_after_id = None
         if self.tip is not None or not self.text:
             return
         x = self.widget.winfo_rootx() + 20
@@ -31,10 +43,27 @@ class _Tooltip:
             font=("Segoe UI", 9),
         ).pack()
 
-    def _hide(self, _event):
-        if self.tip is not None:
-            self.tip.destroy()
-            self.tip = None
+    def _on_leave(self, _event):
+        if self._close_after_id is not None:
+            self.widget.after_cancel(self._close_after_id)
+        self._close_after_id = self.widget.after(
+            self._CLOSE_DELAY_MS, self._maybe_close
+        )
+
+    def _maybe_close(self):
+        self._close_after_id = None
+        if self.tip is None:
+            return
+        # Pointer immer noch über dem Widget (z.B. in einem Child)? Dann offen lassen.
+        x, y = self.widget.winfo_pointerxy()
+        wx = self.widget.winfo_rootx()
+        wy = self.widget.winfo_rooty()
+        ww = self.widget.winfo_width()
+        wh = self.widget.winfo_height()
+        if wx <= x < wx + ww and wy <= y < wy + wh:
+            return
+        self.tip.destroy()
+        self.tip = None
 
 
 def attach_tooltip(widget: tk.Widget, text: str) -> None:

--- a/src/ui.py
+++ b/src/ui.py
@@ -287,8 +287,7 @@ class App:
                         w.bind("<Enter>", lambda e, c=cell, dl=day_lbl, tl=time_lbl, hb=hover_bg: self._cell_hover(c, dl, tl, hb))
                         w.bind("<Leave>", lambda e, c=cell, dl=day_lbl, tl=time_lbl, ob=bg: self._cell_hover(c, dl, tl, ob))
                     if day_date in holidays_map:
-                        for w in (cell, day_lbl, time_lbl):
-                            attach_tooltip(w, f"Feiertag: {holidays_map[day_date]}")
+                        attach_tooltip(cell, f"Feiertag: {holidays_map[day_date]}")
                 elif day_date in holidays_map:
                     cell = self._build_holiday_cell(
                         new_frame,
@@ -396,8 +395,7 @@ class App:
                     w.bind("<Enter>", lambda e, c=cell, dl=day_lbl, tl=time_lbl, hb=hover_bg: self._cell_hover(c, dl, tl, hb))
                     w.bind("<Leave>", lambda e, c=cell, dl=day_lbl, tl=time_lbl, ob=bg: self._cell_hover(c, dl, tl, ob))
                 if day_date in holidays_map:
-                    for w in (cell, day_lbl, time_lbl):
-                        attach_tooltip(w, f"Feiertag: {holidays_map[day_date]}")
+                    attach_tooltip(cell, f"Feiertag: {holidays_map[day_date]}")
             elif day_date in holidays_map:
                 cell = self._build_holiday_cell(
                     new_frame,
@@ -476,15 +474,16 @@ class App:
             name_lbl.config(wraplength=cell_size[0] - 6, justify="center")
         name_lbl.pack(pady=(0, 4))
 
-        is_truncated = truncated != name
         for w in (cell, day_lbl, name_lbl):
             w.bind("<Button-1>", lambda e: on_click())
             w.bind("<Enter>", lambda e, c=cell, dl=day_lbl, nl=name_lbl:
                 self._cell_hover(c, dl, nl, HOLIDAY_BG_HOVER))
             w.bind("<Leave>", lambda e, c=cell, dl=day_lbl, nl=name_lbl:
                 self._cell_hover(c, dl, nl, HOLIDAY_BG))
-            if is_truncated:
-                attach_tooltip(w, name)
+        if truncated != name:
+            # Nur am äußersten Frame binden, sonst gleichzeitige Tooltips, weil
+            # Tk Enter-Events an Frame und Child unabhängig schickt.
+            attach_tooltip(cell, name)
         return cell
 
     @staticmethod

--- a/src/version.py
+++ b/src/version.py
@@ -1,1 +1,1 @@
-VERSION = "1.8.1"
+VERSION = "1.8.2"


### PR DESCRIPTION
## Summary
- Tooltip wurde an Frame **und** allen Child-Labels gebunden — Tk feuert `<Enter>` für jedes davon, sichtbar als zwei (oder mehr) gleichzeitig offene Tooltips
- Fix: nur am äußersten Frame binden. `_Tooltip._on_leave` schließt jetzt mit ~80 ms Delay und prüft via `winfo_pointerxy()`, ob der Pointer noch im Widget (inkl. Children) ist — Übergang Frame→Child schließt den Tooltip nicht mehr fälschlich

## Test plan
- [ ] Hover über Feiertagszelle: genau ein Tooltip
- [ ] Maus-Bewegung über Tag-Nummer und Name-Label im Frame: Tooltip bleibt offen, kein Flicker
- [ ] Konflikt-Tag (Eintrag + Feiertag): genau ein „Feiertag: …"-Tooltip
- [ ] Beim Verlassen der Zelle nach links/rechts/oben/unten: Tooltip schließt zügig (max ~80 ms)
- [ ] 98 Tests grün

🤖 Generated with [Claude Code](https://claude.com/claude-code)