### PR TITLE
ci(release): SHA256SUMS-Prüfsummen ins Release aufnehmen (#52)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,6 +148,22 @@ jobs:
       - name: List downloaded artefacts
         run: ls -la dist/
 
+      - name: Generate SHA256 checksums
+        shell: bash
+        run: |
+          VERSION="${{ needs.pre-check.outputs.version }}"
+          # Prüfsummen mit reinen Dateinamen (ohne dist/-Pfad), damit der Nutzer
+          # nach dem Download `sha256sum -c SHA256SUMS` im Ordner laufen lassen
+          # kann. Explizite Namen statt Glob — sonst hasht SHA256SUMS sich selbst.
+          cd dist
+          sha256sum \
+            Zeiterfassung_Setup.exe \
+            "Zeiterfassung-${VERSION}-arm64.dmg" \
+            "Zeiterfassung-${VERSION}-x86_64.AppImage" \
+            > SHA256SUMS
+          echo "=== SHA256SUMS ==="
+          cat SHA256SUMS
+
       - name: Tag and publish release
         shell: bash
         env:
@@ -162,5 +178,6 @@ jobs:
             dist/Zeiterfassung_Setup.exe \
             dist/Zeiterfassung-${VERSION}-arm64.dmg \
             dist/Zeiterfassung-${VERSION}-x86_64.AppImage \
+            dist/SHA256SUMS \
             --title "Zeiterfassung v${VERSION}" \
             --generate-notes


### PR DESCRIPTION
## Was

Der Release-Workflow (`release.yml`, `publish`-Job) erzeugt jetzt eine `SHA256SUMS`-Datei über die gebauten Artefakte und lädt sie als zusätzliches Release-Asset hoch.

## Warum

Der Update-Pfad öffnet den Download-Link im Browser, ohne Integritätsprüfung. Mit den veröffentlichten Prüfsummen kann jeder die Downloads manuell verifizieren — GitHub + HTTPS bleibt Trust-Anchor.

## Details

- Neuer Step **„Generate SHA256 checksums"**: `sha256sum` über die drei Artefakte mit **reinen Dateinamen** (kein `dist/`-Pfad), damit `sha256sum -c SHA256SUMS` im Download-Ordner des Nutzers funktioniert. Explizite Namen statt Glob → `SHA256SUMS` hasht sich nicht selbst.
- `dist/SHA256SUMS` an `gh release create` angehängt.

## Verifikation

- `yaml.safe_load(release.yml)` → OK (Syntax).
- `sha256sum`-Kommando lokal mit Dummy-Artefakten nachgestellt: korrektes Format, keine Selbst-Referenz, `sha256sum -c` Gegenprobe alle **OK**.
- Vollständig scharf erst im nächsten echten Release-Lauf (Workflow triggert nur auf Push nach master mit `release:*`-Label).

## Scope

Deckt **Stufe 1** aus #52 ab (Prüfsummen-Datei). In-App-Anzeige/Auto-Verify (Stufe 2) ist bewusst nicht enthalten — die App lädt Artefakte nicht selbst, das wäre ein eigener Umbau.

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)