### PR TITLE
docs: cache-bust release badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Desktop-App zur Erfassung von Arbeitszeiten mit Kalenderansicht, PDF-Report und automatischem Gmail-Versand.
 
-[![Release](https://img.shields.io/github/v/release/margenheld/Zeiterfassung?label=Release&color=success)](https://github.com/margenheld/Zeiterfassung/releases/latest) ![Python](https://img.shields.io/badge/Python-3.10+-blue) ![Platform](https://img.shields.io/badge/Platform-Windows%20%7C%20macOS%20%7C%20Linux-lightgrey)
+[![Release](https://img.shields.io/github/v/release/margenheld/Zeiterfassung?label=Release&color=success&logo=github)](https://github.com/margenheld/Zeiterfassung/releases/latest) ![Python](https://img.shields.io/badge/Python-3.10+-blue) ![Platform](https://img.shields.io/badge/Platform-Windows%20%7C%20macOS%20%7C%20Linux-lightgrey)
 
 ## Features
 


### PR DESCRIPTION
## Summary
GitHub Camo cached an invalid shields.io response from when v1.9.1 was being published. Adding `&logo=github` to the badge URL bypasses the cache and adds the GitHub logo as a bonus.

shields.io directly returns the correct `Release | v1.9.1` SVG — only Camo had the stale entry.

## Test plan
- [x] Verified shields.io live response: `Release: v1.9.1`
- [ ] After merge: badge shows `Release | v1.9.1` with GitHub logo

🤖 Generated with [Claude Code](https://claude.com/claude-code)