### PR TITLE
feat(build): Release-/Dev-Kanal stempeln + Titel-Marker (#45)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,8 @@ jobs:
         shell: powershell
         run: choco install innosetup -y --no-progress
       - name: Build
+        env:
+          ZEIT_RELEASE: "1"
         run: python build.py
       - uses: actions/upload-artifact@v7
         with:
@@ -98,6 +100,8 @@ jobs:
       - name: Install create-dmg
         run: brew install create-dmg
       - name: Build
+        env:
+          ZEIT_RELEASE: "1"
         run: python build.py
       - uses: actions/upload-artifact@v7
         with:
@@ -125,6 +129,8 @@ jobs:
       - name: Install Python dependencies
         run: pip install -r requirements.txt pyinstaller pip-licenses
       - name: Build
+        env:
+          ZEIT_RELEASE: "1"
         run: python build.py
       - uses: actions/upload-artifact@v7
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ logs/
 dist/
 build/
 *.spec
+src/build_info.py
 .claude/
 .superpowers/
 .venv/

--- a/build.py
+++ b/build.py
@@ -4,6 +4,7 @@ import platform
 import shutil
 import subprocess
 import sys
+from datetime import datetime, timezone
 
 from src.version import VERSION
 
@@ -79,6 +80,10 @@ def _pyinstaller_common(extra_args):
         sys.executable, "-m", "PyInstaller",
         "--noconfirm",
         "--name", "Zeiterfassung",
+        # build_info wird in einem function-/try-Import (src/version.py) geladen
+        # und von PyInstaller sonst evtl. nicht erfasst — explizit einbündeln,
+        # damit der Release-Kanal-Stempel im Artefakt landet.
+        "--hidden-import", "src.build_info",
         "--add-data", add_data,
         "--collect-all", "xhtml2pdf",
         "--collect-all", "reportlab",
@@ -215,7 +220,43 @@ def build_linux():
     print(f"AppImage created: {appimage_path}")
 
 
+def generate_build_info():
+    """Schreibt src/build_info.py mit dem Build-Kanal-Stempel (#45). Wird beim
+    Build erzeugt (gitignored) und von PyInstaller mitgebündelt — daher VOR dem
+    eigentlichen Build aufrufen.
+
+    Nur der Release-Workflow setzt ZEIT_RELEASE=1 → CHANNEL='release'. Lokales
+    `python build.py` ohne Flag → 'dev' + Commit-Hash. Der Release-Tag vX.Y.Z
+    entsteht erst nach dem Build, taugt daher nicht zur Kanal-Erkennung — daher
+    das explizite Flag."""
+    channel = "release" if os.environ.get("ZEIT_RELEASE") == "1" else "dev"
+
+    def _git(args):
+        try:
+            return subprocess.run(
+                ["git", *args], capture_output=True, text=True, check=True,
+            ).stdout.strip()
+        except (subprocess.CalledProcessError, OSError):
+            return ""
+
+    sha = _git(["rev-parse", "--short", "HEAD"])
+    dirty = bool(_git(["status", "--porcelain"]))
+    build_time = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    path = os.path.join("src", "build_info.py")
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(
+            "# Generiert von build.py — NICHT committen (s. .gitignore).\n"
+            f'CHANNEL = "{channel}"\n'
+            f'GIT_SHA = "{sha}"\n'
+            f"GIT_DIRTY = {dirty}\n"
+            f'BUILD_TIME = "{build_time}"\n'
+        )
+    print(f"build_info: CHANNEL={channel} SHA={sha or '-'} DIRTY={dirty}")
+
+
 def main():
+    generate_build_info()
     system = platform.system()
     if system == "Windows":
         build_windows()

--- a/src/ui.py
+++ b/src/ui.py
@@ -19,7 +19,7 @@ from src.holidays_de import get_holidays
 from src.tooltip import attach_tooltip
 from src.mail import fetch_user_email, refresh_token_if_needed, TokenAuthError, TokenNetworkError
 from src.drive import DriveAuthError, DriveNetworkError
-from src.version import VERSION
+from src.version import VERSION, version_label
 from src.updater import (
     check_latest_release,
     is_newer,
@@ -124,7 +124,7 @@ class App:
         self.base_path = base_path
         self.conflicts_store = conflicts_store
         self.reservation_store = reservation_store
-        self.root.title(f"Zeiterfassung v{VERSION}")
+        self.root.title(f"Zeiterfassung v{version_label()}")
         self.root.configure(bg=BG)
         apply_dark_titlebar(self.root)
 

--- a/src/version.py
+++ b/src/version.py
@@ -1,1 +1,31 @@
 VERSION = "1.14.1"
+
+# build_info wird beim Build von build.py generiert (gitignored) und von
+# PyInstaller mitgebündelt. Beim Start aus dem Quellcode existiert es nicht —
+# dann gilt Kanal "source". Der Import steht bewusst auf Modulebene (im
+# try/except), damit PyInstaller die Abhängigkeit statisch erkennt.
+try:
+    from src import build_info as _build_info
+except ImportError:
+    _build_info = None
+
+
+def _format_version_label(version, channel, sha):
+    """Anzeige-Label für den Fenstertitel. Release → reine Version; jeder andere
+    Kanal (dev/source) → '-dev'-Suffix, mit Kurz-SHA in Klammern falls vorhanden."""
+    if channel == "release":
+        return version
+    if sha:
+        return f"{version}-dev ({sha})"
+    return f"{version}-dev"
+
+
+def version_label():
+    """Versions-Label inkl. Kanal-Marker für die Titelzeile. Liest den beim Build
+    gestempelten Kanal; fehlt build_info (Quellcode-Start), gilt 'source'."""
+    if _build_info is None:
+        channel, sha = "source", ""
+    else:
+        channel = getattr(_build_info, "CHANNEL", "dev")
+        sha = getattr(_build_info, "GIT_SHA", "")
+    return _format_version_label(VERSION, channel, sha)

--- a/tests/test_version_label.py
+++ b/tests/test_version_label.py
@@ -1,0 +1,25 @@
+"""Build-Kanal-Marker im Fenstertitel (#45).
+
+Getestet wird die reine Label-Formatierung `_format_version_label`. Der Reader
+`version_label()` (liest das beim Build generierte build_info-Modul) und die
+Tk-Titelzeile sind Verdrahtung und werden manuell verifiziert.
+"""
+from src.version import _format_version_label
+
+
+def test_release_channel_is_plain_version():
+    # Release: reine Version, SHA wird bewusst ignoriert.
+    assert _format_version_label("1.14.1", "release", "abc1234") == "1.14.1"
+
+
+def test_dev_build_shows_dev_and_sha():
+    assert _format_version_label("1.14.1", "dev", "abc1234") == "1.14.1-dev (abc1234)"
+
+
+def test_dev_without_sha_shows_only_dev():
+    assert _format_version_label("1.14.1", "dev", "") == "1.14.1-dev"
+
+
+def test_source_channel_shows_dev_without_sha():
+    # Start aus dem Quellcode (kein build_info) → 'source', kein SHA.
+    assert _format_version_label("1.14.1", "source", "") == "1.14.1-dev"


### PR DESCRIPTION
## Was

Zur Laufzeit erkennbar machen, ob ein **offizielles Release** oder eine **Zwischenversion** (lokal gebaut / aus dem Quellcode) läuft — sichtbar als Marker im Fenstertitel.

| Lauf | Fenstertitel |
|------|--------------|
| Offizielles Release | `Zeiterfassung v1.14.1` |
| Lokaler `build.py`-Build | `Zeiterfassung v1.14.1-dev (abc1234)` |
| Start aus dem Quellcode | `Zeiterfassung v1.14.1-dev` |

## Wie

- **`build.py`** erzeugt vor dem Build (in `main()`) ein gitignored `src/build_info.py` mit `CHANNEL` (`release`|`dev`), `GIT_SHA`, `GIT_DIRTY`, `BUILD_TIME`.
- **Kanal-Logik:** Nur der Release-Workflow setzt `ZEIT_RELEASE=1` an den Build-Steps → `CHANNEL=release`. Lokales `build.py` → `dev` + Commit. Kein `build_info` (Quellcode-Start) → `source`.
  - Der Release-Tag `vX.Y.Z` entsteht erst **nach** dem Build, taugt also nicht zur Kanal-Erkennung — daher das explizite Flag.
- **`src/version.py`**: Reader (`version_label()`) + reine Formatierfunktion `_format_version_label`.
- **`src/ui.py`**: Fenstertitel nutzt `version_label()`. Toast-Absender/AUMID bleiben unverändert (nur Titel).
- **Bündelung:** top-level `try`-Import in `version.py` **+** `--hidden-import src.build_info` → build_info landet sicher im PyInstaller-Artefakt.

## Verifikation

- Unit `_format_version_label` (release / dev+sha / dev-ohne-sha / source); `pytest` → **395 passed, 1 skipped**; ruff clean.
- **Echter lokaler Build:** `python build.py` → gebaute `dist/Zeiterfassung.exe` zeigt im Fenstertitel `Zeiterfassung v1.14.1-dev (90a3f27)` — beweist Bündelung **und** Laufzeit-Read. Installierte Release daneben zeigt `Zeiterfassung v1.14.1` → Kanäle live unterscheidbar.
- Release-Pfad simuliert (`ZEIT_RELEASE=1` → `CHANNEL=release` → reine Version).
- Keine Netzabhängigkeit, deterministisch, kein Runtime-git; App-Start ohne Regression.

## Out of scope

Updater-Unterdrückung bei Dev-Builds und Checksum-Tamper-Verifikation (s. Issue) — könnten später auf diesen Stempel aufsetzen.

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)