### PR TITLE
ci(release): push-Trigger statt pull_request — Fork-PR-Releases reparieren

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,28 +1,52 @@
 name: Release
 
 on:
-  pull_request:
-    types: [closed]
+  push:
     branches: [master]
+  workflow_dispatch:
 
 jobs:
   pre-check:
-    if: >
-      github.event.pull_request.merged == true &&
-      (contains(github.event.pull_request.labels.*.name, 'release:major') ||
-       contains(github.event.pull_request.labels.*.name, 'release:minor') ||
-       contains(github.event.pull_request.labels.*.name, 'release:patch'))
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       version: ${{ steps.version.outputs.version }}
+      should_release: ${{ steps.gate.outputs.should_release }}
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
 
+      # Push-Events tragen keine PR-Labels. Das release:*-Gate wird daher über
+      # den zum Merge-Commit gehörenden PR per API geprüft. Manuelle Läufe
+      # (workflow_dispatch) sind ein bewusster Auslöser und umgehen das Gate.
+      - name: Decide whether to release
+        id: gate
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "Manueller Lauf → Release."
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          labels=$(gh api "repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" \
+            --jq '.[].labels[].name' 2>/dev/null || true)
+          echo "Labels des zugehörigen PR: ${labels:-<keine>}"
+          if echo "$labels" | grep -qE '^release:(major|minor|patch)$'; then
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Kein release:*-Label → übersprungen."
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Read version
         id: version
+        if: steps.gate.outputs.should_release == 'true'
         shell: bash
         run: |
           VERSION=$(python -c "from src.version import VERSION; print(VERSION)")
@@ -30,16 +54,18 @@ jobs:
           echo "Releasing v${VERSION}"
 
       - name: Fail if tag already exists
+        if: steps.gate.outputs.should_release == 'true'
         shell: bash
         run: |
           git fetch --tags
           if git rev-parse "v${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
-            echo "::error::Tag v${{ steps.version.outputs.version }} already exists. Bump src/version.py in your PR before merging."
+            echo "::error::Tag v${{ steps.version.outputs.version }} already exists. Bump src/version.py vor dem Merge."
             exit 1
           fi
 
   build-windows:
     needs: pre-check
+    if: needs.pre-check.outputs.should_release == 'true'
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v6
@@ -60,6 +86,7 @@ jobs:
 
   build-macos-arm:
     needs: pre-check
+    if: needs.pre-check.outputs.should_release == 'true'
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v6
@@ -79,6 +106,7 @@ jobs:
 
   build-linux:
     needs: pre-check
+    if: needs.pre-check.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -105,6 +133,7 @@ jobs:
 
   publish:
     needs: [pre-check, build-windows, build-macos-arm, build-linux]
+    if: needs.pre-check.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Problem

Das Release von v1.14.0 (PR #36) schlug im `publish`-Job fehl:

```
remote: Permission to margenheld/Zeiterfassung.git denied to github-actions[bot].
fatal: ... error: 403   (git push origin v1.14.0)
```

Ursache: `release.yml` triggerte auf `pull_request: closed`. **PR #36 kam aus einem Fork** (Xveyn/Zeiterfassung), und GitHub erzwingt für `pull_request`-Events aus Forks einen **read-only `GITHUB_TOKEN`** — die `permissions: contents: write`-Angabe kann das nicht anheben, und Secrets/PAT sind in diesem Kontext ebenfalls nicht verfügbar. v1.13.2 lief nur durch, weil dessen PR ein Branch im selben Repo war.

## Fix

- **Trigger** `pull_request:closed` → **`push: [master]` + `workflow_dispatch`**. `push`-Events laufen im Basis-Repo-Kontext mit vollem Schreib-Token, unabhängig davon, ob der PR aus einem Fork kam.
- **`release:*`-Label-Gate bleibt:** `pull_request` trägt auf `push` keine Labels, daher ermittelt `pre-check` den zum Merge-Commit gehörenden PR via `gh api repos/.../commits/<sha>/pulls` und prüft dessen Labels. Manuelle Läufe (`workflow_dispatch`) umgehen das Gate bewusst.
- **`should_release`-Output** gatet die Build-/Publish-Jobs; Merges ohne `release:*`-Label überspringen still (kein roter Lauf mehr bei jedem Merge).

## Recovery für v1.14.0

Dieser PR ist **bewusst ohne `release:*`-Label** — sein Merge soll kein Release auslösen. Master ist bereits auf v1.14.0 (`version.py`), aber ohne Tag. Nach dem Merge:

➡️ **Actions → Release → „Run workflow" auf `master`** (`workflow_dispatch`) → veröffentlicht v1.14.0 mit vollem Token.

Künftige Fork-PRs mit `release:*`-Label releasen dann automatisch über den `push`-Trigger.

## Verify

- `release.yml` lokal mit PyYAML validiert (Syntax + Job-Struktur).
- Echte Verifikation = der `workflow_dispatch`-Lauf nach Merge.