### PR TITLE
fix(ui): Stray-Klick nach Dialog-Schließen kurz sperren (#44)

### DIFF
--- a/src/theme.py
+++ b/src/theme.py
@@ -1,5 +1,6 @@
 import os
 import platform
+import time
 import tkinter as tk
 from tkinter import ttk
 from typing import TypedDict
@@ -395,6 +396,24 @@ def _parent_workarea(parent):
     return (0, 0, max_w, max_h)
 
 
+STRAY_CLICK_GUARD_S = 0.2
+
+
+def _stray_click_suppressed(closed_at, now, window=STRAY_CLICK_GUARD_S):
+    """True, wenn ein Klick unterdrückt werden soll, weil gerade (< `window`
+    Sekunden) ein Dialog geschlossen wurde — sonst schlägt der Schließ-Klick auf
+    eine Kalenderzelle durch (#44).
+
+    `closed_at` ist ein `time.monotonic()`-Wert oder 0/None (nie ein Dialog
+    geschlossen). Grenze offen: genau bei `window` wird nicht mehr unterdrückt.
+    now < closed_at (Uhr-Anomalie, mit monotonic praktisch unmöglich) → nicht
+    unterdrücken.
+    """
+    if not closed_at:
+        return False
+    return 0 <= (now - closed_at) < window
+
+
 def center_dialog_on_parent(dialog, parent):
     """Position a Toplevel dialog over its parent's screen rect.
 
@@ -454,6 +473,22 @@ def center_dialog_on_parent(dialog, parent):
         # öffnet er bei verstecktem Hauptfenster unfokussiert im Hintergrund.
         dialog.lift()
         dialog.focus_force()
+
+    # Stray-Klick-Guard (#44): Schließt dieser Dialog, während das Hauptfenster
+    # sichtbar dahinter liegt, kann der Schließ-Klick auf eine Kalenderzelle
+    # durchschlagen. Beim Zerstören den Schließzeitpunkt aufs Toplevel stempeln;
+    # die Klick-Handler in ui.py ignorieren Klicks im Guard-Fenster. Nur bei
+    # sichtbarem Parent (im Tray-/withdrawn-Zustand gibt es keinen Durchschlag).
+    def _stamp_close(event, _dialog=dialog, _parent=parent):
+        if str(event.widget) != str(_dialog):
+            return  # Destroy eines Kind-Widgets, nicht des Dialogs selbst.
+        try:
+            if _parent.winfo_viewable():
+                _parent.winfo_toplevel()._dialog_closed_at = time.monotonic()
+        except tk.TclError:
+            pass  # Parent bereits zerstört (App-Teardown) — irrelevant.
+
+    dialog.bind("<Destroy>", _stamp_close, add="+")
 
 
 def _hex_to_colorref(hex_color: str) -> int:

--- a/src/ui.py
+++ b/src/ui.py
@@ -8,6 +8,7 @@ import logging
 import os
 import platform
 import threading
+import time
 import traceback
 import webbrowser
 from src.time_utils import (
@@ -40,6 +41,7 @@ from src.theme import (
     CELL_BG_HOVER, WEEKEND_BG_HOVER, ENTRY_BG_HOVER, WEEKEND_ENTRY_BG_HOVER,
     apply_dark_titlebar, themed_askyesno, themed_ask_delete_choice, themed_showinfo,
     icon_button, label_button, secondary_button, set_toggle_active, toggle_button,
+    _stray_click_suppressed,
 )
 
 
@@ -1202,6 +1204,9 @@ class App:
         (_reservations_active); das Löschen einer Reservierung stößt den
         Kalender-Abgleich an.
         """
+        if _stray_click_suppressed(getattr(self.root, "_dialog_closed_at", 0),
+                                   time.monotonic()):
+            return  # Rechtsklick schlägt von einem eben geschlossenen Dialog durch (#44).
         entry = self.storage.get(date_str)
         reservation = (
             self.reservation_store.get(date_str)
@@ -1244,6 +1249,9 @@ class App:
             self._trigger_calendar_reconcile()
 
     def _open_dialog(self, date_str):
+        if _stray_click_suppressed(getattr(self.root, "_dialog_closed_at", 0),
+                                   time.monotonic()):
+            return  # Linksklick schlägt von einem eben geschlossenen Dialog durch (#44).
         # Bei deaktiviertem Kalender-Sync KEIN reservation_store an den Dialog
         # geben — dann wird der Reservierungs-Block nicht angezeigt und ist per
         # Linksklick nicht setzbar (open_entry_dialog wertet None entsprechend).

--- a/tests/test_click_guard.py
+++ b/tests/test_click_guard.py
@@ -1,0 +1,37 @@
+"""Stray-Klick-Guard (#44): Klicks unmittelbar nach Dialog-Schließen
+unterdrücken, damit ein durchschlagender Schließ-Klick nicht versehentlich
+eine Kalenderzelle trifft.
+
+Getestet wird die reine Entscheidungslogik `_stray_click_suppressed`. Die Tk-
+Verdrahtung (Stempel in `center_dialog_on_parent`, Guard in
+`_open_dialog`/`_delete_day`) ist UI-Schicht und wird wie dort üblich manuell
+verifiziert.
+"""
+from src.theme import _stray_click_suppressed, STRAY_CLICK_GUARD_S
+
+
+def test_no_dialog_closed_never_suppresses():
+    # closed_at = 0/None → es wurde nie ein Dialog geschlossen → Klick erlaubt.
+    assert _stray_click_suppressed(0, 1000.0) is False
+    assert _stray_click_suppressed(None, 1000.0) is False
+
+
+def test_click_within_window_is_suppressed():
+    closed = 1000.0
+    assert _stray_click_suppressed(closed, closed + STRAY_CLICK_GUARD_S / 2) is True
+
+
+def test_click_after_window_is_allowed():
+    closed = 1000.0
+    assert _stray_click_suppressed(closed, closed + STRAY_CLICK_GUARD_S * 2) is False
+
+
+def test_window_boundary_is_exclusive():
+    # Genau am Fensterende nicht mehr unterdrücken (Grenze offen).
+    closed = 1000.0
+    assert _stray_click_suppressed(closed, closed + STRAY_CLICK_GUARD_S) is False
+
+
+def test_clock_anomaly_now_before_close_not_suppressed():
+    # now < closed_at (mit time.monotonic praktisch unmöglich) → defensiv erlauben.
+    assert _stray_click_suppressed(1000.0, 999.0) is False


### PR DESCRIPTION
## Was

Nach dem Schließen eines modalen Dialogs sind Kalender-Klicks (Links **und** Rechts) für ~200 ms gesperrt — verhindert, dass der Schließ-Klick auf eine dahinterliegende Zelle durchschlägt und ungewollt den Tages-Dialog öffnet oder einen Eintrag löscht.

## Warum

Schließt man einen Dialog (Button oder Escape) und der Cursor liegt über einer Kalenderzelle, schlug derselbe Klick auf den Kalender durch und triggerte sofort `_open_dialog`/`_delete_day` — wie ein versehentlicher Doppel-Trigger.

## Verhalten

- `center_dialog_on_parent` stempelt beim `<Destroy>` jedes modalen Dialogs den Schließzeitpunkt (`time.monotonic`) aufs Hauptfenster — **nur** wenn es sichtbar ist (Tray-/withdrawn-Zustand ausgenommen, dort gibt es keinen Durchschlag).
- Die Kalender-Handler (`_open_dialog`, `_delete_day`) ignorieren Klicks innerhalb von `STRAY_CLICK_GUARD_S` (200 ms).
- Gilt für **alle** modalen Dialoge (entry/send/share/settings/import + die `themed_*`), plattformübergreifend (rein Tk-Event-basiert).

## Tests

- Neu: `tests/test_click_guard.py` — reine Guard-Logik `_stray_click_suppressed` (Grenzfälle: kein Dialog geschlossen, im Fenster, nach Fenster, Grenze exklusiv, Uhr-Anomalie).
- `pytest` → **391 passed, 1 skipped**.
- Echter Tk-Smoke (Toplevel öffnen/schließen): Stempel gesetzt nur bei sichtbarem Parent, Unterdrückung im Fenster, Freigabe nach Ablauf, withdrawn ausgenommen.
- Manuell in der laufenden App bestätigt: Dialog so über einer Zelle geschlossen, dass „Speichern" über einem anderen Tag liegt → schnelles Klicken öffnet **nicht** sofort wieder einen Dialog.

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)