### PR TITLE
feat(ui): pfeiltasten navigieren monat/woche

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v1.8.3
+- Pfeiltasten `<Left>` / `<Right>` navigieren im Hauptfenster durch Monate bzw. Wochen — analog zu den `‹`/`›` Buttons im Header. Modal-Dialoge fangen die Tasten automatisch ab, sodass `<Left>`/`<Right>` in Eingabefeldern weiterhin den Cursor bewegen
+
 ## v1.8.2
 - Doppelter Tooltip an Feiertags-/Eintragszellen behoben: `attach_tooltip` wird jetzt nur am äußersten Frame gebunden und erkennt beim Pointer-Übergang in Child-Widgets, dass die Maus weiterhin im Cluster ist (keine Re-Open-Stacking)
 

--- a/docs/superpowers/plans/2026-04-27-arrow-key-navigation.md
+++ b/docs/superpowers/plans/2026-04-27-arrow-key-navigation.md
@@ -1,0 +1,105 @@
+# Arrow-Key Navigation (Monat/Woche) Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Im Hauptfenster mit `<Left>` / `<Right>` durch Monate bzw. Wochen navigieren — analog zu den `‹`/`›` Icon-Buttons im Header.
+
+**Architecture:** Zwei `bind`-Aufrufe am Root-Fenster in `App.__init__`. Die View-abhängige Logik (Monat vs. Woche) lebt unverändert in den existierenden `_prev`/`_next`-Methoden. Modal-Dialoge nutzen alle `grab_set()` und fangen Tastenevents automatisch ab — kein expliziter Focus-Tracking-Code nötig.
+
+**Tech Stack:** Tkinter (stdlib). Keine neuen Dependencies.
+
+**Spec reference:** `docs/superpowers/specs/2026-04-27-arrow-key-navigation-design.md`
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `src/ui.py` | Modify | Zwei `bind`-Aufrufe in `App.__init__` nach `_build_footer()` ergänzen |
+
+Keine neuen Dateien. Keine Tests (Tk-Mainloop-Bindings unter pytest fummelig; `_prev`/`_next` selbst ändern sich nicht — manuelle Verifikation ist die richtige Wahl).
+
+---
+
+## Chunk 1: Pfeiltasten-Bindings ergänzen
+
+### Task 1: Bindings am Root-Fenster registrieren
+
+**Files:**
+- Modify: `src/ui.py` (`App.__init__`, Zeilen 71–75)
+
+Diese Task hat keine automatisierten Tests. Verifikation: `python -m pytest -v` (keine Regressionen). Manueller Smoke-Test ist Sache des Controllers.
+
+- [ ] **Step 1: Edit anwenden**
+
+In `src/ui.py::App.__init__` finde den folgenden Block (aktuell Zeilen 71–75):
+
+```python
+        self._build_header()
+        self._build_grid()
+        self._build_footer()
+        self._refresh()
+        self._proactive_token_refresh()
+```
+
+Ersetze ihn durch:
+
+```python
+        self._build_header()
+        self._build_grid()
+        self._build_footer()
+        self.root.bind("<Left>", lambda e: self._prev())
+        self.root.bind("<Right>", lambda e: self._next())
+        self._refresh()
+        self._proactive_token_refresh()
+```
+
+**Wichtig:**
+- Die Bindings stehen **nach** allen `_build_*`-Aufrufen — vorher würden sie an einem leeren Toplevel hängen, was zwar funktioniert, aber konzeptuell unsauber ist.
+- Die Bindings stehen **vor** `_refresh()` und `_proactive_token_refresh()` — beides verändert UI-State bzw. startet Hintergrund-Threads, was für die Bindings irrelevant ist.
+- `lambda e: ...` ist nötig, weil Tk dem Handler ein Event-Objekt übergibt, `_prev`/`_next` aber argumentlos sind.
+
+- [ ] **Step 2: Statisch prüfen, dass nur diese Stelle berührt wurde**
+
+Run:
+
+```bash
+git diff src/ui.py
+```
+
+Expected: Genau zwei `+`-Zeilen mit `self.root.bind(...)`, keine `-`-Zeilen außerhalb des Diff-Kontexts, keine weiteren Änderungen.
+
+- [ ] **Step 3: Volle Test-Suite laufen lassen**
+
+Run: `python -m pytest -v`
+Expected: Alle Tests grün, keine Regressionen.
+
+- [ ] **Step 4: SKIP — manueller UI-Smoke-Test (Controller's Aufgabe)**
+
+Der Controller verifiziert manuell:
+- App starten, Hauptfenster fokussiert → `<Left>` geht zum vorigen Monat, `<Right>` zum nächsten.
+- Auf "Woche" umschalten → `<Left>`/`<Right>` navigieren wochenweise.
+- Eintrags-Dialog öffnen, in einem `Entry`-Feld → `<Left>`/`<Right>` bewegen den Cursor im Feld, navigieren **nicht** das Hauptfenster.
+- Anderes Programm fokussieren → Pfeiltasten dort beeinflussen die Zeiterfassung nicht.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ui.py
+git commit -m "feat(ui): pfeiltasten navigieren monat/woche
+
+<Left>/<Right> am Root-Fenster gebunden — ruft die existierenden
+_prev/_next auf, die je nach view_mode Monat oder Woche verschieben.
+Modal-Dialoge (grab_set) fangen die Events automatisch ab, kein
+expliziter Focus-Check nötig."
+```
+
+---
+
+## Verification checklist (post-implementation)
+
+- [ ] `python -m pytest -v` alle grün (keine Regressionen)
+- [ ] `git diff master -- src/ui.py` zeigt genau zwei zusätzliche Zeilen
+- [ ] Manueller Smoke-Test (Controller, siehe Step 4 oben): Pfeiltasten wirken im Hauptfenster, nicht in Dialogen, nicht im Hintergrund
+- [ ] Ein Commit auf dem Branch mit der Message oben

--- a/docs/superpowers/specs/2026-04-27-arrow-key-navigation-design.md
+++ b/docs/superpowers/specs/2026-04-27-arrow-key-navigation-design.md
@@ -21,7 +21,7 @@ Voraussetzung "Hauptfenster ist fokussiert" wird **implizit** erfüllt: Tk schic
 
 ### `src/ui.py::App.__init__`
 
-Direkt nach `_build_footer()` (aktuell Zeile 73) zwei Bindings ergänzen:
+Direkt nach dem `_build_footer()`-Aufruf in `__init__` (aktuell Zeile 73) zwei Bindings ergänzen:
 
 ```python
 self._build_header()

--- a/docs/superpowers/specs/2026-04-27-arrow-key-navigation-design.md
+++ b/docs/superpowers/specs/2026-04-27-arrow-key-navigation-design.md
@@ -1,0 +1,56 @@
+# Arrow-Key Navigation (Monat/Woche) — Design Spec
+
+## Overview
+
+Die App soll im Hauptfenster mit den Pfeiltasten **Links** und **Rechts** durch Monate bzw. Wochen navigierbar sein — also genau das, was die `‹`/`›` Icon-Buttons im Header heute tun. Welche Einheit verschoben wird, hängt wie bei den Buttons vom aktuellen `view_mode` ab (Monat oder Woche).
+
+Voraussetzung "Hauptfenster ist fokussiert" wird **implizit** erfüllt: Tk schickt Tastenevents nur an das aktive Fenster, und alle Dialoge der App nutzen `grab_set()` (modal). Wenn ein Dialog offen ist, gehen die Events an den Dialog, nicht ans Root — kein expliziter Focus-Tracking-Code nötig.
+
+## Scope decisions
+
+| # | Decision | Consequence |
+|---|----------|-------------|
+| 1 | Nur `<Left>` / `<Right>` werden gebunden | Minimaler Eingriff, deckt den User-Wunsch ab. Up/Down/PageUp/PageDown/Home bleiben frei für spätere Erweiterungen |
+| 2 | Bindings am Root-Fenster (`self.root.bind`), nicht `bind_all` | Events bubblen via Bindtag-Chain vom fokussierten Child-Widget hoch zum Toplevel — passt zur restlichen App und respektiert die Modal-Grabs der Dialoge |
+| 3 | Handler ruft die existierenden `_prev` / `_next` direkt auf | Keine doppelte Logik. View-abhängige Verzweigung (Monat vs. Woche) lebt weiter zentral in `_prev`/`_next` |
+| 4 | Kein Debounce / Repeat-Limit | Bei gehaltener Taste feuert Tk wiederholt → schnelles Durchskippen, gewollt. Falls es ruckelt, kann später nachgezogen werden — YAGNI |
+| 5 | Keine neuen Tests | Bindings auf das Tk-Mainloop sind unter pytest fummelig zu testen, und `_prev`/`_next` selbst ändern sich nicht. Manuelle Verifikation reicht |
+| 6 | Versions-Bump und CHANGELOG nicht Teil dieser Spec | Wird im Release-PR gebündelt |
+
+## Implementation
+
+### `src/ui.py::App.__init__`
+
+Direkt nach `_build_footer()` (aktuell Zeile 73) zwei Bindings ergänzen:
+
+```python
+self._build_header()
+self._build_grid()
+self._build_footer()
+self.root.bind("<Left>",  lambda e: self._prev())
+self.root.bind("<Right>", lambda e: self._next())
+self._refresh()
+self._proactive_token_refresh()
+```
+
+`_prev` und `_next` (Zeilen 155–183) bleiben unverändert — sie verzweigen bereits korrekt nach `view_mode`.
+
+### Verhalten in den Modal-Dialogen
+
+`entry_dialog.py`, `send_dialog.py`, `settings_dialog.py` nutzen alle `grab_set()`. Solange ein Dialog offen ist:
+
+- Tastenevents gehen an das Dialog-Fenster, nicht an Root → unsere Bindings feuern nicht.
+- In Dialog-internen `Entry`-Widgets bewegen `<Left>`/`<Right>` weiter den Cursor wie gewohnt (Tk-Default-Bindings auf der Entry-Klasse).
+
+Kein Code in den Dialogen muss angefasst werden.
+
+### Tastatur-Repeat
+
+Tk feuert bei gehaltener Pfeiltaste wiederholt — `_refresh()` baut bei jedem Event das Grid neu auf. Das ist für realistisches Halten (1–2 s) verkraftbar; sollte sich rauskristallisieren, dass es ruckelt, kommt ein Debounce nach. Out of scope für diesen PR.
+
+## Out of scope
+
+- Up/Down, PageUp/PageDown, Home/End, oder Modifier-Kombinationen (z.B. `Shift+Right` für Jahresprung).
+- "Heute"-Sprung-Shortcut — der Toggle-Click erfüllt diese Rolle bereits (siehe Spec `2026-04-24-view-toggle-jumps-to-today-design.md`).
+- Verhalten ändern, wenn ein Dialog offen ist — der natürliche Modal-Grab reicht.
+- Tests für die Bindings.

--- a/src/ui.py
+++ b/src/ui.py
@@ -71,6 +71,8 @@ class App:
         self._build_header()
         self._build_grid()
         self._build_footer()
+        self.root.bind("<Left>", lambda e: self._prev())
+        self.root.bind("<Right>", lambda e: self._next())
         self._refresh()
         self._proactive_token_refresh()
 

--- a/src/version.py
+++ b/src/version.py
@@ -1,1 +1,1 @@
-VERSION = "1.8.2"
+VERSION = "1.8.3"


### PR DESCRIPTION
## Summary
- `<Left>` / `<Right>` am Root-Fenster gebunden — navigieren durch Monate bzw. Wochen, abhängig vom aktuellen `view_mode`.
- Ruft die existierenden `_prev` / `_next` Methoden auf — keine doppelte Logik.
- Modal-Dialoge nutzen `grab_set()` und fangen die Events automatisch ab; kein expliziter Focus-Tracking-Code nötig.

## Test Plan
- [x] Hauptfenster fokussiert, Monat-Modus → `<Left>`/`<Right>` springen Monat
- [x] Auf "Woche" toggeln → Pfeiltasten navigieren wochenweise
- [x] Eintrags-Dialog offen, Cursor in Entry → Pfeiltasten bewegen den Cursor, Hauptfenster bleibt stehen
- [x] Anderes Programm fokussiert → keine Wirkung auf Zeiterfassung
- [x] `pytest -v` — 98 Tests grün

Spec: `docs/superpowers/specs/2026-04-27-arrow-key-navigation-design.md`
Plan: `docs/superpowers/plans/2026-04-27-arrow-key-navigation.md`