### PR TITLE
v1.15.0 — Tray-Schnellaktionen, einheitliches Rechtsklick-Löschen & Dialog-Polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## 1.15.0 — 2026-06-19
+
+### Hinzugefügt
+- Schnellaktionen im Infobereich-Menü (Tray): „Monat senden", „Teilen…" und
+  „Mit Google Drive synchronisieren" lassen sich direkt über das Tray-Icon
+  auslösen, ohne das Hauptfenster zu öffnen. Das Sync-Ergebnis erscheint als
+  Windows-Benachrichtigung (Toast) mit App-Logo. (Der Sync-Eintrag ist nur bei
+  aktivierter Synchronisation sichtbar.)
+- Veröffentlichte Releases enthalten jetzt eine `SHA256SUMS`-Datei zur
+  Integritätsprüfung der heruntergeladenen Dateien.
+
+### Geändert
+- Einheitliches Löschen im Kalender: Rechtsklick auf einen Tag löscht – immer
+  mit Rückfrage. Liegen Arbeitszeit und Reservierung am selben Tag, fragt ein
+  Auswahldialog, was gelöscht werden soll. Der Tages-Dialog (Linksklick) dient
+  auf Windows/Linux nur noch dem Anlegen/Bearbeiten; seine Lösch-Schaltflächen
+  sind entfallen. Auf macOS bleiben sie erhalten (Rechtsklick ist dort
+  systembedingt unzuverlässig).
+- Die Dialoge des „Sync-Daten kompaktieren"-Vorgangs erscheinen jetzt im dunklen
+  App-Design statt als helle System-Meldungen.
+- Selbst gebaute bzw. aus dem Quellcode gestartete Versionen weisen sich im
+  Fenstertitel mit „-dev" (samt Commit-Kürzel) aus; offizielle Releases zeigen
+  unverändert nur die Versionsnummer.
+
+### Behoben
+- Versehentliche Klicks direkt nach dem Schließen eines Dialogs lösen keine
+  ungewollte Aktion mehr aus: Der Kalender ignoriert für einen kurzen Moment
+  Klicks, sodass der Schließen-Klick nicht auf einer dahinterliegenden Zelle
+  „durchschlägt".
+
 ## 1.14.1 — 2026-06-15
 
 ### Hinzugefügt

--- a/src/version.py
+++ b/src/version.py
@@ -1,4 +1,4 @@
-VERSION = "1.14.1"
+VERSION = "1.15.0"
 
 # build_info wird beim Build von build.py generiert (gitignored) und von
 # PyInstaller mitgebündelt. Beim Start aus dem Quellcode existiert es nicht —


### PR DESCRIPTION
Release **v1.15.0** (Minor). Version-Bump `1.14.1 → 1.15.0` + CHANGELOG.

> **Beim Merge** (squash) erkennt `release.yml` das `release:minor`-Label am Merge-PR und baut Win/macOS/Linux + `SHA256SUMS`, taggt `v1.15.0` und veröffentlicht das Release. Die Build-Steps setzen `ZEIT_RELEASE=1` → die Artefakte zeigen den Release-Kanal (Titel ohne `-dev`).

## Enthalten seit v1.14.1

| PR | Änderung |
|----|----------|
| #43 | Tray-Schnellaktionen (Senden/Teilen/Sync) + Sync-Toast mit Logo |
| #41 | Einheitliches Rechtsklick-Löschen (Arbeitszeit + Reservierung) |
| #44 | Stray-Klick-Guard nach Dialog-Schließen |
| #45 | Build-/Dev-Kanal-Marker im Fenstertitel |
| #46 | „Sync-Daten kompaktieren"-Dialoge im App-Theme |
| #52 | `SHA256SUMS` im Release (Download-Integrität) |
| #50 | *(intern)* ruff-Lint-Gate + Dependency-Pinning |

## CHANGELOG (1.15.0)

### Hinzugefügt
- Tray-Schnellaktionen (Senden / Teilen / Sync) + Sync-Toast mit App-Logo.
- `SHA256SUMS` zur Integritätsprüfung der Downloads.

### Geändert
- Einheitliches Löschen: Rechtsklick = löschen (mit Rückfrage; Checkbox-Auswahl bei Arbeitszeit + Reservierung). Lösch-Buttons im Tages-Dialog entfernt (Win/Linux; macOS behält sie).
- Kompaktier-Dialoge im dunklen App-Design.
- `-dev`-Marker im Titel für selbst gebaute / Quellcode-Versionen.

### Behoben
- Stray-Klick direkt nach Dialog-Schließen löst keine ungewollte Aktion mehr aus.

## Vor dem Merge

- [ ] CHANGELOG-Wording final
- [ ] Tag `v1.15.0` ist noch frei (geprüft ✓)

🤖 Generated with [Claude Code](https://claude.com/claude-code)