### PR TITLE
feat: Dev-Mode (--dev) mit Fake-Google-Diensten und Log-Konsole

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ build/
 .aider*
 credentials.lnk
 release-artifacts/
+reservations.json*
+
+# Dev-Mode Daten-Verzeichnis (python -m src.main --dev)
+dev-data/

--- a/docs/superpowers/plans/2026-05-28-dev-mode.md
+++ b/docs/superpowers/plans/2026-05-28-dev-mode.md
@@ -1,0 +1,1066 @@
+# Dev-Mode Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ein über `python -m src.main --dev` aktivierter Entwickler-Modus mit gefakten Google-Diensten, isoliertem Dev-Daten-Verzeichnis, einem Log-Konsolen-Fenster samt Aktions-Buttons und einem „Dev-Mode"-Hinweis im Fenstertitel.
+
+**Architecture:** Ein isoliertes Paket `src/dev/`, das im Normalbetrieb nie importiert wird. `main()` setzt bei `--dev` ein Dev-Daten-Verzeichnis über die vorhandene `ZEITERFASSUNG_DATA_DIR`-Override und ruft `src.dev.activate()`, das die Google-Eintrittspunkte in `mail`/`drive`/`gcal` per Monkeypatch durch Fakes ersetzt und Sample-Daten seedet. Das Konsolen-Fenster (`DevConsole`) hängt einen Logging-Handler an den Root-Logger und bietet Buttons, die schmale Methoden auf `App` aufrufen.
+
+**Tech Stack:** Python 3, Tkinter, pytest, unittest.mock. Keine neuen Dependencies.
+
+**Referenz-Spec:** `docs/superpowers/specs/2026-05-28-dev-mode-design.md`
+
+---
+
+## Wichtige Vorab-Erkenntnisse (Begründung der Entscheidungen)
+
+- **Nur 2 Dialoge brauchen Import-Umstellung, nicht 3.** `send_dialog.py` und `share_dialog.py` importieren `get_gmail_service`/`send_email`/`is_offline_error` auf Modul-Ebene (Bindung *vor* `activate()`) → Patch greift dort nicht ohne Umstellung. `settings_dialog.py` importiert `get_gmail_service` dagegen **lazy** innerhalb einer Funktion (`from src.mail import ... get_gmail_service`) — das liest das Modul-Attribut zur Aufrufzeit und nimmt den Patch automatisch mit. `drive`/`gcal` werden überall modul-qualifiziert aufgerufen.
+- **Kein `token.json` seeden.** `ui.py` bindet `refresh_token_if_needed`/`fetch_user_email` top-level (vor `activate()`), patchen wäre wirkungslos. Stattdessen: ohne `token.json` liefert `refresh_token_if_needed` sauber `"no_token"` und `_proactive_sender_email_fetch` kehrt früh zurück (`if not os.path.exists(token_path): return`). So gibt es beim Dev-Start keine Token-Popups und keine Netzwerk-Calls. Ein Dummy-`credentials.json` wird trotzdem geschrieben, damit etwaige Existenz-Checks zufrieden sind.
+- **Fakes patchen nur Modul-Funktionen** (keine googleapiclient-Resource-Ketten): `mail.get_gmail_service`, `mail.send_email`, `drive.get_drive_service/find_sync_file/download/upload`, `gcal.get_calendar_service/list_app_events/create_event/update_event/delete_event`.
+
+---
+
+## File Structure
+
+| Datei | Verantwortung |
+|-------|---------------|
+| `src/dev/__init__.py` | `activate(base_path)` — Monkeypatch + Seed, einziger Einstiegspunkt |
+| `src/dev/fakes.py` | Fake-Implementierungen der Google-Modul-Funktionen + prozessweiter Fake-State |
+| `src/dev/seed.py` | Sample-Daten ins Dev-Verzeichnis schreiben (`seed_if_empty`, `reseed`) |
+| `src/dev/console.py` | `DevConsole` — Tk-Toplevel Log-Viewer + Aktions-Buttons + Logging-Handler |
+| `src/storage.py` | `Storage.reload()` ergänzen (für „Sample-Daten neu laden") |
+| `src/main.py` | `--dev`-Erkennung, ENV-Override, `activate()`, `dev_mode` an `App` |
+| `src/ui.py` | `App(dev_mode=...)`, Titel-Suffix, `dev_sync_pull/push/reload`, `DevConsole` erzeugen |
+| `src/dialogs/send_dialog.py` | Import-Vereinheitlichung `from src import mail` |
+| `src/dialogs/share_dialog.py` | Import-Vereinheitlichung `from src import mail` |
+| `.gitignore` | `dev-data/` ignorieren |
+| `tests/test_dev_fakes.py` | Tests für Fakes |
+| `tests/test_dev_seed.py` | Tests für Seed |
+| `tests/test_dev_activate.py` | Tests für Patching + Guard (kein Dev-Import im Normalstart) |
+
+---
+
+## Task 1: `Storage.reload()`
+
+**Files:**
+- Modify: `src/storage.py`
+- Test: `tests/test_storage.py` (anhängen)
+
+- [ ] **Step 1: Write the failing test**
+
+In `tests/test_storage.py` anhängen:
+
+```python
+def test_reload_picks_up_external_file_change(tmp_path):
+    from src.storage import Storage
+    fp = tmp_path / "z.json"
+    fp.write_text('{}', encoding="utf-8")
+    s = Storage(str(fp), device_id="dev")
+    assert s.get_all() == {}
+
+    # Datei extern ersetzen (simuliert Reseed)
+    fp.write_text(
+        '{"2026-05-28": {"start": "08:00", "end": "16:00", "pause": 30,'
+        ' "modified_at": "2026-05-28T00:00:00Z", "device_id": "dev", "deleted": false}}',
+        encoding="utf-8",
+    )
+    s.reload()
+    assert s.get("2026-05-28") == {"start": "08:00", "end": "16:00", "pause": 30}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_storage.py::test_reload_picks_up_external_file_change -v`
+Expected: FAIL mit `AttributeError: 'Storage' object has no attribute 'reload'`
+
+- [ ] **Step 3: Implement `reload()`**
+
+In `src/storage.py`, nach der `_load`-Methode (nach Zeile 56) einfügen:
+
+```python
+    def reload(self):
+        """Verwirft den In-Memory-Stand und liest die Datei neu ein.
+
+        Für Dev-Tools, die die JSON-Datei unter der laufenden App ersetzen
+        (z.B. Reseed). Setzt `_data` erst leer, damit ein Reload nach dem
+        Löschen der Datei nicht den alten Stand behält."""
+        self._data = {}
+        self._load()
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_storage.py::test_reload_picks_up_external_file_change -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/storage.py tests/test_storage.py
+git commit -m "feat(storage): add reload() to re-read file from disk"
+```
+
+---
+
+## Task 2: `src/dev/fakes.py` — Fake-Google-Layer
+
+**Files:**
+- Create: `src/dev/__init__.py` (zunächst leer — Paket-Marker; `activate` kommt in Task 4)
+- Create: `src/dev/fakes.py`
+- Test: `tests/test_dev_fakes.py`
+
+- [ ] **Step 1: Paket-Marker anlegen**
+
+Create `src/dev/__init__.py` mit leerem Inhalt (eine Kommentarzeile):
+
+```python
+# src/dev/ — Entwickler-Modus. Wird nur bei `python -m src.main --dev` importiert.
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `tests/test_dev_fakes.py`:
+
+```python
+import logging
+
+import pytest
+
+from src.dev import fakes
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    fakes.reset_state()
+    yield
+    fakes.reset_state()
+
+
+def test_fake_send_email_logs_and_returns_id(caplog):
+    with caplog.at_level(logging.INFO, logger="zeiterfassung.dev"):
+        msg_id = fakes.fake_send_email(
+            object(), "a@b.de", "Betreff", "<html></html>",
+            attachment_filename="report.pdf",
+        )
+    assert msg_id.startswith("dev-msg-")
+    assert "würde Mail senden" in caplog.text
+    assert "a@b.de" in caplog.text
+
+
+def test_fake_drive_roundtrip():
+    service = fakes.fake_get_drive_service("c.json", "t.json")
+    assert fakes.fake_find_sync_file(service) is None
+
+    content = b'{"entries": {"x": 1}}'
+    file_id, ver1 = fakes.fake_upload(service, content)
+    assert file_id == "dev-file"
+    assert fakes.fake_find_sync_file(service) == "dev-file"
+
+    data, ver2 = fakes.fake_download(service, file_id)
+    assert data == content
+    assert ver2 == ver1
+
+    _, ver3 = fakes.fake_upload(service, b'{"entries": {}}', file_id)
+    assert int(ver3) > int(ver1)
+
+
+def test_fake_calendar_create_list_delete():
+    service = fakes.fake_get_calendar_service()
+    assert fakes.fake_list_app_events(service, "cal") == []
+
+    eid = fakes.fake_create_event(service, "cal", "2026-05-28", "08:00", "16:00", "m1")
+    events = fakes.fake_list_app_events(service, "cal")
+    assert len(events) == 1
+    assert events[0]["event_id"] == eid
+    assert events[0]["date"] == "2026-05-28"
+
+    fakes.fake_update_event(service, "cal", eid, "2026-05-28", "09:00", "17:00", "m2")
+    assert fakes.fake_list_app_events(service, "cal")[0]["start"] == "09:00"
+
+    fakes.fake_delete_event(service, "cal", eid)
+    assert fakes.fake_list_app_events(service, "cal") == []
+
+
+def test_simulate_auth_error_once_raises_then_clears():
+    from src.mail import TokenAuthError
+    fakes.simulate_auth_error_once()
+    with pytest.raises(TokenAuthError):
+        fakes.fake_get_gmail_service()
+    # Nur einmal — danach wieder normal
+    assert fakes.fake_get_gmail_service() is not None
+
+
+def test_reset_state_clears_drive_and_calendar():
+    service = fakes.fake_get_drive_service("c", "t")
+    fakes.fake_upload(service, b"{}")
+    fakes.fake_create_event(service, "cal", "2026-05-28", "08:00", "16:00", "m")
+    fakes.reset_state()
+    assert fakes.fake_find_sync_file(service) is None
+    assert fakes.fake_list_app_events(service, "cal") == []
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `pytest tests/test_dev_fakes.py -v`
+Expected: FAIL mit `ImportError` / `AttributeError` (fakes-Funktionen existieren nicht)
+
+- [ ] **Step 4: Implement `src/dev/fakes.py`**
+
+Create `src/dev/fakes.py`:
+
+```python
+"""Fake-Implementierungen der Google-Eintrittspunkte für den Dev-Mode.
+
+Alle Funktionen spiegeln die Signaturen der echten Wrapper in src/mail.py,
+src/drive.py und src/gcal.py. Sie führen keine Netzwerk-Calls aus, liefern
+kanonische Erfolge und loggen, was passiert wäre. Der Drive- und Kalender-
+State lebt prozessweit als Modul-Globals.
+"""
+
+import json
+import logging
+
+log = logging.getLogger("zeiterfassung.dev")
+
+
+class _FakeService:
+    """Platzhalter-Objekt, das die gemockten Builder zurückgeben. Wird nur
+    durchgereicht, nie aufgerufen."""
+
+
+_drive_doc = None        # dict | None
+_drive_version = 0
+_events = {}             # event_id -> {date, start, end, modified_at, event_id}
+_event_counter = 0
+_msg_counter = 0
+_simulate_auth_error = False
+
+
+def reset_state():
+    """Setzt Drive-Doc, Kalender und Zähler zurück (für 'Sample-Daten neu laden')."""
+    global _drive_doc, _drive_version, _events, _event_counter, _msg_counter
+    global _simulate_auth_error
+    _drive_doc = None
+    _drive_version = 0
+    _events = {}
+    _event_counter = 0
+    _msg_counter = 0
+    _simulate_auth_error = False
+
+
+def simulate_auth_error_once():
+    """Lässt den nächsten Service-Builder-Aufruf einmalig TokenAuthError werfen."""
+    global _simulate_auth_error
+    _simulate_auth_error = True
+
+
+def _maybe_raise_auth():
+    global _simulate_auth_error
+    if _simulate_auth_error:
+        _simulate_auth_error = False
+        from src.mail import TokenAuthError
+        log.warning("DEV: simulierter TokenAuthError")
+        raise TokenAuthError("DEV: simulierter Token-Fehler")
+
+
+# --- Gmail ---------------------------------------------------------------
+
+def fake_get_gmail_service(credentials_path="credentials.json",
+                           token_path="token.json",
+                           sync_enabled=False, gcal_enabled=False):
+    _maybe_raise_auth()
+    log.info("DEV fake_get_gmail_service()")
+    return _FakeService()
+
+
+def fake_send_email(service, to, subject, html_body,
+                    attachment_bytes=None, attachment_filename=None,
+                    attachment_subtype="pdf",
+                    pdf_bytes=None, pdf_filename=None):
+    global _msg_counter
+    _msg_counter += 1
+    filename = attachment_filename or pdf_filename
+    log.info("DEV: würde Mail senden an=%s betreff=%s anhang=%s",
+             to, subject, filename)
+    return f"dev-msg-{_msg_counter}"
+
+
+# --- Drive ---------------------------------------------------------------
+
+def fake_get_drive_service(credentials_path, token_path, gcal_enabled=False):
+    _maybe_raise_auth()
+    log.info("DEV fake_get_drive_service()")
+    return _FakeService()
+
+
+def fake_find_sync_file(service):
+    return "dev-file" if _drive_doc is not None else None
+
+
+def fake_download(service, file_id):
+    payload = _drive_doc if _drive_doc is not None else {}
+    data = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+    log.info("DEV fake_download() version=%s", _drive_version)
+    return data, str(_drive_version)
+
+
+def fake_upload(service, content_bytes, file_id=None, expected_etag=None):
+    global _drive_doc, _drive_version
+    _drive_doc = json.loads(content_bytes)
+    _drive_version += 1
+    log.info("DEV fake_upload() -> version=%s", _drive_version)
+    return "dev-file", str(_drive_version)
+
+
+# --- Calendar ------------------------------------------------------------
+
+def fake_get_calendar_service(credentials_path="credentials.json",
+                              token_path="token.json", sync_enabled=False):
+    _maybe_raise_auth()
+    log.info("DEV fake_get_calendar_service()")
+    return _FakeService()
+
+
+def fake_list_app_events(service, calendar_id):
+    return [dict(ev) for ev in _events.values()]
+
+
+def fake_create_event(service, calendar_id, date_str, start, end, modified_at):
+    global _event_counter
+    _event_counter += 1
+    event_id = f"dev-evt-{_event_counter}"
+    _events[event_id] = {
+        "date": date_str, "start": start, "end": end,
+        "modified_at": modified_at, "event_id": event_id,
+    }
+    log.info("DEV fake_create_event() id=%s date=%s", event_id, date_str)
+    return event_id
+
+
+def fake_update_event(service, calendar_id, event_id, date_str, start, end, modified_at):
+    _events[event_id] = {
+        "date": date_str, "start": start, "end": end,
+        "modified_at": modified_at, "event_id": event_id,
+    }
+    log.info("DEV fake_update_event() id=%s", event_id)
+
+
+def fake_delete_event(service, calendar_id, event_id):
+    _events.pop(event_id, None)
+    log.info("DEV fake_delete_event() id=%s", event_id)
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pytest tests/test_dev_fakes.py -v`
+Expected: PASS (6 Tests)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/dev/__init__.py src/dev/fakes.py tests/test_dev_fakes.py
+git commit -m "feat(dev): add fake Google service layer for dev-mode"
+```
+
+---
+
+## Task 3: `src/dev/seed.py` — Sample-Daten
+
+**Files:**
+- Create: `src/dev/seed.py`
+- Test: `tests/test_dev_seed.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_dev_seed.py`:
+
+```python
+import json
+import os
+
+from src.dev import seed
+
+
+def test_seed_if_empty_creates_files(tmp_path):
+    base = str(tmp_path)
+    seed.seed_if_empty(base)
+    z = json.loads((tmp_path / "zeiterfassung.json").read_text(encoding="utf-8"))
+    assert len(z) >= 1
+    # Einträge haben die volle Storage-Form inkl. Sync-Metadaten
+    first = next(iter(z.values()))
+    assert set(first) == {"start", "end", "pause", "modified_at", "device_id", "deleted"}
+    assert (tmp_path / "settings.json").exists()
+    assert (tmp_path / "credentials.json").exists()
+    # KEIN token.json — sonst Token-Popups beim Dev-Start
+    assert not (tmp_path / "token.json").exists()
+
+
+def test_seed_if_empty_is_noop_when_entries_exist(tmp_path):
+    base = str(tmp_path)
+    (tmp_path / "zeiterfassung.json").write_text('{"keep": 1}', encoding="utf-8")
+    seed.seed_if_empty(base)
+    z = json.loads((tmp_path / "zeiterfassung.json").read_text(encoding="utf-8"))
+    assert z == {"keep": 1}
+
+
+def test_reseed_overwrites(tmp_path):
+    base = str(tmp_path)
+    (tmp_path / "zeiterfassung.json").write_text('{"keep": 1}', encoding="utf-8")
+    seed.reseed(base)
+    z = json.loads((tmp_path / "zeiterfassung.json").read_text(encoding="utf-8"))
+    assert "keep" not in z
+    assert len(z) >= 1
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_dev_seed.py -v`
+Expected: FAIL mit `ImportError` / `AttributeError` (seed-Funktionen fehlen)
+
+- [ ] **Step 3: Implement `src/dev/seed.py`**
+
+Create `src/dev/seed.py`:
+
+```python
+"""Sample-Daten für das Dev-Daten-Verzeichnis.
+
+Schreibt Einträge, Settings und ein Dummy-credentials.json — aber bewusst
+KEIN token.json (siehe Plan-Header: hält den Dev-Start frei von Token-Popups).
+"""
+
+import datetime
+import json
+import os
+
+_DATA_FILES = ("zeiterfassung.json", "settings.json", "credentials.json")
+
+
+def _utc_now_iso():
+    return datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _sample_entries():
+    today = datetime.date.today()
+    now = _utc_now_iso()
+    entries = {}
+    for delta in (0, 1, 2, 7):
+        day = today - datetime.timedelta(days=delta)
+        entries[day.isoformat()] = {
+            "start": "08:00",
+            "end": "16:30",
+            "pause": 30,
+            "modified_at": now,
+            "device_id": "dev",
+            "deleted": False,
+        }
+    return entries
+
+
+def _write_all(base_path):
+    os.makedirs(base_path, exist_ok=True)
+    with open(os.path.join(base_path, "zeiterfassung.json"), "w", encoding="utf-8") as f:
+        json.dump(_sample_entries(), f, indent=2, ensure_ascii=False)
+
+    settings = {
+        "name": "Dev User",
+        "recipient": "dev@example.com",
+        "sync_enabled": False,
+        "gcal_enabled": False,
+    }
+    with open(os.path.join(base_path, "settings.json"), "w", encoding="utf-8") as f:
+        json.dump(settings, f, indent=2, ensure_ascii=False)
+
+    creds = {"installed": {"client_id": "dev", "client_secret": "dev",
+                           "auth_uri": "", "token_uri": ""}}
+    with open(os.path.join(base_path, "credentials.json"), "w", encoding="utf-8") as f:
+        json.dump(creds, f)
+
+
+def seed_if_empty(base_path):
+    """Schreibt Sample-Daten nur, wenn noch keine zeiterfassung.json existiert."""
+    os.makedirs(base_path, exist_ok=True)
+    if os.path.exists(os.path.join(base_path, "zeiterfassung.json")):
+        return
+    _write_all(base_path)
+
+
+def reseed(base_path):
+    """Löscht die Daten-Dateien und schreibt frische Sample-Daten."""
+    for name in _DATA_FILES:
+        path = os.path.join(base_path, name)
+        if os.path.exists(path):
+            os.remove(path)
+    _write_all(base_path)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_dev_seed.py -v`
+Expected: PASS (3 Tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/dev/seed.py tests/test_dev_seed.py
+git commit -m "feat(dev): seed sample data into dev data dir"
+```
+
+---
+
+## Task 4: `activate()` + Guard-Test
+
+**Files:**
+- Modify: `src/dev/__init__.py`
+- Test: `tests/test_dev_activate.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_dev_activate.py`:
+
+```python
+import importlib
+import pathlib
+import subprocess
+import sys
+
+import pytest
+
+
+def test_activate_patches_module_functions(tmp_path):
+    from src import drive, gcal, mail
+    from src.dev import activate, fakes
+
+    # Originale merken, um nach dem Test wiederherzustellen
+    originals = {
+        (mail, "get_gmail_service"): mail.get_gmail_service,
+        (mail, "send_email"): mail.send_email,
+        (drive, "get_drive_service"): drive.get_drive_service,
+        (drive, "find_sync_file"): drive.find_sync_file,
+        (drive, "download"): drive.download,
+        (drive, "upload"): drive.upload,
+        (gcal, "get_calendar_service"): gcal.get_calendar_service,
+        (gcal, "list_app_events"): gcal.list_app_events,
+        (gcal, "create_event"): gcal.create_event,
+        (gcal, "update_event"): gcal.update_event,
+        (gcal, "delete_event"): gcal.delete_event,
+    }
+    try:
+        activate(str(tmp_path))
+        assert mail.send_email is fakes.fake_send_email
+        assert mail.get_gmail_service is fakes.fake_get_gmail_service
+        assert drive.upload is fakes.fake_upload
+        assert drive.find_sync_file is fakes.fake_find_sync_file
+        assert gcal.create_event is fakes.fake_create_event
+        assert gcal.list_app_events is fakes.fake_list_app_events
+        # Seed lief mit
+        assert (tmp_path / "zeiterfassung.json").exists()
+    finally:
+        for (module, name), fn in originals.items():
+            setattr(module, name, fn)
+
+
+def test_normal_import_does_not_load_dev():
+    """Ein Import von src.main (ohne --dev) zieht src.dev NICHT mit rein."""
+    pytest.importorskip("tkinter")  # CI ohne tkinter überspringt diesen Guard
+    repo = pathlib.Path(__file__).resolve().parents[1]
+    code = (
+        "import sys; import src.main; "
+        "leaked = [m for m in sys.modules if m.startswith('src.dev')]; "
+        "assert not leaked, leaked"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True, text=True, cwd=str(repo),
+    )
+    assert result.returncode == 0, result.stderr
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_dev_activate.py -v`
+Expected: FAIL mit `ImportError: cannot import name 'activate' from 'src.dev'`
+
+- [ ] **Step 3: Implement `activate()` in `src/dev/__init__.py`**
+
+`src/dev/__init__.py` ersetzen durch:
+
+```python
+# src/dev/ — Entwickler-Modus. Wird nur bei `python -m src.main --dev` importiert.
+import logging
+
+
+def activate(base_path):
+    """Installiert die Fakes (Monkeypatch) und seedet Sample-Daten.
+
+    Aufzurufen aus main(), nachdem base_path feststeht und bevor Storage/
+    Settings konstruiert werden (sie lesen die geseedeten Dateien)."""
+    from src import drive, gcal, mail
+    from src.dev import fakes, seed
+
+    mail.get_gmail_service = fakes.fake_get_gmail_service
+    mail.send_email = fakes.fake_send_email
+
+    drive.get_drive_service = fakes.fake_get_drive_service
+    drive.find_sync_file = fakes.fake_find_sync_file
+    drive.download = fakes.fake_download
+    drive.upload = fakes.fake_upload
+
+    gcal.get_calendar_service = fakes.fake_get_calendar_service
+    gcal.list_app_events = fakes.fake_list_app_events
+    gcal.create_event = fakes.fake_create_event
+    gcal.update_event = fakes.fake_update_event
+    gcal.delete_event = fakes.fake_delete_event
+
+    seed.seed_if_empty(base_path)
+    logging.getLogger("zeiterfassung.dev").info(
+        "Dev-Mode aktiviert — Daten=%s", base_path)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_dev_activate.py -v`
+Expected: PASS (2 Tests; der Guard wird ggf. übersprungen, falls tkinter fehlt)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/dev/__init__.py tests/test_dev_activate.py
+git commit -m "feat(dev): activate() installs fakes and seeds data"
+```
+
+---
+
+## Task 5: `src/dev/console.py` — Konsolen-Fenster
+
+**Files:**
+- Create: `src/dev/console.py`
+- Test: `tests/test_dev_activate.py` (Handler-Formatierung anhängen — tkinter-frei testbar)
+
+- [ ] **Step 1: Write the failing test (nur die Handler-Formatierung)**
+
+In `tests/test_dev_activate.py` anhängen:
+
+```python
+def test_log_handler_formats_record():
+    import logging as _logging
+    from src.dev.console import _TkLogHandler
+
+    captured = []
+
+    class _FakeWidget:
+        def config(self, **k): pass
+        def insert(self, *a): captured.append(a[1])
+        def see(self, *a): pass
+
+    class _FakeRoot:
+        def after(self, _delay, fn, *args):
+            fn(*args)  # synchron ausführen statt über die Tk-Eventloop
+
+    handler = _TkLogHandler(_FakeWidget(), _FakeRoot())
+    record = _logging.LogRecord("zeiterfassung.dev", _logging.INFO,
+                                "x.py", 1, "Hallo Welt", None, None)
+    handler.emit(record)
+    assert any("Hallo Welt" in line for line in captured)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_dev_activate.py::test_log_handler_formats_record -v`
+Expected: FAIL mit `ModuleNotFoundError: No module named 'src.dev.console'`
+
+- [ ] **Step 3: Implement `src/dev/console.py`**
+
+Create `src/dev/console.py`:
+
+```python
+"""Dev-Konsole: Tk-Toplevel mit Live-Log-Viewer und Aktions-Buttons.
+
+Nur im Dev-Mode aus App erzeugt. Der Logging-Handler schiebt Records
+thread-sicher per root.after ins Text-Widget (Logs kommen aus Worker-Threads).
+"""
+
+import logging
+import tkinter as tk
+
+from src.theme import BG, TEXT
+
+
+class _TkLogHandler(logging.Handler):
+    def __init__(self, widget, root):
+        super().__init__()
+        self._widget = widget
+        self._root = root
+        self.setFormatter(logging.Formatter(
+            "%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+            datefmt="%H:%M:%S",
+        ))
+
+    def emit(self, record):
+        try:
+            msg = self.format(record)
+        except Exception:
+            return
+        self._root.after(0, self._append, msg)
+
+    def _append(self, msg):
+        try:
+            self._widget.config(state="normal")
+            self._widget.insert("end", msg + "\n")
+            self._widget.see("end")
+            self._widget.config(state="disabled")
+        except tk.TclError:
+            pass  # Fenster wurde geschlossen
+
+
+class DevConsole:
+    def __init__(self, root, app):
+        self.app = app
+        self.win = tk.Toplevel(root)
+        self.win.title("Dev-Konsole")
+        self.win.configure(bg=BG)
+        self.win.geometry("760x460")
+
+        btns = tk.Frame(self.win, bg=BG)
+        btns.pack(side="top", fill="x", padx=6, pady=6)
+        actions = (
+            ("Sync Pull", self.app.dev_sync_pull),
+            ("Sync Push", self.app.dev_sync_push),
+            ("Token-Fehler simulieren", self._simulate_auth_error),
+            ("Sample-Daten neu laden", self.app.dev_reload_sample_data),
+            ("Daten-Ordner öffnen", self._open_data_dir),
+            ("Log leeren", self._clear),
+            ("Kopieren", self._copy),
+        )
+        for label, cmd in actions:
+            tk.Button(btns, text=label, command=cmd).pack(side="left", padx=3)
+
+        self.text = tk.Text(self.win, bg="#101010", fg=TEXT,
+                            insertbackground=TEXT, font=("Consolas", 9),
+                            state="disabled", wrap="none")
+        scroll = tk.Scrollbar(self.win, command=self.text.yview)
+        self.text.configure(yscrollcommand=scroll.set)
+        scroll.pack(side="right", fill="y")
+        self.text.pack(side="left", fill="both", expand=True, padx=(6, 0), pady=(0, 6))
+
+        self._handler = _TkLogHandler(self.text, root)
+        root_logger = logging.getLogger()
+        root_logger.setLevel(logging.DEBUG)
+        root_logger.addHandler(self._handler)
+        logging.getLogger("zeiterfassung.dev").info("Dev-Konsole geöffnet")
+
+    def _simulate_auth_error(self):
+        from src.dev import fakes
+        fakes.simulate_auth_error_once()
+        logging.getLogger("zeiterfassung.dev").info(
+            "Nächster Google-Aufruf wirft TokenAuthError")
+
+    def _open_data_dir(self):
+        from src.platform_open import open_folder
+        open_folder(self.app.base_path)
+
+    def _clear(self):
+        self.text.config(state="normal")
+        self.text.delete("1.0", "end")
+        self.text.config(state="disabled")
+
+    def _copy(self):
+        content = self.text.get("1.0", "end-1c")
+        self.win.clipboard_clear()
+        self.win.clipboard_append(content)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_dev_activate.py::test_log_handler_formats_record -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/dev/console.py tests/test_dev_activate.py
+git commit -m "feat(dev): add DevConsole log viewer window with action buttons"
+```
+
+---
+
+## Task 6: `App` — dev_mode, Titel, Dev-Methoden, DevConsole
+
+**Files:**
+- Modify: `src/ui.py` (`App.__init__` Zeile 45-53 und 106; neue Methoden nach `on_sync_pull_error`)
+
+> Hinweis: Reines UI-/Threading-Verhalten — manuell verifiziert in Task 9 (kein headless-Tkinter-Test).
+
+- [ ] **Step 1: `dev_mode`-Parameter + Titel-Suffix**
+
+In `src/ui.py`, `App.__init__`-Signatur (Zeile 45-46) ändern:
+
+```python
+    def __init__(self, root, storage, settings, base_path=".", conflicts_store=None,
+                 reservation_store=None, dev_mode=False):
+```
+
+Direkt nach `self.reservation_store = reservation_store` (Zeile 52) einfügen:
+
+```python
+        self.dev_mode = dev_mode
+```
+
+Zeile 53 ersetzen:
+
+```python
+        self.root.title(f"Zeiterfassung v{VERSION}" + (" — Dev-Mode" if dev_mode else ""))
+```
+
+- [ ] **Step 2: DevConsole am Ende von `__init__` erzeugen**
+
+Direkt nach `self.root.protocol("WM_DELETE_WINDOW", self._on_close)` (Zeile 106) einfügen:
+
+```python
+        self._dev_console = None
+        if self.dev_mode:
+            from src.dev.console import DevConsole
+            self._dev_console = DevConsole(self.root, self)
+```
+
+- [ ] **Step 3: Dev-Methoden hinzufügen**
+
+In `src/ui.py` nach der Methode `on_sync_pull_error` (nach Zeile 1096) einfügen:
+
+```python
+    def dev_sync_pull(self):
+        """Dev-Konsole: stößt denselben Hintergrund-Pull an wie der App-Start."""
+        from src.main import _run_pull_in_background
+
+        def cb(ok, error, tb=""):
+            def apply():
+                if ok:
+                    self.on_sync_pull_success()
+                else:
+                    self.on_sync_pull_error(error, tb)
+            self.root.after(0, apply)
+
+        threading.Thread(
+            target=_run_pull_in_background,
+            args=(self.storage, self.settings, self.conflicts_store, self.base_path, cb),
+            daemon=True,
+        ).start()
+
+    def dev_sync_push(self):
+        """Dev-Konsole: synchroner Push (Ergebnis landet im Log)."""
+        from src.main import _run_push_blocking
+
+        def work():
+            result = _run_push_blocking(
+                self.storage, self.settings, self.conflicts_store, self.base_path)
+            logging.getLogger("zeiterfassung.dev").info("DEV push result=%s", result)
+
+        threading.Thread(target=work, daemon=True).start()
+
+    def dev_reload_sample_data(self):
+        """Dev-Konsole: Fake-State zurücksetzen, Daten neu seeden, UI refreshen."""
+        from src.dev import fakes, seed
+        fakes.reset_state()
+        seed.reseed(self.base_path)
+        self.storage.reload()
+        self._refresh()
+        logging.getLogger("zeiterfassung.dev").info("DEV Sample-Daten neu geladen")
+```
+
+> `threading` und `logging` sind in `ui.py` bereits importiert (siehe `_proactive_token_refresh`). Falls nicht, oben ergänzen.
+
+- [ ] **Step 4: Sanity-Check (Syntax/Import)**
+
+Run: `python -c "import ast; ast.parse(open('src/ui.py', encoding='utf-8').read())"`
+Expected: kein Fehler (parst sauber)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ui.py
+git commit -m "feat(ui): dev-mode title, DevConsole, and dev sync/reload hooks"
+```
+
+---
+
+## Task 7: Import-Vereinheitlichung in den Dialogen
+
+**Files:**
+- Modify: `src/dialogs/send_dialog.py` (Zeile 9, 185, 196, 226)
+- Modify: `src/dialogs/share_dialog.py` (Zeile 10, 87, 106, 127)
+
+> Begründung: Beide binden `get_gmail_service`/`send_email`/`is_offline_error` top-level — nur modul-qualifizierter Zugriff (`mail.x`) nimmt den Monkeypatch mit. `settings_dialog.py` braucht KEINE Änderung (lazy Import in Funktion).
+
+- [ ] **Step 1: `send_dialog.py` Import ersetzen**
+
+Zeile 9:
+
+```python
+from src.mail import get_gmail_service, is_offline_error, send_email
+```
+→
+```python
+from src import mail
+```
+
+- [ ] **Step 2: `send_dialog.py` Aufrufstellen anpassen**
+
+- Zeile ~185: `service = get_gmail_service(` → `service = mail.get_gmail_service(`
+- Zeile ~196: `send_email(service, recipient, subject, html,` → `mail.send_email(service, recipient, subject, html,`
+- Zeile ~226: `if is_offline_error(e):` → `if mail.is_offline_error(e):`
+
+> Die lazy `from src.mail import fetch_user_email` (≈Zeile 203) kann bleiben.
+
+- [ ] **Step 3: `share_dialog.py` Import ersetzen**
+
+Zeile 10:
+
+```python
+from src.mail import get_gmail_service, is_offline_error, send_email
+```
+→
+```python
+from src import mail
+```
+
+- [ ] **Step 4: `share_dialog.py` Aufrufstellen anpassen**
+
+- Zeile ~87: `service = get_gmail_service(` → `service = mail.get_gmail_service(`
+- Zeile ~106: `send_email(` → `mail.send_email(`
+- Zeile ~127: `if is_offline_error(e):` → `if mail.is_offline_error(e):`
+
+- [ ] **Step 5: Verify keine bare Referenzen mehr übrig**
+
+Run: `grep -rn "get_gmail_service\|send_email\|is_offline_error" src/dialogs/send_dialog.py src/dialogs/share_dialog.py`
+Expected: alle Treffer sind `mail.`-qualifiziert oder die lazy `from src.mail import fetch_user_email`-Zeile. Kein bare `get_gmail_service(` / `send_email(` / `is_offline_error(`.
+
+- [ ] **Step 6: Bestehende Tests laufen lassen**
+
+Run: `pytest -q`
+Expected: PASS (keine Regression; falls Dialog-Tests existieren, bleiben sie grün)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/dialogs/send_dialog.py src/dialogs/share_dialog.py
+git commit -m "refactor(dialogs): use module-qualified mail access for dev-mode patching"
+```
+
+---
+
+## Task 8: `main.py` — `--dev` Verdrahtung
+
+**Files:**
+- Modify: `src/main.py` (`main()`, Zeile 171-191)
+
+- [ ] **Step 1: `--dev`-Erkennung + ENV-Override + activate + dev_mode an App**
+
+In `src/main.py`, `main()` (ab Zeile 171). Den Block am Anfang von `main()` so erweitern:
+
+```python
+def main():
+    dev_mode = "--dev" in sys.argv
+    if dev_mode and not os.environ.get("ZEITERFASSUNG_DATA_DIR"):
+        repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        os.environ["ZEITERFASSUNG_DATA_DIR"] = os.path.join(repo_root, "dev-data")
+
+    base = get_base_path()
+    try:
+        setup_logging(base)
+        logging.getLogger(__name__).info("Zeiterfassung v%s gestartet", VERSION)
+    except Exception:
+        pass
+
+    if dev_mode:
+        from src.dev import activate
+        activate(base)
+
+    settings = Settings(os.path.join(base, "settings.json"))
+```
+
+Den Rest von `main()` unverändert lassen bis zum `App(...)`-Aufruf.
+
+- [ ] **Step 2: `dev_mode` an `App` durchreichen**
+
+Den `App(...)`-Aufruf (Zeile 190-191) ersetzen:
+
+```python
+    app = App(root, storage, settings, base_path=base, conflicts_store=conflicts_store,
+              reservation_store=reservation_store, dev_mode=dev_mode)
+```
+
+- [ ] **Step 3: Syntax-Check**
+
+Run: `python -c "import ast; ast.parse(open('src/main.py', encoding='utf-8').read())"`
+Expected: kein Fehler
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main.py
+git commit -m "feat(main): wire --dev flag to dev data dir, fakes, and dev-mode App"
+```
+
+---
+
+## Task 9: `.gitignore` + manuelle Verifikation
+
+**Files:**
+- Modify: `.gitignore`
+
+- [ ] **Step 1: `dev-data/` ignorieren**
+
+In `.gitignore` anhängen (falls noch nicht vorhanden):
+
+```
+# Dev-Mode Daten-Verzeichnis (python -m src.main --dev)
+dev-data/
+```
+
+- [ ] **Step 2: Volle Testsuite**
+
+Run: `pytest -q`
+Expected: alle grün.
+
+- [ ] **Step 3: Normalstart-Regression (kein Dev)**
+
+Run: `python -m src.main`
+Erwartung: App startet wie gewohnt, Titel ohne „Dev-Mode", kein Konsolen-Fenster, keine `dev-data/`-Erzeugung. Schließen.
+
+- [ ] **Step 4: Dev-Start verifizieren**
+
+Run: `python -m src.main --dev`
+Erwartung:
+- Titel zeigt `Zeiterfassung v<ver> — Dev-Mode`.
+- Zweites Fenster „Dev-Konsole" öffnet sich mit Log-Ausgabe (u.a. „Dev-Mode aktiviert").
+- Kalender zeigt die Sample-Einträge (heute, gestern, vorgestern, vor 7 Tagen).
+- `dev-data/` existiert mit `zeiterfassung.json`, `settings.json`, `credentials.json` (kein `token.json`).
+- „Senden"-Flow durchklicken → Log zeigt `DEV: würde Mail senden …`, keine echte Mail.
+- Button **Sync Push** dann **Sync Pull** → Log zeigt fake upload/download, keine Fehler.
+- Button **Token-Fehler simulieren**, dann einen Sende-/Verbinden-Flow → Fehler-UI erscheint.
+- Button **Sample-Daten neu laden** → Kalender wird neu befüllt.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .gitignore
+git commit -m "chore: ignore dev-data/ directory"
+```
+
+---
+
+## Self-Review (vom Plan-Autor durchgeführt)
+
+**Spec-Abdeckung:**
+- Fake-Google-Layer (Spec §1, §2) → Task 2, 4.
+- Isoliertes Dev-Daten-Verzeichnis + Seed (Spec §1, §4) → Task 3, 8.
+- Konsolen-Fenster mit Aktions-Buttons (Spec §3) → Task 5, 6.
+- Titel-Indikator (Spec §5) → Task 6.
+- Import-Vereinheitlichung (Spec §2) → Task 7 (präzisiert: 2 statt 3 Dialoge, mit Begründung).
+- Tests (Spec §Tests) → Task 2, 3, 4, 5 (inkl. Guard, dass `src.dev` im Normalstart nicht lädt).
+- `.gitignore` → Task 9.
+
+**Abweichung von der Spec (bewusst, dokumentiert):** Es wird **kein** `token.json` geseedet (Spec nannte es). Grund im Plan-Header: vermeidet Token-Popups/Netzwerk-Calls beim Dev-Start, weil `ui.py` die Token-Funktionen top-level bindet und ein Patch dort nicht greift. Dummy-`credentials.json` bleibt.
+
+**Platzhalter-Scan:** Keine TBD/TODO; jeder Code-Step zeigt vollständigen Code.
+
+**Typ-/Namens-Konsistenz:** Fake-Funktionsnamen (`fake_*`), `reset_state`, `simulate_auth_error_once`, `seed_if_empty`, `reseed`, `Storage.reload`, `DevConsole`, `_TkLogHandler`, `dev_sync_pull/dev_sync_push/dev_reload_sample_data` durchgängig identisch über alle Tasks verwendet.

--- a/docs/superpowers/specs/2026-05-28-dev-mode-design.md
+++ b/docs/superpowers/specs/2026-05-28-dev-mode-design.md
@@ -1,0 +1,231 @@
+# Design: Dedizierter Dev-Mode
+
+**Datum:** 2026-05-28
+**Branch:** feat/dev-mode (von `master`)
+**Status:** Entwurf zur Review
+
+## Ziel
+
+Ein dedizierter Entwickler-Modus, der ausschließlich über `python -m src.main --dev`
+aktiviert wird. Er erlaubt das gefahrlose Durchklicken aller App-Flows ohne echte
+Google-Dienste, ohne echte Nutzerdaten zu berühren, und macht zur Laufzeit sichtbar,
+was die App tut.
+
+Drei Bausteine plus ein UI-Indikator:
+
+1. **Fake-Google-Layer** — Gmail, Drive und Calendar komplett gemockt (kein OAuth,
+   kein Netzwerk, kanonische Erfolge, alles geloggt).
+2. **Isoliertes Dev-Daten-Verzeichnis** — getrennt von echten Einträgen/Settings/Token,
+   mit Sample-Daten geseedet.
+3. **Konsolen-Fenster** — Live-Log-Viewer (DEBUG) mit Dev-Aktions-Buttons.
+4. **Titel-Indikator** — „Dev-Mode" neben der Version im Fenstertitel.
+
+## Nicht-Ziele
+
+- Kein Python-REPL im Konsolen-Fenster (read-only Log + Buttons genügt).
+- Keine separaten echten Test-Credentials gegen echte Google-APIs.
+- Kein `--dev`-Schalter in der UI; Aktivierung nur über das CLI-Flag.
+- Kein Dev-Code im Produktionspfad: `src/dev/` wird im Normalbetrieb nie importiert.
+
+## Architektur
+
+Neues, isoliertes Paket `src/dev/`:
+
+```
+src/dev/
+  __init__.py     # activate() — installiert Fakes, Einstiegspunkt
+  fakes.py        # Fake-Implementierungen der Google-Modul-Funktionen
+  seed.py         # Sample-Daten ins Dev-Daten-Verzeichnis schreiben
+  console.py      # Tk-Toplevel Log-Viewer + Aktions-Buttons
+```
+
+`src/dev/` wird **nur** importiert, wenn `--dev` gesetzt ist. Im Normalstart bleibt der
+Import-Graph unverändert.
+
+### Mock-Strategie: Monkeypatch der Modul-Funktionen
+
+Alle Eintrittspunkte zu Google sind Modul-Funktionen, und alle Aufrufstellen rufen sie
+(bis auf drei Dialog-Imports, s.u.) modul-qualifiziert auf. `activate()` ersetzt deshalb
+beim Start die folgenden Attribute durch Fakes:
+
+| Modul | Ersetzte Funktionen |
+|-------|---------------------|
+| `src.mail` | `get_gmail_service`, `send_email` |
+| `src.drive` | `get_drive_service`, `find_sync_file`, `download`, `upload` |
+| `src.gcal` | `get_calendar_service`, `list_app_events`, `create_event`, `update_event`, `delete_event` |
+
+Damit muss kein googleapiclient-Resource-Chain (`service.files().list().execute()`)
+nachgebaut werden — die Builder liefern nur ein Sentinel-Objekt, die eigentliche
+Logik sitzt in den modul-qualifiziert aufgerufenen Operationen.
+
+**Erforderliche Import-Vereinheitlichung:** Drei Dialoge importieren per
+`from src.mail import get_gmail_service, send_email` — ein nach `activate()` gesetzter
+Monkeypatch auf `src.mail` greift dort nicht, weil der Name beim Import gebunden wurde.
+Umstellen auf modul-qualifizierten Zugriff:
+
+- `src/dialogs/send_dialog.py`
+- `src/dialogs/share_dialog.py`
+- `src/dialogs/settings_dialog.py`
+
+Konkret: `from src.mail import get_gmail_service, is_offline_error, send_email` →
+`from src import mail` und an den Aufrufstellen `mail.get_gmail_service(...)`,
+`mail.send_email(...)`, `mail.is_offline_error(...)`. Rein mechanisch, kein Verhaltensänderung
+im Normalbetrieb.
+
+## Komponenten
+
+### 1. Aktivierung & Verdrahtung — `src/main.py`
+
+Ganz am Anfang von `main()`, **vor** `get_base_path()`:
+
+```python
+dev_mode = "--dev" in sys.argv
+if dev_mode:
+    if not os.environ.get("ZEITERFASSUNG_DATA_DIR"):
+        repo = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        os.environ["ZEITERFASSUNG_DATA_DIR"] = os.path.join(repo, "dev-data")
+    from src.dev import activate
+    activate()
+```
+
+`activate()`:
+1. Monkeypatcht die Tabelle oben.
+2. Seedet Sample-Daten ins Dev-Daten-Verzeichnis, falls leer (s. Komponente 4).
+
+`base = get_base_path()` liefert danach automatisch das Dev-Verzeichnis (Override greift).
+`App(...)` bekommt `dev_mode=True` durchgereicht.
+
+### 2. Fake-Google-Layer — `src/dev/fakes.py`
+
+- `_Sentinel` — Platzhalter-Objekt, das die Builder zurückgeben. Wird nur durchgereicht,
+  nie aufgerufen.
+- `fake_get_gmail_service(*a, **k)` → `_Sentinel`.
+- `fake_send_email(service, to, subject, html_body, attachment_bytes=None,
+  attachment_filename=None, ...)` → loggt
+  `DEV: würde Mail senden an=<to> betreff=<subject> anhang=<filename>` auf INFO,
+  liefert `"dev-msg-<n>"`.
+- `fake_get_drive_service(*a, **k)` → `_Sentinel`.
+- Drive-Sync-Doc lebt prozessweit als Modul-State (`_drive_doc`, `_drive_version`):
+  - `fake_find_sync_file(service)` → `"dev-file"` falls Doc existiert, sonst `None`.
+  - `fake_download(service, file_id)` → `(json-bytes(_drive_doc), str(_drive_version))`.
+  - `fake_upload(service, content, file_id=None, expected_etag=None)` → speichert Doc,
+    erhöht Version, liefert `("dev-file", str(version))`.
+- `fake_get_calendar_service(*a, **k)` → `_Sentinel`.
+- Kalender-State (`_events: dict[event_id, event]`):
+  - `fake_list_app_events(service, calendar_id)` → Liste der Events im erwarteten Format.
+  - `fake_create_event(...)` → neue `event_id`, speichert, loggt.
+  - `fake_update_event(...)` / `fake_delete_event(...)` → mutiert State, loggt.
+
+Signaturen spiegeln die echten Funktionen exakt (siehe `src/mail.py`, `src/drive.py`,
+`src/gcal.py`), damit die Aufrufer unverändert funktionieren.
+
+`reset_state()` setzt Drive-Doc und Kalender zurück — vom „Sample-Daten neu laden"-Button
+genutzt.
+
+### 3. Konsolen-Fenster — `src/dev/console.py`
+
+`DevConsole(root)`:
+- Eigenes `tk.Toplevel`, Titel „Dev-Konsole".
+- Read-only `Text`-Widget mit Scrollbar, monospaced, dunkles Theme passend zur App.
+- `_TkLogHandler(logging.Handler)`: `emit()` formatiert den Record und schiebt ihn per
+  `root.after(0, ...)` ins Text-Widget (thread-sicher — Logs kommen aus Worker-Threads).
+  Autoscroll ans Ende. Handler wird am Root-Logger registriert; Root-Level auf `DEBUG`.
+- Button-Leiste:
+  - **Sync Pull** / **Sync Push** — triggern die vorhandenen Sync-Pfade (Callback von App).
+  - **Token-Fehler simulieren** — setzt ein Flag, das `fake_*`-Auth einmalig
+    `TokenAuthError` werfen lässt, um Fehler-UI zu testen.
+  - **Sample-Daten neu laden** — `fakes.reset_state()` + `seed`-Reseed + UI-Refresh.
+  - **Daten-Ordner öffnen** — `platform_open` auf das Dev-Verzeichnis.
+  - **Log leeren** — Text-Widget leeren.
+  - **Kopieren** — Text-Inhalt in die Zwischenablage.
+- Schließt zusammen mit dem Hauptfenster (`root` ist Parent).
+
+App-Anbindung: in `App.__init__`, wenn `dev_mode`, nach dem Bau der UI
+`self._dev_console = DevConsole(self.root, app=self)` erzeugen. Die Buttons rufen
+schmale Methoden auf `App` auf (Sync triggern, Refresh) — keine Logik im Fenster selbst.
+
+### 4. Sample-Daten — `src/dev/seed.py`
+
+`seed_if_empty(base_path)`:
+- No-op, wenn `zeiterfassung.json` im Dev-Verzeichnis bereits existiert.
+- Sonst schreiben:
+  - `zeiterfassung.json` — eine Handvoll Einträge über die aktuelle und letzte Woche.
+  - `settings.json` — sinnvolle Defaults (Empfänger-Mail Platzhalter, `sync_enabled`/
+    `gcal_enabled` aus, damit nichts ungewollt triggert — die Buttons triggern explizit).
+  - `credentials.json` + `token.json` — Dummy-Inhalte, damit `os.path.exists`-Checks
+    und Token-Refresh-Pfade nicht nach OAuth fragen. (Die Fakes lesen sie nie aus.)
+
+`reseed(base_path)` für den Button: löscht die Daten-Dateien und ruft `seed_if_empty`.
+
+### 5. Titel-Indikator — `src/ui.py`
+
+`App.__init__` bekommt `dev_mode=False`. Zeile 53:
+
+```python
+suffix = " — Dev-Mode" if dev_mode else ""
+self.root.title(f"Zeiterfassung v{VERSION}{suffix}")
+```
+
+## Datenfluss
+
+```
+python -m src.main --dev
+  └─ main(): ZEITERFASSUNG_DATA_DIR → ./dev-data
+             src.dev.activate()  ── monkeypatch mail/drive/gcal + seed_if_empty()
+             get_base_path() → ./dev-data
+             App(dev_mode=True)
+               ├─ Titel „… — Dev-Mode"
+               └─ DevConsole(root)  ── _TkLogHandler am Root-Logger, Level DEBUG
+  └─ Nutzer klickt „Senden" → mail.send_email (=fake) → Log: „DEV: würde Mail senden …"
+  └─ Nutzer klickt „Sync Pull" → drive.find_sync_file/download (=fake) → In-Memory-Doc
+```
+
+## Fehlerbehandlung
+
+- Fakes werfen im Normalfall nie — sie liefern kanonische Erfolge.
+- „Token-Fehler simulieren" lässt den nächsten Auth-Aufruf `TokenAuthError` werfen, damit
+  die echte Fehler-UI (Messagebox-Pfade in `mail.py`/Dialogen) getestet werden kann.
+- `activate()` schlägt nur fehl, wenn `src/dev/` defekt ist — das wäre ein Entwicklerfehler
+  und soll laut crashen (kein stilles Verschlucken).
+
+## Tests
+
+- `tests/test_dev_fakes.py`:
+  - `fake_send_email` loggt und liefert eine ID, sendet nichts.
+  - Drive-Fake Roundtrip: `upload` → `find_sync_file` → `download` liefert dasselbe Doc,
+    Version steigt.
+  - Calendar-Fake: `create_event` → `list_app_events` enthält das Event; `delete_event`
+    entfernt es.
+  - `reset_state()` leert Drive-Doc und Kalender.
+- `tests/test_dev_activate.py`:
+  - Nach `activate()` zeigen `mail.send_email`, `drive.upload`, `gcal.create_event` auf
+    die Fakes.
+  - **Guard:** Ein Import von `src.main` (ohne `--dev`) importiert `src.dev` nicht
+    (Prüfung über `sys.modules`).
+- Konsolen-Fenster: nur die Handler-Formatierung wird getestet (Record → erwartete Zeile);
+  das Tk-Toplevel selbst wird nicht headless getestet.
+- `tests/test_seed.py`: `seed_if_empty` legt Dateien an; zweiter Aufruf ist No-op;
+  `reseed` schreibt neu.
+
+CI-Hinweis (`.github/workflows/test.yml`): Die Fakes dürfen google-Libs **nicht** eager
+importieren (CI installiert `requirements.txt` nicht). `TokenAuthError` kommt aus
+`src.mail` (pure Python, kein C-Dep) — Import ist unbedenklich.
+
+## Betroffene Dateien
+
+| Datei | Änderung |
+|-------|----------|
+| `src/main.py` | `--dev`-Erkennung, ENV-Override, `src.dev.activate()`, `dev_mode` an `App` |
+| `src/ui.py` | `App.__init__(dev_mode=False)`, Titel-Suffix, optional `DevConsole` erzeugen, schmale Sync/Refresh-Hooks für die Buttons |
+| `src/dialogs/send_dialog.py` | Import-Vereinheitlichung `from src import mail` |
+| `src/dialogs/share_dialog.py` | Import-Vereinheitlichung `from src import mail` |
+| `src/dialogs/settings_dialog.py` | Import-Vereinheitlichung `from src import mail` |
+| `src/dev/__init__.py` | neu — `activate()` |
+| `src/dev/fakes.py` | neu — Fake-Funktionen + State |
+| `src/dev/seed.py` | neu — Sample-Daten |
+| `src/dev/console.py` | neu — Log-Viewer + Buttons |
+| `tests/test_dev_fakes.py` | neu |
+| `tests/test_dev_activate.py` | neu |
+| `tests/test_seed.py` | neu |
+| `.gitignore` | `dev-data/` ignorieren |
+```

--- a/src/dev/__init__.py
+++ b/src/dev/__init__.py
@@ -1,1 +1,29 @@
 # src/dev/ — Entwickler-Modus. Wird nur bei `python -m src.main --dev` importiert.
+import logging
+
+
+def activate(base_path):
+    """Installiert die Fakes (Monkeypatch) und seedet Sample-Daten.
+
+    Aufzurufen aus main(), nachdem base_path feststeht und bevor Storage/
+    Settings konstruiert werden (sie lesen die geseedeten Dateien)."""
+    from src import drive, gcal, mail
+    from src.dev import fakes, seed
+
+    mail.get_gmail_service = fakes.fake_get_gmail_service
+    mail.send_email = fakes.fake_send_email
+
+    drive.get_drive_service = fakes.fake_get_drive_service
+    drive.find_sync_file = fakes.fake_find_sync_file
+    drive.download = fakes.fake_download
+    drive.upload = fakes.fake_upload
+
+    gcal.get_calendar_service = fakes.fake_get_calendar_service
+    gcal.list_app_events = fakes.fake_list_app_events
+    gcal.create_event = fakes.fake_create_event
+    gcal.update_event = fakes.fake_update_event
+    gcal.delete_event = fakes.fake_delete_event
+
+    seed.seed_if_empty(base_path)
+    logging.getLogger("zeiterfassung.dev").info(
+        "Dev-Mode aktiviert — Daten=%s", base_path)

--- a/src/dev/__init__.py
+++ b/src/dev/__init__.py
@@ -19,6 +19,7 @@ def activate(base_path):
     drive.upload = fakes.fake_upload
 
     gcal.get_calendar_service = fakes.fake_get_calendar_service
+    gcal.list_calendars = fakes.fake_list_calendars
     gcal.list_app_events = fakes.fake_list_app_events
     gcal.create_event = fakes.fake_create_event
     gcal.update_event = fakes.fake_update_event

--- a/src/dev/__init__.py
+++ b/src/dev/__init__.py
@@ -1,0 +1,1 @@
+# src/dev/ — Entwickler-Modus. Wird nur bei `python -m src.main --dev` importiert.

--- a/src/dev/console.py
+++ b/src/dev/console.py
@@ -1,0 +1,94 @@
+"""Dev-Konsole: Tk-Toplevel mit Live-Log-Viewer und Aktions-Buttons.
+
+Nur im Dev-Mode aus App erzeugt. Der Logging-Handler schiebt Records
+thread-sicher per root.after ins Text-Widget (Logs kommen aus Worker-Threads).
+"""
+
+import logging
+import tkinter as tk
+
+from src.theme import BG, TEXT
+
+
+class _TkLogHandler(logging.Handler):
+    def __init__(self, widget, root):
+        super().__init__()
+        self._widget = widget
+        self._root = root
+        self.setFormatter(logging.Formatter(
+            "%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+            datefmt="%H:%M:%S",
+        ))
+
+    def emit(self, record):
+        try:
+            msg = self.format(record)
+        except Exception:
+            return
+        self._root.after(0, self._append, msg)
+
+    def _append(self, msg):
+        try:
+            self._widget.config(state="normal")
+            self._widget.insert("end", msg + "\n")
+            self._widget.see("end")
+            self._widget.config(state="disabled")
+        except tk.TclError:
+            pass  # Fenster wurde geschlossen
+
+
+class DevConsole:
+    def __init__(self, root, app):
+        self.app = app
+        self.win = tk.Toplevel(root)
+        self.win.title("Dev-Konsole")
+        self.win.configure(bg=BG)
+        self.win.geometry("760x460")
+
+        btns = tk.Frame(self.win, bg=BG)
+        btns.pack(side="top", fill="x", padx=6, pady=6)
+        actions = (
+            ("Sync Pull", self.app.dev_sync_pull),
+            ("Sync Push", self.app.dev_sync_push),
+            ("Token-Fehler simulieren", self._simulate_auth_error),
+            ("Sample-Daten neu laden", self.app.dev_reload_sample_data),
+            ("Daten-Ordner öffnen", self._open_data_dir),
+            ("Log leeren", self._clear),
+            ("Kopieren", self._copy),
+        )
+        for label, cmd in actions:
+            tk.Button(btns, text=label, command=cmd).pack(side="left", padx=3)
+
+        self.text = tk.Text(self.win, bg="#101010", fg=TEXT,
+                            insertbackground=TEXT, font=("Consolas", 9),
+                            state="disabled", wrap="none")
+        scroll = tk.Scrollbar(self.win, command=self.text.yview)
+        self.text.configure(yscrollcommand=scroll.set)
+        scroll.pack(side="right", fill="y")
+        self.text.pack(side="left", fill="both", expand=True, padx=(6, 0), pady=(0, 6))
+
+        self._handler = _TkLogHandler(self.text, root)
+        root_logger = logging.getLogger()
+        root_logger.setLevel(logging.DEBUG)
+        root_logger.addHandler(self._handler)
+        logging.getLogger("zeiterfassung.dev").info("Dev-Konsole geöffnet")
+
+    def _simulate_auth_error(self):
+        from src.dev import fakes
+        fakes.simulate_auth_error_once()
+        logging.getLogger("zeiterfassung.dev").info(
+            "Nächster Google-Aufruf wirft TokenAuthError")
+
+    def _open_data_dir(self):
+        from src.platform_open import open_folder
+        open_folder(self.app.base_path)
+
+    def _clear(self):
+        self.text.config(state="normal")
+        self.text.delete("1.0", "end")
+        self.text.config(state="disabled")
+
+    def _copy(self):
+        content = self.text.get("1.0", "end-1c")
+        self.win.clipboard_clear()
+        self.win.clipboard_append(content)

--- a/src/dev/fakes.py
+++ b/src/dev/fakes.py
@@ -1,0 +1,139 @@
+"""Fake-Implementierungen der Google-Eintrittspunkte für den Dev-Mode.
+
+Alle Funktionen spiegeln die Signaturen der echten Wrapper in src/mail.py,
+src/drive.py und src/gcal.py. Sie führen keine Netzwerk-Calls aus, liefern
+kanonische Erfolge und loggen, was passiert wäre. Der Drive- und Kalender-
+State lebt prozessweit als Modul-Globals.
+"""
+
+import json
+import logging
+
+log = logging.getLogger("zeiterfassung.dev")
+
+
+class _FakeService:
+    """Platzhalter-Objekt, das die gemockten Builder zurückgeben. Wird nur
+    durchgereicht, nie aufgerufen."""
+
+
+_drive_doc = None        # dict | None
+_drive_version = 0
+_events = {}             # event_id -> {date, start, end, modified_at, event_id}
+_event_counter = 0
+_msg_counter = 0
+_simulate_auth_error = False
+
+
+def reset_state():
+    """Setzt Drive-Doc, Kalender und Zähler zurück (für 'Sample-Daten neu laden')."""
+    global _drive_doc, _drive_version, _events, _event_counter, _msg_counter
+    global _simulate_auth_error
+    _drive_doc = None
+    _drive_version = 0
+    _events = {}
+    _event_counter = 0
+    _msg_counter = 0
+    _simulate_auth_error = False
+
+
+def simulate_auth_error_once():
+    """Lässt den nächsten Service-Builder-Aufruf einmalig TokenAuthError werfen."""
+    global _simulate_auth_error
+    _simulate_auth_error = True
+
+
+def _maybe_raise_auth():
+    global _simulate_auth_error
+    if _simulate_auth_error:
+        _simulate_auth_error = False
+        from src.mail import TokenAuthError
+        log.warning("DEV: simulierter TokenAuthError")
+        raise TokenAuthError("DEV: simulierter Token-Fehler")
+
+
+# --- Gmail ---------------------------------------------------------------
+
+def fake_get_gmail_service(credentials_path="credentials.json",
+                           token_path="token.json",
+                           sync_enabled=False, gcal_enabled=False):
+    _maybe_raise_auth()
+    log.info("DEV fake_get_gmail_service()")
+    return _FakeService()
+
+
+def fake_send_email(service, to, subject, html_body,
+                    attachment_bytes=None, attachment_filename=None,
+                    attachment_subtype="pdf",
+                    pdf_bytes=None, pdf_filename=None):
+    global _msg_counter
+    _msg_counter += 1
+    filename = attachment_filename or pdf_filename
+    log.info("DEV: würde Mail senden an=%s betreff=%s anhang=%s",
+             to, subject, filename)
+    return f"dev-msg-{_msg_counter}"
+
+
+# --- Drive ---------------------------------------------------------------
+
+def fake_get_drive_service(credentials_path, token_path, gcal_enabled=False):
+    _maybe_raise_auth()
+    log.info("DEV fake_get_drive_service()")
+    return _FakeService()
+
+
+def fake_find_sync_file(service):
+    return "dev-file" if _drive_doc is not None else None
+
+
+def fake_download(service, file_id):
+    payload = _drive_doc if _drive_doc is not None else {}
+    data = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+    log.info("DEV fake_download() version=%s", _drive_version)
+    return data, str(_drive_version)
+
+
+def fake_upload(service, content_bytes, file_id=None, expected_etag=None):
+    global _drive_doc, _drive_version
+    _drive_doc = json.loads(content_bytes)
+    _drive_version += 1
+    log.info("DEV fake_upload() -> version=%s", _drive_version)
+    return "dev-file", str(_drive_version)
+
+
+# --- Calendar ------------------------------------------------------------
+
+def fake_get_calendar_service(credentials_path="credentials.json",
+                              token_path="token.json", sync_enabled=False):
+    _maybe_raise_auth()
+    log.info("DEV fake_get_calendar_service()")
+    return _FakeService()
+
+
+def fake_list_app_events(service, calendar_id):
+    return [dict(ev) for ev in _events.values()]
+
+
+def fake_create_event(service, calendar_id, date_str, start, end, modified_at):
+    global _event_counter
+    _event_counter += 1
+    event_id = f"dev-evt-{_event_counter}"
+    _events[event_id] = {
+        "date": date_str, "start": start, "end": end,
+        "modified_at": modified_at, "event_id": event_id,
+    }
+    log.info("DEV fake_create_event() id=%s date=%s", event_id, date_str)
+    return event_id
+
+
+def fake_update_event(service, calendar_id, event_id, date_str, start, end, modified_at):
+    _events[event_id] = {
+        "date": date_str, "start": start, "end": end,
+        "modified_at": modified_at, "event_id": event_id,
+    }
+    log.info("DEV fake_update_event() id=%s", event_id)
+
+
+def fake_delete_event(service, calendar_id, event_id):
+    _events.pop(event_id, None)
+    log.info("DEV fake_delete_event() id=%s", event_id)

--- a/src/dev/fakes.py
+++ b/src/dev/fakes.py
@@ -110,6 +110,13 @@ def fake_get_calendar_service(credentials_path="credentials.json",
     return _FakeService()
 
 
+def fake_list_calendars(service):
+    return [
+        {"id": "primary", "summary": "Dev-Kalender (primary)"},
+        {"id": "dev-cal-2", "summary": "Dev-Zweitkalender"},
+    ]
+
+
 def fake_list_app_events(service, calendar_id):
     return [dict(ev) for ev in _events.values()]
 

--- a/src/dev/seed.py
+++ b/src/dev/seed.py
@@ -1,0 +1,69 @@
+"""Sample-Daten für das Dev-Daten-Verzeichnis.
+
+Schreibt Einträge, Settings und ein Dummy-credentials.json — aber bewusst
+KEIN token.json (siehe Plan-Header: hält den Dev-Start frei von Token-Popups).
+"""
+
+import datetime
+import json
+import os
+
+_DATA_FILES = ("zeiterfassung.json", "settings.json", "credentials.json")
+
+
+def _utc_now_iso():
+    return datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _sample_entries():
+    today = datetime.date.today()
+    now = _utc_now_iso()
+    entries = {}
+    for delta in (0, 1, 2, 7):
+        day = today - datetime.timedelta(days=delta)
+        entries[day.isoformat()] = {
+            "start": "08:00",
+            "end": "16:30",
+            "pause": 30,
+            "modified_at": now,
+            "device_id": "dev",
+            "deleted": False,
+        }
+    return entries
+
+
+def _write_all(base_path):
+    os.makedirs(base_path, exist_ok=True)
+    with open(os.path.join(base_path, "zeiterfassung.json"), "w", encoding="utf-8") as f:
+        json.dump(_sample_entries(), f, indent=2, ensure_ascii=False)
+
+    settings = {
+        "name": "Dev User",
+        "recipient": "dev@example.com",
+        "sync_enabled": False,
+        "gcal_enabled": False,
+    }
+    with open(os.path.join(base_path, "settings.json"), "w", encoding="utf-8") as f:
+        json.dump(settings, f, indent=2, ensure_ascii=False)
+
+    creds = {"installed": {"client_id": "dev", "client_secret": "dev",
+                           "auth_uri": "", "token_uri": ""}}
+    with open(os.path.join(base_path, "credentials.json"), "w", encoding="utf-8") as f:
+        json.dump(creds, f)
+
+
+def seed_if_empty(base_path):
+    """Schreibt Sample-Daten nur, wenn noch keine zeiterfassung.json existiert."""
+    os.makedirs(base_path, exist_ok=True)
+    if os.path.exists(os.path.join(base_path, "zeiterfassung.json")):
+        return
+    _write_all(base_path)
+
+
+def reseed(base_path):
+    """Löscht die Daten-Dateien und schreibt frische Sample-Daten."""
+    for name in _DATA_FILES:
+        path = os.path.join(base_path, name)
+        if os.path.exists(path):
+            os.remove(path)
+    _write_all(base_path)

--- a/src/dialogs/send_dialog.py
+++ b/src/dialogs/send_dialog.py
@@ -6,7 +6,7 @@ import tkinter as tk
 import traceback
 from tkinter import messagebox
 
-from src.mail import get_gmail_service, is_offline_error, send_email
+from src import mail
 from src.platform_open import open_folder
 from src.report import generate_pdf, generate_report
 from src.theme import (
@@ -182,7 +182,7 @@ def open_send_dialog(parent, storage, settings, base_path):
 
         try:
             pdf_bytes = generate_pdf(date_from, date_to, entries, name=settings.get("name"))
-            service = get_gmail_service(
+            service = mail.get_gmail_service(
                 credentials_path, token_path,
                 sync_enabled=settings.get("sync_enabled"),
                 gcal_enabled=settings.get("gcal_enabled"),
@@ -193,7 +193,7 @@ def open_send_dialog(parent, storage, settings, base_path):
                 .replace("{gesamt}", f"{total}h")
             )
             pdf_filename = f"Zeiterfassung_{date_from.strftime('%Y%m%d')}_{date_to.strftime('%Y%m%d')}.pdf"
-            send_email(service, recipient, subject, html,
+            mail.send_email(service, recipient, subject, html,
                        attachment_bytes=pdf_bytes,
                        attachment_filename=pdf_filename,
                        attachment_subtype="pdf")
@@ -223,7 +223,7 @@ def open_send_dialog(parent, storage, settings, base_path):
             # zeigen wir dem Nutzer aber eine verständliche Meldung statt des
             # kryptischen Tracebacks — das ist kein Bug, sondern fehlendes Netz.
             logging.getLogger(__name__).exception("Senden fehlgeschlagen")
-            if is_offline_error(e):
+            if mail.is_offline_error(e):
                 messagebox.showerror(
                     "Keine Internetverbindung",
                     "Der Bericht konnte nicht gesendet werden, weil keine "

--- a/src/dialogs/share_dialog.py
+++ b/src/dialogs/share_dialog.py
@@ -7,7 +7,7 @@ import traceback
 from tkinter import messagebox
 
 from src.dialogs.send_dialog import show_missing_credentials_dialog
-from src.mail import get_gmail_service, is_offline_error, send_email
+from src import mail
 from src.share import build_share_doc, serialize_share_doc
 from src.theme import (
     BG, FONT, TEXT,
@@ -84,7 +84,7 @@ def open_share_dialog(parent, storage, settings, base_path):
         try:
             doc = build_share_doc(storage, sender_email)
             payload = serialize_share_doc(doc)
-            service = get_gmail_service(
+            service = mail.get_gmail_service(
                 credentials_path, token_path,
                 sync_enabled=settings.get("sync_enabled"),
                 gcal_enabled=settings.get("gcal_enabled"),
@@ -103,7 +103,7 @@ def open_share_dialog(parent, storage, settings, base_path):
                 "</body></html>"
             )
             filename = f"zeiterfassung-share-{doc['exported_at'][:10].replace('-', '')}.json"
-            send_email(
+            mail.send_email(
                 service, share_recipient, subject, html,
                 attachment_bytes=payload,
                 attachment_filename=filename,
@@ -124,7 +124,7 @@ def open_share_dialog(parent, storage, settings, base_path):
             # zeigen wir dem Nutzer aber eine verständliche Meldung statt des
             # kryptischen Tracebacks — das ist kein Bug, sondern fehlendes Netz.
             logging.getLogger(__name__).exception("Teilen fehlgeschlagen")
-            if is_offline_error(e):
+            if mail.is_offline_error(e):
                 messagebox.showerror(
                     "Keine Internetverbindung",
                     "Die Arbeitszeiten konnten nicht gesendet werden, weil "

--- a/src/main.py
+++ b/src/main.py
@@ -169,12 +169,21 @@ def run_calendar_reconcile(reservation_store, settings, base):
 
 
 def main():
+    dev_mode = "--dev" in sys.argv
+    if dev_mode and not os.environ.get("ZEITERFASSUNG_DATA_DIR"):
+        repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        os.environ["ZEITERFASSUNG_DATA_DIR"] = os.path.join(repo_root, "dev-data")
+
     base = get_base_path()
     try:
         setup_logging(base)
         logging.getLogger(__name__).info("Zeiterfassung v%s gestartet", VERSION)
     except Exception:
         pass
+
+    if dev_mode:
+        from src.dev import activate
+        activate(base)
 
     settings = Settings(os.path.join(base, "settings.json"))
     device_id = _ensure_device_id(settings)
@@ -188,7 +197,7 @@ def main():
 
     root = tk.Tk()
     app = App(root, storage, settings, base_path=base, conflicts_store=conflicts_store,
-              reservation_store=reservation_store)
+              reservation_store=reservation_store, dev_mode=dev_mode)
 
     if "--minimized" in sys.argv:
         root.iconify()

--- a/src/storage.py
+++ b/src/storage.py
@@ -55,6 +55,15 @@ class Storage:
             entry["device_id"] = self.device_id
             entry["deleted"] = False
 
+    def reload(self):
+        """Verwirft den In-Memory-Stand und liest die Datei neu ein.
+
+        Für Dev-Tools, die die JSON-Datei unter der laufenden App ersetzen
+        (z.B. Reseed). Setzt `_data` erst leer, damit ein Reload nach dem
+        Löschen der Datei nicht den alten Stand behält."""
+        self._data = {}
+        self._load()
+
     def _save_to_disk(self):
         tmp = self.filepath + ".tmp"
         with open(tmp, "w", encoding="utf-8") as f:

--- a/src/ui.py
+++ b/src/ui.py
@@ -43,14 +43,15 @@ from src.theme import (
 
 class App:
     def __init__(self, root, storage, settings, base_path=".", conflicts_store=None,
-                 reservation_store=None):
+                 reservation_store=None, dev_mode=False):
         self.root = root
         self.storage = storage
         self.settings = settings
         self.base_path = base_path
         self.conflicts_store = conflicts_store
         self.reservation_store = reservation_store
-        self.root.title(f"Zeiterfassung v{VERSION}")
+        self.dev_mode = dev_mode
+        self.root.title(f"Zeiterfassung v{VERSION}" + (" — Dev-Mode" if dev_mode else ""))
         self.root.configure(bg=BG)
         apply_dark_titlebar(self.root)
 
@@ -108,6 +109,11 @@ class App:
         self._proactive_update_check()
         self._proactive_calendar_reconcile()
         self.root.protocol("WM_DELETE_WINDOW", self._on_close)
+
+        self._dev_console = None
+        if self.dev_mode:
+            from src.dev.console import DevConsole
+            self._dev_console = DevConsole(self.root, self)
 
     def _proactive_token_refresh(self):
         """Erneuert den Gmail-Token beim App-Start im Hintergrund.
@@ -1103,6 +1109,44 @@ class App:
         mb.showerror("Synchronisation fehlgeschlagen",
                       f"Beim Abrufen der Drive-Daten ist ein Fehler aufgetreten:\n\n{detail}")
         self._update_sync_status_label()
+
+    def dev_sync_pull(self):
+        """Dev-Konsole: stößt denselben Hintergrund-Pull an wie der App-Start."""
+        from src.main import _run_pull_in_background
+
+        def cb(ok, error, tb=""):
+            def apply():
+                if ok:
+                    self.on_sync_pull_success()
+                else:
+                    self.on_sync_pull_error(error, tb)
+            self.root.after(0, apply)
+
+        threading.Thread(
+            target=_run_pull_in_background,
+            args=(self.storage, self.settings, self.conflicts_store, self.base_path, cb),
+            daemon=True,
+        ).start()
+
+    def dev_sync_push(self):
+        """Dev-Konsole: synchroner Push (Ergebnis landet im Log)."""
+        from src.main import _run_push_blocking
+
+        def work():
+            result = _run_push_blocking(
+                self.storage, self.settings, self.conflicts_store, self.base_path)
+            logging.getLogger("zeiterfassung.dev").info("DEV push result=%s", result)
+
+        threading.Thread(target=work, daemon=True).start()
+
+    def dev_reload_sample_data(self):
+        """Dev-Konsole: Fake-State zurücksetzen, Daten neu seeden, UI refreshen."""
+        from src.dev import fakes, seed
+        fakes.reset_state()
+        seed.reseed(self.base_path)
+        self.storage.reload()
+        self._refresh()
+        logging.getLogger("zeiterfassung.dev").info("DEV Sample-Daten neu geladen")
 
     def _update_sync_status_label(self):
         if not hasattr(self, "sync_status_label"):

--- a/tests/test_dev_activate.py
+++ b/tests/test_dev_activate.py
@@ -53,3 +53,25 @@ def test_normal_import_does_not_load_dev():
         capture_output=True, text=True, cwd=str(repo),
     )
     assert result.returncode == 0, result.stderr
+
+
+def test_log_handler_formats_record():
+    import logging as _logging
+    from src.dev.console import _TkLogHandler
+
+    captured = []
+
+    class _FakeWidget:
+        def config(self, **k): pass
+        def insert(self, *a): captured.append(a[1])
+        def see(self, *a): pass
+
+    class _FakeRoot:
+        def after(self, _delay, fn, *args):
+            fn(*args)  # synchron ausführen statt über die Tk-Eventloop
+
+    handler = _TkLogHandler(_FakeWidget(), _FakeRoot())
+    record = _logging.LogRecord("zeiterfassung.dev", _logging.INFO,
+                                "x.py", 1, "Hallo Welt", None, None)
+    handler.emit(record)
+    assert any("Hallo Welt" in line for line in captured)

--- a/tests/test_dev_activate.py
+++ b/tests/test_dev_activate.py
@@ -37,6 +37,7 @@ def test_activate_patches_module_functions(tmp_path):
     finally:
         for (module, name), fn in originals.items():
             setattr(module, name, fn)
+        fakes.reset_state()
 
 
 def test_normal_import_does_not_load_dev():

--- a/tests/test_dev_activate.py
+++ b/tests/test_dev_activate.py
@@ -19,6 +19,7 @@ def test_activate_patches_module_functions(tmp_path):
         (drive, "download"): drive.download,
         (drive, "upload"): drive.upload,
         (gcal, "get_calendar_service"): gcal.get_calendar_service,
+        (gcal, "list_calendars"): gcal.list_calendars,
         (gcal, "list_app_events"): gcal.list_app_events,
         (gcal, "create_event"): gcal.create_event,
         (gcal, "update_event"): gcal.update_event,
@@ -32,6 +33,7 @@ def test_activate_patches_module_functions(tmp_path):
         assert drive.find_sync_file is fakes.fake_find_sync_file
         assert gcal.create_event is fakes.fake_create_event
         assert gcal.list_app_events is fakes.fake_list_app_events
+        assert gcal.list_calendars is fakes.fake_list_calendars
         # Seed lief mit
         assert (tmp_path / "zeiterfassung.json").exists()
     finally:

--- a/tests/test_dev_activate.py
+++ b/tests/test_dev_activate.py
@@ -1,0 +1,55 @@
+import importlib
+import pathlib
+import subprocess
+import sys
+
+import pytest
+
+
+def test_activate_patches_module_functions(tmp_path):
+    from src import drive, gcal, mail
+    from src.dev import activate, fakes
+
+    # Originale merken, um nach dem Test wiederherzustellen
+    originals = {
+        (mail, "get_gmail_service"): mail.get_gmail_service,
+        (mail, "send_email"): mail.send_email,
+        (drive, "get_drive_service"): drive.get_drive_service,
+        (drive, "find_sync_file"): drive.find_sync_file,
+        (drive, "download"): drive.download,
+        (drive, "upload"): drive.upload,
+        (gcal, "get_calendar_service"): gcal.get_calendar_service,
+        (gcal, "list_app_events"): gcal.list_app_events,
+        (gcal, "create_event"): gcal.create_event,
+        (gcal, "update_event"): gcal.update_event,
+        (gcal, "delete_event"): gcal.delete_event,
+    }
+    try:
+        activate(str(tmp_path))
+        assert mail.send_email is fakes.fake_send_email
+        assert mail.get_gmail_service is fakes.fake_get_gmail_service
+        assert drive.upload is fakes.fake_upload
+        assert drive.find_sync_file is fakes.fake_find_sync_file
+        assert gcal.create_event is fakes.fake_create_event
+        assert gcal.list_app_events is fakes.fake_list_app_events
+        # Seed lief mit
+        assert (tmp_path / "zeiterfassung.json").exists()
+    finally:
+        for (module, name), fn in originals.items():
+            setattr(module, name, fn)
+
+
+def test_normal_import_does_not_load_dev():
+    """Ein Import von src.main (ohne --dev) zieht src.dev NICHT mit rein."""
+    pytest.importorskip("tkinter")  # CI ohne tkinter überspringt diesen Guard
+    repo = pathlib.Path(__file__).resolve().parents[1]
+    code = (
+        "import sys; import src.main; "
+        "leaked = [m for m in sys.modules if m.startswith('src.dev')]; "
+        "assert not leaked, leaked"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True, text=True, cwd=str(repo),
+    )
+    assert result.returncode == 0, result.stderr

--- a/tests/test_dev_fakes.py
+++ b/tests/test_dev_fakes.py
@@ -1,0 +1,75 @@
+import logging
+
+import pytest
+
+from src.dev import fakes
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    fakes.reset_state()
+    yield
+    fakes.reset_state()
+
+
+def test_fake_send_email_logs_and_returns_id(caplog):
+    with caplog.at_level(logging.INFO, logger="zeiterfassung.dev"):
+        msg_id = fakes.fake_send_email(
+            object(), "a@b.de", "Betreff", "<html></html>",
+            attachment_filename="report.pdf",
+        )
+    assert msg_id.startswith("dev-msg-")
+    assert "würde Mail senden" in caplog.text
+    assert "a@b.de" in caplog.text
+
+
+def test_fake_drive_roundtrip():
+    service = fakes.fake_get_drive_service("c.json", "t.json")
+    assert fakes.fake_find_sync_file(service) is None
+
+    content = b'{"entries": {"x": 1}}'
+    file_id, ver1 = fakes.fake_upload(service, content)
+    assert file_id == "dev-file"
+    assert fakes.fake_find_sync_file(service) == "dev-file"
+
+    data, ver2 = fakes.fake_download(service, file_id)
+    assert data == content
+    assert ver2 == ver1
+
+    _, ver3 = fakes.fake_upload(service, b'{"entries": {}}', file_id)
+    assert int(ver3) > int(ver1)
+
+
+def test_fake_calendar_create_list_delete():
+    service = fakes.fake_get_calendar_service()
+    assert fakes.fake_list_app_events(service, "cal") == []
+
+    eid = fakes.fake_create_event(service, "cal", "2026-05-28", "08:00", "16:00", "m1")
+    events = fakes.fake_list_app_events(service, "cal")
+    assert len(events) == 1
+    assert events[0]["event_id"] == eid
+    assert events[0]["date"] == "2026-05-28"
+
+    fakes.fake_update_event(service, "cal", eid, "2026-05-28", "09:00", "17:00", "m2")
+    assert fakes.fake_list_app_events(service, "cal")[0]["start"] == "09:00"
+
+    fakes.fake_delete_event(service, "cal", eid)
+    assert fakes.fake_list_app_events(service, "cal") == []
+
+
+def test_simulate_auth_error_once_raises_then_clears():
+    from src.mail import TokenAuthError
+    fakes.simulate_auth_error_once()
+    with pytest.raises(TokenAuthError):
+        fakes.fake_get_gmail_service()
+    # Nur einmal — danach wieder normal
+    assert fakes.fake_get_gmail_service() is not None
+
+
+def test_reset_state_clears_drive_and_calendar():
+    service = fakes.fake_get_drive_service("c", "t")
+    fakes.fake_upload(service, b"{}")
+    fakes.fake_create_event(service, "cal", "2026-05-28", "08:00", "16:00", "m")
+    fakes.reset_state()
+    assert fakes.fake_find_sync_file(service) is None
+    assert fakes.fake_list_app_events(service, "cal") == []

--- a/tests/test_dev_fakes.py
+++ b/tests/test_dev_fakes.py
@@ -40,6 +40,15 @@ def test_fake_drive_roundtrip():
     assert int(ver3) > int(ver1)
 
 
+def test_fake_list_calendars_returns_id_summary_dicts():
+    service = fakes.fake_get_calendar_service()
+    calendars = fakes.fake_list_calendars(service)
+    assert len(calendars) >= 1
+    for cal in calendars:
+        assert set(cal) == {"id", "summary"}
+    assert any(c["id"] == "primary" for c in calendars)
+
+
 def test_fake_calendar_create_list_delete():
     service = fakes.fake_get_calendar_service()
     assert fakes.fake_list_app_events(service, "cal") == []

--- a/tests/test_dev_seed.py
+++ b/tests/test_dev_seed.py
@@ -1,0 +1,35 @@
+import json
+import os
+
+from src.dev import seed
+
+
+def test_seed_if_empty_creates_files(tmp_path):
+    base = str(tmp_path)
+    seed.seed_if_empty(base)
+    z = json.loads((tmp_path / "zeiterfassung.json").read_text(encoding="utf-8"))
+    assert len(z) >= 1
+    # Einträge haben die volle Storage-Form inkl. Sync-Metadaten
+    first = next(iter(z.values()))
+    assert set(first) == {"start", "end", "pause", "modified_at", "device_id", "deleted"}
+    assert (tmp_path / "settings.json").exists()
+    assert (tmp_path / "credentials.json").exists()
+    # KEIN token.json — sonst Token-Popups beim Dev-Start
+    assert not (tmp_path / "token.json").exists()
+
+
+def test_seed_if_empty_is_noop_when_entries_exist(tmp_path):
+    base = str(tmp_path)
+    (tmp_path / "zeiterfassung.json").write_text('{"keep": 1}', encoding="utf-8")
+    seed.seed_if_empty(base)
+    z = json.loads((tmp_path / "zeiterfassung.json").read_text(encoding="utf-8"))
+    assert z == {"keep": 1}
+
+
+def test_reseed_overwrites(tmp_path):
+    base = str(tmp_path)
+    (tmp_path / "zeiterfassung.json").write_text('{"keep": 1}', encoding="utf-8")
+    seed.reseed(base)
+    z = json.loads((tmp_path / "zeiterfassung.json").read_text(encoding="utf-8"))
+    assert "keep" not in z
+    assert len(z) >= 1

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -167,3 +167,20 @@ def test_save_many_pause_default_zero(tmp_storage):
     """Pause-Feld fehlt → wird auf 0 default-gesetzt (analog zu save())."""
     tmp_storage.save_many({"2026-05-14": {"start": "08:00", "end": "16:00"}})
     assert tmp_storage.get_all()["2026-05-14"]["pause"] == 0
+
+
+def test_reload_picks_up_external_file_change(tmp_path):
+    from src.storage import Storage
+    fp = tmp_path / "z.json"
+    fp.write_text('{}', encoding="utf-8")
+    s = Storage(str(fp), device_id="dev")
+    assert s.get_all() == {}
+
+    # Datei extern ersetzen (simuliert Reseed)
+    fp.write_text(
+        '{"2026-05-28": {"start": "08:00", "end": "16:00", "pause": 30,'
+        ' "modified_at": "2026-05-28T00:00:00Z", "device_id": "dev", "deleted": false}}',
+        encoding="utf-8",
+    )
+    s.reload()
+    assert s.get("2026-05-28") == {"start": "08:00", "end": "16:00", "pause": 30}


### PR DESCRIPTION
## Summary

Ein dedizierter Entwickler-Modus, aktiviert ausschließlich über `python -m src.main --dev`. Erlaubt das gefahrlose Durchklicken aller App-Flows ohne echte Google-Dienste und ohne echte Nutzerdaten zu berühren.

- **Fake-Google-Layer**: Gmail/Drive/Calendar komplett gemockt (kein OAuth, kein Netzwerk). Per Monkeypatch in `activate()` ersetzte Modul-Funktionen liefern kanonische Erfolge und loggen, was passiert wäre. Isoliert in `src/dev/` — wird im Normalbetrieb nie importiert (Guard-Test stellt das sicher).
- **Isoliertes Dev-Daten-Verzeichnis**: `./dev-data/` via vorhandenen `ZEITERFASSUNG_DATA_DIR`-Override, automatisch mit Sample-Einträgen + Dummy-`credentials.json` geseedet (bewusst kein `token.json`, damit der Start frei von Token-Popups bleibt). In `.gitignore`.
- **Dev-Konsole**: zweites Tk-Fenster mit Live-Log (DEBUG) und Aktions-Buttons (Sync Pull/Push, Token-Fehler simulieren, Sample-Daten neu laden, Daten-Ordner öffnen, Leeren, Kopieren). Thread-sicherer Logging-Handler via `root.after`.
- **Titel-Indikator**: `Zeiterfassung v<ver> — Dev-Mode`.
- Dialog-Imports (`send_dialog`, `share_dialog`) auf modul-qualifizierten `mail`-Zugriff umgestellt, damit der Monkeypatch greift.

Spec und Plan unter `docs/superpowers/specs/2026-05-28-dev-mode-design.md` bzw. `docs/superpowers/plans/2026-05-28-dev-mode.md`.

## Test Plan

- [x] `pytest` grün (330 passed, 1 skipped) inkl. neuer Tests für Fakes, Seed, `activate()` und Guard (kein `src.dev`-Import im Normalstart)
- [x] Normalstart (`python -m src.main`): unverändert, kein Dev-Fenster, kein `dev-data/`
- [x] Dev-Start (`python -m src.main --dev`): Titel-Suffix, Dev-Konsole, Sample-Daten, kein `token.json`
- [x] Senden-Flow → Log `DEV: würde Mail senden …`, keine echte Mail
- [x] Sync Push/Pull über die Konsole → Fake-Roundtrip ohne Fehler
- [x] Kalender-Dropdown in den Einstellungen lädt Fake-Kalender

🤖 Generated with [Claude Code](https://claude.com/claude-code)