### PR TITLE
docs: SECURITY + CONTRIBUTING + Google-Setup-Aktualisierung & Release-Push-Trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,28 +1,52 @@
 name: Release
 
 on:
-  pull_request:
-    types: [closed]
+  push:
     branches: [master]
+  workflow_dispatch:
 
 jobs:
   pre-check:
-    if: >
-      github.event.pull_request.merged == true &&
-      (contains(github.event.pull_request.labels.*.name, 'release:major') ||
-       contains(github.event.pull_request.labels.*.name, 'release:minor') ||
-       contains(github.event.pull_request.labels.*.name, 'release:patch'))
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       version: ${{ steps.version.outputs.version }}
+      should_release: ${{ steps.gate.outputs.should_release }}
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
 
+      # Push-Events tragen keine PR-Labels. Das release:*-Gate wird daher über
+      # den zum Merge-Commit gehörenden PR per API geprüft. Manuelle Läufe
+      # (workflow_dispatch) sind ein bewusster Auslöser und umgehen das Gate.
+      - name: Decide whether to release
+        id: gate
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "Manueller Lauf → Release."
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          labels=$(gh api "repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" \
+            --jq '.[].labels[].name' 2>/dev/null || true)
+          echo "Labels des zugehörigen PR: ${labels:-<keine>}"
+          if echo "$labels" | grep -qE '^release:(major|minor|patch)$'; then
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Kein release:*-Label → übersprungen."
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Read version
         id: version
+        if: steps.gate.outputs.should_release == 'true'
         shell: bash
         run: |
           VERSION=$(python -c "from src.version import VERSION; print(VERSION)")
@@ -30,16 +54,18 @@ jobs:
           echo "Releasing v${VERSION}"
 
       - name: Fail if tag already exists
+        if: steps.gate.outputs.should_release == 'true'
         shell: bash
         run: |
           git fetch --tags
           if git rev-parse "v${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
-            echo "::error::Tag v${{ steps.version.outputs.version }} already exists. Bump src/version.py in your PR before merging."
+            echo "::error::Tag v${{ steps.version.outputs.version }} already exists. Bump src/version.py vor dem Merge."
             exit 1
           fi
 
   build-windows:
     needs: pre-check
+    if: needs.pre-check.outputs.should_release == 'true'
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v6
@@ -60,6 +86,7 @@ jobs:
 
   build-macos-arm:
     needs: pre-check
+    if: needs.pre-check.outputs.should_release == 'true'
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v6
@@ -79,6 +106,7 @@ jobs:
 
   build-linux:
     needs: pre-check
+    if: needs.pre-check.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -105,6 +133,7 @@ jobs:
 
   publish:
     needs: [pre-check, build-windows, build-macos-arm, build-linux]
+    if: needs.pre-check.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,71 @@
+# Mitwirken
+
+Danke für dein Interesse an Zeiterfassung! Beiträge sind willkommen — egal ob
+Bugfix, Feature oder Doku-Korrektur.
+
+## Entwicklungsumgebung
+
+```bash
+git clone https://github.com/margenheld/Zeiterfassung.git
+cd Zeiterfassung
+pip install -r requirements.txt
+python -m src.main          # App aus dem Repo starten
+```
+
+Die App **muss** als Modul gestartet werden (`python -m src.main`), nicht als
+Script — die Imports innerhalb von `src/` sind absolut (`from src...`).
+
+Voraussetzungen und plattformspezifische Hinweise (z. B. Tkinter unter Linux)
+stehen im [README](README.md#aus-dem-source-code).
+
+## Tests
+
+```bash
+pytest                                   # alle Tests
+pytest tests/test_storage.py             # eine Datei
+pytest tests/test_storage.py::test_name  # einzelner Test
+```
+
+`pytest` ist das Gate: **alle Tests müssen grün sein, bevor ein PR gemerged wird.**
+Wer testbares Verhalten ändert (Feature wie Bugfix), schreibt einen passenden Test
+mit — bei Bugfixes idealerweise erst einen Test, der den Fehler reproduziert.
+
+## Pull Requests
+
+1. Branch von `master` abzweigen.
+2. Änderung umsetzen, Tests grün halten.
+3. PR gegen `master` öffnen mit einer kurzen Beschreibung, **was** sich verhält und
+   **warum**.
+
+Nur anfassen, was die Änderung verlangt, und den vorhandenen Stil matchen. `master`
+ist protected — Merge erfolgt über PR.
+
+## Commit-Konventionen
+
+- Commit-**Typ** englisch im Conventional-Commits-Stil: `feat:`, `fix:`, `docs:`,
+  `ci:`, `refactor:` … Der Body darf deutsch sein.
+- Code und Bezeichner englisch; UI-Texte und Konversation deutsch.
+
+## Wichtige Projekt-Konventionen
+
+- **Datumsformat:** intern **immer ISO** (`YYYY-MM-DD`, Timestamps `…THH:MM…`) für
+  Storage, Filter, Sync und Payloads. In der **UI immer deutsch** (`TT.MM.JJJJ`) über
+  die Helfer in `src/time_utils.py` (`format_iso_date` / `format_iso_datetime`) — nicht
+  roh `isoformat()`/`str()` ausgeben.
+- **Sichtbare Fehler:** Fehler im Sendepfad (Gmail, PDF) müssen per
+  `messagebox.showerror` mit `traceback.format_exc()` angezeigt werden — `--noconsole`
+  im Build unterdrückt sonst jede Spur.
+- Weitere Details (UTF-8 in der Mail-Pipeline, Build, CI-Eigenheiten) stehen in
+  [`CLAUDE.md`](CLAUDE.md).
+
+## Releases
+
+Releases erstellt der Maintainer über ein `release:*`-Label am gemergten PR
+(siehe [`CLAUDE.md`](CLAUDE.md#release-prozess)). Als Contributor musst du dich
+darum nicht kümmern — Versionsbump und Changelog übernimmt der Maintainer beim
+Release-PR.
+
+## Sicherheit
+
+Sicherheitslücken bitte **nicht** über öffentliche Issues melden, sondern wie in
+[`SECURITY.md`](SECURITY.md) beschrieben.

--- a/README.md
+++ b/README.md
@@ -147,25 +147,27 @@ Damit die App E-Mails versenden kann, muss einmalig ein Google Cloud Projekt mit
 1. **APIs & Dienste** → **Bibliothek**
 2. Nach "Gmail API" suchen → **Aktivieren**
 
-### 3. OAuth-Zustimmungsbildschirm
+### 3. OAuth-Zustimmungsbildschirm (Google Auth Platform)
 
-1. **APIs & Dienste** → **OAuth-Zustimmungsbildschirm**
-2. **Extern** → **Erstellen**
-3. Ausfüllen:
-   - App-Name: "Zeiterfassung"
-   - Support-E-Mail: deine Gmail-Adresse
-   - Entwickler-E-Mail: deine Gmail-Adresse
-4. **Speichern und fortfahren**
-5. Bei **Bereiche**: `gmail.send` und `userinfo.email` hinzufügen → **Aktualisieren** → **Speichern**
-   - `userinfo.email` wird benötigt, damit die App die Absender-E-Mail-Adresse automatisch aus dem Google-Konto übernehmen kann (non-sensitive, keine Verifizierung nötig)
-6. Bei **Testnutzer**: deine Gmail-Adresse hinzufügen → **Speichern**
+Google hat die OAuth-Konfiguration 2025 unter **Google Auth Platform** zusammengezogen (früher „OAuth-Zustimmungsbildschirm" unter APIs & Dienste).
+
+1. **Menü ☰ → Google Auth Platform** öffnen (oder direkt [console.cloud.google.com/auth/overview](https://console.cloud.google.com/auth/overview))
+2. Falls noch nicht konfiguriert: **Jetzt starten** / **Get Started** klicken
+3. **Branding**: App-Name "Zeiterfassung" + Support-E-Mail (deine Gmail-Adresse)
+4. **Zielgruppe / Audience**: Nutzertyp **Extern** wählen
+5. **Kontaktinformationen**: deine E-Mail-Adresse für Benachrichtigungen
+6. Datenschutzbedingungen akzeptieren → **Erstellen / Finish**
+7. Anschließend unter **Zielgruppe / Audience → Testnutzer → Nutzer hinzufügen**: deine Gmail-Adresse eintragen
+
+Die Scopes werden nicht hier, sondern unter **Data Access** vergeben — entweder fügt sie der Consent-Flow beim ersten Versand automatisch hinzu, oder du trägst sie manuell ein (siehe Hinweis unten und den Sync-/Kalender-Abschnitt). Für reinen Gmail-Versand reichen `gmail.send` und `userinfo.email`.
+
+- `userinfo.email` wird benötigt, damit die App die Absender-E-Mail-Adresse automatisch aus dem Google-Konto übernehmen kann (non-sensitive, keine Verifizierung nötig)
 
 ### 4. OAuth2 Client-ID erstellen
 
-1. **APIs & Dienste** → **Anmeldedaten**
-2. **Anmeldedaten erstellen** → **OAuth-Client-ID**
-3. Anwendungstyp: **Desktopanwendung** → Name: "Zeiterfassung" → **Erstellen**
-4. **JSON herunterladen** → als `credentials.json` speichern:
+1. **Menü ☰ → Google Auth Platform → Clients** → **Client erstellen** (alternativ weiterhin unter **APIs & Dienste → Anmeldedaten → Anmeldedaten erstellen → OAuth-Client-ID**)
+2. Anwendungstyp: **Desktop-App** → Name: "Zeiterfassung" → **Erstellen**
+3. **JSON herunterladen** → als `credentials.json` speichern:
    - **Entwicklung (aus dem Source):** im Projekt-Root
    - **Windows (installiert):** `%LOCALAPPDATA%\Programs\Zeiterfassung\`
    - **macOS (installiert):** `~/Library/Application Support/Zeiterfassung/`
@@ -176,13 +178,15 @@ Damit die App E-Mails versenden kann, muss einmalig ein Google Cloud Projekt mit
 1. App starten
 2. Unter **Einstellungen** (⚙) E-Mail und Empfänger eintragen
 3. **Monat senden** klicken
-4. Browser öffnet sich → mit Google anmelden → Zugriff erlauben
-5. `token.json` wird automatisch erstellt — ab jetzt kein erneutes Anmelden nötig
+4. Browser öffnet sich → mit Google anmelden → Zugriff erlauben (bei unverifizierter App: **Erweitert → „Zu Zeiterfassung (unsicher)"**)
+5. `token.json` wird automatisch erstellt
 
 ### Hinweise
 
-- Die App läuft im **Test-Modus** — nur eingetragene Testnutzer können sich authentifizieren
-- Das Token wird automatisch erneuert; bei Ablauf öffnet sich der Browser erneut
+- **Test-Modus läuft alle 7 Tage ab:** Solange das Cloud-Projekt den Veröffentlichungsstatus **„Testing"** hat und Scopes über `userinfo.email`/`profile` hinaus anfordert (Gmail, Drive, Kalender — also bei dieser App immer), widerruft Google den Refresh-Token nach **7 Tagen** ([Google-Doku](https://developers.google.com/identity/protocols/oauth2)). Folge: ungefähr wöchentlich öffnet sich der Anmelde-Browser erneut.
+  - **Abhilfe:** Unter **Google Auth Platform → Zielgruppe / Audience** den Status auf **„In Produktion"** setzen. Dann bleibt der Refresh-Token langlebig. Für rein **private** Nutzung ist **keine** Google-Verifizierung nötig — die App bleibt „nicht verifiziert" (Warnscreen beim ersten Login, Limit 100 Nutzer), funktioniert aber dauerhaft ohne wöchentliche Neuanmeldung.
+- Im Test-Modus können sich nur eingetragene **Testnutzer** authentifizieren (deine eigene Gmail-Adresse zählt mit)
+- Innerhalb der Token-Gültigkeit wird der Access-Token automatisch erneuert; läuft der Refresh-Token ab, öffnet sich der Browser erneut
 - `credentials.json` und `token.json` gehören **nicht** ins Repository
 
 ## Multi-Device-Sync einrichten (optional)
@@ -246,6 +250,35 @@ Wiederhole Schritte 3-4 auf jedem weiteren Gerät mit demselben Google-Konto.
 - **Wo die Sync-Datei liegt:** Im versteckten `appDataFolder` deines Google Drives — nicht über `drive.google.com` einsehbar, nur diese App kommt dran.
 - **Test-Modus:** Solange dein Cloud-Projekt im Test-Modus bleibt, müssen alle Nutzer (deine eigenen Geräte zählen mit deiner E-Mail) als Testnutzer eingetragen sein. Verifizierung durch Google ist für rein private Nutzung nicht nötig.
 - **Tombstones wachsen unbeschränkt** — gelöschte Einträge bleiben als Marker im Sync-File, damit Löschungen sich gegen veraltete Speicherungen anderer Geräte durchsetzen. Bei normalem Gebrauch unproblematisch über Jahre; siehe [`docs/known-limitations.md`](docs/known-limitations.md).
+
+## Google-Kalender für Reservierungen einrichten (optional)
+
+Die Reservierungs-Funktion (zukünftige Soll-Zeiten) kann optional mit einem wählbaren Google Kalender abgeglichen werden. Dafür braucht die App zwei zusätzliche Scopes — analog zum Drive-Sync.
+
+**Voraussetzung:** Gmail API ist bereits eingerichtet (siehe Abschnitt oben).
+
+### 1. Google Calendar API aktivieren
+
+1. [Google Cloud Console](https://console.cloud.google.com/) öffnen, dein bestehendes Zeiterfassungs-Projekt wählen
+2. **APIs & Dienste** → **Bibliothek**
+3. Nach "Google Calendar API" suchen → **Aktivieren**
+
+### 2. Kalender-Scopes hinzufügen
+
+**Menü ☰ → Google Auth Platform → Data Access** → **Bereiche hinzufügen oder entfernen**. Zwei Scopes setzen:
+
+- `.../auth/calendar.events` — Reservierungs-Events im gewählten Kalender lesen/schreiben
+- `.../auth/calendar.calendarlist.readonly` — Liste deiner Kalender zur Auswahl abrufen
+
+Beide sind **sensitive** Scopes (im Gegensatz zu `drive.appdata`). Für rein private Nutzung gilt dasselbe wie beim Versand: kein Verifizierungs-Review nötig, aber siehe den 7-Tage-Hinweis oben — bei aktivem Kalender-Abgleich greift er erst recht.
+
+### 3. Bestehendes Token verwerfen
+
+Ein bereits gespeicherter Token ohne die Kalender-Scopes löst keinen neuen Consent-Flow aus. `token.json` löschen (Pfade siehe Sync-Abschnitt oben) — beim nächsten Start fordert die App den Consent inkl. Kalender neu an. Die App erkennt fehlende Scopes auch selbst und erzwingt dann einen frischen Flow.
+
+### 4. Kalender in der App wählen
+
+Reservierungen anlegen und den Abgleich über die App-Oberfläche aktivieren; beim ersten Zugriff zeigt der Consent-Screen die beiden Kalender-Berechtigungen zusätzlich an.
 
 ## Einstellungen
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,57 @@
+# Sicherheitsrichtlinie
+
+## Unterstützte Versionen
+
+Zeiterfassung ist ein kleines Desktop-Tool ohne Server-Komponente. Sicherheits-Fixes
+fließen ausschließlich in die **jeweils aktuelle Release-Version** ein. Ältere Versionen
+werden nicht rückwirkend gepatcht — bitte vor einer Meldung auf das
+[neueste Release](https://github.com/margenheld/Zeiterfassung/releases/latest)
+aktualisieren.
+
+| Version            | Unterstützt |
+|--------------------|:-----------:|
+| Neuestes Release   | ✅          |
+| Ältere Versionen   | ❌          |
+
+## Schwachstelle melden
+
+Bitte melde Sicherheitslücken **nicht** über öffentliche GitHub-Issues.
+
+Bevorzugter Weg ist eine private Meldung über GitHub:
+
+1. [**Security Advisories**](https://github.com/margenheld/Zeiterfassung/security/advisories/new) → „Report a vulnerability"
+
+Alternativ per E-Mail an **sven@margen-held.de**.
+
+Hilfreich für eine schnelle Einschätzung:
+
+- Betroffene Version und Plattform (Windows / macOS / Linux)
+- Beschreibung der Schwachstelle und der möglichen Auswirkung
+- Schritte zur Reproduktion oder ein Proof of Concept
+- Falls vorhanden: ein Vorschlag zur Behebung
+
+Als privates Hobby-Projekt gibt es keine garantierten Reaktionszeiten. Eine erste
+Rückmeldung erfolgt in der Regel innerhalb weniger Tage. Bitte gib uns Gelegenheit,
+ein Problem zu beheben, bevor du Details öffentlich machst (Coordinated Disclosure).
+
+## Sicherheitsrelevante Hinweise zur Nutzung
+
+Die App speichert sensible Daten **lokal im Klartext**. Wer das damit verbundene
+Risiko kennt, kann es vermeiden:
+
+- **`token.json`** enthält einen langlebigen OAuth-Refresh-Token mit laufendem Zugriff
+  auf das verbundene Google-Konto (Gmail-Versand, Drive-Sync, ggf. Kalender). Unter
+  macOS/Linux wird die Datei per `chmod 0600` nur für den eigenen Benutzer lesbar
+  gemacht; unter Windows schützt die ACL des Benutzerprofils. **Wer den Daten- bzw.
+  Installationsordner kopiert, sichert oder in die Cloud synchronisiert, nimmt diesen
+  Token mit** — den Ordner entsprechend vertraulich behandeln.
+- **`credentials.json`** (OAuth-Client-Secret des eigenen Google-Cloud-Projekts) und
+  **`token.json`** gehören **nicht** ins Repository und werden über `.gitignore`
+  ausgeschlossen.
+- Bei Verdacht auf Kompromittierung den App-Zugriff in den
+  [Google-Kontoeinstellungen](https://myaccount.google.com/permissions) entziehen und
+  `token.json` löschen — die App startet beim nächsten Versand einen neuen
+  Anmelde-Flow.
+
+Weitere Details zur Datenspeicherung stehen im
+[README](README.md#datenspeicherung).


### PR DESCRIPTION
## Überblick

Bündelt vier Commits: drei Doku-Ergänzungen plus die bereits vorhandene CI-Änderung am Release-Trigger.

## Änderungen

**CI** (`47f3bfa`)
- `release.yml` auf Push-Trigger umgestellt — Fork-PR-Releases scheiterten sonst am read-only Token.

**Doku**
- **SECURITY.md** (neu) — Meldeweg (GitHub Security Advisory + Mail), Versions-Support-Policy, Token-Sicherheitshinweise.
- **CONTRIBUTING.md** (neu) — Dev-Setup, `pytest` als Merge-Gate, Commit-Konventionen, Projekt-Eigenheiten (ISO-vs-deutsch-Datum, sichtbare Fehler trotz `--noconsole`), Release-Prozess.
- **README.md** — Google-Cloud-Einrichtung auf die aktuelle „Google Auth Platform"-Console-UI umgeschrieben; 7-Tage-Refresh-Token-Ablauf im Test-Modus dokumentiert (+ Empfehlung „In Produktion"); fehlenden Google-Kalender-Setup-Abschnitt für Reservierungen ergänzt.

## Verifikation

- README-Setup-Schritte und OAuth-Scopes gegen die aktuelle Google-Doku (OAuth2, Configure OAuth consent, Create credentials) und den Code (`src/mail.py`) abgeglichen.
- Reine Doku-/CI-Änderung — kein testbares App-Verhalten betroffen.

## Hinweis

Kein `release:*`-Label → dieser PR triggert bewusst **kein** Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)