### PR TITLE
feat(tray): Quick-Actions im Infobereich-Menü (Senden, Teilen, Sync)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,29 @@ Anzeige-Formatierung, ISO bleibt die Quelle). Neue datumsanzeigende
 UI-Stellen über diese Helfer formatieren, nicht roh `isoformat()`/`str()`
 ausgeben.
 
+## Kalender-Interaktion: Linksklick speichert, Rechtsklick löscht
+
+Im Kalender gilt ein striktes Modell: **Linksklick** öffnet den Tages-Dialog
+zum Anlegen/Bearbeiten (Ist-Zeit *und* Reservierung), **Rechtsklick** löscht.
+Rechtsklick löscht nie ohne Bestätigung; liegen an einem Tag Ist-Zeit **und**
+Reservierung, fragt ein Checkbox-Dialog (`themed_ask_delete_choice`), was
+gelöscht wird. Gebunden an `<Button-3>` auf allen Zelltypen
+(`src/ui.py::_delete_day`, für Eintrags-, Leer- und Feiertagszellen).
+
+Der Tages-Dialog (`src/dialogs/entry_dialog.py`) ist deshalb bewusst **rein
+zum Speichern** — er hat **keine** Lösch-Buttons.
+
+**Plattform-Ausnahme macOS:** Tkinters Maustasten-Nummerierung macht den
+Rechtsklick (`<Button-3>`) auf macOS unzuverlässig (Sekundärklick ist je nach
+Tk-Version `<Button-2>` bzw. Control-Klick). Damit Löschen auf dem Mac
+überhaupt erreichbar bleibt, behält der Dialog **dort** seine Lösch-Buttons
+(„Löschen" / „Reservierung löschen"). Gesteuert über
+`_SHOW_DELETE_IN_DIALOG = platform.system() == "Darwin"` in `entry_dialog.py`.
+Auf Windows/Linux ist Löschen ausschließlich der Rechtsklick.
+
+Neue Lösch-/Rechtsklick-Stellen müssen dieses Modell einhalten (kein zweiter
+Lösch-Pfad im Linksklick-Dialog auf Win/Linux).
+
 ## Tests / CI
 
 `.github/workflows/test.yml` installiert gezielt nur die Pakete, die die Tests brauchen (`pytest`, `holidays`), **nicht** `requirements.txt`. Grund: `pycairo` (transitive Dep von `xhtml2pdf`) braucht Cairo-Systemheader auf Ubuntu und bricht sonst den CI-Build. Der Import von `xhtml2pdf` in `src/report.py::generate_pdf` ist lazy, daher laufen die Report-Tests ohne die Lib. `holidays` ist pure Python ohne C-Deps und problemlos installierbar.

--- a/src/dialogs/entry_dialog.py
+++ b/src/dialogs/entry_dialog.py
@@ -1,4 +1,5 @@
 import datetime
+import platform
 import tkinter as tk
 from tkinter import messagebox
 
@@ -11,6 +12,14 @@ from src.theme import (
     dark_combo, primary_button, secondary_button, themed_askyesno,
 )
 from src.time_utils import validate_entry
+
+
+# Löschen folgt im Kalender dem Muster „Linksklick = speichern, Rechtsklick =
+# löschen". Der Dialog (Linksklick) ist daher rein zum Anlegen/Bearbeiten — die
+# Lösch-Buttons sind dort raus. AUSNAHME macOS: Tkinters Maustasten-Nummerierung
+# macht den Rechtsklick (`<Button-3>`) dort unzuverlässig; damit Löschen auf dem
+# Mac überhaupt erreichbar bleibt, behält der Dialog dort seine Lösch-Buttons.
+_SHOW_DELETE_IN_DIALOG = platform.system() == "Darwin"
 
 
 def open_entry_dialog(parent, date_str, storage, settings, on_change,
@@ -118,7 +127,7 @@ def open_entry_dialog(parent, date_str, storage, settings, on_change,
     btn_frame = tk.Frame(dialog, bg=BG)
     btn_frame.grid(row=3, column=0, columnspan=2, pady=12)
     primary_button(btn_frame, "Speichern", save).pack(side=tk.LEFT, padx=5)
-    if entry is not None:
+    if entry is not None and _SHOW_DELETE_IN_DIALOG:
         secondary_button(btn_frame, "Löschen", delete).pack(side=tk.LEFT, padx=5)
 
     # --- Reservierung ---
@@ -171,7 +180,7 @@ def open_entry_dialog(parent, date_str, storage, settings, on_change,
         res_btn_frame.grid(row=7, column=0, columnspan=2, pady=12)
         primary_button(res_btn_frame, "Reservierung speichern",
                        save_reservation).pack(side=tk.LEFT, padx=5)
-        if existing_reservation is not None:
+        if existing_reservation is not None and _SHOW_DELETE_IN_DIALOG:
             secondary_button(res_btn_frame, "Reservierung löschen",
                              delete_reservation).pack(side=tk.LEFT, padx=5)
 

--- a/src/dialogs/send_dialog.py
+++ b/src/dialogs/send_dialog.py
@@ -12,7 +12,7 @@ from src.report import generate_pdf, generate_report
 from src.theme import (
     BG, FONT, TEXT,
     apply_app_icon, apply_combobox_style, apply_dark_titlebar,
-    attach_unfocus_on_click, bring_dialog_to_front, center_dialog_on_parent,
+    attach_unfocus_on_click, center_dialog_on_parent,
     disable_min_max, dark_combo, primary_button, secondary_button,
     themed_showinfo,
 )
@@ -247,4 +247,3 @@ def open_send_dialog(parent, storage, settings, base_path):
     secondary_button(btn_frame, "Abbrechen", dialog.destroy).pack(side=tk.LEFT, padx=5)
 
     center_dialog_on_parent(dialog, parent)
-    bring_dialog_to_front(dialog)

--- a/src/dialogs/send_dialog.py
+++ b/src/dialogs/send_dialog.py
@@ -12,8 +12,9 @@ from src.report import generate_pdf, generate_report
 from src.theme import (
     BG, FONT, TEXT,
     apply_app_icon, apply_combobox_style, apply_dark_titlebar,
-    attach_unfocus_on_click, center_dialog_on_parent, disable_min_max,
-    dark_combo, primary_button, secondary_button, themed_showinfo,
+    attach_unfocus_on_click, bring_dialog_to_front, center_dialog_on_parent,
+    disable_min_max, dark_combo, primary_button, secondary_button,
+    themed_showinfo,
 )
 
 
@@ -246,3 +247,4 @@ def open_send_dialog(parent, storage, settings, base_path):
     secondary_button(btn_frame, "Abbrechen", dialog.destroy).pack(side=tk.LEFT, padx=5)
 
     center_dialog_on_parent(dialog, parent)
+    bring_dialog_to_front(dialog)

--- a/src/dialogs/share_dialog.py
+++ b/src/dialogs/share_dialog.py
@@ -14,7 +14,8 @@ from src.theme import (
     BG, FONT, TEXT,
     apply_app_icon, apply_dark_titlebar, attach_unfocus_on_click,
     center_dialog_on_parent, disable_min_max,
-    dark_entry, primary_button, secondary_button, themed_showinfo,
+    dark_entry, primary_button, secondary_button,
+    set_primary_button_enabled, themed_showinfo,
 )
 
 
@@ -106,11 +107,7 @@ def open_share_dialog(parent, storage, settings, base_path, reservation_store=No
         want_entries = include_entries_var.get()
         want_res = include_res_var.get()
         if not want_entries and not want_res:
-            messagebox.showerror(
-                "Nichts ausgewählt",
-                "Bitte mindestens einen Datentyp zum Teilen auswählen.",
-                parent=dialog,
-            )
+            # „Senden" ist in diesem Zustand deaktiviert (s.u.) — No-op.
             return
         share_recipient = recipient_var.get().strip()
         if not share_recipient:
@@ -194,7 +191,17 @@ def open_share_dialog(parent, storage, settings, base_path, reservation_store=No
     btn_frame = tk.Frame(dialog, bg=BG)
     btn_frame.grid(row=row, column=0, columnspan=2, pady=(0, 16))
 
-    primary_button(btn_frame, "Senden", do_send).pack(side=tk.LEFT, padx=5)
+    send_btn = primary_button(btn_frame, "Senden", do_send)
+    send_btn.pack(side=tk.LEFT, padx=5)
     secondary_button(btn_frame, "Abbrechen", dialog.destroy).pack(side=tk.LEFT, padx=5)
+
+    def _refresh_send_btn(*_):
+        # „Senden" nur klickbar, wenn mind. ein Datentyp gewählt ist.
+        set_primary_button_enabled(
+            send_btn, include_entries_var.get() or include_res_var.get())
+
+    cb_entries.config(command=_refresh_send_btn)
+    cb_res.config(command=_refresh_send_btn)
+    _refresh_send_btn()
 
     center_dialog_on_parent(dialog, parent)

--- a/src/dialogs/share_dialog.py
+++ b/src/dialogs/share_dialog.py
@@ -13,7 +13,7 @@ from src.share import build_share_doc, serialize_share_doc
 from src.theme import (
     BG, FONT, TEXT,
     apply_app_icon, apply_dark_titlebar, attach_unfocus_on_click,
-    bring_dialog_to_front, center_dialog_on_parent, disable_min_max,
+    center_dialog_on_parent, disable_min_max,
     dark_entry, primary_button, secondary_button, themed_showinfo,
 )
 
@@ -198,4 +198,3 @@ def open_share_dialog(parent, storage, settings, base_path, reservation_store=No
     secondary_button(btn_frame, "Abbrechen", dialog.destroy).pack(side=tk.LEFT, padx=5)
 
     center_dialog_on_parent(dialog, parent)
-    bring_dialog_to_front(dialog)

--- a/src/dialogs/share_dialog.py
+++ b/src/dialogs/share_dialog.py
@@ -13,7 +13,7 @@ from src.share import build_share_doc, serialize_share_doc
 from src.theme import (
     BG, FONT, TEXT,
     apply_app_icon, apply_dark_titlebar, attach_unfocus_on_click,
-    center_dialog_on_parent, disable_min_max,
+    bring_dialog_to_front, center_dialog_on_parent, disable_min_max,
     dark_entry, primary_button, secondary_button, themed_showinfo,
 )
 
@@ -198,3 +198,4 @@ def open_share_dialog(parent, storage, settings, base_path, reservation_store=No
     secondary_button(btn_frame, "Abbrechen", dialog.destroy).pack(side=tk.LEFT, padx=5)
 
     center_dialog_on_parent(dialog, parent)
+    bring_dialog_to_front(dialog)

--- a/src/theme.py
+++ b/src/theme.py
@@ -411,6 +411,24 @@ def center_dialog_on_parent(dialog, parent):
     dialog.geometry(f"+{x}+{y}")
 
 
+def bring_dialog_to_front(dialog):
+    """Holt einen Dialog sicher in den Vordergrund und gibt ihm den Tastatur-
+    Fokus.
+
+    Nötig, wenn der Parent (Hauptfenster) gerade `withdraw()`n ist — etwa bei
+    einer Tray-Quick-Action (Senden/Teilen aus dem Tray-Menü): Windows
+    aktiviert den neuen Toplevel dann nicht von selbst, der Dialog erscheint
+    unfokussiert hinter anderen Fenstern. `grab_set()`+`focus_set()` allein
+    reichen dafür nicht. Der kurze topmost-Toggle hebt das Fenster über andere,
+    ohne es dauerhaft anzupinnen; `focus_force()` zieht den Eingabefokus.
+
+    Harmlos, wenn der Parent sichtbar ist (Dialog ist dann ohnehin vorn)."""
+    dialog.lift()
+    dialog.attributes("-topmost", True)
+    dialog.attributes("-topmost", False)
+    dialog.focus_force()
+
+
 def _hex_to_colorref(hex_color: str) -> int:
     """Wandelt '#RRGGBB' in Win32 COLORREF (0x00BBGGRR) — Win32 erwartet
     BGR-Byteorder, nicht RGB."""

--- a/src/theme.py
+++ b/src/theme.py
@@ -392,8 +392,19 @@ def center_dialog_on_parent(dialog, parent):
 
     Muss gerufen werden, nachdem alle Widgets erstellt sind, damit
     winfo_reqwidth/reqheight die finale Größe liefern.
+
+    transient() bindet den Dialog an den Parent (Z-Order über Parent, Icon,
+    gemeinsames Minimieren). ABER: Ist der Parent gerade `withdraw()`n (Tray-
+    Modus — Dialog kommt aus einer Tray-Quick-Action), zeigt der Window-Manager
+    ein transientes Fenster zu einem versteckten Master NICHT sauber an: es
+    erscheint unfokussiert hinter anderen Fenstern und die Dark-Titelleiste
+    wird nicht gerendert. Daher transient nur bei sichtbarem Parent setzen; ist
+    er versteckt, bleibt der Dialog ein eigenständiges Top-Level und wird unten
+    selbst in den Vordergrund geholt und fokussiert.
     """
-    dialog.transient(parent)
+    parent_viewable = bool(parent.winfo_viewable())
+    if parent_viewable:
+        dialog.transient(parent)
     dialog.update_idletasks()
     w = dialog.winfo_reqwidth()
     h = dialog.winfo_reqheight()
@@ -410,23 +421,11 @@ def center_dialog_on_parent(dialog, parent):
     y = max(wa_top, min(y, max(wa_top, wa_bottom - h)))
     dialog.geometry(f"+{x}+{y}")
 
-
-def bring_dialog_to_front(dialog):
-    """Holt einen Dialog sicher in den Vordergrund und gibt ihm den Tastatur-
-    Fokus.
-
-    Nötig, wenn der Parent (Hauptfenster) gerade `withdraw()`n ist — etwa bei
-    einer Tray-Quick-Action (Senden/Teilen aus dem Tray-Menü): Windows
-    aktiviert den neuen Toplevel dann nicht von selbst, der Dialog erscheint
-    unfokussiert hinter anderen Fenstern. `grab_set()`+`focus_set()` allein
-    reichen dafür nicht. Der kurze topmost-Toggle hebt das Fenster über andere,
-    ohne es dauerhaft anzupinnen; `focus_force()` zieht den Eingabefokus.
-
-    Harmlos, wenn der Parent sichtbar ist (Dialog ist dann ohnehin vorn)."""
-    dialog.lift()
-    dialog.attributes("-topmost", True)
-    dialog.attributes("-topmost", False)
-    dialog.focus_force()
+    if not parent_viewable:
+        # Ohne transient-Bindung muss der Dialog selbst nach vorn — sonst
+        # öffnet er bei verstecktem Hauptfenster unfokussiert im Hintergrund.
+        dialog.lift()
+        dialog.focus_force()
 
 
 def _hex_to_colorref(hex_color: str) -> int:

--- a/src/theme.py
+++ b/src/theme.py
@@ -413,12 +413,19 @@ def center_dialog_on_parent(dialog, parent):
     pw = parent.winfo_width()
     ph = parent.winfo_height()
     wa_left, wa_top, wa_right, wa_bottom = _parent_workarea(parent)
-    x = px + max(0, (pw - w) // 2)
-    y = py + max(0, (ph - h) // 2)
-    # max(wa_*, wa_*_far - *) sorgt dafür, dass bei einem Dialog größer als
-    # der Bildschirm der obere/linke Rand sichtbar bleibt.
-    x = max(wa_left, min(x, max(wa_left, wa_right - w)))
-    y = max(wa_top, min(y, max(wa_top, wa_bottom - h)))
+    if parent_viewable:
+        x = px + max(0, (pw - w) // 2)
+        y = py + max(0, (ph - h) // 2)
+        # max(wa_*, wa_*_far - *) sorgt dafür, dass bei einem Dialog größer als
+        # der Bildschirm der obere/linke Rand sichtbar bleibt.
+        x = max(wa_left, min(x, max(wa_left, wa_right - w)))
+        y = max(wa_top, min(y, max(wa_top, wa_bottom - h)))
+    else:
+        # Hauptfenster versteckt (Tray-Quick-Action): an der letzten Parent-
+        # Position zu zentrieren wirkt zufällig. Stattdessen auf der Arbeits-
+        # fläche des (zuletzt genutzten) Monitors mittig setzen.
+        x = wa_left + max(0, (wa_right - wa_left - w) // 2)
+        y = wa_top + max(0, (wa_bottom - wa_top - h) // 2)
     dialog.geometry(f"+{x}+{y}")
 
     if not parent_viewable:

--- a/src/theme.py
+++ b/src/theme.py
@@ -245,6 +245,27 @@ def secondary_button(parent, text, command, font=FONT, padx=16, pady=4):
     )
 
 
+def set_primary_button_enabled(btn, enabled):
+    """Schaltet einen `primary_button` optisch aktiv/inaktiv: deaktiviert =
+    gedämpfter Rotton (ACCENT_DISABLED) + Pfeil-Cursor, kein Hover-Wechsel.
+
+    Mutiert `_colors` (die Enter/Leave-Handler lesen frisch daraus) analog
+    set_toggle_active. Wichtig: nur die OPTIK — die `command`/on_click-Bindung
+    bleibt aktiv, daher muss der Callback selbst bei disabled ein No-op machen
+    (Klick auf einen optisch deaktivierten Button soll nichts tun)."""
+    cursor = "hand2" if enabled else "arrow"
+    c = (
+        {"bg": ACCENT, "fg": "#ffffff",
+         "hover_bg": ACCENT_HOVER, "hover_fg": "#ffffff"}
+        if enabled else
+        {"bg": ACCENT_DISABLED, "fg": TEXT_MUTED,
+         "hover_bg": ACCENT_DISABLED, "hover_fg": TEXT_MUTED}
+    )
+    btn._colors = c
+    btn.config(bg=c["bg"], cursor=cursor)
+    btn._label.config(bg=c["bg"], fg=c["fg"], cursor=cursor)
+
+
 def _toggle_colors(active) -> _ToggleColors:
     if active:
         # Aktive Toggle-Variante: kein Hover-Farbwechsel (würde wie "klickbar" aussehen)
@@ -727,21 +748,9 @@ def themed_ask_delete_choice(parent, title: str, message: str, options):
     secondary_button(btn_frame, "Abbrechen", click_cancel).pack(side=tk.LEFT, padx=6)
 
     def _refresh_delete_btn(*_):
-        """Löschen-Button nur klickbar, wenn mind. eine Option gewählt ist —
-        sonst gedämpfter Rotton + Pfeil-Cursor (sichtbar deaktiviert). Mutiert
-        `_colors` analog set_toggle_active; die Hover-Handler lesen frisch."""
-        enabled = any(var.get() for var in vars_by_key.values())
-        cursor = "hand2" if enabled else "arrow"
-        c = (
-            {"bg": ACCENT, "fg": "#ffffff",
-             "hover_bg": ACCENT_HOVER, "hover_fg": "#ffffff"}
-            if enabled else
-            {"bg": ACCENT_DISABLED, "fg": TEXT_MUTED,
-             "hover_bg": ACCENT_DISABLED, "hover_fg": TEXT_MUTED}
-        )
-        delete_btn._colors = c
-        delete_btn.config(bg=c["bg"], cursor=cursor)
-        delete_btn._label.config(bg=c["bg"], fg=c["fg"], cursor=cursor)
+        # Löschen nur klickbar, wenn mind. eine Option gewählt ist.
+        set_primary_button_enabled(
+            delete_btn, any(var.get() for var in vars_by_key.values()))
 
     for cb in checkbuttons:
         cb.config(command=_refresh_delete_btn)

--- a/src/tray.py
+++ b/src/tray.py
@@ -32,12 +32,28 @@ class TrayIcon:
         tray.start()
         ...
         tray.stop()
+
+    actions: optionale Liste von (label, callback, visible)-Tupeln, die als
+    Quick-Actions zwischen „Anzeigen" und „Beenden" ins Menü kommen. `callback`
+    ist eine 0-arg-Funktion (sollte selbst auf den Tk-Thread marshallen, wie
+    on_show/on_quit). `visible` ist None (immer sichtbar) oder eine 0-arg-
+    Funktion → Bool.
+
+    Plattform-Unterschied bei `visible`: Das win32-Backend baut das Popup-Menü
+    bei jedem Rechtsklick neu, wertet die Callable also LIVE aus (ein Sync-
+    Eintrag erscheint/verschwindet sofort, wenn sich die Settings ändern). Das
+    macOS-Backend (NSStatusItem, kein `menuNeedsUpdate:`-Delegate) baut das Menü
+    dagegen nur EINMAL beim Tray-Start — dort ist `visible` ein Snapshot vom
+    Start-Zeitpunkt. Für uns unkritisch: Bei verstecktem Fenster sind die
+    Einstellungen nicht erreichbar, und das Icon wird ohnehin neu gebaut, wenn
+    der Minimieren-Schalter umgelegt wird. Linux hat kein Tray (is_supported()).
     """
 
-    def __init__(self, base_path, on_show, on_quit):
+    def __init__(self, base_path, on_show, on_quit, actions=None):
         self.base_path = base_path
         self._on_show = on_show
         self._on_quit = on_quit
+        self._actions = actions or []
         self._icon = None
         self._thread = None
 
@@ -67,11 +83,19 @@ class TrayIcon:
             self._on_quit()
 
         image = self._load_image()
-        menu = pystray.Menu(
+        items = [
             pystray.MenuItem("Anzeigen", _on_show_click, default=True),
             pystray.Menu.SEPARATOR,
-            pystray.MenuItem("Beenden", _on_quit_click),
-        )
+        ]
+        for label, callback, visible in self._actions:
+            items.append(pystray.MenuItem(
+                label, self._wrap_action(callback),
+                visible=self._wrap_visible(visible),
+            ))
+        if self._actions:
+            items.append(pystray.Menu.SEPARATOR)
+        items.append(pystray.MenuItem("Beenden", _on_quit_click))
+        menu = pystray.Menu(*items)
         icon = pystray.Icon(
             "zeiterfassung",
             image,
@@ -88,6 +112,74 @@ class TrayIcon:
 
         self._thread = threading.Thread(target=_run, daemon=True)
         self._thread.start()
+
+    @staticmethod
+    def _wrap_action(callback):
+        """pystray-Handler-Signatur ist (icon, item); der Caller-Callback ist
+        0-arg. Der läuft im pystray-Thread und marshallt selbst auf den Tk-
+        Thread (siehe Klassen-Docstring)."""
+        def handler(icon, item):
+            callback()
+        return handler
+
+    @staticmethod
+    def _wrap_visible(visible):
+        """`visible` ist None (immer sichtbar) oder eine 0-arg-Funktion → Bool.
+        pystray erwartet entweder einen Bool oder ein Callable mit (item)-
+        Signatur und wertet Callables bei jedem Menü-Öffnen neu aus."""
+        if visible is None:
+            return True
+        return lambda item: bool(visible())
+
+    def notify(self, message, title="Zeiterfassung"):
+        """Zeigt eine System-Benachrichtigung (Toast) über das Tray-Icon.
+        Fehlertolerant — nicht jedes Backend unterstützt notify()."""
+        if self._icon is None:
+            return
+        # Bevorzugt der Toast MIT App-Icon (Windows); bei anderem Backend oder
+        # Fehler Fallback auf pystrays Standard-notify().
+        if self._notify_with_icon(message, title):
+            return
+        try:
+            self._icon.notify(message, title)
+        except Exception:
+            logging.getLogger(__name__).exception("Tray-Notify fehlgeschlagen")
+
+    def _notify_with_icon(self, message, title):
+        """Windows-only: Toast mit dem App-Icon als großem Balloon-Icon.
+
+        pystrays eigenes notify() setzt KEIN Balloon-Icon (dwInfoFlags bleibt 0
+        = NIIF_NONE) — dann zeigt Windows je nach Version ein generisches oder
+        gar kein Logo. Wir setzen NIIF_USER|NIIF_LARGE_ICON plus das HICON des
+        bereits gesetzten Tray-Icons, damit das Logo im Toast erscheint.
+
+        Greift bewusst in pystray-Interna (`_icon._message`, `_icon_handle`,
+        `_util.win32`). Jeder Fehler oder ein Nicht-win32-Backend → False, der
+        Aufrufer fällt dann auf das Standard-notify() zurück."""
+        import platform
+        if platform.system() != "Windows":
+            return False
+        try:
+            from pystray._util import win32
+            handle = getattr(self._icon, "_icon_handle", None)
+            if not handle:
+                return False
+            # Konstanten sind in pystrays win32-Util nicht definiert.
+            NIIF_USER = 0x00000004
+            NIIF_LARGE_ICON = 0x00000020
+            self._icon._message(
+                win32.NIM_MODIFY,
+                win32.NIF_INFO,
+                szInfo=message,
+                szInfoTitle=title or "",
+                dwInfoFlags=NIIF_USER | NIIF_LARGE_ICON,
+                hBalloonIcon=handle,
+            )
+            return True
+        except Exception:
+            logging.getLogger(__name__).exception(
+                "Tray-Notify mit Icon fehlgeschlagen — Fallback auf Standard")
+            return False
 
     def stop(self):
         """Beendet das Tray-Icon. Idempotent."""

--- a/src/ui.py
+++ b/src/ui.py
@@ -127,11 +127,26 @@ class App:
         apply_dark_titlebar(self.root)
 
         # Set unique AppUserModelID so Windows shows our icon in taskbar.
-        # Dieser String ist ohne registrierten DisplayName auch der Absender-
-        # Name oben in Toast-Benachrichtigungen — daher den lesbaren App-Namen
-        # statt einer technischen ID ("margenheld.zeiterfassung") verwenden.
+        # Die AUMID ist ohne registrierten DisplayName auch der Absender-Name
+        # oben in Toast-Benachrichtigungen. Sie darf aber KEINE Leerzeichen
+        # enthalten — daher die ID leerzeichenfrei halten und den lesbaren
+        # Namen (inkl. dynamischer Version) separat als DisplayName in der
+        # Registry registrieren. Den greift Windows für die Toast-Attribution.
+        app_aumid = "Zeiterfassung"
         try:
-            ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID("Zeiterfassung")
+            ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(app_aumid)
+        except Exception:
+            pass
+        try:
+            import winreg
+            with winreg.CreateKeyEx(
+                winreg.HKEY_CURRENT_USER,
+                rf"Software\Classes\AppUserModelId\{app_aumid}",
+            ) as _aumid_key:
+                winreg.SetValueEx(
+                    _aumid_key, "DisplayName", 0, winreg.REG_SZ,
+                    f"Zeiterfassung v{VERSION}",
+                )
         except Exception:
             pass
 

--- a/src/ui.py
+++ b/src/ui.py
@@ -126,9 +126,12 @@ class App:
         self.root.configure(bg=BG)
         apply_dark_titlebar(self.root)
 
-        # Set unique AppUserModelID so Windows shows our icon in taskbar
+        # Set unique AppUserModelID so Windows shows our icon in taskbar.
+        # Dieser String ist ohne registrierten DisplayName auch der Absender-
+        # Name oben in Toast-Benachrichtigungen — daher den lesbaren App-Namen
+        # statt einer technischen ID ("margenheld.zeiterfassung") verwenden.
         try:
-            ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID("margenheld.zeiterfassung")
+            ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID("Zeiterfassung")
         except Exception:
             pass
 

--- a/src/ui.py
+++ b/src/ui.py
@@ -1352,14 +1352,18 @@ class App:
         self._update_sync_status_label()
         if self._tray is None:
             return
+        # title="" — kein fetter Titel: der Absender oben („Zeiterfassung
+        # vX.Y.Z") nennt die App bereits, eine zusätzliche „Zeiterfassung"-
+        # Titelzeile wäre redundant. Es bleibt nur die Statusmeldung.
         if result.get("ok"):
             n = (self.conflicts_store.count_unresolved()
                  if self.conflicts_store is not None else 0)
             msg = ("Synchronisiert." if n == 0
                    else f"Synchronisiert — {n} Konflikt{'e' if n != 1 else ''} offen.")
-            self._tray.notify(msg)
+            self._tray.notify(msg, title="")
         else:
-            self._tray.notify(f"Sync fehlgeschlagen:\n{result.get('error', '?')}")
+            self._tray.notify(f"Sync fehlgeschlagen:\n{result.get('error', '?')}",
+                              title="")
 
     def _on_close(self):
         # Bei aktivem Minimize-to-Tray klappt der X-Button das Fenster nur weg;

--- a/src/ui.py
+++ b/src/ui.py
@@ -636,6 +636,15 @@ class App:
                 self.base_path,
                 on_show=lambda: self.root.after(0, self._restore_from_tray),
                 on_quit=lambda: self.root.after(0, self._quit_with_sync_push),
+                actions=[
+                    ("Monat senden",
+                     lambda: self.root.after(0, self._send), None),
+                    ("Teilen…",
+                     lambda: self.root.after(0, self._share), None),
+                    ("Mit Google Drive synchronisieren",
+                     lambda: self.root.after(0, self._tray_sync),
+                     lambda: bool(self.settings.get("sync_enabled"))),
+                ],
             )
             try:
                 tray.start()
@@ -1299,6 +1308,40 @@ class App:
         # markers appear immediately without requiring a manual view-change.
         self._refresh()
         self._update_sync_status_label()
+
+    def _tray_sync(self):
+        """Drive-Sync aus dem Tray-Menü. Wie _on_sync_clicked, aber das Ergebnis
+        geht als Tray-Toast zurück statt ins (im Tray-Modus versteckte) Status-
+        Label. Der Menüpunkt ist ohnehin nur bei aktivem Sync sichtbar; der
+        Guard fängt den Grenzfall ab, dass Sync zwischen Menü-Öffnen und Klick
+        deaktiviert wurde."""
+        if not self.settings.get("sync_enabled"):
+            return
+        import threading
+        from src.main import _run_push_blocking
+
+        def _do():
+            result = _run_push_blocking(
+                self.storage, self.settings, self.conflicts_store,
+                self.base_path, timeout_seconds=15,
+            )
+            self.root.after(0, lambda: self._on_tray_sync_done(result))
+        threading.Thread(target=_do, daemon=True).start()
+
+    def _on_tray_sync_done(self, result):
+        # Still aktualisieren, damit der nächste Fenster-Aufruf den Stand zeigt.
+        self._refresh()
+        self._update_sync_status_label()
+        if self._tray is None:
+            return
+        if result.get("ok"):
+            n = (self.conflicts_store.count_unresolved()
+                 if self.conflicts_store is not None else 0)
+            msg = ("Synchronisiert." if n == 0
+                   else f"Synchronisiert — {n} Konflikt{'e' if n != 1 else ''} offen.")
+            self._tray.notify(msg)
+        else:
+            self._tray.notify(f"Sync fehlgeschlagen:\n{result.get('error', '?')}")
 
     def _on_close(self):
         # Bei aktivem Minimize-to-Tray klappt der X-Button das Fenster nur weg;

--- a/src/ui.py
+++ b/src/ui.py
@@ -127,12 +127,13 @@ class App:
         apply_dark_titlebar(self.root)
 
         # Set unique AppUserModelID so Windows shows our icon in taskbar.
-        # Die AUMID ist ohne registrierten DisplayName auch der Absender-Name
-        # oben in Toast-Benachrichtigungen. Sie darf aber KEINE Leerzeichen
-        # enthalten — daher die ID leerzeichenfrei halten und den lesbaren
-        # Namen (inkl. dynamischer Version) separat als DisplayName in der
-        # Registry registrieren. Den greift Windows für die Toast-Attribution.
-        app_aumid = "Zeiterfassung"
+        # Die AUMID bleibt bewusst die stabile, namespaced ID — Windows knüpft
+        # Taskbar-Pins und Fenster-Gruppierung daran; ein Wechsel würde
+        # bestehende Pins beim Update lösen. Den lesbaren Absender-Namen für
+        # Toast-Benachrichtigungen (inkl. dynamischer Version) registrieren wir
+        # separat als DisplayName unter dem AUMID-Registry-Key — den greift
+        # Windows für die Toast-Attribution, ohne die AUMID selbst zu ändern.
+        app_aumid = "margenheld.zeiterfassung"
         try:
             ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(app_aumid)
         except Exception:


### PR DESCRIPTION
## Überblick

Dieser Branch baut auf #41 auf. Gegen `upstream/master` enthält der Diff daher **beides**: das vereinheitlichte Lösch-Modell (aus #41) **und** die neuen Tray-Quick-Actions samt Folge-Fixes. Nach Merge von #41 reduziert sich der Diff automatisch auf die Tray-Themen (sinnvolle Reihenfolge: erst #41, dann #43).

## Klick-Modell: Linksklick speichert, Rechtsklick löscht

- **Rechtsklick** auf eine Kalenderzelle löscht — mit Bestätigung; liegt an einem Tag Ist-Zeit **und** Reservierung, fragt ein Checkbox-Dialog (`themed_ask_delete_choice`), was gelöscht wird. Gilt für Eintrags-, Leer- und Feiertagszellen (`_delete_day`).
- **Linksklick** öffnet den Tages-Dialog rein zum Anlegen/Bearbeiten — **keine** Lösch-Buttons mehr.
- **macOS-Ausnahme:** Tkinters Maustasten-Nummerierung macht `<Button-3>` auf macOS unzuverlässig (Sekundärklick ist je nach Tk-Version `<Button-2>` bzw. Control-Klick). Damit Löschen dort erreichbar bleibt, behält der Dialog auf macOS seine Lösch-Buttons (`_SHOW_DELETE_IN_DIALOG = platform.system()=="Darwin"`). Auf Windows/Linux ist Löschen ausschließlich der Rechtsklick. Dokumentiert in `CLAUDE.md`.

## Neu: Tray-Quick-Actions

Drei Aktionen im Infobereich-Menü, um häufige Dinge ohne geöffnetes Hauptfenster zu erreichen:

| Menüpunkt | Aktion |
|---|---|
| Monat senden | öffnet direkt den Senden-Dialog |
| Teilen… | öffnet direkt den Teilen-Dialog |
| Mit Google Drive synchronisieren | Sync im Hintergrund (nur sichtbar bei aktivem Sync) |

Menü: **Anzeigen · — · [Quick-Actions] · — · Beenden**. `TrayIcon` bekommt dafür einen `actions`-Parameter `(label, callback, visible)`; Sichtbarkeit live unter win32, Snapshot beim Start unter macOS (darwin-Backend ohne `menuNeedsUpdate:`-Delegate, im Code dokumentiert).

## Neu: Sync-Benachrichtigung (Toast)

`TrayIcon.notify()` ist neu (das bisherige Tray-Menü hatte keine Benachrichtigung). Die Sync-Quick-Action meldet ihr Ergebnis als Windows-Toast:

- **App-Logo** im Toast (`NIIF_USER | NIIF_LARGE_ICON` + Tray-HICON — pystrays Standard-`notify()` setzt kein Balloon-Icon).
- **Absender „Zeiterfassung vX.Y.Z"**: AUMIDs erlauben keine Leerzeichen, daher den Anzeigenamen inkl. dynamischer Version als `DisplayName` in der Registry (`HKCU\…\AppUserModelId`) registrieren.
- Nur die **Statuszeile** (z.B. „Synchronisiert.") — ohne redundante App-Namen-Titelzeile.

Gekapselt mit Fallback auf pystrays `notify()` (Nicht-Windows/Fehler).

## Tray-Dialoge bei verstecktem Hauptfenster

Bei einer Tray-Quick-Action ist das Hauptfenster `withdraw()`n. `transient()` zu einem versteckten Master ließ den Dialog unfokussiert im Hintergrund und mit heller Titelleiste erscheinen. Fixes in `center_dialog_on_parent`:

- `transient` nur bei sichtbarem Parent; sonst eigenständiges Top-Level + `lift()`/`focus_force()` → korrekter Fokus und dunkle Titelleiste.
- Bei verstecktem Parent **mittig auf der Bildschirm-Arbeitsfläche** statt an der letzten Fensterposition.

## Teilen-Dialog: „Senden" deaktiviert bei leerer Auswahl

Solange weder Arbeitszeiten noch Reservierungen angehakt sind, ist „Senden" gedämpft und nicht klickbar (statt Fehler-Messagebox beim Klick) — analog zum Checkbox-Lösch-Dialog. Gemeinsamer Helfer `set_primary_button_enabled`.

## Plattformen

- **Windows:** voll funktionsfähig (getestet, inkl. installiertem Build).
- **macOS:** Tray-Menü + Toast funktionieren; Sync-Sichtbarkeit ist ein Snapshot vom Tray-Start; Lösch-Buttons bleiben bewusst im Dialog.
- **Linux:** weiterhin kein Tray (`is_supported()`). Feature-Request: #42.

## Tests

- `pytest` → **386 passed, 1 skipped**
- Tray-Menü/Sichtbarkeit, Dialog-Fokus/Titelleiste/Zentrierung über withdrawn-Parent per Harness verifiziert; Quick-Actions, Toast (Logo/Name/Version) und Klick-Modell im installierten Windows-Build manuell getestet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
