### PR TITLE
fix(entry-dialog): hide Löschen button when no entry exists

### DIFF
--- a/src/dialogs/entry_dialog.py
+++ b/src/dialogs/entry_dialog.py
@@ -90,6 +90,7 @@ def open_entry_dialog(parent, date_str, storage, settings, on_change):
     btn_frame.grid(row=3, column=0, columnspan=2, pady=12)
 
     primary_button(btn_frame, "Speichern", save).pack(side=tk.LEFT, padx=5)
-    secondary_button(btn_frame, "Löschen", delete).pack(side=tk.LEFT, padx=5)
+    if entry is not None:
+        secondary_button(btn_frame, "Löschen", delete).pack(side=tk.LEFT, padx=5)
 
     center_dialog_on_parent(dialog, parent)


### PR DESCRIPTION
## Summary
- Wenn ein Tag keinen gespeicherten Eintrag hat, wurde im Entry-Dialog trotzdem ein „Löschen"-Button angezeigt. Drücken hatte keine Wirkung — UI-Lüge.
- Fix: `secondary_button("Löschen", …)` nur erzeugen, wenn `entry is not None`.

## Test plan
- [ ] App starten, leeren Tag anklicken → Dialog zeigt nur „Speichern"
- [ ] Tag mit Eintrag anklicken → Dialog zeigt „Speichern" + „Löschen"

🤖 Generated with [Claude Code](https://claude.com/claude-code)