### PR TITLE
fix(ui): rechtsklick-löschen für arbeitszeiten und reservierungen vereinheitlichen

### DIFF
--- a/src/theme.py
+++ b/src/theme.py
@@ -20,6 +20,9 @@ CELL_BG = "#16213e"
 WEEKEND_BG = "#0f3460"
 ACCENT = "#e94560"
 ACCENT_HOVER = "#c73550"
+# Gedämpfter, entsättigter Akzent für deaktivierte Primary-Buttons — klar als
+# "nicht klickbar" erkennbar, behält aber den Rot-Charakter des Löschen-Buttons.
+ACCENT_DISABLED = "#5c2a37"
 STATUS_OK = "#4ade80"
 TEXT = "#e0e0e0"
 TEXT_MUTED = "#888888"
@@ -633,6 +636,96 @@ def themed_askyesno(parent, title: str, message: str) -> bool:
     dialog.bind("<Return>", lambda e: click_yes())
     dialog.bind("<Escape>", lambda e: click_no())
     dialog.protocol("WM_DELETE_WINDOW", click_no)
+
+    center_dialog_on_parent(dialog, parent)
+    dialog.grab_set()
+    dialog.wait_window()
+    return result["value"]
+
+
+def themed_ask_delete_choice(parent, title: str, message: str, options):
+    """Modaler Lösch-Dialog mit Checkboxen — das Gegenstück zu `themed_askyesno`
+    für Tage, an denen mehrere löschbare Objekte liegen (Ist-Zeit UND
+    Reservierung).
+
+    `options` ist eine Liste von (key, label)-Tupeln; alle Checkboxen sind
+    vorausgewählt. Rückgabe: die Menge der angehakten keys, die der User mit
+    „Löschen" bestätigt — oder None bei Abbruch (Escape / Schließen /
+    „Abbrechen"). Sind alle Checkboxen abgewählt, ist „Löschen" deaktiviert
+    (gedämpfter Rotton, nicht klickbar) — so kann der Klick nicht versehentlich
+    den Dialog schließen und auf einem Kalendertag dahinter landen.
+    """
+    dialog = tk.Toplevel(parent)
+    dialog.title(title)
+    dialog.resizable(False, False)
+    dialog.configure(bg=BG)
+    apply_dark_titlebar(dialog)
+    disable_min_max(dialog)
+    apply_app_icon(dialog)
+    dialog.focus_set()
+
+    result = {"value": None}
+
+    tk.Label(
+        dialog, text=message, font=FONT, bg=BG, fg=TEXT,
+        wraplength=380, justify="left",
+    ).pack(padx=24, pady=(20, 10))
+
+    checkbuttons = []
+    vars_by_key = {}
+    for key, label in options:
+        var = tk.BooleanVar(value=True)
+        vars_by_key[key] = var
+        cb = tk.Checkbutton(
+            dialog, text=label, variable=var, font=FONT,
+            bg=BG, fg=TEXT, selectcolor=CELL_BG,
+            activebackground=BG, activeforeground=TEXT, cursor="hand2",
+        )
+        cb.pack(padx=28, anchor="w")
+        checkbuttons.append(cb)
+
+    def click_delete():
+        selected = {key for key, var in vars_by_key.items() if var.get()}
+        # Leere Auswahl ist ein No-Op: Dialog NICHT schließen, sonst landet der
+        # Klick auf einem Kalendertag dahinter und öffnet den Speichern-Dialog.
+        if not selected:
+            return
+        result["value"] = selected
+        dialog.destroy()
+
+    def click_cancel():
+        dialog.destroy()
+
+    btn_frame = tk.Frame(dialog, bg=BG)
+    btn_frame.pack(pady=(14, 18))
+    delete_btn = primary_button(btn_frame, "Löschen", click_delete)
+    delete_btn.pack(side=tk.LEFT, padx=6)
+    secondary_button(btn_frame, "Abbrechen", click_cancel).pack(side=tk.LEFT, padx=6)
+
+    def _refresh_delete_btn(*_):
+        """Löschen-Button nur klickbar, wenn mind. eine Option gewählt ist —
+        sonst gedämpfter Rotton + Pfeil-Cursor (sichtbar deaktiviert). Mutiert
+        `_colors` analog set_toggle_active; die Hover-Handler lesen frisch."""
+        enabled = any(var.get() for var in vars_by_key.values())
+        cursor = "hand2" if enabled else "arrow"
+        c = (
+            {"bg": ACCENT, "fg": "#ffffff",
+             "hover_bg": ACCENT_HOVER, "hover_fg": "#ffffff"}
+            if enabled else
+            {"bg": ACCENT_DISABLED, "fg": TEXT_MUTED,
+             "hover_bg": ACCENT_DISABLED, "hover_fg": TEXT_MUTED}
+        )
+        delete_btn._colors = c
+        delete_btn.config(bg=c["bg"], cursor=cursor)
+        delete_btn._label.config(bg=c["bg"], fg=c["fg"], cursor=cursor)
+
+    for cb in checkbuttons:
+        cb.config(command=_refresh_delete_btn)
+    _refresh_delete_btn()
+
+    dialog.bind("<Return>", lambda e: click_delete())
+    dialog.bind("<Escape>", lambda e: click_cancel())
+    dialog.protocol("WM_DELETE_WINDOW", click_cancel)
 
     center_dialog_on_parent(dialog, parent)
     dialog.grab_set()

--- a/src/ui.py
+++ b/src/ui.py
@@ -38,7 +38,7 @@ from src.theme import (
     RESERVATION_ACCENT, TODAY_ACCENT,
     FONT, FONT_BOLD, FONT_HEADER, FONT_HEADER_SMALL, FONT_FOOTER, FONT_SMALL, FONT_TINY,
     CELL_BG_HOVER, WEEKEND_BG_HOVER, ENTRY_BG_HOVER, WEEKEND_ENTRY_BG_HOVER,
-    apply_dark_titlebar, themed_askyesno, themed_showinfo,
+    apply_dark_titlebar, themed_askyesno, themed_ask_delete_choice, themed_showinfo,
     icon_button, label_button, secondary_button, set_toggle_active, toggle_button,
 )
 
@@ -768,7 +768,7 @@ class App:
         time_lbl.pack(pady=(0, pad))
         for w in (cell, day_lbl, time_lbl):
             w.bind("<Button-1>", lambda e, d=date_str: self._open_dialog(d))
-            w.bind("<Button-3>", lambda e, d=date_str: self._delete_entry(d))
+            w.bind("<Button-3>", lambda e, d=date_str: self._delete_day(d))
             w.bind("<Enter>", lambda e, c=cell, dl=day_lbl, tl=time_lbl, hb=hover_bg: self._cell_hover(c, dl, tl, hb))
             w.bind("<Leave>", lambda e, c=cell, dl=day_lbl, tl=time_lbl, ob=bg: self._cell_hover(c, dl, tl, ob))
         return cell
@@ -818,6 +818,7 @@ class App:
         day_lbl.pack(expand=True)
         for w in (cell, day_lbl):
             w.bind("<Button-1>", lambda e, d=date_str: self._open_dialog(d))
+            w.bind("<Button-3>", lambda e, d=date_str: self._delete_day(d))
             w.bind("<Enter>", lambda e, c=cell, dl=day_lbl, hb=hover_bg: self._empty_hover(c, dl, hb))
             w.bind("<Leave>", lambda e, c=cell, dl=day_lbl, ob=bg: self._empty_hover(c, dl, ob))
         return cell
@@ -846,6 +847,7 @@ class App:
                 parent, day_text=day_text,
                 name=holidays_map[day_date], max_name_len=holiday_max_len,
                 on_click=lambda d=date_str: self._open_dialog(d),
+                on_right_click=lambda d=date_str: self._delete_day(d),
                 cell_size=cell_size,
                 name_font=holiday_name_font,
                 # Bei zusätzlicher Reservierung übernimmt der Reservierungs-
@@ -1088,7 +1090,7 @@ class App:
 
     def _build_holiday_cell(self, parent, day_text, name, max_name_len, on_click,
                              cell_size=None, name_font=FONT_SMALL,
-                             name_tooltip=True):
+                             name_tooltip=True, on_right_click=None):
         """Grüne Feiertagszelle. Layout analog zur Eintragszelle.
 
         cell_size: optional (width_px, height_px). Wenn gesetzt, wird der Frame
@@ -1125,6 +1127,8 @@ class App:
 
         for w in (cell, day_lbl, name_lbl):
             w.bind("<Button-1>", lambda e: on_click())
+            if on_right_click is not None:
+                w.bind("<Button-3>", lambda e: on_right_click())
             w.bind("<Enter>", lambda e, c=cell, dl=day_lbl, nl=name_lbl:
                 self._cell_hover(c, dl, nl, HOLIDAY_BG_HOVER))
             w.bind("<Leave>", lambda e, c=cell, dl=day_lbl, nl=name_lbl:
@@ -1158,11 +1162,58 @@ class App:
         if marker is not None:
             marker.config(bg=bg)
 
-    def _delete_entry(self, date_str):
-        if themed_askyesno(self.root, "Eintrag löschen",
-                           f"Eintrag für {format_iso_date(date_str)} löschen?"):
+    def _delete_day(self, date_str):
+        """Rechtsklick-Löschen für einen Tag. Löscht NIE ohne Bestätigung.
+
+        Je nachdem, was am Tag liegt:
+        - nur Arbeitszeit   → Ja/Nein-Abfrage
+        - nur Reservierung  → Ja/Nein-Abfrage
+        - beides            → Checkbox-Auswahl, was gelöscht werden soll
+
+        Reservierungen werden nur berücksichtigt, wenn sie aktiv sind
+        (_reservations_active); das Löschen einer Reservierung stößt den
+        Kalender-Abgleich an.
+        """
+        entry = self.storage.get(date_str)
+        reservation = (
+            self.reservation_store.get(date_str)
+            if self._reservations_active() else None
+        )
+        if entry is None and reservation is None:
+            return
+
+        date_de = format_iso_date(date_str)
+        delete_entry = False
+        delete_reservation = False
+
+        if entry is not None and reservation is not None:
+            choice = themed_ask_delete_choice(
+                self.root, "Löschen", f"Was für den {date_de} löschen?",
+                [("entry", "Arbeitszeit"), ("reservation", "Reservierung")],
+            )
+            if not choice:
+                return
+            delete_entry = "entry" in choice
+            delete_reservation = "reservation" in choice
+        elif entry is not None:
+            if not themed_askyesno(self.root, "Arbeitszeit löschen",
+                                   f"Arbeitszeit für {date_de} löschen?"):
+                return
+            delete_entry = True
+        else:
+            if not themed_askyesno(self.root, "Reservierung löschen",
+                                   f"Reservierung für {date_de} löschen?"):
+                return
+            delete_reservation = True
+
+        if delete_entry:
             self.storage.delete(date_str)
-            self._refresh()
+        if delete_reservation:
+            self.reservation_store.delete(date_str)
+
+        self._refresh()
+        if delete_reservation:
+            self._trigger_calendar_reconcile()
 
     def _open_dialog(self, date_str):
         # Bei deaktiviertem Kalender-Sync KEIN reservation_store an den Dialog


### PR DESCRIPTION
## Was

Vereinheitlicht das Löschen von Arbeitszeiten und Reservierungen im Kalender: **Rechtsklick = löschen**, konsistent auf allen Zelltypen und **immer mit Bestätigung**.

## Warum

Vorher inkonsistent: Ist-Zeiten ließen sich per Rechtsklick löschen, Reservierungen nur umständlich über die Buttons im Tages-Dialog.

## Verhalten

| Tag enthält | Rechtsklick |
|---|---|
| nur Arbeitszeit | Ja/Nein-Abfrage |
| nur Reservierung | Ja/Nein-Abfrage |
| beides | neuer Checkbox-Dialog zur Auswahl |
| nichts | passiert nichts |

Linksklick (Anlegen/Bearbeiten) bleibt unverändert.

## Sicherheit gegen Fehlklicks

Im Checkbox-Dialog ist „Löschen" deaktiviert (gedämpfter Rotton + Pfeil-Cursor), solange keine Box angehakt ist. Der Klick schließt den Dialog dann nicht und kann nicht auf einen dahinterliegenden Kalendertag durchfallen.

## Tests

- `pytest` → **386 passed, 1 skipped**
- Dialog-Rendering (aktiv/deaktiviert) per Screenshot geprüft

🤖 Generated with [Claude Code](https://claude.com/claude-code)
