### PR TITLE
feat: update-check banner (v1.9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.9.0
+- Update-Check beim App-Start: einmal pro Kalendertag wird die GitHub-Releases-API abgefragt. Liegt eine neuere Version vor, erscheint zwischen Header und Kalender ein Banner mit dem Versions-Hinweis und einem **Download**-Button, der direkt das passende Plattform-Asset (`.exe` / `.dmg` / `.AppImage`) im Browser öffnet
+- Fallback auf die Release-Page, falls kein Plattform-Asset gefunden wird (z.B. Intel-Mac oder ARM-Linux)
+- ✕-Symbol blendet die jeweilige Version dauerhaft aus — Banner kommt erst wieder, wenn eine noch neuere Version released wird (Tooltip: „Diese Version ausblenden")
+- Netzwerk-/API-Fehler werden still verschluckt — der Hinweis ist nice-to-have und stört einen Offline-Start nicht. Drosselung und Dismiss werden in `settings.json` persistiert (`last_update_check_at`, `dismissed_version`)
+
 ## v1.8.3
 - Pfeiltasten `<Left>` / `<Right>` navigieren im Hauptfenster durch Monate bzw. Wochen — analog zu den `‹`/`›` Buttons im Header. Modal-Dialoge fangen die Tasten automatisch ab, sodass `<Left>`/`<Right>` in Eingabefeldern weiterhin den Cursor bewegen
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Desktop-App zur Erfassung von Arbeitszeiten mit Kalenderansicht, PDF-Report und 
 - **Zeitraumwahl** — Flexibler Datumsbereich für Reports
 - **Einstellungen** — E-Mail-Vorlagen mit Platzhaltern, Standardpause, Empfänger
 - **Autostart** — Optionaler minimierter Start bei Anmeldung (Windows, macOS, Linux)
+- **Update-Check** — Prüft beim Start einmal pro Tag auf neuere Releases und zeigt einen unaufdringlichen Banner mit Direkt-Download
 - **Dark Mode UI** — Modernes dunkles Design
 - **Standalone .exe** — Per PyInstaller als einzelne Datei paketierbar
 
@@ -27,6 +28,7 @@ Zeiterfassung/
 │   ├── report.py        # HTML- & PDF-Reportgenerierung
 │   ├── mail.py          # Gmail OAuth2-Authentifizierung & Versand
 │   ├── autostart.py     # Plattformabhängiger Autostart (Windows/macOS/Linux)
+│   ├── updater.py       # GitHub-Releases-Check (stdlib-only, gedrosselt 1×/Tag)
 │   ├── time_utils.py    # Zeitberechnung und Validierung
 │   └── paths.py         # Pfadauflösung (Script- vs. Frozen-Modus)
 ├── tests/               # pytest-Testdateien

--- a/docs/superpowers/plans/2026-04-28-update-check.md
+++ b/docs/superpowers/plans/2026-04-28-update-check.md
@@ -1,0 +1,778 @@
+# Update-Check & Banner Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Beim App-Start einmal täglich die GitHub-Releases-API abfragen und bei neuerer Version einen unaufdringlichen Banner unter dem Header anzeigen, der mit einem Klick das richtige Plattform-Asset im Browser öffnet.
+
+**Architecture:** Neues stdlib-only Modul `src/updater.py` (HTTP-Call, Versionsvergleich, Asset-Match, Drosselung). Integration in `src/ui.py::App` über einen Daemon-Worker analog zu `_proactive_token_refresh` — mit dem Unterschied, dass der Worker nur den Netz-Call macht und sämtliche State-Mutationen (Settings + Banner-Aufbau) per `root.after(0, ...)` auf den UI-Thread marshallt, weil `Settings` keinen Lock hat. Banner wird als eigenes Frame zwischen Header und Grid gepackt und ist von `_build_grid` entkoppelt.
+
+**Tech Stack:** Python stdlib (`urllib.request`, `json`, `dataclasses`, `datetime`, `threading`, `webbrowser`), Tkinter, pytest, `unittest.mock`.
+
+**Spec:** `docs/superpowers/specs/2026-04-28-update-check-design.md`
+
+---
+
+## File Structure
+
+| File | Aktion | Zweck |
+|---|---|---|
+| `src/updater.py` | **Create** | Reine Logik: HTTP-Call, Datenklassen, Versionsvergleich, Asset-Match, Throttle. Keine Tk-Imports, voll testbar. |
+| `tests/test_updater.py` | **Create** | Unit-Tests für alle Funktionen in `updater.py`. Netz-Calls per `unittest.mock.patch` auf `urllib.request.urlopen`. |
+| `src/settings.py` | **Modify** | Zwei neue Defaults (`last_update_check_at`, `dismissed_version`) im `DEFAULTS`-Dict. |
+| `tests/test_settings.py` | **Modify** | Default-Tests für die zwei neuen Felder. |
+| `src/ui.py` | **Modify** | Imports erweitern, `__init__` initialisiert `self._update_banner = None` und ruft `_proactive_update_check`, neue Methoden `_proactive_update_check`, `_handle_update_check_result`, `_show_update_banner`, `_open_update_download`, `_dismiss_update_banner`. |
+
+---
+
+## Chunk 1: updater.py — Logik-Modul
+
+### Task 1: `is_newer` und Tuple-Helper
+
+**Files:**
+- Create: `src/updater.py`
+- Create: `tests/test_updater.py`
+
+- [ ] **Step 1: Failing Tests schreiben**
+
+`tests/test_updater.py` (neu):
+
+```python
+from src.updater import is_newer
+
+
+class TestIsNewer:
+    def test_same_version_is_not_newer(self):
+        assert is_newer("1.8.3", "1.8.3") is False
+
+    def test_higher_minor_is_newer(self):
+        assert is_newer("1.8.3", "1.9.0") is True
+
+    def test_lower_is_not_newer(self):
+        assert is_newer("1.9.0", "1.8.3") is False
+
+    def test_two_digit_patch_compares_numerically_not_lex(self):
+        assert is_newer("1.8.3", "1.8.10") is True
+
+    def test_higher_major_is_newer(self):
+        assert is_newer("1.8.3", "2.0.0") is True
+```
+
+- [ ] **Step 2: Tests laufen lassen — sollen failen**
+
+```
+pytest tests/test_updater.py -v
+```
+
+Expected: `ModuleNotFoundError: No module named 'src.updater'`.
+
+- [ ] **Step 3: Minimale Implementierung**
+
+`src/updater.py` (neu):
+
+```python
+"""Update-Check gegen GitHub-Releases (stdlib-only).
+
+Single Purpose: Netzwerk-Call, Versions-Vergleich, Asset-Match, Throttle.
+Keine Tk-Imports; UI-Layer ruft die Funktionen aus einem Worker-Thread.
+"""
+
+
+def _to_tuple(version: str) -> tuple[int, ...]:
+    return tuple(int(part) for part in version.split("."))
+
+
+def is_newer(current: str, latest: str) -> bool:
+    """True, wenn `latest` strikt neuer ist als `current`. Beide ohne v-Prefix."""
+    return _to_tuple(latest) > _to_tuple(current)
+```
+
+- [ ] **Step 4: Tests laufen — sollen passen**
+
+```
+pytest tests/test_updater.py -v
+```
+
+Expected: 5 passed.
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/updater.py tests/test_updater.py
+git commit -m "feat(updater): add is_newer version comparison"
+```
+
+---
+
+### Task 2: `today_iso` und `should_check_today`
+
+**Files:**
+- Modify: `src/updater.py`
+- Modify: `tests/test_updater.py`
+
+- [ ] **Step 1: Failing Tests schreiben**
+
+In `tests/test_updater.py` ergänzen:
+
+```python
+from datetime import date
+
+from src.updater import should_check_today, today_iso
+
+
+class TestTodayIso:
+    def test_returns_iso_date_string(self):
+        result = today_iso()
+        # Roundtrip-Parse stellt sicher, dass es ein gültiges ISO-Datum ist
+        assert date.fromisoformat(result) == date.today()
+
+
+class TestShouldCheckToday:
+    def test_empty_string_returns_true(self):
+        assert should_check_today("", today=date(2026, 4, 28)) is True
+
+    def test_none_returns_true(self):
+        assert should_check_today(None, today=date(2026, 4, 28)) is True
+
+    def test_yesterday_returns_true(self):
+        assert should_check_today("2026-04-27", today=date(2026, 4, 28)) is True
+
+    def test_today_returns_false(self):
+        assert should_check_today("2026-04-28", today=date(2026, 4, 28)) is False
+
+    def test_invalid_string_returns_true(self):
+        assert should_check_today("not-a-date", today=date(2026, 4, 28)) is True
+```
+
+- [ ] **Step 2: Tests laufen — sollen failen**
+
+```
+pytest tests/test_updater.py -v
+```
+
+Expected: `ImportError: cannot import name 'should_check_today' from 'src.updater'`.
+
+- [ ] **Step 3: Implementierung ergänzen**
+
+In `src/updater.py` am Ende:
+
+```python
+from datetime import date
+
+
+def today_iso() -> str:
+    """Heutiges Datum als ISO-Format `YYYY-MM-DD` (lokale Zeitzone)."""
+    return date.today().isoformat()
+
+
+def should_check_today(last_check: str | None, today: date | None = None) -> bool:
+    """True, wenn der letzte Check vor dem heutigen Kalendertag lag.
+
+    Drosselung pro Kalendertag (lokale Zeit), nicht pro 24-h-Fenster.
+    Bei leerem oder ungültigem `last_check` wird ebenfalls True geliefert,
+    damit ein einmal kaputter Wert nicht den Check für immer blockiert.
+    """
+    if not last_check:
+        return True
+    today = today or date.today()
+    try:
+        last = date.fromisoformat(last_check)
+    except ValueError:
+        return True
+    return last < today
+```
+
+Den Import `from datetime import date` an den Anfang der Datei verschieben (Stilkonsistenz).
+
+- [ ] **Step 4: Tests laufen**
+
+```
+pytest tests/test_updater.py -v
+```
+
+Expected: alle bisherigen + 6 neue passed.
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/updater.py tests/test_updater.py
+git commit -m "feat(updater): add daily check throttling helpers"
+```
+
+---
+
+### Task 3: `Release`/`Asset` Datenklassen + `pick_asset_url`
+
+**Files:**
+- Modify: `src/updater.py`
+- Modify: `tests/test_updater.py`
+
+- [ ] **Step 1: Failing Tests schreiben**
+
+In `tests/test_updater.py` ergänzen:
+
+```python
+from src.updater import Asset, pick_asset_url
+
+
+def _three_assets(version: str) -> list[Asset]:
+    return [
+        Asset(name="Zeiterfassung_Setup.exe", url="https://example.com/exe"),
+        Asset(name=f"Zeiterfassung-{version}-arm64.dmg", url="https://example.com/dmg"),
+        Asset(name=f"Zeiterfassung-{version}-x86_64.AppImage", url="https://example.com/appimage"),
+    ]
+
+
+class TestPickAssetUrl:
+    def test_windows_picks_exe(self):
+        assets = _three_assets("1.9.0")
+        assert pick_asset_url(assets, "Windows", "1.9.0") == "https://example.com/exe"
+
+    def test_darwin_picks_arm_dmg(self):
+        assets = _three_assets("1.9.0")
+        assert pick_asset_url(assets, "Darwin", "1.9.0") == "https://example.com/dmg"
+
+    def test_linux_picks_appimage(self):
+        assets = _three_assets("1.9.0")
+        assert pick_asset_url(assets, "Linux", "1.9.0") == "https://example.com/appimage"
+
+    def test_unknown_system_returns_none(self):
+        assets = _three_assets("1.9.0")
+        assert pick_asset_url(assets, "FreeBSD", "1.9.0") is None
+
+    def test_missing_asset_returns_none(self):
+        # Nur Linux-Asset vorhanden, Plattform Windows
+        assets = [Asset(name="Zeiterfassung-1.9.0-x86_64.AppImage", url="u")]
+        assert pick_asset_url(assets, "Windows", "1.9.0") is None
+
+    def test_version_mismatch_in_dmg_name_returns_none(self):
+        # Versionsfeld passt nicht — DMG/AppImage tragen die Version im Namen
+        assets = [Asset(name="Zeiterfassung-1.8.0-arm64.dmg", url="u")]
+        assert pick_asset_url(assets, "Darwin", "1.9.0") is None
+```
+
+- [ ] **Step 2: Tests laufen — sollen failen**
+
+```
+pytest tests/test_updater.py -v
+```
+
+Expected: `ImportError: cannot import name 'Asset' from 'src.updater'`.
+
+- [ ] **Step 3: Implementierung ergänzen**
+
+In `src/updater.py` ergänzen (Imports oben, Code am Ende):
+
+```python
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Asset:
+    name: str
+    url: str
+
+
+@dataclass(frozen=True)
+class Release:
+    version: str        # ohne v-Prefix, z.B. "1.9.0"
+    html_url: str       # Release-Page auf GitHub
+    assets: tuple[Asset, ...]
+
+
+def pick_asset_url(assets, system: str, latest_version: str) -> str | None:
+    """Liefert die Download-URL für das Plattform-Asset oder None."""
+    expected_name = {
+        "Windows": "Zeiterfassung_Setup.exe",
+        "Darwin": f"Zeiterfassung-{latest_version}-arm64.dmg",
+        "Linux": f"Zeiterfassung-{latest_version}-x86_64.AppImage",
+    }.get(system)
+    if expected_name is None:
+        return None
+    for asset in assets:
+        if asset.name == expected_name:
+            return asset.url
+    return None
+```
+
+`Release.assets` ist ein Tuple statt Liste, weil `frozen=True` keine Mutationen erlaubt — das ist ok, der Caller iteriert nur.
+
+- [ ] **Step 4: Tests laufen**
+
+```
+pytest tests/test_updater.py -v
+```
+
+Expected: alle bisherigen + 6 neue passed.
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/updater.py tests/test_updater.py
+git commit -m "feat(updater): add Release/Asset dataclasses and pick_asset_url"
+```
+
+---
+
+### Task 4: `check_latest_release` (HTTP-Call, gemockt)
+
+**Files:**
+- Modify: `src/updater.py`
+- Modify: `tests/test_updater.py`
+
+- [ ] **Step 1: Failing Tests schreiben**
+
+In `tests/test_updater.py` ergänzen:
+
+```python
+import json
+import socket
+from io import BytesIO
+from unittest.mock import patch
+from urllib.error import HTTPError, URLError
+
+from src.updater import Release, check_latest_release
+
+
+def _api_response(payload: dict) -> BytesIO:
+    return BytesIO(json.dumps(payload).encode("utf-8"))
+
+
+HAPPY_PAYLOAD = {
+    "tag_name": "v1.9.0",
+    "html_url": "https://github.com/MargenHeld/Zeiterfassung/releases/tag/v1.9.0",
+    "assets": [
+        {"name": "Zeiterfassung_Setup.exe", "browser_download_url": "https://example.com/exe"},
+        {"name": "Zeiterfassung-1.9.0-arm64.dmg", "browser_download_url": "https://example.com/dmg"},
+        {"name": "Zeiterfassung-1.9.0-x86_64.AppImage", "browser_download_url": "https://example.com/appimage"},
+    ],
+}
+
+
+class TestCheckLatestRelease:
+    def test_happy_path_strips_v_prefix_and_parses_assets(self):
+        with patch("src.updater.urlopen", return_value=_api_response(HAPPY_PAYLOAD)):
+            release = check_latest_release("MargenHeld/Zeiterfassung")
+        assert release is not None
+        assert release.version == "1.9.0"
+        assert release.html_url.endswith("/v1.9.0")
+        assert len(release.assets) == 3
+        assert release.assets[0].name == "Zeiterfassung_Setup.exe"
+        assert release.assets[0].url == "https://example.com/exe"
+
+    def test_url_error_returns_none(self):
+        with patch("src.updater.urlopen", side_effect=URLError("offline")):
+            assert check_latest_release("any/repo") is None
+
+    def test_http_404_returns_none(self):
+        err = HTTPError(url="x", code=404, msg="Not Found", hdrs=None, fp=None)
+        with patch("src.updater.urlopen", side_effect=err):
+            assert check_latest_release("any/repo") is None
+
+    def test_socket_timeout_returns_none(self):
+        with patch("src.updater.urlopen", side_effect=socket.timeout()):
+            assert check_latest_release("any/repo") is None
+
+    def test_invalid_json_returns_none(self):
+        with patch("src.updater.urlopen", return_value=BytesIO(b"not json{{")):
+            assert check_latest_release("any/repo") is None
+
+    def test_missing_tag_name_returns_none(self):
+        payload = {"html_url": "x", "assets": []}
+        with patch("src.updater.urlopen", return_value=_api_response(payload)):
+            assert check_latest_release("any/repo") is None
+
+    def test_malformed_assets_are_filtered(self):
+        # Asset ohne browser_download_url + Asset als String → werden geskippt
+        payload = {
+            "tag_name": "v1.9.0",
+            "html_url": "x",
+            "assets": [
+                {"name": "ok", "browser_download_url": "u1"},
+                {"name": "incomplete"},                       # ohne URL
+                "not-a-dict",                                 # falscher Typ
+                {"name": "ok2", "browser_download_url": "u2"},
+            ],
+        }
+        with patch("src.updater.urlopen", return_value=_api_response(payload)):
+            release = check_latest_release("any/repo")
+        assert release is not None
+        assert len(release.assets) == 2
+        assert {a.name for a in release.assets} == {"ok", "ok2"}
+
+    def test_uppercase_v_prefix_is_stripped(self):
+        payload = dict(HAPPY_PAYLOAD, tag_name="V1.9.0")
+        with patch("src.updater.urlopen", return_value=_api_response(payload)):
+            release = check_latest_release("any/repo")
+        assert release is not None
+        assert release.version == "1.9.0"
+```
+
+- [ ] **Step 2: Tests laufen — sollen failen**
+
+```
+pytest tests/test_updater.py::TestCheckLatestRelease -v
+```
+
+Expected: `ImportError: cannot import name 'check_latest_release' from 'src.updater'`.
+
+- [ ] **Step 3: Implementierung ergänzen**
+
+Imports oben in `src/updater.py` ergänzen (zusätzlich zum bestehenden `from datetime import date` und `from dataclasses import dataclass`):
+
+```python
+import json
+from urllib.error import URLError
+from urllib.request import Request, urlopen
+
+from src.version import VERSION
+```
+
+`src/version.py` bleibt unverändert — wir lesen nur `VERSION` für den User-Agent-Header.
+
+Am Ende der Datei `src/updater.py` ergänzen:
+
+```python
+def check_latest_release(repo: str, timeout: float = 5.0) -> Release | None:
+    """Fragt die GitHub-API nach dem neuesten Release.
+
+    Liefert `None` bei jedem Fehler (Netzwerk, Timeout, kaputtes JSON,
+    fehlendes `tag_name`). Caller darf sich darauf verlassen, dass keine
+    Exception bubbled — Update-Hinweis ist nice-to-have.
+    """
+    url = f"https://api.github.com/repos/{repo}/releases/latest"
+    request = Request(
+        url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "User-Agent": f"Zeiterfassung/{VERSION}",
+        },
+    )
+    try:
+        with urlopen(request, timeout=timeout) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+        tag = payload.get("tag_name")
+        html_url = payload.get("html_url")
+        if not tag or not html_url:
+            return None
+        # Sowohl 'v' als auch 'V' strippen; Tags sind normiert, defensiv ist billig.
+        if tag[:1] in ("v", "V"):
+            tag = tag[1:]
+        raw_assets = payload.get("assets") or []
+        assets = tuple(
+            Asset(name=a["name"], url=a["browser_download_url"])
+            for a in raw_assets
+            if isinstance(a, dict) and "name" in a and "browser_download_url" in a
+        )
+        return Release(version=tag, html_url=html_url, assets=assets)
+    except (URLError, OSError, json.JSONDecodeError, TypeError, KeyError, AttributeError):
+        # URLError fängt auch HTTPError (4xx/5xx); OSError fängt socket.timeout etc.
+        # TypeError/KeyError/AttributeError fangen kaputte Payload-Strukturen ab.
+        return None
+```
+
+- [ ] **Step 4: Tests laufen — sollen passen**
+
+```
+pytest tests/test_updater.py -v
+```
+
+Expected: alle Tests passen (Summe aus Tasks 1–4).
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/updater.py tests/test_updater.py
+git commit -m "feat(updater): add check_latest_release with mocked HTTP tests"
+```
+
+---
+
+## Chunk 2: Settings + UI-Integration
+
+### Task 5: Neue Settings-Defaults
+
+**Files:**
+- Modify: `src/settings.py:4-18` (DEFAULTS-Dict)
+- Modify: `tests/test_settings.py`
+
+- [ ] **Step 1: Failing Tests schreiben**
+
+In `tests/test_settings.py` ergänzen:
+
+```python
+def test_last_update_check_at_default(tmp_settings):
+    assert tmp_settings.get("last_update_check_at") == ""
+
+
+def test_dismissed_version_default(tmp_settings):
+    assert tmp_settings.get("dismissed_version") == ""
+```
+
+- [ ] **Step 2: Tests laufen — sollen failen**
+
+```
+pytest tests/test_settings.py -v
+```
+
+Expected: 2 neue Tests failen mit `assert None == ""` (Schlüssel nicht in DEFAULTS, `.get()` liefert `None`).
+
+- [ ] **Step 3: DEFAULTS erweitern**
+
+In `src/settings.py` im `DEFAULTS`-Dict zwei Einträge ergänzen (am Ende, vor der schließenden `}`):
+
+```python
+    "last_update_check_at": "",
+    "dismissed_version": "",
+```
+
+- [ ] **Step 4: Tests laufen**
+
+```
+pytest tests/test_settings.py -v
+```
+
+Expected: alle Tests passen.
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/settings.py tests/test_settings.py
+git commit -m "feat(settings): add update-check throttle and dismiss fields"
+```
+
+---
+
+### Task 6: UI-Integration in `App`
+
+**Files:**
+- Modify: `src/ui.py` (Imports am Anfang, `__init__`, neue Methoden)
+
+Hinweis: Tk-Bindings und Banner-Aufbau werden nicht automatisiert getestet — analog zur Arrow-Key-Spec (`docs/superpowers/specs/2026-04-27-arrow-key-navigation-design.md`) liegt der Verifikations-Aufwand bei manuellem Smoke-Test in Task 7. Die Logik darunter (`updater.py`) ist vollständig unit-getestet.
+
+- [ ] **Step 1: Imports erweitern**
+
+In `src/ui.py` direkt nach `import traceback` (aktuell Zeile 10), um den Stdlib-Block alphabetisch zu erhalten:
+
+```python
+import webbrowser
+```
+
+Und nach den bestehenden `from src...`-Imports (vor dem Block aus `src.dialogs`):
+
+```python
+from src.updater import (
+    check_latest_release,
+    is_newer,
+    pick_asset_url,
+    should_check_today,
+    today_iso,
+    Release,
+)
+```
+
+- [ ] **Step 2: `__init__` erweitern**
+
+In `src/ui.py::App.__init__`, nach Zeile 77 (`self._proactive_token_refresh()`) einfügen:
+
+```python
+        self._update_banner = None
+        self._proactive_update_check()
+```
+
+- [ ] **Step 3: `_proactive_update_check` implementieren**
+
+Direkt unter `_proactive_token_refresh` (also nach Zeile 106) neue Methode anhängen:
+
+```python
+    def _proactive_update_check(self):
+        """Fragt einmal pro Kalendertag GitHub nach einer neueren Version.
+
+        Der HTTP-Call läuft in einem Daemon-Thread; alle State-Mutationen
+        (Settings-Write, Banner-Aufbau) werden via `root.after(0, ...)` auf
+        den UI-Thread marshallt, damit `Settings.set` nicht parallel zu
+        Schreibvorgängen aus dem Settings-Dialog läuft.
+
+        Fehler werden still verschluckt — Update-Hinweis ist nice-to-have.
+        """
+        if not should_check_today(self.settings.get("last_update_check_at")):
+            return
+
+        def worker():
+            try:
+                release = check_latest_release("MargenHeld/Zeiterfassung")
+                if release is None:
+                    return
+                newer = is_newer(VERSION, release.version)
+            except Exception:
+                # Pure Logik, robust gegen exotische Tags. Bei jedem Fehler:
+                # nichts persistieren, nichts anzeigen — morgen nochmal probieren.
+                return
+            self.root.after(
+                0, lambda: self._handle_update_check_result(release, newer)
+            )
+
+        threading.Thread(target=worker, daemon=True).start()
+
+    def _handle_update_check_result(self, release: "Release", newer: bool):
+        """Läuft im UI-Thread. Persistiert den Check-Stand und zeigt ggf. den Banner.
+
+        `is_newer` ist bereits im Worker ausgewertet, damit hier keine ungeschützte
+        Logik im Tk-Event-Loop läuft.
+        """
+        self.settings.set("last_update_check_at", today_iso())
+        if not newer:
+            return
+        if release.version == self.settings.get("dismissed_version"):
+            return
+        self._show_update_banner(release)
+```
+
+- [ ] **Step 4: Banner-Methoden implementieren**
+
+Direkt darunter anhängen. Hinweis zur Theme-Wahl: Die Spec listet `fg=BG` als Beispiel; in der Implementierung verwenden wir `fg="#ffffff"` für Label und Icon, weil der bestehende `primary_button` (in `theme.py`) ebenfalls `bg=ACCENT, fg="#ffffff"` nutzt — so bleibt die Banner-Optik im Kontrast konsistent mit dem Rest der App.
+
+```python
+    def _show_update_banner(self, release: "Release"):
+        if self._update_banner is not None:
+            return
+        self._update_banner = tk.Frame(self.root, bg=ACCENT)
+        self._update_banner.pack(
+            before=self.grid_frame, fill=tk.X, padx=10, pady=(5, 0),
+        )
+
+        tk.Label(
+            self._update_banner,
+            text=f"Version {release.version} verfügbar",
+            bg=ACCENT, fg="#ffffff", font=FONT_BOLD,
+        ).pack(side=tk.LEFT, padx=10, pady=6)
+
+        icon_button(
+            self._update_banner, "✕",
+            lambda: self._dismiss_update_banner(release.version),
+            fg="#ffffff", hover_fg=TEXT,
+        ).pack(side=tk.RIGHT, padx=(0, 6))
+
+        secondary_button(
+            self._update_banner, "Download",
+            lambda: self._open_update_download(release),
+            padx=12,
+        ).pack(side=tk.RIGHT, padx=6)
+
+    def _open_update_download(self, release: "Release"):
+        url = pick_asset_url(
+            release.assets, platform.system(), release.version,
+        ) or release.html_url
+        webbrowser.open(url)
+
+    def _dismiss_update_banner(self, version: str):
+        self.settings.set("dismissed_version", version)
+        if self._update_banner is not None:
+            self._update_banner.destroy()
+            self._update_banner = None
+```
+
+Hinweis: `Release` ist als String-Type-Hint annotiert (`"Release"`), damit der Forward-Reference auch funktioniert, falls jemand später die Import-Reihenfolge ändert. `Release` ist sowieso schon konkret importiert — ohne Quotes ginge auch.
+
+- [ ] **Step 5: Smoke-Test (Syntax)**
+
+```
+python -m py_compile src/ui.py
+```
+
+Expected: kein Output (= ok).
+
+```
+pytest tests/ -v
+```
+
+Expected: alle Tests passen (kein Test wurde durch UI-Änderung gebrochen).
+
+- [ ] **Step 6: Commit**
+
+```
+git add src/ui.py
+git commit -m "feat(ui): show update banner when newer GitHub release exists"
+```
+
+---
+
+### Task 7: Manuelle End-to-End-Verifikation
+
+**Files:** keine.
+
+Tk-Bindings, Banner-Layout und Browser-Open lassen sich unter pytest nicht sinnvoll testen. Manueller Smoke-Test deckt das ab.
+
+- [ ] **Step 1: App starten und Banner provozieren**
+
+In einer temporären lokalen Änderung in `src/version.py` `VERSION` auf einen Wert setzen, der **kleiner** ist als der aktuelle GitHub-Release-Tag (z.B. `"1.0.0"`):
+
+```python
+VERSION = "1.0.0"
+```
+
+App starten:
+
+```
+python -m src.main
+```
+
+Expected:
+- Hauptfenster öffnet sich normal.
+- Nach kurzer Verzögerung (Netz-Call) erscheint der Streifen unter dem Header: `Version <aktuelle> verfügbar` mit `[Download]` und `✕`.
+- In `settings.json` (im Repo-Root) erscheint nach dem Check ein Eintrag `"last_update_check_at": "<heute>"`.
+
+- [ ] **Step 2: Download-Button testen**
+
+Klick auf **Download** → Browser öffnet sich auf der korrekten Plattform-Asset-URL (Windows: `Zeiterfassung_Setup.exe`-Download startet, oder GitHub-Browser-Page für das Asset).
+
+- [ ] **Step 3: Dismiss testen**
+
+App neu starten (Banner ist erst wieder am nächsten Tag fällig — daher `last_update_check_at` in `settings.json` auf gestriges Datum setzen, z.B. `"2026-04-27"`, dann starten).
+
+Banner erscheint wieder. Klick auf **✕** → Banner verschwindet sofort. In `settings.json` steht jetzt `"dismissed_version": "<aktuelle>"`.
+
+App nochmal starten (mit gestrigem `last_update_check_at`). Banner erscheint **nicht** mehr. Manuell `dismissed_version` auf eine ältere Version setzen (z.B. `"0.9.0"`) → Banner kommt wieder.
+
+- [ ] **Step 4: Throttling verifizieren**
+
+`last_update_check_at` in `settings.json` auf heutiges Datum setzen. App starten. Erwartung: kein API-Call, kein Banner (auch wenn neuere Version existiert). Mit `tcpdump` / Network-Monitor optional verifizieren — andernfalls Code-Inspection genügt: `should_check_today` returned False früh.
+
+- [ ] **Step 5: Offline-Verhalten**
+
+Netzwerk trennen (Wi-Fi aus). `last_update_check_at` auf gestriges Datum setzen. App starten.
+
+Expected: keine Messagebox, kein Banner, App bleibt benutzbar. `last_update_check_at` bleibt unverändert (Worker hat keinen erfolgreichen Call gemacht).
+
+- [ ] **Step 6: Negativer Pfad — lokale Version neuer als Release**
+
+`src/version.py` temporär auf `VERSION = "99.0.0"` setzen, `last_update_check_at` in `settings.json` auf gestriges Datum, `dismissed_version` leeren. App starten.
+
+Expected: kein Banner. `last_update_check_at` wird auf heute aktualisiert (Check lief erfolgreich, nur `is_newer` returned False).
+
+- [ ] **Step 7: VERSION zurücksetzen**
+
+`src/version.py` wieder auf den Wirk-Stand setzen (`VERSION = "1.8.3"`). `settings.json` aufräumen oder zurücksetzen (Test-Werte rauslöschen).
+
+- [ ] **Step 8: Final-Check**
+
+```
+pytest tests/ -v
+```
+
+Expected: alle Tests passen.
+
+```
+git status
+```
+
+Expected: clean (keine ungewollten Änderungen).
+
+---
+
+## Out of scope für diesen Plan
+
+- Versions-Bump in `src/version.py` und CHANGELOG-Eintrag — bündeln im Release-PR (siehe `CLAUDE.md::Release-Prozess`).
+- Opt-out-Toggle in den Settings.
+- In-App-Download mit Progress-Bar.
+- Tests für die Tk-Bindings / das Banner-Frame.
+- Pre-Release-Tracking (`/releases/latest` filtert das bereits raus).

--- a/docs/superpowers/specs/2026-04-28-update-check-design.md
+++ b/docs/superpowers/specs/2026-04-28-update-check-design.md
@@ -1,0 +1,271 @@
+# Update-Check & Banner — Design Spec
+
+## Overview
+
+Die App soll beim Start prüfen, ob auf GitHub eine neuere Release-Version verfügbar ist, und bei Treffer einen unaufdringlichen Banner unter dem Header anzeigen. Klick auf **Download** öffnet das passende Plattform-Asset im Browser; Klick auf **✕** dismissed die jeweilige Version dauerhaft. Der Check ist auf 1×/Tag gedrosselt und scheitert still bei Netzwerk-/API-Problemen — er darf die Zeiterfassung nicht stören.
+
+Repo wird hartcodiert auf `MargenHeld/Zeiterfassung`. Public GitHub-API genügt (60 Requests/h pro IP, kein Auth nötig). Keine neue Dependency: `urllib.request` aus der Stdlib reicht.
+
+## Scope decisions
+
+| # | Decision | Consequence |
+|---|----------|-------------|
+| 1 | Throttling auf 1×/Tag, persistiert in `settings.json` als ISO-Datum | Schont Rate-Limit auch bei Power-Usern, die die App häufig öffnen |
+| 2 | Dismiss pro Version (`dismissed_version` in Settings) | Banner verschwindet bis zur nächsten neueren Version — übliches Pattern |
+| 3 | Kein Opt-out-Toggle in Settings | YAGNI; falls jemand das später braucht, ist ein Bool-Flag trivial nachzuziehen |
+| 4 | Download-Button öffnet plattformspezifisches Asset (Browser), Fallback auf Release-Page | Ein Klick weniger als „Release-Seite → richtiges Asset finden" |
+| 5 | Kein In-App-Download / Auto-Update | Auf 3 Plattformen mit jeweils eigenem Installer-Pfad zu komplex; Browser-Download + manuelle Installation reicht |
+| 6 | Update-Check und Token-Refresh laufen parallel als getrennte Daemon-Threads | Keine Abhängigkeit, bestehender Pattern bleibt unverändert |
+| 7 | Bei Netzwerk-/API-Fehler **still scheitern** (kein Dialog, keine Logzeile) | Update-Hinweis ist Nice-to-have; analog zu `TokenNetworkError` |
+| 8 | Repo-Slug hartcodiert | Kein Settings-Feld, keine Form-UI — wenn der Slug sich mal ändert, ist das ein Code-Edit |
+| 9 | Versions-Vergleich via Tuple-Split nach `.` | `tag_name` ist immer `vX.Y.Z` (Workflow erzwungen); kein semver-Lib nötig |
+| 10 | Versions-Bump und CHANGELOG nicht Teil dieser Spec | Wird im Release-PR gebündelt |
+
+## Architecture
+
+Neues Modul **`src/updater.py`** — single-purpose, gut testbar, keine Tk-Imports.
+
+### Public API
+
+```python
+@dataclass
+class Release:
+    version: str        # ohne v-Prefix, z.B. "1.9.0"
+    html_url: str       # Release-Page auf GitHub
+    assets: list[Asset] # [(name, browser_download_url), ...]
+
+@dataclass
+class Asset:
+    name: str
+    url: str
+
+def check_latest_release(repo: str, timeout: float = 5.0) -> Release | None
+def is_newer(current: str, latest: str) -> bool
+def pick_asset_url(assets: list[Asset], system: str, latest_version: str) -> str | None
+def should_check_today(last_check: str | None, today: date | None = None) -> bool
+def today_iso() -> str
+```
+
+### `check_latest_release`
+
+- GET `https://api.github.com/repos/{repo}/releases/latest` mit Header `Accept: application/vnd.github+json` und `User-Agent: Zeiterfassung/{VERSION}` (GitHub erfordert UA).
+- Timeout 5s.
+- Erfolg: JSON parsen, `tag_name` (mit Strip von `v`-Prefix), `html_url`, `assets[].name` und `assets[].browser_download_url` extrahieren → `Release`.
+- Fehlschlag (URLError, HTTPError, Timeout, JSONDecodeError, KeyError, fehlendes `tag_name`): `None`.
+
+### `is_newer`
+
+```python
+def is_newer(current: str, latest: str) -> bool:
+    return _to_tuple(latest) > _to_tuple(current)
+
+def _to_tuple(v: str) -> tuple[int, ...]:
+    return tuple(int(part) for part in v.split("."))
+```
+
+`tag_name` aus dem GitHub-API kommt mit `v`-Prefix; `check_latest_release` strippt das vorher. `VERSION` aus `src/version.py` ist bereits prefixlos. Edge: nicht-numerische Komponenten (z.B. `1.9.0-rc1`) sind durch den Workflow ausgeschlossen — `pre-check` validiert nicht explizit, aber der Tag-Name wird vom Workflow selbst aus `VERSION` gebildet, und `VERSION` ist im Repo immer pure SemVer. Falls doch mal: `int(...)` raised `ValueError`, der Caller in `_proactive_update_check` fängt mit breitem `except` und der Banner erscheint einfach nicht.
+
+### `pick_asset_url`
+
+Plattform-Pattern (Asset-Namen aus `release.yml`):
+
+| `system` (`platform.system()`) | Asset-Name-Pattern |
+|---|---|
+| `"Windows"` | `Zeiterfassung_Setup.exe` |
+| `"Darwin"` | `Zeiterfassung-{version}-arm64.dmg` |
+| `"Linux"` | `Zeiterfassung-{version}-x86_64.AppImage` |
+
+Match strikt per Name-Equality, nicht via `in`/regex — die Workflow-Asset-Namen sind stabil. Bei Mismatch (Intel-Mac, exotisches Linux, Asset im Release fehlt): `None` → Caller fällt auf `release.html_url` zurück, Banner funktioniert weiterhin.
+
+### `should_check_today` / `today_iso`
+
+```python
+def today_iso() -> str:
+    return date.today().isoformat()  # "YYYY-MM-DD"
+
+def should_check_today(last_check: str | None, today: date | None = None) -> bool:
+    if not last_check:
+        return True
+    today = today or date.today()
+    try:
+        last = date.fromisoformat(last_check)
+    except ValueError:
+        return True   # kaputter Wert → einfach prüfen, überschreibt sich gleich
+    return last < today
+```
+
+Lokales Datum, nicht UTC — Drosselung pro Kalendertag des Users ist intuitiver als ein UTC-Cutoff um 01:00 lokaler Zeit.
+
+## Settings-Schema
+
+Erweitere `DEFAULTS` in `src/settings.py`:
+
+```python
+"last_update_check_at": "",   # ISO-Datum "YYYY-MM-DD"
+"dismissed_version": "",      # ohne v-Prefix, z.B. "1.9.0"
+```
+
+`Settings._load` mergt mit `DEFAULTS` (`self._data.update(loaded)`), bestehende `settings.json` bekommen die Felder beim ersten `set(...)` automatisch geschrieben. Keine Migration.
+
+## Integration in `App` (`src/ui.py`)
+
+Neue Methode `_proactive_update_check`, parallel zu `_proactive_token_refresh` aufgerufen am Ende von `__init__`:
+
+```python
+def _proactive_update_check(self):
+    if not should_check_today(self.settings.get("last_update_check_at")):
+        return
+
+    def worker():
+        try:
+            release = check_latest_release("MargenHeld/Zeiterfassung")
+        except Exception:
+            return
+        if release is None:
+            return
+        self.settings.set("last_update_check_at", today_iso())
+        if not is_newer(VERSION, release.version):
+            return
+        if release.version == self.settings.get("dismissed_version"):
+            return
+        self.root.after(0, lambda: self._show_update_banner(release))
+
+    threading.Thread(target=worker, daemon=True).start()
+```
+
+Reihenfolge in `__init__` (analog zur bestehenden Struktur):
+
+```python
+self._build_header()
+self._build_grid()
+self._build_footer()
+self.root.bind("<Left>",  lambda e: self._prev())
+self.root.bind("<Right>", lambda e: self._next())
+self._refresh()
+self._proactive_token_refresh()
+self._proactive_update_check()
+```
+
+`last_update_check_at` wird nur bei erfolgreichem API-Call geschrieben — schlägt der Check still fehl (Offline-Start), wird beim nächsten Start erneut probiert, statt einen ganzen Tag zu warten.
+
+## UI: Update-Banner
+
+Neuer Frame zwischen Header und Grid. Wird **nicht** in `_build_grid` oder `_build_header` integriert, sondern dynamisch via `pack(before=self.grid_frame, fill=tk.X, padx=10, pady=(5, 0))` eingehängt — so bleibt der Initial-Build unverändert und der Banner erscheint nur, wenn er gebraucht wird.
+
+```
+┌────────────────────────────────────────────────────────────┐
+│  Version 1.9.0 verfügbar       [ Download ]    ✕            │
+└────────────────────────────────────────────────────────────┘
+```
+
+### Methoden
+
+```python
+def _show_update_banner(self, release: Release):
+    self._update_banner = tk.Frame(self.root, bg=ACCENT)
+    self._update_banner.pack(before=self.grid_frame, fill=tk.X, padx=10, pady=(5, 0))
+
+    tk.Label(
+        self._update_banner,
+        text=f"Version {release.version} verfügbar",
+        bg=ACCENT, fg=BG, font=FONT_BOLD,
+    ).pack(side=tk.LEFT, padx=10, pady=6)
+
+    icon_button(
+        self._update_banner, "✕",
+        lambda: self._dismiss_update_banner(release.version),
+        fg=BG, hover_fg=TEXT,
+    ).pack(side=tk.RIGHT, padx=(0, 6))
+
+    secondary_button(
+        self._update_banner, "Download",
+        lambda: self._open_update_download(release),
+        padx=12,
+    ).pack(side=tk.RIGHT, padx=6)
+
+def _open_update_download(self, release: Release):
+    url = pick_asset_url(release.assets, platform.system(), release.version) or release.html_url
+    webbrowser.open(url)
+
+def _dismiss_update_banner(self, version: str):
+    self.settings.set("dismissed_version", version)
+    if self._update_banner is not None:
+        self._update_banner.destroy()
+        self._update_banner = None
+```
+
+### Theme-Anbindung
+
+Der Banner verwendet das bestehende Theme-Vokabular (`ACCENT`, `BG`, `TEXT`, `FONT_BOLD`, `icon_button`, `secondary_button` aus `src/theme.py`). Keine neuen Theme-Konstanten nötig. Falls der `ACCENT`-Hintergrund mit dem schwarzen `BG`-Text bei der Implementierung als zu schreiend empfunden wird, ist ein Wechsel auf einen gedämpfteren Ton ein Ein-Zeilen-Edit — nicht hier festgenagelt.
+
+### Lifecycle
+
+`_update_banner` wird in `__init__` als `None` initialisiert. Erst `_show_update_banner` legt das Frame an. Nach Dismiss → `destroy()` und zurück auf `None`. Ein zweiter Call von `_show_update_banner` während eines Sessions sollte nicht passieren (jeder Start prüft genau einmal), aber der Code darf keinen alten Frame liegen lassen — defensiver Check oben:
+
+```python
+if getattr(self, "_update_banner", None) is not None:
+    return
+```
+
+## Fehlerbehandlung
+
+Konsequent **still scheitern** für Update-bezogene Probleme — der User darf nichts merken, wenn der Check schief geht.
+
+| Szenario | Verhalten |
+|---|---|
+| Offline / DNS / Timeout | `check_latest_release` → `None`, Banner erscheint nicht, `last_update_check_at` bleibt leer (nächster Start prüft wieder) |
+| 403 Rate-Limit | gleich wie oben |
+| 404 (Repo umbenannt o.ä.) | gleich wie oben |
+| 5xx | gleich wie oben |
+| Kaputtes JSON / fehlendes `tag_name` | `None` |
+| Asset-Match fehlgeschlagen | `pick_asset_url` → `None`, Banner zeigt sich, Button öffnet Release-Page |
+| `is_newer` raised (z.B. exotischer Tag) | Worker `except Exception: return`, Banner erscheint nicht |
+
+Keine Logzeile, keine Messagebox. Begründung: ein User, der das Tool dreimal pro Tag öffnet, soll nicht beim Offline-Start eine Fehlermeldung sehen.
+
+## Tests
+
+Neue Datei `tests/test_updater.py`. Keine echten Netzwerk-Calls — alle HTTP-Aufrufe gemockt via `unittest.mock.patch` auf `urllib.request.urlopen`.
+
+### Test-Cases
+
+**`is_newer`:**
+- gleich (`1.8.3` vs `1.8.3`) → `False`
+- höher (`1.8.3` vs `1.9.0`) → `True`
+- niedriger (`1.9.0` vs `1.8.3`) → `False`
+- Patch-Sprung (`1.8.3` vs `1.8.10`) → `True` (kein Lex-Vergleich)
+- Major (`1.8.3` vs `2.0.0`) → `True`
+
+**`pick_asset_url`:**
+- Windows + passendes Asset → korrekte URL
+- Darwin + passendes Asset → korrekte URL (mit Version im Namen)
+- Linux + passendes Asset → korrekte URL
+- Unbekanntes System (`"FreeBSD"`) → `None`
+- Plattform passt, Asset fehlt → `None`
+- Plattform passt, Version im Asset-Namen mismatcht → `None`
+
+**`should_check_today`:**
+- leerer String → `True`
+- gestriges Datum → `True`
+- heutiges Datum → `False`
+- kaputter Wert (`"abc"`) → `True`
+
+**`check_latest_release`:**
+- Happy Path: JSON mit `tag_name="v1.9.0"` und 3 Assets → `Release(version="1.9.0", ...)`, v-Prefix gestrippt
+- `URLError` → `None`
+- `HTTPError(404)` → `None`
+- `socket.timeout` → `None`
+- Kaputtes JSON → `None`
+- JSON ohne `tag_name` → `None`
+
+CI-Workflow `test.yml` muss nichts dazu installieren — alles stdlib. Run lokal: `pytest tests/test_updater.py`.
+
+## Out of scope
+
+- In-App-Download mit Progress-Bar oder Auto-Update.
+- Pre-Release-Tracking (`/releases/latest` filtert Pre-Releases bereits raus).
+- Update-Check via Settings-Dialog manuell auslösbar machen.
+- Opt-out-Checkbox.
+- Telemetrie / Logging.
+- Intel-Mac- oder ARM-Linux-Asset-Matching (gibt es nicht im Release).
+- Versions-Bump und CHANGELOG für dieses Feature — wird im Release-PR gebündelt.

--- a/docs/superpowers/specs/2026-04-28-update-check-design.md
+++ b/docs/superpowers/specs/2026-04-28-update-check-design.md
@@ -123,15 +123,20 @@ def _proactive_update_check(self):
             return
         if release is None:
             return
-        self.settings.set("last_update_check_at", today_iso())
-        if not is_newer(VERSION, release.version):
-            return
-        if release.version == self.settings.get("dismissed_version"):
-            return
-        self.root.after(0, lambda: self._show_update_banner(release))
+        self.root.after(0, lambda: self._handle_update_check_result(release))
 
     threading.Thread(target=worker, daemon=True).start()
+
+def _handle_update_check_result(self, release: Release):
+    self.settings.set("last_update_check_at", today_iso())
+    if not is_newer(VERSION, release.version):
+        return
+    if release.version == self.settings.get("dismissed_version"):
+        return
+    self._show_update_banner(release)
 ```
+
+Begründung Marshal: `Settings.set` ist nicht thread-safe (kein Lock in `src/settings.py`). Der UI-Thread kann jederzeit über den Settings-Dialog schreiben — gleichzeitiger Worker-Write könnte die JSON-Datei korrumpieren. `root.after(0, ...)` schiebt die Settings-Mutation und den Banner-Aufbau zusammen auf den UI-Thread, der den State-Mutationen serialisiert. Der HTTP-Call selbst bleibt im Worker, damit der UI-Thread nicht blockiert.
 
 Reihenfolge in `__init__` (analog zur bestehenden Struktur):
 
@@ -200,11 +205,14 @@ Der Banner verwendet das bestehende Theme-Vokabular (`ACCENT`, `BG`, `TEXT`, `FO
 
 ### Lifecycle
 
-`_update_banner` wird in `__init__` als `None` initialisiert. Erst `_show_update_banner` legt das Frame an. Nach Dismiss → `destroy()` und zurück auf `None`. Ein zweiter Call von `_show_update_banner` während eines Sessions sollte nicht passieren (jeder Start prüft genau einmal), aber der Code darf keinen alten Frame liegen lassen — defensiver Check oben:
+`self._update_banner = None` in `__init__` (vor `_proactive_update_check`). Erst `_show_update_banner` legt das Frame an. Nach Dismiss → `destroy()` und zurück auf `None`. Ein zweiter Call sollte nicht passieren (jeder App-Start prüft genau einmal), aber `_show_update_banner` schützt sich defensiv als erste Zeile:
 
 ```python
-if getattr(self, "_update_banner", None) is not None:
-    return
+def _show_update_banner(self, release: Release):
+    if self._update_banner is not None:
+        return
+    self._update_banner = tk.Frame(self.root, bg=ACCENT)
+    # ... Aufbau wie oben
 ```
 
 ## Fehlerbehandlung

--- a/src/settings.py
+++ b/src/settings.py
@@ -15,6 +15,8 @@ DEFAULTS = {
     "mail_closing": "Mit freundlichen Grüßen",
     "hourly_rate": 0.0,
     "state": "",
+    "last_update_check_at": "",
+    "dismissed_version": "",
 }
 
 class Settings:

--- a/src/ui.py
+++ b/src/ui.py
@@ -8,11 +8,20 @@ import os
 import platform
 import threading
 import traceback
+import webbrowser
 from src.time_utils import calculate_hours, get_week_dates, get_week_label, week_spans_months
 from src.holidays_de import get_holidays
 from src.tooltip import attach_tooltip
 from src.mail import refresh_token_if_needed, TokenAuthError, TokenNetworkError
 from src.version import VERSION
+from src.updater import (
+    check_latest_release,
+    is_newer,
+    pick_asset_url,
+    should_check_today,
+    today_iso,
+    Release,
+)
 
 from src.dialogs.entry_dialog import open_entry_dialog
 from src.dialogs.send_dialog import open_send_dialog
@@ -75,6 +84,8 @@ class App:
         self.root.bind("<Right>", lambda e: self._next())
         self._refresh()
         self._proactive_token_refresh()
+        self._update_banner = None
+        self._proactive_update_check()
 
     def _proactive_token_refresh(self):
         """Erneuert den Gmail-Token beim App-Start im Hintergrund.
@@ -104,6 +115,86 @@ class App:
                 ))
 
         threading.Thread(target=worker, daemon=True).start()
+
+    def _proactive_update_check(self):
+        """Fragt einmal pro Kalendertag GitHub nach einer neueren Version.
+
+        Der HTTP-Call läuft in einem Daemon-Thread; alle State-Mutationen
+        (Settings-Write, Banner-Aufbau) werden via `root.after(0, ...)` auf
+        den UI-Thread marshallt, damit `Settings.set` nicht parallel zu
+        Schreibvorgängen aus dem Settings-Dialog läuft.
+
+        Fehler werden still verschluckt — Update-Hinweis ist nice-to-have.
+        """
+        if not should_check_today(self.settings.get("last_update_check_at")):
+            return
+
+        def worker():
+            try:
+                release = check_latest_release("MargenHeld/Zeiterfassung")
+                if release is None:
+                    return
+                newer = is_newer(VERSION, release.version)
+            except Exception:
+                # Pure Logik, robust gegen exotische Tags. Bei jedem Fehler:
+                # nichts persistieren, nichts anzeigen — morgen nochmal probieren.
+                return
+            self.root.after(
+                0, lambda: self._handle_update_check_result(release, newer)
+            )
+
+        threading.Thread(target=worker, daemon=True).start()
+
+    def _handle_update_check_result(self, release: "Release", newer: bool):
+        """Läuft im UI-Thread. Persistiert den Check-Stand und zeigt ggf. den Banner.
+
+        `is_newer` ist bereits im Worker ausgewertet, damit hier keine ungeschützte
+        Logik im Tk-Event-Loop läuft.
+        """
+        self.settings.set("last_update_check_at", today_iso())
+        if not newer:
+            return
+        if release.version == self.settings.get("dismissed_version"):
+            return
+        self._show_update_banner(release)
+
+    def _show_update_banner(self, release: "Release"):
+        if self._update_banner is not None:
+            return
+        self._update_banner = tk.Frame(self.root, bg=ACCENT)
+        self._update_banner.pack(
+            before=self.grid_frame, fill=tk.X, padx=10, pady=(5, 0),
+        )
+
+        tk.Label(
+            self._update_banner,
+            text=f"Version {release.version} verfügbar",
+            bg=ACCENT, fg="#ffffff", font=FONT_BOLD,
+        ).pack(side=tk.LEFT, padx=10, pady=6)
+
+        icon_button(
+            self._update_banner, "✕",
+            lambda: self._dismiss_update_banner(release.version),
+            fg="#ffffff", hover_fg=TEXT,
+        ).pack(side=tk.RIGHT, padx=(0, 6))
+
+        secondary_button(
+            self._update_banner, "Download",
+            lambda: self._open_update_download(release),
+            padx=12,
+        ).pack(side=tk.RIGHT, padx=6)
+
+    def _open_update_download(self, release: "Release"):
+        url = pick_asset_url(
+            release.assets, platform.system(), release.version,
+        ) or release.html_url
+        webbrowser.open(url)
+
+    def _dismiss_update_banner(self, version: str):
+        self.settings.set("dismissed_version", version)
+        if self._update_banner is not None:
+            self._update_banner.destroy()
+            self._update_banner = None
 
     def _build_header(self):
         frame = tk.Frame(self.root, bg=BG)

--- a/src/ui.py
+++ b/src/ui.py
@@ -27,7 +27,7 @@ from src.dialogs.entry_dialog import open_entry_dialog
 from src.dialogs.send_dialog import open_send_dialog
 from src.dialogs.settings_dialog import open_settings_dialog
 from src.theme import (
-    BG, CELL_BG, WEEKEND_BG, ACCENT, TEXT, TEXT_MUTED,
+    BG, CELL_BG, WEEKEND_BG, ACCENT, ACCENT_HOVER, TEXT, TEXT_MUTED,
     ENTRY_BG, WEEKEND_ENTRY_BG, WEEKEND_FG,
     HOLIDAY_BG, HOLIDAY_BG_HOVER, HOLIDAY_ACCENT,
     FONT, FONT_BOLD, FONT_HEADER, FONT_FOOTER, FONT_SMALL,
@@ -172,17 +172,21 @@ class App:
             bg=ACCENT, fg="#ffffff", font=FONT_BOLD,
         ).pack(side=tk.LEFT, padx=10, pady=6)
 
-        icon_button(
-            self._update_banner, "✕",
-            lambda: self._dismiss_update_banner(release.version),
-            fg="#ffffff", hover_fg=TEXT,
-        ).pack(side=tk.RIGHT, padx=(0, 6))
+        tk.Button(
+            self._update_banner, text="✕",
+            command=lambda: self._dismiss_update_banner(release.version),
+            font=FONT_BOLD, bg=ACCENT, fg="#ffffff",
+            activebackground=ACCENT_HOVER, activeforeground="#ffffff",
+            relief=tk.FLAT, cursor="hand2", bd=0, padx=8,
+        ).pack(side=tk.RIGHT, padx=(0, 4))
 
-        secondary_button(
-            self._update_banner, "Download",
-            lambda: self._open_update_download(release),
-            padx=12,
-        ).pack(side=tk.RIGHT, padx=6)
+        tk.Button(
+            self._update_banner, text="Download",
+            command=lambda: self._open_update_download(release),
+            font=FONT_BOLD, bg="#ffffff", fg=ACCENT,
+            activebackground="#f0f0f0", activeforeground=ACCENT_HOVER,
+            relief=tk.FLAT, cursor="hand2", bd=0, padx=14, pady=2,
+        ).pack(side=tk.RIGHT, padx=8, pady=4)
 
     def _open_update_download(self, release: "Release"):
         url = pick_asset_url(

--- a/src/ui.py
+++ b/src/ui.py
@@ -172,13 +172,15 @@ class App:
             bg=ACCENT, fg="#ffffff", font=FONT_BOLD,
         ).pack(side=tk.LEFT, padx=10, pady=6)
 
-        tk.Button(
+        dismiss_btn = tk.Button(
             self._update_banner, text="✕",
             command=lambda: self._dismiss_update_banner(release.version),
             font=FONT_BOLD, bg=ACCENT, fg="#ffffff",
             activebackground=ACCENT_HOVER, activeforeground="#ffffff",
             relief=tk.FLAT, cursor="hand2", bd=0, padx=8,
-        ).pack(side=tk.RIGHT, padx=(0, 4))
+        )
+        dismiss_btn.pack(side=tk.RIGHT, padx=(0, 4))
+        attach_tooltip(dismiss_btn, "Diese Version ausblenden")
 
         tk.Button(
             self._update_banner, text="Download",

--- a/src/updater.py
+++ b/src/updater.py
@@ -1,0 +1,14 @@
+"""Update-Check gegen GitHub-Releases (stdlib-only).
+
+Single Purpose: Netzwerk-Call, Versions-Vergleich, Asset-Match, Throttle.
+Keine Tk-Imports; UI-Layer ruft die Funktionen aus einem Worker-Thread.
+"""
+
+
+def _to_tuple(version: str) -> tuple[int, ...]:
+    return tuple(int(part) for part in version.split("."))
+
+
+def is_newer(current: str, latest: str) -> bool:
+    """True, wenn `latest` strikt neuer ist als `current`. Beide ohne v-Prefix."""
+    return _to_tuple(latest) > _to_tuple(current)

--- a/src/updater.py
+++ b/src/updater.py
@@ -4,6 +4,7 @@ Single Purpose: Netzwerk-Call, Versions-Vergleich, Asset-Match, Throttle.
 Keine Tk-Imports; UI-Layer ruft die Funktionen aus einem Worker-Thread.
 """
 
+from dataclasses import dataclass
 from datetime import date
 
 
@@ -36,3 +37,31 @@ def should_check_today(last_check: str | None, today: date | None = None) -> boo
     except ValueError:
         return True
     return last < today
+
+
+@dataclass(frozen=True)
+class Asset:
+    name: str
+    url: str
+
+
+@dataclass(frozen=True)
+class Release:
+    version: str        # ohne v-Prefix, z.B. "1.9.0"
+    html_url: str       # Release-Page auf GitHub
+    assets: tuple[Asset, ...]
+
+
+def pick_asset_url(assets, system: str, latest_version: str) -> str | None:
+    """Liefert die Download-URL für das Plattform-Asset oder None."""
+    expected_name = {
+        "Windows": "Zeiterfassung_Setup.exe",
+        "Darwin": f"Zeiterfassung-{latest_version}-arm64.dmg",
+        "Linux": f"Zeiterfassung-{latest_version}-x86_64.AppImage",
+    }.get(system)
+    if expected_name is None:
+        return None
+    for asset in assets:
+        if asset.name == expected_name:
+            return asset.url
+    return None

--- a/src/updater.py
+++ b/src/updater.py
@@ -4,6 +4,8 @@ Single Purpose: Netzwerk-Call, Versions-Vergleich, Asset-Match, Throttle.
 Keine Tk-Imports; UI-Layer ruft die Funktionen aus einem Worker-Thread.
 """
 
+from datetime import date
+
 
 def _to_tuple(version: str) -> tuple[int, ...]:
     return tuple(int(part) for part in version.split("."))
@@ -12,3 +14,25 @@ def _to_tuple(version: str) -> tuple[int, ...]:
 def is_newer(current: str, latest: str) -> bool:
     """True, wenn `latest` strikt neuer ist als `current`. Beide ohne v-Prefix."""
     return _to_tuple(latest) > _to_tuple(current)
+
+
+def today_iso() -> str:
+    """Heutiges Datum als ISO-Format `YYYY-MM-DD` (lokale Zeitzone)."""
+    return date.today().isoformat()
+
+
+def should_check_today(last_check: str | None, today: date | None = None) -> bool:
+    """True, wenn der letzte Check vor dem heutigen Kalendertag lag.
+
+    Drosselung pro Kalendertag (lokale Zeit), nicht pro 24-h-Fenster.
+    Bei leerem oder ungültigem `last_check` wird ebenfalls True geliefert,
+    damit ein einmal kaputter Wert nicht den Check für immer blockiert.
+    """
+    if not last_check:
+        return True
+    today = today or date.today()
+    try:
+        last = date.fromisoformat(last_check)
+    except ValueError:
+        return True
+    return last < today

--- a/src/updater.py
+++ b/src/updater.py
@@ -4,8 +4,13 @@ Single Purpose: Netzwerk-Call, Versions-Vergleich, Asset-Match, Throttle.
 Keine Tk-Imports; UI-Layer ruft die Funktionen aus einem Worker-Thread.
 """
 
+import json
 from dataclasses import dataclass
 from datetime import date
+from urllib.error import URLError
+from urllib.request import Request, urlopen
+
+from src.version import VERSION
 
 
 def _to_tuple(version: str) -> tuple[int, ...]:
@@ -65,3 +70,41 @@ def pick_asset_url(assets, system: str, latest_version: str) -> str | None:
         if asset.name == expected_name:
             return asset.url
     return None
+
+
+def check_latest_release(repo: str, timeout: float = 5.0) -> Release | None:
+    """Fragt die GitHub-API nach dem neuesten Release.
+
+    Liefert `None` bei jedem Fehler (Netzwerk, Timeout, kaputtes JSON,
+    fehlendes `tag_name`). Caller darf sich darauf verlassen, dass keine
+    Exception bubbled — Update-Hinweis ist nice-to-have.
+    """
+    url = f"https://api.github.com/repos/{repo}/releases/latest"
+    request = Request(
+        url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "User-Agent": f"Zeiterfassung/{VERSION}",
+        },
+    )
+    try:
+        with urlopen(request, timeout=timeout) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+        tag = payload.get("tag_name")
+        html_url = payload.get("html_url")
+        if not tag or not html_url:
+            return None
+        # Sowohl 'v' als auch 'V' strippen; Tags sind normiert, defensiv ist billig.
+        if tag[:1] in ("v", "V"):
+            tag = tag[1:]
+        raw_assets = payload.get("assets") or []
+        assets = tuple(
+            Asset(name=a["name"], url=a["browser_download_url"])
+            for a in raw_assets
+            if isinstance(a, dict) and "name" in a and "browser_download_url" in a
+        )
+        return Release(version=tag, html_url=html_url, assets=assets)
+    except (URLError, OSError, json.JSONDecodeError, TypeError, KeyError, AttributeError):
+        # URLError fängt auch HTTPError (4xx/5xx); OSError fängt socket.timeout etc.
+        # TypeError/KeyError/AttributeError fangen kaputte Payload-Strukturen ab.
+        return None

--- a/src/version.py
+++ b/src/version.py
@@ -1,1 +1,1 @@
-VERSION = "1.8.3"
+VERSION = "1.9.0"

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -39,3 +39,11 @@ def test_recipient_default(tmp_settings):
 
 def test_autostart_default(tmp_settings):
     assert tmp_settings.get("autostart") == False
+
+
+def test_last_update_check_at_default(tmp_settings):
+    assert tmp_settings.get("last_update_check_at") == ""
+
+
+def test_dismissed_version_default(tmp_settings):
+    assert tmp_settings.get("dismissed_version") == ""

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -1,0 +1,18 @@
+from src.updater import is_newer
+
+
+class TestIsNewer:
+    def test_same_version_is_not_newer(self):
+        assert is_newer("1.8.3", "1.8.3") is False
+
+    def test_higher_minor_is_newer(self):
+        assert is_newer("1.8.3", "1.9.0") is True
+
+    def test_lower_is_not_newer(self):
+        assert is_newer("1.9.0", "1.8.3") is False
+
+    def test_two_digit_patch_compares_numerically_not_lex(self):
+        assert is_newer("1.8.3", "1.8.10") is True
+
+    def test_higher_major_is_newer(self):
+        assert is_newer("1.8.3", "2.0.0") is True

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -1,6 +1,6 @@
 from datetime import date
 
-from src.updater import is_newer, should_check_today, today_iso
+from src.updater import Asset, is_newer, pick_asset_url, should_check_today, today_iso
 
 
 class TestIsNewer:
@@ -42,3 +42,37 @@ class TestShouldCheckToday:
 
     def test_invalid_string_returns_true(self):
         assert should_check_today("not-a-date", today=date(2026, 4, 28)) is True
+
+
+def _three_assets(version: str) -> list[Asset]:
+    return [
+        Asset(name="Zeiterfassung_Setup.exe", url="https://example.com/exe"),
+        Asset(name=f"Zeiterfassung-{version}-arm64.dmg", url="https://example.com/dmg"),
+        Asset(name=f"Zeiterfassung-{version}-x86_64.AppImage", url="https://example.com/appimage"),
+    ]
+
+
+class TestPickAssetUrl:
+    def test_windows_picks_exe(self):
+        assets = _three_assets("1.9.0")
+        assert pick_asset_url(assets, "Windows", "1.9.0") == "https://example.com/exe"
+
+    def test_darwin_picks_arm_dmg(self):
+        assets = _three_assets("1.9.0")
+        assert pick_asset_url(assets, "Darwin", "1.9.0") == "https://example.com/dmg"
+
+    def test_linux_picks_appimage(self):
+        assets = _three_assets("1.9.0")
+        assert pick_asset_url(assets, "Linux", "1.9.0") == "https://example.com/appimage"
+
+    def test_unknown_system_returns_none(self):
+        assets = _three_assets("1.9.0")
+        assert pick_asset_url(assets, "FreeBSD", "1.9.0") is None
+
+    def test_missing_asset_returns_none(self):
+        assets = [Asset(name="Zeiterfassung-1.9.0-x86_64.AppImage", url="u")]
+        assert pick_asset_url(assets, "Windows", "1.9.0") is None
+
+    def test_version_mismatch_in_dmg_name_returns_none(self):
+        assets = [Asset(name="Zeiterfassung-1.8.0-arm64.dmg", url="u")]
+        assert pick_asset_url(assets, "Darwin", "1.9.0") is None

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -1,4 +1,6 @@
-from src.updater import is_newer
+from datetime import date
+
+from src.updater import is_newer, should_check_today, today_iso
 
 
 class TestIsNewer:
@@ -16,3 +18,27 @@ class TestIsNewer:
 
     def test_higher_major_is_newer(self):
         assert is_newer("1.8.3", "2.0.0") is True
+
+
+class TestTodayIso:
+    def test_returns_iso_date_string(self):
+        result = today_iso()
+        # Roundtrip-Parse stellt sicher, dass es ein gültiges ISO-Datum ist
+        assert date.fromisoformat(result) == date.today()
+
+
+class TestShouldCheckToday:
+    def test_empty_string_returns_true(self):
+        assert should_check_today("", today=date(2026, 4, 28)) is True
+
+    def test_none_returns_true(self):
+        assert should_check_today(None, today=date(2026, 4, 28)) is True
+
+    def test_yesterday_returns_true(self):
+        assert should_check_today("2026-04-27", today=date(2026, 4, 28)) is True
+
+    def test_today_returns_false(self):
+        assert should_check_today("2026-04-28", today=date(2026, 4, 28)) is False
+
+    def test_invalid_string_returns_true(self):
+        assert should_check_today("not-a-date", today=date(2026, 4, 28)) is True

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -131,6 +131,11 @@ class TestCheckLatestRelease:
         with patch("src.updater.urlopen", return_value=_api_response(payload)):
             assert check_latest_release("any/repo") is None
 
+    def test_missing_html_url_returns_none(self):
+        payload = {"tag_name": "v1.9.0", "assets": []}
+        with patch("src.updater.urlopen", return_value=_api_response(payload)):
+            assert check_latest_release("any/repo") is None
+
     def test_malformed_assets_are_filtered(self):
         # Asset ohne browser_download_url + Asset als String → werden geskippt
         payload = {

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -1,6 +1,11 @@
+import json
+import socket
 from datetime import date
+from io import BytesIO
+from unittest.mock import patch
+from urllib.error import HTTPError, URLError
 
-from src.updater import Asset, is_newer, pick_asset_url, should_check_today, today_iso
+from src.updater import Asset, Release, check_latest_release, is_newer, pick_asset_url, should_check_today, today_iso
 
 
 class TestIsNewer:
@@ -76,3 +81,77 @@ class TestPickAssetUrl:
     def test_version_mismatch_in_dmg_name_returns_none(self):
         assets = [Asset(name="Zeiterfassung-1.8.0-arm64.dmg", url="u")]
         assert pick_asset_url(assets, "Darwin", "1.9.0") is None
+
+
+def _api_response(payload: dict) -> BytesIO:
+    return BytesIO(json.dumps(payload).encode("utf-8"))
+
+
+HAPPY_PAYLOAD = {
+    "tag_name": "v1.9.0",
+    "html_url": "https://github.com/MargenHeld/Zeiterfassung/releases/tag/v1.9.0",
+    "assets": [
+        {"name": "Zeiterfassung_Setup.exe", "browser_download_url": "https://example.com/exe"},
+        {"name": "Zeiterfassung-1.9.0-arm64.dmg", "browser_download_url": "https://example.com/dmg"},
+        {"name": "Zeiterfassung-1.9.0-x86_64.AppImage", "browser_download_url": "https://example.com/appimage"},
+    ],
+}
+
+
+class TestCheckLatestRelease:
+    def test_happy_path_strips_v_prefix_and_parses_assets(self):
+        with patch("src.updater.urlopen", return_value=_api_response(HAPPY_PAYLOAD)):
+            release = check_latest_release("MargenHeld/Zeiterfassung")
+        assert release is not None
+        assert release.version == "1.9.0"
+        assert release.html_url.endswith("/v1.9.0")
+        assert len(release.assets) == 3
+        assert release.assets[0].name == "Zeiterfassung_Setup.exe"
+        assert release.assets[0].url == "https://example.com/exe"
+
+    def test_url_error_returns_none(self):
+        with patch("src.updater.urlopen", side_effect=URLError("offline")):
+            assert check_latest_release("any/repo") is None
+
+    def test_http_404_returns_none(self):
+        err = HTTPError(url="x", code=404, msg="Not Found", hdrs=None, fp=None)
+        with patch("src.updater.urlopen", side_effect=err):
+            assert check_latest_release("any/repo") is None
+
+    def test_socket_timeout_returns_none(self):
+        with patch("src.updater.urlopen", side_effect=socket.timeout()):
+            assert check_latest_release("any/repo") is None
+
+    def test_invalid_json_returns_none(self):
+        with patch("src.updater.urlopen", return_value=BytesIO(b"not json{{")):
+            assert check_latest_release("any/repo") is None
+
+    def test_missing_tag_name_returns_none(self):
+        payload = {"html_url": "x", "assets": []}
+        with patch("src.updater.urlopen", return_value=_api_response(payload)):
+            assert check_latest_release("any/repo") is None
+
+    def test_malformed_assets_are_filtered(self):
+        # Asset ohne browser_download_url + Asset als String → werden geskippt
+        payload = {
+            "tag_name": "v1.9.0",
+            "html_url": "x",
+            "assets": [
+                {"name": "ok", "browser_download_url": "u1"},
+                {"name": "incomplete"},                       # ohne URL
+                "not-a-dict",                                 # falscher Typ
+                {"name": "ok2", "browser_download_url": "u2"},
+            ],
+        }
+        with patch("src.updater.urlopen", return_value=_api_response(payload)):
+            release = check_latest_release("any/repo")
+        assert release is not None
+        assert len(release.assets) == 2
+        assert {a.name for a in release.assets} == {"ok", "ok2"}
+
+    def test_uppercase_v_prefix_is_stripped(self):
+        payload = dict(HAPPY_PAYLOAD, tag_name="V1.9.0")
+        with patch("src.updater.urlopen", return_value=_api_response(payload)):
+            release = check_latest_release("any/repo")
+        assert release is not None
+        assert release.version == "1.9.0"


### PR DESCRIPTION
## Summary

- Beim App-Start prüft die App einmal pro Kalendertag die GitHub-Releases-API. Bei einer neueren Version erscheint ein unaufdringlicher Banner zwischen Header und Kalender mit Versions-Hinweis, **Download**-Button und ✕ zum Ausblenden
- **Download** öffnet das passende Plattform-Asset im Browser (`Zeiterfassung_Setup.exe` / `*-arm64.dmg` / `*-x86_64.AppImage`); Fallback auf die Release-Page bei Plattform-Mismatch (Intel-Mac, ARM-Linux)
- ✕ persistiert die Version als `dismissed_version` in `settings.json` — Banner erscheint erst wieder, wenn eine noch neuere Version released wird
- Netzwerk-/API-Fehler werden still verschluckt (analog zum bestehenden `_proactive_token_refresh`-Pattern). Update-Hinweis ist nice-to-have, soll keinen Offline-Start stören

## Implementierung

- Neues stdlib-only Modul `src/updater.py` (~110 Zeilen): `check_latest_release`, `is_newer`, `pick_asset_url`, `should_check_today`, `today_iso`, `Release`/`Asset` Dataclasses
- `src/ui.py::App` erweitert um Daemon-Worker und Banner-Methoden — `is_newer` läuft im Worker, damit kein ungeschützter Logik-Call im Tk-Event-Loop landet; `Settings.set` wird via `root.after` auf den UI-Thread marshallt (kein Race mit dem Settings-Dialog)
- 26 neue Unit-Tests in `tests/test_updater.py` (alle HTTP-Calls gemockt)
- 2 neue Settings-Defaults: `last_update_check_at`, `dismissed_version`

## Test plan

- [x] 126/126 Unit-Tests grün (`pytest tests/`)
- [x] Manueller Smoke-Test: Banner erscheint bei `VERSION="1.0.0"`, Download öffnet `.exe`-Asset, ✕ blendet aus, Tooltip erscheint
- [ ] Auf macOS / Linux nicht verifiziert (CI baut aber alle drei Plattformen)

## Spec & Plan

- Spec: `docs/superpowers/specs/2026-04-28-update-check-design.md`
- Plan: `docs/superpowers/plans/2026-04-28-update-check.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)