### PR TITLE
chore: Projekt-Hygiene — ruff-Lint-Gate, pyproject, Deps pinnen (#50)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,5 +10,15 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
-      - run: pip install pytest holidays google-api-python-client google-auth google-auth-oauthlib
+      - run: pip install pytest "holidays==0.99" google-api-python-client google-auth google-auth-oauthlib
       - run: pytest tests/
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.10'
+      - run: pip install ruff==0.15.10
+      - run: ruff check .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[tool.ruff]
+target-version = "py310"
+line-length = 100
+
+[tool.ruff.lint]
+# Kuratierter Default: pyflakes (F, echte Bugs wie unused/undefined) plus die
+# semantisch relevanten pycodestyle-Gruppen E4/E7/E9. Bewusst OHNE Whitespace-/
+# Zeilenlängen-Regeln (E1/E2/E3/E501) — das ist Formatter-Sache, kein Gate.
+select = ["E4", "E7", "E9", "F"]
+
+[tool.ruff.lint.per-file-ignores]
+# Test-Dateien gruppieren Imports bewusst vor den zugehörigen Test-Blöcken
+# (Lesbarkeit nach Feature) statt alle am Dateikopf — kein Top-of-File-Zwang.
+"tests/*" = ["E402"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ google-auth-oauthlib>=1.0.0
 google-api-python-client>=2.0.0
 xhtml2pdf>=0.2.11
 pyinstaller>=6.0.0
-holidays
-pystray>=0.19.0
+holidays==0.99
+pystray>=0.19.0,<0.20
 Pillow>=10.0.0

--- a/src/dialogs/conflicts_dialog.py
+++ b/src/dialogs/conflicts_dialog.py
@@ -1,6 +1,6 @@
 # src/dialogs/conflicts_dialog.py
 import tkinter as tk
-from tkinter import ttk, messagebox
+from tkinter import messagebox
 
 from src import sync
 from src.theme import apply_app_icon

--- a/src/drive.py
+++ b/src/drive.py
@@ -5,6 +5,10 @@ Hält die appDataFolder-spezifische Datei `zeiterfassung-sync.json`.
 Scope: drive.appdata (non-sensitive, per-app-isolated).
 """
 
+import io
+import os
+import stat
+
 SYNC_FILENAME = "zeiterfassung-sync.json"
 SYNC_MIMETYPE = "application/json"
 DRIVE_APPDATA_SCOPE = "https://www.googleapis.com/auth/drive.appdata"
@@ -21,10 +25,6 @@ class DriveNetworkError(Exception):
 class DriveConflictError(Exception):
     """ETag-Mismatch beim Upload — Remote wurde inzwischen verändert."""
 
-
-import io
-import os
-import stat
 
 try:
     from google.auth.exceptions import RefreshError, TransportError

--- a/src/sync.py
+++ b/src/sync.py
@@ -149,14 +149,14 @@ def merge(local, remote, last_pull_at):
     # Entries
     all_entry_keys = set(local.get("entries", {}).keys()) | set(remote.get("entries", {}).keys())
     for key in all_entry_keys:
-        l = local.get("entries", {}).get(key)
-        r = remote.get("entries", {}).get(key)
-        winner, conflict = _merge_one(l, r, last_pull_at,
+        loc = local.get("entries", {}).get(key)
+        rem = remote.get("entries", {}).get(key)
+        winner, conflict = _merge_one(loc, rem, last_pull_at,
                                        equal_fn=_values_equal_entry, kind="entry", key=key)
         # Regel 2: Self-Heal — ein zurückgekehrtes (excluded) Gerät darf einen
         # alten, remote-fehlenden lebenden Eintrag nicht auferstehen lassen.
-        if (excluded and r is None and l is not None
-                and (l.get("modified_at") or "") < remote_wm):
+        if (excluded and rem is None and loc is not None
+                and (loc.get("modified_at") or "") < remote_wm):
             winner = None
         if winner is not None:
             merged["entries"][key] = winner
@@ -165,9 +165,9 @@ def merge(local, remote, last_pull_at):
 
     # Settings (Whitelist)
     for key in SYNCED_SETTING_KEYS:
-        l = local.get("settings", {}).get(key)
-        r = remote.get("settings", {}).get(key)
-        winner, conflict = _merge_one(l, r, last_pull_at,
+        loc = local.get("settings", {}).get(key)
+        rem = remote.get("settings", {}).get(key)
+        winner, conflict = _merge_one(loc, rem, last_pull_at,
                                        equal_fn=_values_equal_setting, kind="setting", key=key)
         if winner is not None:
             merged["settings"][key] = winner

--- a/src/theme.py
+++ b/src/theme.py
@@ -584,7 +584,6 @@ def _apply_dark_titlebar_now(window):
         text = ctypes.c_int(_hex_to_colorref(TEXT))
 
         DWMWA_BORDER_COLOR, DWMWA_CAPTION_COLOR, DWMWA_TEXT_COLOR = 34, 35, 36
-        DWMWA_USE_IMMERSIVE_DARK_MODE = 20
 
         set_attr(hwnd, DWMWA_CAPTION_COLOR, ctypes.byref(bg), ctypes.sizeof(bg))
         set_attr(hwnd, DWMWA_TEXT_COLOR, ctypes.byref(text), ctypes.sizeof(text))

--- a/tests/test_autostart.py
+++ b/tests/test_autostart.py
@@ -1,6 +1,5 @@
 # tests/test_autostart.py
 import os
-import sys
 import platform
 import plistlib
 import pytest

--- a/tests/test_conflicts_store.py
+++ b/tests/test_conflicts_store.py
@@ -1,4 +1,3 @@
-import json
 
 import pytest
 

--- a/tests/test_drive.py
+++ b/tests/test_drive.py
@@ -27,7 +27,7 @@ def test_get_drive_service_uses_existing_valid_token(tmp_path):
     with mock.patch("src.drive.Credentials") as mock_cred_cls, \
          mock.patch("src.drive.build") as mock_build:
         mock_cred_cls.from_authorized_user_file.return_value = mock_creds
-        service = get_drive_service("credentials.json", str(token_path))
+        get_drive_service("credentials.json", str(token_path))
 
     mock_cred_cls.from_authorized_user_file.assert_called_once()
     assert mock_build.called
@@ -87,7 +87,6 @@ def test_find_sync_file_queries_appdatafolder():
     assert "zeiterfassung-sync.json" in call_kwargs.get("q", "")
 
 
-import io
 
 from src.drive import download, upload
 

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -233,7 +233,6 @@ def test_send_email_json_attachment_uses_subtype():
 
 
 import platform  # noqa: E402
-import stat  # noqa: E402
 
 
 @pytest.mark.skipif(

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,5 +1,4 @@
 import datetime
-import pytest
 from src.report import generate_report
 
 def test_empty_entries():

--- a/tests/test_reservations.py
+++ b/tests/test_reservations.py
@@ -1,4 +1,3 @@
-import os
 from unittest import mock
 
 import pytest

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -41,7 +41,7 @@ def test_recipient_default(tmp_settings):
     assert tmp_settings.get("recipient") == ""
 
 def test_autostart_default(tmp_settings):
-    assert tmp_settings.get("autostart") == False
+    assert tmp_settings.get("autostart") is False
 
 
 def test_last_update_check_at_default(tmp_settings):
@@ -355,7 +355,7 @@ def test_get_synced_doc_empty_when_nothing_set(tmp_settings):
 def test_set_synced_stamps_meta_per_key(tmp_path):
     """Regression: simulate Settings-Dialog save behavior — synced keys must
     stamp _synced_meta, otherwise sync silently drops them."""
-    from src.settings import Settings, SYNCED_SETTING_KEYS
+    from src.settings import Settings
     s = Settings(str(tmp_path / "settings.json"))
     s.device_id_for_sync = "dev-1"
     updates = {"recipient": "a@b.de", "name": "Max", "default_pause": 45}
@@ -400,7 +400,6 @@ def test_gcal_defaults_present():
 
 
 def test_gcal_calendar_id_is_synced_setting():
-    from src.settings import SYNCED_SETTING_KEYS
     assert "gcal_calendar_id" in SYNCED_SETTING_KEYS
 
 

--- a/tests/test_storage_migration.py
+++ b/tests/test_storage_migration.py
@@ -1,7 +1,6 @@
 import json
 import os
 
-import pytest
 
 from src.storage import Storage
 

--- a/tests/test_time_calc.py
+++ b/tests/test_time_calc.py
@@ -1,4 +1,3 @@
-import pytest
 from src.time_utils import parse_time, calculate_hours, validate_entry
 
 def test_parse_valid_time():

--- a/tests/test_ui_autostart_target.py
+++ b/tests/test_ui_autostart_target.py
@@ -1,6 +1,5 @@
 # tests/test_ui_autostart_target.py
 import sys
-import pytest
 from src.autostart import resolve_autostart_target
 
 

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -5,7 +5,7 @@ from io import BytesIO
 from unittest.mock import patch
 from urllib.error import HTTPError, URLError
 
-from src.updater import Asset, Release, check_latest_release, is_newer, pick_asset_url, should_check_today, today_iso
+from src.updater import Asset, check_latest_release, is_newer, pick_asset_url, should_check_today, today_iso
 
 
 class TestIsNewer:


### PR DESCRIPTION
## Was

Projekt-Hygiene aus #50 (Stufen 1–3): Dependencies pinnen, zentrale Tool-Konfiguration, ruff als CI-Gate. Bestehender Code ruff-clean gemacht.

## Änderungen

**Dependencies**
- `holidays==0.99` (exakt auf die genutzte Version gepinnt — strikte Reproduzierbarkeit; war ungepinnt).
- `pystray>=0.19.0,<0.20` — Obergrenze, weil der Sync-Toast bewusst auf `pystray`-Interna zugreift (s. #43); ein Minor-Bump könnte die brechen.
- CI installiert `holidays==0.99` ebenfalls (die Test-CI installiert eine Minimal-Paketliste, daher separat zu pinnen).

**`pyproject.toml` (neu)**
- `[tool.ruff]`: `select = ["E4","E7","E9","F"]` — pyflakes + semantisch relevante pycodestyle-Gruppen, **ohne** Whitespace/Zeilenlänge (Formatter-Sache, kein Gate).
- `per-file-ignores`: E402 für `tests/*` (Test-Dateien gruppieren Imports bewusst vor Test-Blöcken).
- `[tool.pytest.ini_options]`: `testpaths = ["tests"]`.

**CI-Gate (`test.yml`)**
- Separater `lint`-Job: `ruff==0.15.10` (gepinnt → deterministisches Gate) + `ruff check .`. CI bricht bei Lint-Fehlern ab.

**Code ruff-clean**
- 13 unused-imports / redundante Re-Imports auto-entfernt (`ruff --fix`).
- `drive.py`: `io/os/stat` an den Dateikopf (E402).
- `sync.merge`: `l/r → loc/rem` (E741, **reiner Rename**, keine Logikänderung).
- `theme.py`: unused Win32-Konstante entfernt; Test: `== False → is False`.

## Verifikation

- `ruff check .` → **All checks passed**.
- `pytest` → **391 passed, 1 skipped**.
- `pyproject.toml`/`test.yml` validiert.

## Scope

Stufe 4 (mypy/Type-Hints) bewusst **nicht** enthalten — das Issue markiert sie als „optional später".

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)