### PR TITLE
feat(ui): Kompaktier-Dialoge im App-Theme statt nativer messagebox (#46)

### DIFF
--- a/src/dialogs/settings_dialog.py
+++ b/src/dialogs/settings_dialog.py
@@ -16,7 +16,7 @@ from src.theme import (
     center_dialog_on_parent, disable_min_max,
     dark_combo, dark_entry, dark_text,
     primary_button, secondary_button,
-    themed_askyesno, themed_showinfo,
+    themed_askyesno, themed_showinfo, themed_showwarning, themed_showerror,
 )
 from src.holidays_de import STATES
 from src.settings import WEEKDAY_KEYS, SYNCED_SETTING_KEYS
@@ -526,12 +526,12 @@ def open_settings_dialog(parent, settings, base_path, on_change, *,
 
     if settings.get("sync_enabled") and storage is not None and conflicts_store is not None:
         def _on_compact_clicked():
-            confirmed = messagebox.askyesno(
+            confirmed = themed_askyesno(
+                dialog,
                 "Sync-Daten kompaktieren",
                 "Entfernt alte gelöschte Einträge endgültig aus dem Sync.\n\n"
                 "Nur ausführen, wenn ALLE deine Geräte auf der aktuellen Version "
                 "sind und kürzlich synchronisiert haben.\n\nFortfahren?",
-                parent=dialog,
             )
             if not confirmed:
                 return
@@ -540,23 +540,23 @@ def open_settings_dialog(parent, settings, base_path, on_change, *,
                 if not dialog.winfo_exists():
                     return
                 if res.get("reason") == "old_version":
-                    messagebox.showwarning(
+                    themed_showwarning(
+                        dialog,
                         "Kompaktierung abgebrochen",
                         "Ein Gerät nutzt noch eine ältere Version — bitte erst "
                         "alle Geräte aktualisieren und synchronisieren.",
-                        parent=dialog,
                     )
                 elif not res.get("ok"):
                     detail = f"{res.get('error', '?')}\n\n{res.get('tb', '')}"
-                    messagebox.showerror(
+                    themed_showerror(
+                        dialog,
                         "Kompaktierung fehlgeschlagen",
                         f"Die Kompaktierung ist fehlgeschlagen:\n\n{detail}",
-                        parent=dialog,
                     )
                 else:
-                    messagebox.showinfo(
+                    themed_showinfo(
+                        dialog,
                         "Kompaktierung", "Sync-Daten wurden kompaktiert.",
-                        parent=dialog,
                     )
 
             def _do():

--- a/src/theme.py
+++ b/src/theme.py
@@ -25,6 +25,9 @@ ACCENT_HOVER = "#c73550"
 # "nicht klickbar" erkennbar, behält aber den Rot-Charakter des Löschen-Buttons.
 ACCENT_DISABLED = "#5c2a37"
 STATUS_OK = "#4ade80"
+# Amber für Warn-Dialoge (dezenter Akzentbalken) — hebt Warnung von neutralem
+# Info ab, ohne den roten Fehler-/Lösch-Akzent (ACCENT) zu verwenden.
+WARNING = "#e8a13a"
 TEXT = "#e0e0e0"
 TEXT_MUTED = "#888888"
 ENTRY_BG = "#1a3a5c"
@@ -800,11 +803,13 @@ def themed_ask_delete_choice(parent, title: str, message: str, options):
     return result["value"]
 
 
-def themed_showinfo(parent, title: str, message: str) -> None:
-    """Modaler Info-Dialog im App-Theme. Drop-in für `messagebox.showinfo`.
+def _themed_ok_dialog(parent, title: str, message: str, accent=None) -> None:
+    """Modaler OK-Dialog im App-Theme — Basis für info/warning/error.
 
-    Eigener Toplevel mit Dark-Theme-Farben und gebrandeter Titelleiste —
-    `tkinter.messagebox.*` ist eine Black-Box ohne Customization-Hooks.
+    Eigener Toplevel mit Dark-Theme-Farben und gebrandeter Titelleiste
+    (`tkinter.messagebox.*` ist eine Black-Box ohne Customization-Hooks).
+    `accent`: optionale Farbe für einen dezenten Balken am oberen Rand, der
+    Warnung (amber) bzw. Fehler (rot) vom neutralen Info-Dialog abhebt.
     """
     dialog = tk.Toplevel(parent)
     dialog.title(title)
@@ -814,6 +819,11 @@ def themed_showinfo(parent, title: str, message: str) -> None:
     disable_min_max(dialog)
     apply_app_icon(dialog)
     dialog.focus_set()
+
+    if accent is not None:
+        bar = tk.Frame(dialog, bg=accent, height=4)
+        bar.pack(fill=tk.X)
+        bar.pack_propagate(False)
 
     tk.Label(
         dialog, text=message, font=FONT, bg=BG, fg=TEXT,
@@ -831,6 +841,21 @@ def themed_showinfo(parent, title: str, message: str) -> None:
     center_dialog_on_parent(dialog, parent)
     dialog.grab_set()
     dialog.wait_window()
+
+
+def themed_showinfo(parent, title: str, message: str) -> None:
+    """Modaler Info-Dialog im App-Theme. Drop-in für `messagebox.showinfo`."""
+    _themed_ok_dialog(parent, title, message)
+
+
+def themed_showwarning(parent, title: str, message: str) -> None:
+    """Modaler Warn-Dialog im App-Theme. Drop-in für `messagebox.showwarning`."""
+    _themed_ok_dialog(parent, title, message, accent=WARNING)
+
+
+def themed_showerror(parent, title: str, message: str) -> None:
+    """Modaler Fehler-Dialog im App-Theme. Drop-in für `messagebox.showerror`."""
+    _themed_ok_dialog(parent, title, message, accent=ACCENT)
 
 
 def icon_button(parent, text, command, fg=ACCENT, hover_fg=None):


### PR DESCRIPTION
## Was

Der Flow hinter **„Sync-Daten kompaktieren"** (Einstellungen) nutzte native `tkinter.messagebox`-Dialoge (heller System-Look). Jetzt durchgehend im Dark-Theme mit gebrandeter Titelleiste.

## Änderungen

**`src/theme.py`**
- `themed_showinfo` in eine geteilte Basis `_themed_ok_dialog(parent, title, message, accent=None)` refaktoriert (verhaltensneutral).
- Neu: `themed_showwarning` / `themed_showerror` — setzen einen dezenten **4px-Akzentbalken** oben (amber `WARNING` bzw. rot `ACCENT`) zur Unterscheidung Warnung/Fehler. Info bleibt ohne Balken.
- Neue Palette-Farbe `WARNING = #e8a13a`.

**`src/dialogs/settings_dialog.py`**
- Die 4 Aufrufe in `_on_compact_clicked` umgestellt: `askyesno→themed_askyesno`, `showwarning→themed_showwarning`, `showerror→themed_showerror`, `showinfo→themed_showinfo`.
- Andere `messagebox`-Stellen (Senden-/Teilen-Validierung) **bewusst nicht** angefasst (laut Issue separat).

## Verifikation

- `pytest` → **395 passed, 1 skipped**; ruff clean.
- Tk-Smoke: warning/error/info konstruieren fehlerfrei.
- Akzentbalken deterministisch belegt: error/warning **110px** = info **106px** + 4px.
- `themed_showinfo`-Refactor verhaltensneutral (Höhe unverändert, übrige Caller grün).

## Akzeptanzkriterien

- [x] Alle vier Dialoge im Dark-Theme (`apply_dark_titlebar`, BG/TEXT).
- [x] Keine native `messagebox` mehr im Flow.
- [x] Verhalten (Bestätigen/Abbrechen, Thread-Marshalling) unverändert.

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)