### PR TITLE
feat: Mehrere Timeslots pro Tag mit benutzerdefinierten Kategorien (#53)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,7 +128,7 @@ Lösch-Pfad im Linksklick-Dialog auf Win/Linux).
 
 ## Tests / CI
 
-`.github/workflows/test.yml` installiert gezielt nur die Pakete, die die Tests brauchen (`pytest`, `holidays`), **nicht** `requirements.txt`. Grund: `pycairo` (transitive Dep von `xhtml2pdf`) braucht Cairo-Systemheader auf Ubuntu und bricht sonst den CI-Build. Der Import von `xhtml2pdf` in `src/report.py::generate_pdf` ist lazy, daher laufen die Report-Tests ohne die Lib. `holidays` ist pure Python ohne C-Deps und problemlos installierbar.
+`.github/workflows/test.yml` installiert gezielt nur die Pakete, die die Tests brauchen (`pytest`, `holidays==0.99`, `google-api-python-client`, `google-auth`, `google-auth-oauthlib`), **nicht** `requirements.txt`. Grund: `pycairo` (transitive Dep von `xhtml2pdf`) braucht Cairo-Systemheader auf Ubuntu und bricht sonst den CI-Build. Der Import von `xhtml2pdf` in `src/report.py::generate_pdf` ist lazy, daher laufen die Report-Tests ohne die Lib. `holidays` und die Google-Libs sind pure Python ohne C-Deps und problemlos installierbar — letztere sind nötig, weil Tests `src.ui` importieren (z.B. `tests/test_ui_delete.py`), dessen Importkette die Google-Wrapper zieht. Ein zweiter Job läuft `ruff check .` (Lint).
 
 Lokal: `pytest` aus dem Repo-Root. Alle Tests müssen vor dem PR-Merge grün sein.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,13 @@ gelöscht wird. Gebunden an `<Button-3>` auf allen Zelltypen
 Der Tages-Dialog (`src/dialogs/entry_dialog.py`) ist deshalb bewusst **rein
 zum Speichern** — er hat **keine** Lösch-Buttons.
 
+Das gilt auch für die Multi-Slot-Zeilen: das per-Zeile-**×** erscheint **nur an
+neu hinzugefügten, noch nicht gespeicherten** Slots (über „+ Slot"). Bereits
+gespeicherte Ist-/Reservierungs-Slots tragen **kein ×** — sie lassen sich im
+Dialog editieren/überschreiben, aber **nicht löschen**. Löschen gespeicherter
+Slots läuft ausschließlich über den Rechtsklick im Kalender (mit Slot-Auswahl).
+Gesteuert über den `removable`-Parameter von `add_ist_row`/`add_res_row`.
+
 **Plattform-Ausnahme macOS:** Tkinters Maustasten-Nummerierung macht den
 Rechtsklick (`<Button-3>`) auf macOS unzuverlässig (Sekundärklick ist je nach
 Tk-Version `<Button-2>` bzw. Control-Klick). Damit Löschen auf dem Mac

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,10 +118,13 @@ zum Speichern** — er hat **keine** Lösch-Buttons.
 **Plattform-Ausnahme macOS:** Tkinters Maustasten-Nummerierung macht den
 Rechtsklick (`<Button-3>`) auf macOS unzuverlässig (Sekundärklick ist je nach
 Tk-Version `<Button-2>` bzw. Control-Klick). Damit Löschen auf dem Mac
-überhaupt erreichbar bleibt, behält der Dialog **dort** seine Lösch-Buttons
-(„Löschen" / „Reservierung löschen"). Gesteuert über
-`_SHOW_DELETE_IN_DIALOG = platform.system() == "Darwin"` in `entry_dialog.py`.
-Auf Windows/Linux ist Löschen ausschließlich der Rechtsklick.
+erreichbar bleibt, zeigt die Tageszelle **dort** ein kleines ✕ oben links,
+sobald der Tag löschbare Einheiten hat (Ist-Zeit oder aktive Reservierung).
+Der ✕-Button löst denselben Lösch-Pfad wie der Rechtsklick aus
+(`App._delete_day` inkl. Bestätigung/Slot-Auswahl). Gesteuert über
+`_should_show_delete_button` (`theme.py`) + `App._add_delete_button` (`ui.py`).
+Der Tages-Dialog hat auf **allen** Plattformen keine Lösch-Buttons. Auf
+Windows/Linux ist Löschen ausschließlich der Rechtsklick.
 
 Neue Lösch-/Rechtsklick-Stellen müssen dieses Modell einhalten (kein zweiter
 Lösch-Pfad im Linksklick-Dialog auf Win/Linux).

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -24,3 +24,33 @@ In den Einstellungen steht unter „Synchronisation" die Aktion **„Sync-Daten 
 - **Altes Gerät offline während der Kompaktierung:** Ein Gerät auf einer Version ohne Kompaktierungs-Support, das beim Kompaktieren offline ist und danach mit veralteten, lebenden Daten zurückkehrt, kann Resurrection auslösen, weil es die Self-Heal-Suppression nicht kennt. Mitigation: der v1-Schema-Guard (Best-Effort-Erkennung aktiver v1-Geräte) und die Bestätigung. Ein zum Zeitpunkt der Aktion offline v1-Gerät bleibt unerkennbar — bewusst akzeptiert.
 - **v2-Gerät mit Offline-Edit vor dem Watermark:** Ein v2-Gerät, das beim Kompaktieren offline war und einen lebenden Eintrag mit `modified_at` vor dem Watermark hält, verliert diesen Eintrag beim Zurückkehren (Regel 2 — Self-Heal-Suppression). Extrem selten in der Praxis (offline gewesene Geräte haben typischerweise keine alten unbewegten Einträge).
 - **Clock-Skew:** Wie im bestehenden Sync — bei grob synchronen Uhren vernachlässigbar.
+
+## Sync: Irreführende „älteres Gerät"-Meldung beim Einzelgerät-Upgrade auf v3
+
+Mit dem Multi-Timeslot-/Kategorien-Feature steigt das Sync-Schema auf v3
+(`slots` statt flacher `start/end/pause`-Keys). Der Pull-Pfad lehnt jedes
+pre-v3-Remote-Doc ab (`sync._remote_is_pre_v3` in `src/main.py::_run_pull_in_background`)
+und pausiert mit der Meldung `OLD_REMOTE_VERSION_MSG` („ein anderes Gerät nutzt
+eine ältere App-Version").
+
+**Symptom:** Ein Nutzer mit **nur einem Gerät**, der bisher v2 lokal *und* im
+Sync genutzt hat, sieht beim **ersten** Start nach dem v3-Upgrade genau diese
+Meldung — obwohl es gar kein anderes Gerät gibt. Der Guard greift hier auf das
+**eigene**, zuletzt selbst gepushte v2-Doc auf Drive.
+
+**Self-Heal:** Es korrigiert sich von selbst. Die lokalen Daten sind beim Start
+bereits nach v3 migriert; der nächste Push (manuell oder beim Schließen)
+überschreibt das Drive-Doc mit v3 — der `expected_etag` passt noch auf das
+unveränderte v2-Doc, also kein Konflikt, kein Guard-Abbruch. Ab dem zweiten
+Start ist alles normal.
+
+**Auswirkung:** Reine UX-Kosmetik — **kein Datenverlust, kein Überschreiben**
+fremder Daten. Nur die Meldung ist in diesem Einzelgerät-Fall einmalig
+irreführend.
+
+**Möglicher Fix (später, im Rahmen von PR #60):** Den Pull nicht pausieren,
+wenn das pre-v3-Remote-Doc ausschließlich Einträge des **eigenen** `device_id`
+enthält (= eigenes Alt-Doc, kein fremdes aktives Gerät) — dann still nach v3
+migrieren/pushen. Alternativ die Meldung so umformulieren, dass sie den
+Einzelgerät-Fall mit abdeckt. Der Guard für echte Multi-Device-Fälle bleibt
+unangetastet.

--- a/docs/superpowers/plans/2026-06-19-ap1-datenmodell-migration.md
+++ b/docs/superpowers/plans/2026-06-19-ap1-datenmodell-migration.md
@@ -1,0 +1,1033 @@
+# AP1 — Datenmodell + Migration (Multi-Slot) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `src/storage.py` und `src/reservations.py` auf das Multi-Slot-Datenmodell umstellen (eine Slot-Liste pro Tag statt eines einzelnen Eintrags) und bestehende Ein-Eintrag-Daten idempotent migrieren.
+
+**Architecture:** Der Tag bleibt der Schlüssel und die Sync-Einheit; der Eintragswert wird `{slots: [...], <Metadaten>}`. Ist-Zeit-Slots tragen `{start, end, pause, kategorie}`, Reservierungs-Slots `{start, end, kategorie, gcal_event_id}`. Migration läuft rein in-memory beim Laden (idempotent über das Vorhandensein des `slots`-Keys), wie das bestehende `_migrate_legacy_entries`-Muster.
+
+**Tech Stack:** Python stdlib (json, os, datetime), pytest. Keine neuen Dependencies.
+
+## Global Constraints
+
+- **Sync-Einheit = Tag.** Der Eintragswert ist eine Slot-Liste; Slots haben keine eigenen Sync-Metadaten. (Verbatim aus Spec, Leitentscheidung 1.)
+- **Kategorie = String am Slot**, `""` = keine Kategorie = Verhalten wie vor Migration. (Leitentscheidung 2.)
+- **Pause pro Ist-Zeit-Slot.** Reservierungs-Slots haben **kein** `pause`, dafür `gcal_event_id`. (Leitentscheidung 3 / Datenmodell.)
+- **Migration idempotent:** Erkennung über vorhandenen `"slots"`-Key; bereits migrierte Einträge bleiben unangetastet.
+- **Datumsformat:** intern ISO (`YYYY-MM-DD`, Timestamps `…THH:MM:SSZ`). Nicht ändern.
+- **Harter Schnitt (abgestimmt):** AP1 stellt die Signaturen direkt auf Slots um. Nur die **AP1-eigenen** Testdateien werden in diesem Paket angepasst. Die übrige Test-Suite und die laufende App sind zwischen AP1 und den Consumer-Paketen **bewusst rot/kaputt** — volle Suite wird erst durch die späteren APs wieder grün. Verifikation in AP1 läuft daher **nur** gegen die vier AP1-Testdateien.
+- **Validierung (Zeitformate, Non-Overlap) gehört NICHT in AP1** — Storage/Reservations bleiben (wie heute) permissiv und speichern, was übergeben wird. Non-Overlap kommt in AP3 (`time_utils` + Dialog).
+
+## Forward-Dependencies (bewusst nach AP1 verschoben)
+
+- **`gcal_event_id`-Erhalt über Reservierungs-Edits:** AP1's `ReservationStore.save(date, slots)` speichert die übergebenen Slots wie sie sind (mitgelieferte `gcal_event_id` bleibt, fehlende wird `None`). Das frühere „beim Speichern bestehende event_id bewahren" entfällt. **AP7** löst das Event-Mapping/-Aufräumen über den vollständigen Kalender-Event-Pull (`gcal.list_app_events`) statt über Tombstone-IDs. Tombstones tragen in AP1 daher `slots: []` (keine event_ids mehr).
+
+---
+
+## Dateistruktur
+
+- `src/storage.py` — Ist-Zeit-Persistenz, Slot-Liste pro Tag + Migration. Verantwortung unverändert (nur Schema).
+- `src/reservations.py` — Reservierungs-Persistenz, Slot-Liste pro Tag + neue Migration.
+- `tests/test_storage.py` — Storage-API-Tests (umgeschrieben auf Slots).
+- `tests/test_storage_migration.py` — Storage-Migrationstests (umgeschrieben + erweitert).
+- `tests/test_reservations.py` — Reservations-API-Tests (umgeschrieben auf Slots).
+- `tests/test_reservations_migration.py` — **neu**: Reservations-Migrationstests.
+
+Task 1 (Storage) und Task 2 (Reservations) sind unabhängig (getrennte Dateien); ein Reviewer kann eines abnehmen und das andere ablehnen.
+
+---
+
+## Task 1: Storage — Slot-Datenmodell + Migration
+
+**Files:**
+- Modify: `src/storage.py` (komplette Neufassung der Methoden, siehe Step 3)
+- Test: `tests/test_storage.py` (Neufassung)
+- Test: `tests/test_storage_migration.py` (Neufassung)
+
+**Interfaces:**
+- Produces (von späteren APs genutzt):
+  - `Storage.save(date_str: str, slots: list[dict]) -> None` — Ist-Zeit-Slot `{start, end, pause, kategorie}`; fehlende `pause`→0, `kategorie`→"".
+  - `Storage.save_many(updates: dict[str, dict]) -> None` — `updates = {date: {"slots": [...]}}`.
+  - `Storage.get(date_str) -> dict | None` — `{"slots": [{start, end, pause, kategorie}, ...]}` (frische Kopien) oder `None` bei Tombstone/fehlend.
+  - `Storage.get_all() -> dict[str, dict]` — `{date: {"slots": [...]}}` ohne Tombstones.
+  - `Storage.get_all_raw() -> dict` — komplette Roh-Einträge `{date: {"slots": [...], "modified_at", "device_id", "deleted"}}` inkl. Tombstones.
+  - `Storage.delete(date_str) -> None` — Tombstone `{"slots": [], "deleted": True, ...}`.
+  - `Storage.apply_merge(merged_entries) -> None` — validiert `_REQUIRED_ENTRY_KEYS = {"slots", "modified_at", "device_id", "deleted"}`.
+
+- [ ] **Step 1: `tests/test_storage.py` neu schreiben**
+
+Ersetze den **kompletten** Inhalt von `tests/test_storage.py` durch:
+
+```python
+import os
+from unittest import mock
+
+import pytest
+from src.storage import Storage
+
+
+@pytest.fixture
+def tmp_storage(tmp_path):
+    return Storage(str(tmp_path / "test.json"), device_id="test-device")
+
+
+def _slot(start, end, pause=0, kategorie=""):
+    return {"start": start, "end": end, "pause": pause, "kategorie": kategorie}
+
+
+def test_load_empty(tmp_storage):
+    assert tmp_storage.get_all() == {}
+
+
+def test_save_and_load(tmp_storage):
+    tmp_storage.save("2026-03-23", [_slot("08:00", "16:30")])
+    entries = tmp_storage.get_all()
+    assert entries["2026-03-23"] == {"slots": [_slot("08:00", "16:30")]}
+
+
+def test_save_multiple_slots(tmp_storage):
+    slots = [_slot("08:00", "12:00", 0, "Büro"), _slot("13:00", "17:00", 30, "Homeoffice")]
+    tmp_storage.save("2026-03-23", slots)
+    assert tmp_storage.get("2026-03-23") == {"slots": slots}
+
+
+def test_slot_defaults_pause_and_kategorie(tmp_storage):
+    tmp_storage.save("2026-03-23", [{"start": "08:00", "end": "16:30"}])
+    assert tmp_storage.get("2026-03-23") == {"slots": [_slot("08:00", "16:30", 0, "")]}
+
+
+def test_delete_entry(tmp_storage):
+    tmp_storage.save("2026-03-23", [_slot("08:00", "16:30")])
+    tmp_storage.delete("2026-03-23")
+    assert "2026-03-23" not in tmp_storage.get_all()
+
+
+def test_delete_writes_tombstone(tmp_storage):
+    tmp_storage.save("2026-03-23", [_slot("08:00", "16:30")])
+    tmp_storage.delete("2026-03-23")
+    raw = tmp_storage.get_all_raw()["2026-03-23"]
+    assert raw["deleted"] is True
+    assert raw["slots"] == []
+
+
+def test_delete_nonexistent(tmp_storage):
+    tmp_storage.delete("2026-01-01")  # should not raise
+    assert tmp_storage.get_all_raw() == {}
+
+
+def test_persistence(tmp_path):
+    path = str(tmp_path / "test.json")
+    s1 = Storage(path)
+    s1.save("2026-03-23", [_slot("08:00", "16:30")])
+    s2 = Storage(path)
+    assert s2.get_all()["2026-03-23"] == {"slots": [_slot("08:00", "16:30")]}
+
+
+def test_save_with_pause(tmp_storage):
+    tmp_storage.save("2026-03-23", [_slot("08:00", "16:30", 30)])
+    assert tmp_storage.get("2026-03-23") == {"slots": [_slot("08:00", "16:30", 30)]}
+
+
+def test_corrupt_json_is_quarantined_and_starts_empty(tmp_path):
+    path = tmp_path / "test.json"
+    path.write_text("{not valid json", encoding="utf-8")
+
+    storage = Storage(str(path))
+
+    assert storage.get_all() == {}
+    quarantined = list(tmp_path.glob("test.json.corrupt-*"))
+    assert len(quarantined) == 1
+    assert quarantined[0].read_text(encoding="utf-8") == "{not valid json"
+
+
+def test_save_failure_keeps_original_file_intact(tmp_path):
+    path = tmp_path / "test.json"
+    storage = Storage(str(path))
+    storage.save("2026-03-23", [_slot("08:00", "16:30")])
+    original_bytes = path.read_bytes()
+
+    with mock.patch("os.replace", side_effect=OSError("disk full")):
+        with pytest.raises(OSError):
+            storage.save("2026-03-24", [_slot("09:00", "17:00")])
+
+    assert path.read_bytes() == original_bytes
+    leftovers = [p for p in tmp_path.iterdir() if p.suffix == ".tmp"]
+    assert leftovers == []
+
+
+def test_save_does_not_leave_tmp_files(tmp_path):
+    path = tmp_path / "test.json"
+    storage = Storage(str(path))
+    storage.save("2026-03-23", [_slot("08:00", "16:30")])
+    storage.save("2026-03-24", [_slot("09:00", "17:00")])
+
+    leftovers = [p.name for p in tmp_path.iterdir() if p.name.endswith(".tmp")]
+    assert leftovers == []
+
+
+def test_save_stamps_modified_at_and_device_id(tmp_path):
+    storage = Storage(str(tmp_path / "t.json"), device_id="dev-1")
+    storage.save("2026-05-14", [_slot("08:00", "16:00", 30)])
+    raw = storage.get_all_raw()
+    assert raw["2026-05-14"]["slots"] == [_slot("08:00", "16:00", 30)]
+    assert raw["2026-05-14"]["device_id"] == "dev-1"
+    assert "T" in raw["2026-05-14"]["modified_at"]
+    assert raw["2026-05-14"]["modified_at"].endswith("Z")
+
+
+def test_get_returns_user_shape_without_metadata(tmp_path):
+    storage = Storage(str(tmp_path / "t.json"), device_id="dev-1")
+    storage.save("2026-05-14", [_slot("08:00", "16:00", 30)])
+    assert storage.get("2026-05-14") == {"slots": [_slot("08:00", "16:00", 30)]}
+    assert storage.get_all()["2026-05-14"] == {"slots": [_slot("08:00", "16:00", 30)]}
+
+
+def test_user_shape_returns_independent_copies(tmp_path):
+    """get() darf keine Referenz auf interne Slot-Dicts herausgeben."""
+    storage = Storage(str(tmp_path / "t.json"))
+    storage.save("2026-05-14", [_slot("08:00", "16:00")])
+    got = storage.get("2026-05-14")
+    got["slots"][0]["start"] = "00:00"
+    assert storage.get("2026-05-14")["slots"][0]["start"] == "08:00"
+
+
+def test_apply_merge_rejects_entry_missing_required_keys(tmp_path):
+    storage = Storage(str(tmp_path / "t.json"), device_id="dev-1")
+    with pytest.raises(ValueError, match="missing keys"):
+        storage.apply_merge({"2026-05-14": {"slots": [_slot("08:00", "16:00")]}})
+    # _data unverändert geblieben (kein Halb-Schreiben)
+    assert storage.get_all_raw() == {}
+
+
+def test_apply_merge_accepts_complete_entries(tmp_path):
+    storage = Storage(str(tmp_path / "t.json"), device_id="dev-1")
+    storage.apply_merge({"2026-05-14": {
+        "slots": [_slot("08:00", "16:00", 30)],
+        "modified_at": "2026-05-14T10:00:00Z",
+        "device_id": "other-dev",
+        "deleted": False,
+    }})
+    assert storage.get("2026-05-14") == {"slots": [_slot("08:00", "16:00", 30)]}
+
+
+def test_save_many_empty_is_noop(tmp_path):
+    path = str(tmp_path / "noop.json")
+    s = Storage(path, device_id="d1")
+    s.save_many({})
+    assert not os.path.exists(path)
+
+
+def test_save_many_writes_all_entries(tmp_storage):
+    tmp_storage.save_many({
+        "2026-05-14": {"slots": [_slot("08:00", "16:00", 30)]},
+        "2026-05-15": {"slots": [_slot("09:00", "17:30", 45)]},
+    })
+    entries = tmp_storage.get_all()
+    assert entries["2026-05-14"] == {"slots": [_slot("08:00", "16:00", 30)]}
+    assert entries["2026-05-15"] == {"slots": [_slot("09:00", "17:30", 45)]}
+
+
+def test_save_many_sets_metadata(tmp_storage):
+    tmp_storage.save_many({"2026-05-14": {"slots": [_slot("08:00", "16:00", 30)]}})
+    raw = tmp_storage.get_all_raw()["2026-05-14"]
+    assert raw["device_id"] == "test-device"
+    assert raw["deleted"] is False
+    assert "modified_at" in raw and raw["modified_at"]
+
+
+def test_save_many_overwrites_tombstone(tmp_storage):
+    tmp_storage.save("2026-05-14", [_slot("08:00", "16:00", 30)])
+    tmp_storage.delete("2026-05-14")
+    assert tmp_storage.get("2026-05-14") is None
+    tmp_storage.save_many({"2026-05-14": {"slots": [_slot("09:00", "17:00")]}})
+    assert tmp_storage.get("2026-05-14") == {"slots": [_slot("09:00", "17:00")]}
+
+
+def test_save_many_calls_disk_write_once(tmp_storage):
+    with mock.patch.object(tmp_storage, "_save_to_disk") as m:
+        tmp_storage.save_many({
+            "2026-05-14": {"slots": [_slot("08:00", "16:00", 30)]},
+            "2026-05-15": {"slots": [_slot("09:00", "17:30", 45)]},
+        })
+    assert m.call_count == 1
+
+
+def test_save_many_slot_defaults(tmp_storage):
+    tmp_storage.save_many({"2026-05-14": {"slots": [{"start": "08:00", "end": "16:00"}]}})
+    slot = tmp_storage.get_all()["2026-05-14"]["slots"][0]
+    assert slot["pause"] == 0
+    assert slot["kategorie"] == ""
+```
+
+- [ ] **Step 2: `tests/test_storage_migration.py` neu schreiben**
+
+Ersetze den **kompletten** Inhalt von `tests/test_storage_migration.py` durch:
+
+```python
+import json
+import os
+
+from src.storage import Storage
+
+
+def _write_legacy_json(tmp_path, payload):
+    path = tmp_path / "legacy.json"
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(payload, f)
+    return str(path)
+
+
+def test_legacy_entry_wrapped_into_single_slot(tmp_path):
+    """Alter Ein-Eintrag-Tag ohne Metadaten → 1-Slot-Liste + Sync-Metadaten."""
+    path = _write_legacy_json(tmp_path, {
+        "2026-03-23": {"start": "08:00", "end": "16:30", "pause": 30},
+    })
+    storage = Storage(path, device_id="dev-1")
+    raw = storage.get_all_raw()["2026-03-23"]
+    assert raw["slots"] == [{"start": "08:00", "end": "16:30", "pause": 30, "kategorie": ""}]
+    assert raw["device_id"] == "dev-1"
+    assert raw["deleted"] is False
+    assert raw["modified_at"].endswith("Z")
+    # alte Top-Level-Zeitfelder entfernt
+    assert "start" not in raw and "end" not in raw and "pause" not in raw
+
+
+def test_legacy_modified_at_uses_file_mtime(tmp_path):
+    """Migrationszeitpunkt = mtime der Legacy-Datei (best lower bound)."""
+    path = _write_legacy_json(tmp_path, {
+        "2026-03-23": {"start": "08:00", "end": "16:30", "pause": 30},
+    })
+    fixed_mtime = 1_700_000_000  # 2023-11-14T22:13:20Z
+    os.utime(path, (fixed_mtime, fixed_mtime))
+    storage = Storage(path, device_id="dev-1")
+    assert storage.get_all_raw()["2026-03-23"]["modified_at"] == "2023-11-14T22:13:20Z"
+
+
+def test_user_facing_get_all_after_migration(tmp_path):
+    """UI-Code sieht nach Migration die Slot-Shape."""
+    path = _write_legacy_json(tmp_path, {
+        "2026-03-23": {"start": "08:00", "end": "16:30", "pause": 30},
+    })
+    storage = Storage(path, device_id="dev-1")
+    assert storage.get_all() == {
+        "2026-03-23": {"slots": [{"start": "08:00", "end": "16:30", "pause": 30, "kategorie": ""}]}
+    }
+
+
+def test_v2_entry_with_metadata_gets_slot_wrapped_keeping_metadata(tmp_path):
+    """v2-Eintrag (Metadaten da, aber kein slots-Key) wird in Slots gewrappt;
+    modified_at/device_id bleiben erhalten (keine Re-Stampelung)."""
+    path = _write_legacy_json(tmp_path, {
+        "2026-03-23": {
+            "start": "08:00", "end": "16:30", "pause": 30,
+            "modified_at": "2026-05-01T10:00:00Z",
+            "device_id": "other-device",
+            "deleted": False,
+        },
+    })
+    storage = Storage(path, device_id="dev-1")
+    raw = storage.get_all_raw()["2026-03-23"]
+    assert raw["slots"] == [{"start": "08:00", "end": "16:30", "pause": 30, "kategorie": ""}]
+    assert raw["modified_at"] == "2026-05-01T10:00:00Z"
+    assert raw["device_id"] == "other-device"
+
+
+def test_legacy_tombstone_becomes_empty_slots(tmp_path):
+    """Alt-Tombstone (deleted=true, start=null) → slots=[]."""
+    path = _write_legacy_json(tmp_path, {
+        "2026-03-23": {
+            "start": None, "end": None, "pause": None,
+            "modified_at": "2026-05-01T10:00:00Z",
+            "device_id": "other-device",
+            "deleted": True,
+        },
+    })
+    storage = Storage(path, device_id="dev-1")
+    raw = storage.get_all_raw()["2026-03-23"]
+    assert raw["slots"] == []
+    assert raw["deleted"] is True
+
+
+def test_migration_idempotent_after_persist(tmp_path):
+    """Zweites Laden einer bereits migrierten Datei wrappt nicht erneut."""
+    path = _write_legacy_json(tmp_path, {
+        "2026-03-23": {"start": "08:00", "end": "16:30", "pause": 30},
+    })
+    s1 = Storage(path, device_id="dev-1")
+    s1._save_to_disk()  # migrierte Form persistieren
+    s2 = Storage(path, device_id="dev-1")
+    raw = s2.get_all_raw()["2026-03-23"]
+    assert raw["slots"] == [{"start": "08:00", "end": "16:30", "pause": 30, "kategorie": ""}]
+    # Slot ist nicht doppelt verschachtelt
+    assert "slots" not in raw["slots"][0]
+```
+
+- [ ] **Step 3: Beide Storage-Testdateien laufen lassen — müssen FEHLSCHLAGEN**
+
+Run: `python -m pytest tests/test_storage.py tests/test_storage_migration.py -q`
+Expected: FAIL (altes `storage.py` kennt die Slot-API/Migration noch nicht — u.a. `TypeError`/`AssertionError`/`KeyError`).
+
+- [ ] **Step 4: `src/storage.py` neu schreiben**
+
+Ersetze den **kompletten** Inhalt von `src/storage.py` durch:
+
+```python
+import datetime
+import json
+import os
+
+
+def _utc_now_iso():
+    # Z-Suffix statt +00:00 — kompatibel zu JS/Drive-Konventionen
+    return datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+_REQUIRED_ENTRY_KEYS = frozenset({"slots", "modified_at", "device_id", "deleted"})
+
+
+def _normalize_slot(slot):
+    """Vervollständigt einen Ist-Zeit-Slot auf {start, end, pause, kategorie}.
+
+    Fehlende `pause` → 0, fehlende `kategorie` → "" (= keine Kategorie,
+    Verhalten wie vor der Migration). Storage validiert die Zeitwerte
+    bewusst nicht (wie bisher) — das ist Sache der UI/Validierung (AP3)."""
+    return {
+        "start": slot.get("start"),
+        "end": slot.get("end"),
+        "pause": slot.get("pause", 0),
+        "kategorie": slot.get("kategorie", ""),
+    }
+
+
+class Storage:
+    def __init__(self, filepath="zeiterfassung.json", device_id=""):
+        self.filepath = filepath
+        self.device_id = device_id
+        self._data = {}
+        self._load()
+
+    def _load(self):
+        if not os.path.exists(self.filepath):
+            return
+        try:
+            with open(self.filepath, "r", encoding="utf-8") as f:
+                self._data = json.load(f)
+        except (json.JSONDecodeError, ValueError):
+            stamp = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
+            os.replace(self.filepath, f"{self.filepath}.corrupt-{stamp}")
+            self._data = {}
+            return
+        self._migrate_legacy_entries()
+
+    def _migrate_legacy_entries(self):
+        """Rüstet Sync-Metadaten nach UND wrappt alte Ein-Eintrag-Tage in eine
+        Slot-Liste. Idempotent: Einträge mit `slots` bleiben unangetastet,
+        Einträge mit `modified_at` behalten ihre Metadaten.
+        modified_at wird (für ganz alte Einträge ohne Metadaten) aus der
+        File-mtime abgeleitet (best lower bound)."""
+        try:
+            mtime = os.path.getmtime(self.filepath)
+        except OSError:
+            mtime = None
+        fallback_modified_at = (
+            datetime.datetime.fromtimestamp(mtime, datetime.timezone.utc)
+            .strftime("%Y-%m-%dT%H:%M:%SZ")
+            if mtime is not None
+            else _utc_now_iso()
+        )
+        for date, entry in list(self._data.items()):
+            if not isinstance(entry, dict):
+                continue
+            # 1. Sync-Metadaten für ganz alte Einträge nachrüsten.
+            if "modified_at" not in entry:
+                entry["modified_at"] = fallback_modified_at
+                entry["device_id"] = self.device_id
+                entry.setdefault("deleted", False)
+            # 2. Slot-Wrapping für Einträge im alten Ein-Eintrag-Schema.
+            if "slots" not in entry:
+                if entry.get("deleted"):
+                    entry["slots"] = []
+                else:
+                    entry["slots"] = [{
+                        "start": entry.get("start"),
+                        "end": entry.get("end"),
+                        "pause": entry.get("pause", 0),
+                        "kategorie": "",
+                    }]
+                entry.pop("start", None)
+                entry.pop("end", None)
+                entry.pop("pause", None)
+
+    def _save_to_disk(self):
+        tmp = self.filepath + ".tmp"
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(self._data, f, indent=2, ensure_ascii=False)
+        try:
+            os.replace(tmp, self.filepath)
+        except OSError:
+            if os.path.exists(tmp):
+                os.remove(tmp)
+            raise
+
+    @staticmethod
+    def _user_shape(entry):
+        """Reduziert ein Roh-Entry auf {slots: [...]} für UI-Caller.
+        Liefert frische Kopien, damit Caller den internen Stand nicht mutieren."""
+        return {"slots": [dict(s) for s in entry.get("slots", [])]}
+
+    def get_all(self):
+        """Liefert {date: {slots: [...]}} ohne Tombstones."""
+        return {
+            date: self._user_shape(entry)
+            for date, entry in self._data.items()
+            if not entry.get("deleted")
+        }
+
+    def get_all_raw(self):
+        """Liefert die kompletten Eintragsobjekte inkl. Metadaten und Tombstones.
+        Nur für den Sync-Pfad."""
+        return dict(self._data)
+
+    def get(self, date_str):
+        entry = self._data.get(date_str)
+        if entry is None or entry.get("deleted"):
+            return None
+        return self._user_shape(entry)
+
+    def save(self, date_str, slots):
+        self._data[date_str] = {
+            "slots": [_normalize_slot(s) for s in slots],
+            "modified_at": _utc_now_iso(),
+            "device_id": self.device_id,
+            "deleted": False,
+        }
+        self._save_to_disk()
+
+    def delete(self, date_str):
+        if date_str not in self._data:
+            return
+        # Tombstone: behält die Zeile mit deleted=true, damit der Sync ein
+        # Delete gegen ein veraltetes Save eines anderen Geräts durchsetzen kann.
+        self._data[date_str] = {
+            "slots": [],
+            "modified_at": _utc_now_iso(),
+            "device_id": self.device_id,
+            "deleted": True,
+        }
+        self._save_to_disk()
+
+    def apply_merge(self, merged_entries):
+        """Ersetzt den kompletten Storage-Stand durch das Merge-Ergebnis.
+        merged_entries: {date: {slots, modified_at, device_id, deleted}}.
+        Wirft ValueError, wenn ein Eintrag Pflichtfelder vermissen lässt."""
+        for date, entry in merged_entries.items():
+            missing = _REQUIRED_ENTRY_KEYS - entry.keys()
+            if missing:
+                raise ValueError(
+                    f"apply_merge: entry {date!r} missing keys {sorted(missing)}"
+                )
+        self._data = dict(merged_entries)
+        self._save_to_disk()
+
+    def save_many(self, updates):
+        """Mehrere Einträge in einem einzigen Disk-Write speichern.
+
+        updates: {date_str: {"slots": [...]}}. Jeder Eintrag bekommt
+        frische modified_at/device_id/deleted=False. Existierende Tombstones
+        am selben Datum werden überschrieben.
+
+        Leeres Dict ist No-op (kein Disk-Roundtrip).
+        """
+        if not updates:
+            return
+        now = _utc_now_iso()
+        for date_str, payload in updates.items():
+            self._data[date_str] = {
+                "slots": [_normalize_slot(s) for s in payload.get("slots", [])],
+                "modified_at": now,
+                "device_id": self.device_id,
+                "deleted": False,
+            }
+        self._save_to_disk()
+```
+
+- [ ] **Step 5: Storage-Tests laufen lassen — müssen BESTEHEN**
+
+Run: `python -m pytest tests/test_storage.py tests/test_storage_migration.py -q`
+Expected: PASS (alle Tests grün).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/storage.py tests/test_storage.py tests/test_storage_migration.py
+git commit -m "feat(storage): Multi-Slot-Datenmodell pro Tag + Migration (#53)
+
+Storage speichert pro Tag eine Slot-Liste ({start,end,pause,kategorie})
+statt eines einzelnen Eintrags. Legacy-Einträge (mit/ohne Sync-Metadaten)
+werden idempotent in eine 1-Slot-Liste migriert, Tombstones in slots=[].
+Teil von AP1; harter Schnitt, Consumer-Pakete folgen.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Reservations — Slot-Datenmodell + Migration
+
+**Files:**
+- Modify: `src/reservations.py` (komplette Neufassung, siehe Step 4)
+- Test: `tests/test_reservations.py` (Neufassung)
+- Create: `tests/test_reservations_migration.py`
+
+**Interfaces:**
+- Consumes: nichts aus Task 1 (eigenständige Datei).
+- Produces (von späteren APs, v.a. AP3/AP7, genutzt):
+  - `ReservationStore.save(date_str: str, slots: list[dict]) -> None` — Reservierungs-Slot `{start, end, kategorie, gcal_event_id}`; fehlende `kategorie`→"", `gcal_event_id`→None.
+  - `ReservationStore.get(date_str) -> dict | None` — **User-Shape** `{"slots": [{start, end, kategorie}, ...]}` (ohne `gcal_event_id`) oder `None`.
+  - `ReservationStore.get_all() -> dict` — `{date: {"slots": [{start, end, kategorie}]}}` ohne Tombstones.
+  - `ReservationStore.get_all_raw() -> dict` — komplette Roh-Einträge inkl. `gcal_event_id` pro Slot und Metadaten/Tombstones (für Reconcile, AP7).
+  - `ReservationStore.delete(date_str) -> None` — Tombstone `{"slots": [], "deleted": True, ...}`.
+  - `ReservationStore.apply_reconciled(reconciled) -> None` — validiert `_REQUIRED_RESERVATION_KEYS = {"slots", "modified_at", "deleted"}`.
+
+- [ ] **Step 1: `tests/test_reservations.py` neu schreiben**
+
+Ersetze den **kompletten** Inhalt von `tests/test_reservations.py` durch:
+
+```python
+from unittest import mock
+
+import pytest
+from src.reservations import ReservationStore
+
+
+@pytest.fixture
+def store(tmp_path):
+    return ReservationStore(str(tmp_path / "res.json"))
+
+
+def _slot(start, end, kategorie="", gcal_event_id=None):
+    """Roh-Slot (inkl. gcal_event_id), wie er in get_all_raw erscheint."""
+    return {"start": start, "end": end, "kategorie": kategorie, "gcal_event_id": gcal_event_id}
+
+
+def _ushape(*slots):
+    """Erwartete User-Shape: slots ohne gcal_event_id."""
+    return {"slots": [{"start": s["start"], "end": s["end"], "kategorie": s["kategorie"]}
+                      for s in slots]}
+
+
+def test_load_empty(store):
+    assert store.get_all() == {}
+
+
+def test_save_and_get(store):
+    store.save("2026-06-01", [_slot("09:00", "17:00")])
+    assert store.get("2026-06-01") == _ushape(_slot("09:00", "17:00"))
+    assert store.get_all() == {"2026-06-01": _ushape(_slot("09:00", "17:00"))}
+
+
+def test_save_multiple_slots_with_categories(store):
+    slots = [_slot("09:00", "12:00", "Kundentermin"), _slot("13:00", "17:00", "Büro")]
+    store.save("2026-06-01", slots)
+    assert store.get("2026-06-01") == _ushape(*slots)
+
+
+def test_save_stamps_metadata(store):
+    store.save("2026-06-01", [_slot("09:00", "17:00")])
+    raw = store.get_all_raw()["2026-06-01"]
+    assert raw["deleted"] is False
+    assert raw["modified_at"].endswith("Z") and "T" in raw["modified_at"]
+
+
+def test_save_stores_provided_event_id(store):
+    """save speichert eine mitgelieferte gcal_event_id am Slot. Der Erhalt
+    bestehender event_ids über Edits ist Sache des Reconcile (AP7)."""
+    store.save("2026-06-01", [_slot("09:00", "17:00", "", "ev-1")])
+    assert store.get_all_raw()["2026-06-01"]["slots"][0]["gcal_event_id"] == "ev-1"
+
+
+def test_slot_defaults_kategorie_and_event_id(store):
+    store.save("2026-06-01", [{"start": "09:00", "end": "17:00"}])
+    slot = store.get_all_raw()["2026-06-01"]["slots"][0]
+    assert slot["gcal_event_id"] is None
+    assert slot["kategorie"] == ""
+
+
+def test_user_shape_excludes_event_id(store):
+    store.save("2026-06-01", [_slot("09:00", "17:00", "Büro", "ev-1")])
+    assert store.get("2026-06-01") == {"slots": [{"start": "09:00", "end": "17:00", "kategorie": "Büro"}]}
+
+
+def test_delete_writes_empty_slots_tombstone(store):
+    store.save("2026-06-01", [_slot("09:00", "17:00", "", "ev-1")])
+    store.delete("2026-06-01")
+    assert store.get("2026-06-01") is None
+    tomb = store.get_all_raw()["2026-06-01"]
+    assert tomb["deleted"] is True
+    assert tomb["slots"] == []
+
+
+def test_delete_nonexistent_is_noop(store):
+    store.delete("2026-01-01")
+    assert store.get_all_raw() == {}
+
+
+def test_get_excludes_tombstones(store):
+    store.save("2026-06-01", [_slot("09:00", "17:00")])
+    store.delete("2026-06-01")
+    assert "2026-06-01" not in store.get_all()
+    assert "2026-06-01" in store.get_all_raw()
+
+
+def test_persistence(tmp_path):
+    path = str(tmp_path / "res.json")
+    ReservationStore(path).save("2026-06-01", [_slot("09:00", "17:00")])
+    assert ReservationStore(path).get("2026-06-01") == _ushape(_slot("09:00", "17:00"))
+
+
+def test_apply_reconciled_replaces_data(store):
+    store.save("2026-06-01", [_slot("09:00", "17:00")])
+    store.apply_reconciled({"2026-07-01": {
+        "slots": [_slot("10:00", "18:00", "", "ev-9")],
+        "modified_at": "2026-05-20T10:00:00Z", "deleted": False,
+    }})
+    assert "2026-06-01" not in store.get_all_raw()
+    assert store.get("2026-07-01") == _ushape(_slot("10:00", "18:00"))
+
+
+def test_apply_reconciled_rejects_missing_keys(store):
+    with pytest.raises(ValueError, match="missing keys"):
+        store.apply_reconciled({"2026-06-01": {"slots": [_slot("09:00", "17:00")]}})
+    # _data unverändert (kein Halb-Schreiben)
+    assert store.get_all_raw() == {}
+
+
+def test_corrupt_json_is_quarantined_and_starts_empty(tmp_path):
+    path = tmp_path / "res.json"
+    path.write_text("{not valid", encoding="utf-8")
+    store = ReservationStore(str(path))
+    assert store.get_all() == {}
+    assert len(list(tmp_path.glob("res.json.corrupt-*"))) == 1
+
+
+def test_save_failure_keeps_original_intact(tmp_path):
+    path = tmp_path / "res.json"
+    store = ReservationStore(str(path))
+    store.save("2026-06-01", [_slot("09:00", "17:00")])
+    original = path.read_bytes()
+    with mock.patch("os.replace", side_effect=OSError("disk full")):
+        with pytest.raises(OSError):
+            store.save("2026-06-02", [_slot("09:00", "17:00")])
+    assert path.read_bytes() == original
+    assert [p for p in tmp_path.iterdir() if p.suffix == ".tmp"] == []
+```
+
+- [ ] **Step 2: `tests/test_reservations_migration.py` neu anlegen**
+
+Lege `tests/test_reservations_migration.py` mit folgendem Inhalt an:
+
+```python
+import json
+
+from src.reservations import ReservationStore
+
+
+def _write_legacy(tmp_path, payload):
+    path = tmp_path / "legacy_res.json"
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(payload, f)
+    return str(path)
+
+
+def test_legacy_reservation_wrapped_into_single_slot(tmp_path):
+    path = _write_legacy(tmp_path, {
+        "2026-06-01": {
+            "start": "09:00", "end": "17:00",
+            "modified_at": "2026-05-20T10:00:00Z",
+            "deleted": False, "gcal_event_id": "ev-1",
+        },
+    })
+    store = ReservationStore(path)
+    raw = store.get_all_raw()["2026-06-01"]
+    assert raw["slots"] == [
+        {"start": "09:00", "end": "17:00", "kategorie": "", "gcal_event_id": "ev-1"}
+    ]
+    assert raw["modified_at"] == "2026-05-20T10:00:00Z"
+    assert raw["deleted"] is False
+    # alte Top-Level-Felder entfernt
+    assert "start" not in raw and "end" not in raw and "gcal_event_id" not in raw
+
+
+def test_legacy_reservation_tombstone_becomes_empty_slots(tmp_path):
+    path = _write_legacy(tmp_path, {
+        "2026-06-01": {
+            "start": None, "end": None,
+            "modified_at": "2026-05-20T10:00:00Z",
+            "deleted": True, "gcal_event_id": "ev-1",
+        },
+    })
+    store = ReservationStore(path)
+    raw = store.get_all_raw()["2026-06-01"]
+    assert raw["slots"] == []
+    assert raw["deleted"] is True
+
+
+def test_user_facing_get_all_after_migration(tmp_path):
+    path = _write_legacy(tmp_path, {
+        "2026-06-01": {
+            "start": "09:00", "end": "17:00",
+            "modified_at": "2026-05-20T10:00:00Z",
+            "deleted": False, "gcal_event_id": None,
+        },
+    })
+    store = ReservationStore(path)
+    assert store.get_all() == {
+        "2026-06-01": {"slots": [{"start": "09:00", "end": "17:00", "kategorie": ""}]}
+    }
+
+
+def test_reservation_migration_idempotent_after_persist(tmp_path):
+    path = _write_legacy(tmp_path, {
+        "2026-06-01": {
+            "start": "09:00", "end": "17:00",
+            "modified_at": "2026-05-20T10:00:00Z",
+            "deleted": False, "gcal_event_id": "ev-1",
+        },
+    })
+    s1 = ReservationStore(path)
+    s1._save_to_disk()  # migrierte Form persistieren
+    s2 = ReservationStore(path)
+    raw = s2.get_all_raw()["2026-06-01"]
+    assert raw["slots"] == [
+        {"start": "09:00", "end": "17:00", "kategorie": "", "gcal_event_id": "ev-1"}
+    ]
+    assert "slots" not in raw["slots"][0]
+```
+
+- [ ] **Step 3: Beide Reservations-Testdateien laufen lassen — müssen FEHLSCHLAGEN**
+
+Run: `python -m pytest tests/test_reservations.py tests/test_reservations_migration.py -q`
+Expected: FAIL (altes `reservations.py` kennt Slot-API/Migration noch nicht).
+
+- [ ] **Step 4: `src/reservations.py` neu schreiben**
+
+Ersetze den **kompletten** Inhalt von `src/reservations.py` durch:
+
+```python
+"""JSON-Persistenz der Reservierungen (geplante Arbeitszeiten).
+
+Reservierungen sind ein eigenständiges Konzept neben den erfassten Ist-Zeiten
+(`storage.py`). Sie werden über `gcal.py` / `reservations_sync.py` mit einem
+Google Kalender abgeglichen — NICHT über die Drive-Multi-Device-Sync. Daher
+fehlt hier (anders als bei `Storage`) das `device_id`-Feld.
+
+Schema pro Tag (ISO-Datum als Schlüssel):
+    {slots: [{start, end, kategorie, gcal_event_id}], modified_at, deleted}
+`gcal_event_id` ist None, bis der Slot erstmals in den Kalender gepusht wurde.
+Eine gelöschte Reservierung bleibt als Tombstone (deleted=True, slots=[])
+erhalten, bis der Reconcile die zugehörigen Events entfernt hat.
+"""
+
+import datetime
+import json
+import os
+
+
+def _utc_now_iso():
+    # Z-Suffix statt +00:00 — konsistent zu storage.py / sync.py.
+    return datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+_REQUIRED_RESERVATION_KEYS = frozenset({"slots", "modified_at", "deleted"})
+
+
+def _normalize_slot(slot):
+    """Vervollständigt einen Reservierungs-Slot auf
+    {start, end, kategorie, gcal_event_id}. Fehlende `kategorie` → "",
+    fehlende `gcal_event_id` → None."""
+    return {
+        "start": slot.get("start"),
+        "end": slot.get("end"),
+        "kategorie": slot.get("kategorie", ""),
+        "gcal_event_id": slot.get("gcal_event_id"),
+    }
+
+
+class ReservationStore:
+    def __init__(self, filepath="reservations.json"):
+        self.filepath = filepath
+        self._data = {}
+        self._load()
+
+    def _load(self):
+        if not os.path.exists(self.filepath):
+            return
+        try:
+            with open(self.filepath, "r", encoding="utf-8") as f:
+                self._data = json.load(f)
+        except (json.JSONDecodeError, ValueError):
+            stamp = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
+            os.replace(self.filepath, f"{self.filepath}.corrupt-{stamp}")
+            self._data = {}
+            return
+        self._migrate_legacy_reservations()
+
+    def _migrate_legacy_reservations(self):
+        """Wrappt alte Ein-Reservierung-Tage in eine Slot-Liste. Idempotent:
+        Einträge mit `slots` bleiben unangetastet. modified_at/deleted werden
+        nur gesetzt, falls sie fehlen (alte Dateien tragen sie i.d.R. bereits);
+        Fallback ist die File-mtime (best lower bound)."""
+        try:
+            mtime = os.path.getmtime(self.filepath)
+        except OSError:
+            mtime = None
+        fallback_modified_at = (
+            datetime.datetime.fromtimestamp(mtime, datetime.timezone.utc)
+            .strftime("%Y-%m-%dT%H:%M:%SZ")
+            if mtime is not None
+            else _utc_now_iso()
+        )
+        for date, entry in list(self._data.items()):
+            if not isinstance(entry, dict):
+                continue
+            if "slots" in entry:
+                continue
+            if entry.get("deleted"):
+                entry["slots"] = []
+            else:
+                entry["slots"] = [{
+                    "start": entry.get("start"),
+                    "end": entry.get("end"),
+                    "kategorie": "",
+                    "gcal_event_id": entry.get("gcal_event_id"),
+                }]
+            entry.pop("start", None)
+            entry.pop("end", None)
+            entry.pop("gcal_event_id", None)
+            entry.setdefault("modified_at", fallback_modified_at)
+            entry.setdefault("deleted", False)
+
+    def _save_to_disk(self):
+        tmp = self.filepath + ".tmp"
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(self._data, f, indent=2, ensure_ascii=False)
+        try:
+            os.replace(tmp, self.filepath)
+        except OSError:
+            if os.path.exists(tmp):
+                os.remove(tmp)
+            raise
+
+    @staticmethod
+    def _user_shape(entry):
+        """User-Shape: Slots ohne das interne Feld gcal_event_id."""
+        return {"slots": [
+            {"start": s.get("start"), "end": s.get("end"), "kategorie": s.get("kategorie", "")}
+            for s in entry.get("slots", [])
+        ]}
+
+    def get_all(self):
+        """{date: {slots: [...]}} ohne Tombstones — für die UI."""
+        return {
+            date: self._user_shape(entry)
+            for date, entry in self._data.items()
+            if not entry.get("deleted")
+        }
+
+    def get_all_raw(self):
+        """Komplette Objekte inkl. Metadaten, gcal_event_id und Tombstones —
+        für den Reconcile."""
+        return dict(self._data)
+
+    def get(self, date_str):
+        entry = self._data.get(date_str)
+        if entry is None or entry.get("deleted"):
+            return None
+        return self._user_shape(entry)
+
+    def save(self, date_str, slots):
+        """Legt die Reservierungs-Slots eines Tages an oder überschreibt sie.
+        Die übergebenen Slots werden so gespeichert, wie sie sind (inkl.
+        mitgelieferter gcal_event_id). Das Bewahren bestehender event_ids über
+        Edits hinweg übernimmt der Reconcile (AP7), nicht dieser save-Pfad."""
+        self._data[date_str] = {
+            "slots": [_normalize_slot(s) for s in slots],
+            "modified_at": _utc_now_iso(),
+            "deleted": False,
+        }
+        self._save_to_disk()
+
+    def delete(self, date_str):
+        """Tombstone schreiben (slots=[]). Der Reconcile entfernt die
+        zugehörigen Kalender-Events über den vollständigen Event-Pull (AP7)."""
+        if date_str not in self._data:
+            return
+        self._data[date_str] = {
+            "slots": [],
+            "modified_at": _utc_now_iso(),
+            "deleted": True,
+        }
+        self._save_to_disk()
+
+    def apply_reconciled(self, reconciled):
+        """Ersetzt den kompletten Stand durch das Reconcile-Ergebnis.
+        Wirft ValueError, wenn ein Eintrag Pflichtfelder vermissen lässt —
+        analog zu Storage.apply_merge."""
+        for date, entry in reconciled.items():
+            missing = _REQUIRED_RESERVATION_KEYS - entry.keys()
+            if missing:
+                raise ValueError(
+                    f"apply_reconciled: entry {date!r} missing keys {sorted(missing)}"
+                )
+        self._data = dict(reconciled)
+        self._save_to_disk()
+```
+
+- [ ] **Step 5: Reservations-Tests laufen lassen — müssen BESTEHEN**
+
+Run: `python -m pytest tests/test_reservations.py tests/test_reservations_migration.py -q`
+Expected: PASS (alle Tests grün).
+
+- [ ] **Step 6: AP1-Gesamtverifikation (nur AP1-Dateien)**
+
+Run: `python -m pytest tests/test_storage.py tests/test_storage_migration.py tests/test_reservations.py tests/test_reservations_migration.py -q`
+Expected: PASS.
+
+> **Hinweis:** Ein voller `pytest`-Lauf ist an dieser Stelle **erwartbar rot** (Consumer wie `report.py`, `share.py`, `sync.py`, `ui.py` und deren Tests nutzen noch die alte Signatur). Das ist der bewusste harte Schnitt — die Suite wird durch AP2–AP7 wieder grün. AP1 verifiziert nur die vier obigen Dateien.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/reservations.py tests/test_reservations.py tests/test_reservations_migration.py
+git commit -m "feat(reservations): Multi-Slot-Datenmodell pro Tag + Migration (#53)
+
+ReservationStore speichert pro Tag eine Slot-Liste
+({start,end,kategorie,gcal_event_id}). Legacy-Reservierungen werden
+idempotent in eine 1-Slot-Liste migriert, Tombstones in slots=[].
+User-Shape blendet gcal_event_id aus. event_id-Erhalt über Edits wandert
+in den Reconcile (AP7). Teil von AP1.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+**1. Spec-Coverage (AP1-Scope):**
+- Storage Slot-Liste pro Tag → Task 1 ✓
+- Storage-Migration (lebend + Tombstone + v2-mit-Metadaten) idempotent → Task 1, Step 2/4 ✓
+- Reservations Slot-Liste + `gcal_event_id` pro Slot → Task 2 ✓
+- Reservations-Migration → Task 2 ✓
+- `_REQUIRED_*`-Keys auf neues Schema → beide Tasks ✓
+- Kategorie als String, `""` = keine → `_normalize_slot` + Migration ✓
+- Pause pro Ist-Zeit-Slot, kein Pause bei Reservierung → Slot-Schemata ✓
+- Nicht in AP1 (korrekt ausgelassen): Non-Overlap-Validierung (AP3), Sync-Schema-Bump/`_values_equal_entry` (AP2), gcal-Reconcile (AP7), Consumer-Anpassungen (AP3–7).
+
+**2. Placeholder-Scan:** Keine TBD/TODO/„später"; jeder Code- und Test-Step zeigt vollständigen Inhalt. ✓
+
+**3. Typ-Konsistenz:**
+- `Storage.save(date, slots)` / `save_many({date:{"slots":[...]}})` — konsistent zwischen Interface-Block, Code und Tests. ✓
+- Ist-Zeit-Slot `{start,end,pause,kategorie}` vs. Reservierungs-Slot `{start,end,kategorie,gcal_event_id}` — durchgängig getrennt. ✓
+- Reservations-User-Shape ohne `gcal_event_id`, Raw mit — in Code (`_user_shape`/`get_all_raw`) und Tests (`_ushape` vs. `_slot`) konsistent. ✓
+- `_REQUIRED_ENTRY_KEYS = {slots,modified_at,device_id,deleted}`, `_REQUIRED_RESERVATION_KEYS = {slots,modified_at,deleted}` — wie in den `apply_*`-Tests erwartet. ✓

--- a/docs/superpowers/plans/2026-06-19-ap2-sync-v3-kategorien.md
+++ b/docs/superpowers/plans/2026-06-19-ap2-sync-v3-kategorien.md
@@ -1,0 +1,546 @@
+# AP2 — Sync v3 + Kategorien-Setting Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Die Sync-Engine (`src/sync.py`) auf das Multi-Slot-Schema heben (Schema v2 → v3, Slot-Listen-Vergleich, Konflikt-Durchreichung auf Slot-Basis, Alt-Client-Guard) und eine syncbare Kategorien-Liste in den Settings einführen.
+
+**Architecture:** Der Tag bleibt die Sync-/Konflikt-Einheit (LWW pro Datum, unverändert). Nur die Wert-Gleichheit (`_values_equal_entry`) und die Konflikt-Resolution wechseln von `{start,end,pause}` auf die Slot-Liste. Kategorien sind ein neuer String-Array-Setting-Key, der über die bestehende Settings-Sync-Whitelist mitläuft. Ein neuer `_remote_is_pre_v3`-Guard ersetzt `_remote_is_pre_v2` im Kompaktierungspfad.
+
+**Tech Stack:** Python stdlib, pytest. Keine neuen Dependencies.
+
+## Global Constraints
+
+- **Tag bleibt Sync-/Konflikt-Einheit.** Day-level-LWW, Konflikt-Dedup, Watermark/Tombstone-Kompaktierung und Self-Heal-Regeln bleiben **strukturell unverändert** — sie operieren weiter pro Datum.
+- **`SCHEMA_VERSION = 3`** in `src/sync.py`.
+- **`_values_equal_entry`** vergleicht die **Slot-Liste reihenfolge-normalisiert** (nach Slot-Feldern sortiert) plus `deleted`. Slot-Felder: `start, end, pause (Default 0), kategorie (Default "")`.
+- **Kategorie-Setting:** neuer Key `categories` = `list[str]`, Default `[]`. Muss in **beiden** `SYNCED_SETTING_KEYS` stehen (`src/settings.py` UND `src/sync.py`) — der Test `test_synced_whitelists_in_settings_and_sync_match` erzwingt Gleichheit.
+- **Konflikt-Eingriff bewusst minimal:** Kandidaten tragen die Slot-Liste automatisch; nur `resolve_conflict` (entry-Zweig) und der Resolution-Apply-Block in `merge()` schreiben statt `{start,end,pause}` eine Slot-Liste. Der Konflikt-Flow wird voraussichtlich bald überarbeitet — **keine** neuen tiefen Annahmen verankern.
+- **Alt-Client-Guard:** `_remote_is_pre_v3(remote_doc)` = `(schema_version or 1) < 3`. Ersetzt `_remote_is_pre_v2` im Kompaktierungspfad (`src/main.py`). Bei pre-v3-Remote wird die Kompaktierung ausgesetzt (bestehender `reason="old_version"`-Pfad).
+- **Datumsformat:** intern ISO; nicht ändern.
+- **Harter Schnitt (laufend):** Nur die AP2-Dateien werden angepasst. Consumer außerhalb (report, share, ui, gcal) bleiben rot bis zu ihren Paketen. Verifikation pro Task nur gegen die genannten Testdateien; ein voller `pytest`-Lauf ist weiterhin erwartbar rot.
+
+## Forward-Dependencies / Design-Notes (für den Plan-Review)
+
+- **Regulärer Sync-Pull/Push hat KEINEN Pre-Version-Guard** (`src/main.py` `_run_pull_blocking` Z. 76–79 und der Push-Retry Z. 119–121 rufen `sync.merge` direkt). Mergt man einen **v2-Remote** in einen v3-Client, hat dessen Eintrag kein `slots` → er würde als Leer-Slot-Tag interpretiert und, falls er Merge-Gewinner wird, `apply_merge` verletzen (fehlender `slots`-Key → `ValueError`). **Entscheidung:** AP2 liefert nur den Guard im **Kompaktierungs**-Pfad (bestehende „old_version"-UI) + die `_remote_is_pre_v3`-Primitive. Das Verdrahten des Guards in den **regulären Pull** inkl. UI-Hinweis gehört zu **AP6** (dort lebt der Pull-Result-UI-Handler und der Hinweistext). Bis dahin ist „v3-Client gegen v2-Remote synchronisieren" nicht unterstützt — auf dem unausgelieferten Feature-Branch unkritisch, und die Spec-Empfehlung lautet ohnehin „alle Geräte updaten". *(Dieser Punkt ist bewusst zur Abnahme im Plan-Review markiert.)*
+- **`_coerce` braucht KEINE Änderung** für `list`-Defaults: der bestehende generische Zweig `if isinstance(value, target_type) and not isinstance(value, bool): return value` akzeptiert eine Liste, und ein Nicht-Listen-Wert fällt durch alle Cast-Zweige auf `_COERCE_FAILED` (→ Default `[]`). Wird per Test fixiert, nicht per Code geändert.
+
+---
+
+## Dateistruktur
+
+- `src/settings.py` — `categories`-Default + Whitelist-Eintrag. Verantwortung unverändert.
+- `src/sync.py` — Schema-Bump, Slot-Gleichheit, Konflikt-Resolution auf Slots, `_remote_is_pre_v3`, Whitelist-Eintrag.
+- `src/main.py` — Kompaktierungs-Guard `_remote_is_pre_v2` → `_remote_is_pre_v3` (eine Zeile + Kommentar).
+- `tests/test_settings.py` — Kategorien-Tests.
+- `tests/test_sync.py` — `_e`-Helfer auf Slots, interne Zugriffe + Resolutions/Kandidaten auf Slots, Schema-Assertion, `_remote_is_pre_v3`-Test, neue Slot-Tests.
+
+Task 1 (Kategorien-Setting) berührt `settings.py` + die `sync.py`-Whitelist-Zeile (gekoppelt durch den Whitelist-Match-Test). Task 2 (Sync-Slot-Logik) berührt die Sync-Merge-/Konflikt-Logik + `main.py` + `test_sync.py`.
+
+---
+
+## Task 1: Kategorien-Setting (settings.py + sync.py-Whitelist)
+
+**Files:**
+- Modify: `src/settings.py` (`DEFAULTS`, `SYNCED_SETTING_KEYS`)
+- Modify: `src/sync.py` (`SYNCED_SETTING_KEYS` — nur diese Tupel-Zeile)
+- Test: `tests/test_settings.py` (neue Tests anhängen)
+
+**Interfaces:**
+- Produces: Setting-Key `categories` (`list[str]`, Default `[]`), in beiden `SYNCED_SETTING_KEYS`. Wird von AP6 (`settings_dialog`) via `set_synced("categories", [...])` gepflegt und von AP3/AP4 (Dialog-Pickliste / Report) via `settings.get("categories")` gelesen.
+
+- [ ] **Step 1: Failing-Tests in `tests/test_settings.py` anhängen**
+
+Hänge ans Ende von `tests/test_settings.py` an:
+
+```python
+# --- categories (Multi-Slot-Feature, AP2) ---
+
+
+def test_categories_default_is_empty_list(tmp_settings):
+    assert tmp_settings.get("categories") == []
+
+
+def test_categories_is_synced_setting():
+    assert "categories" in SYNCED_SETTING_KEYS
+
+
+def test_categories_persists_list(tmp_path):
+    path = str(tmp_path / "settings.json")
+    s1 = Settings(path)
+    s1.set("categories", ["Büro", "Homeoffice"])
+    s2 = Settings(path)
+    assert s2.get("categories") == ["Büro", "Homeoffice"]
+
+
+def test_categories_non_list_falls_back_to_default(tmp_path, caplog):
+    """Ein Nicht-Listen-Wert wird von _coerce abgelehnt → Default []."""
+    path = _write_json(tmp_path, json.dumps({"categories": "Büro"}))
+    with caplog.at_level("WARNING"):
+        s = Settings(path)
+    assert s.get("categories") == []
+    assert any("categories" in rec.message for rec in caplog.records)
+
+
+def test_categories_synced_doc_roundtrip(tmp_path):
+    path = str(tmp_path / "settings.json")
+    s = Settings(path)
+    s.device_id_for_sync = "dev-1"
+    s.set_synced("categories", ["Büro", "Kundentermin"])
+    doc = s.get_synced_doc()
+    assert doc["categories"]["value"] == ["Büro", "Kundentermin"]
+    assert doc["categories"]["device_id"] == "dev-1"
+```
+
+- [ ] **Step 2: Tests laufen lassen — müssen FEHLSCHLAGEN**
+
+Run: `python -m pytest tests/test_settings.py -q`
+Expected: FAIL — `categories` ist noch kein Default/kein Synced-Key; `test_synced_whitelists_in_settings_and_sync_match` ist hier noch grün (beide Whitelists ohne `categories`), bricht aber, sobald nur eine Seite ergänzt würde — daher Step 3 ergänzt beide.
+
+- [ ] **Step 3: `src/settings.py` — `categories` ergänzen**
+
+In `src/settings.py`, in `SYNCED_SETTING_KEYS` (aktuell):
+
+```python
+SYNCED_SETTING_KEYS = (
+    "recipient", "name", "hourly_rate",
+    "mail_subject", "mail_greeting", "mail_content", "mail_closing",
+    "gcal_calendar_id",
+)
+```
+
+ändere zu (Komma + neuer Eintrag in letzter Zeile):
+
+```python
+SYNCED_SETTING_KEYS = (
+    "recipient", "name", "hourly_rate",
+    "mail_subject", "mail_greeting", "mail_content", "mail_closing",
+    "gcal_calendar_id", "categories",
+)
+```
+
+Und in `DEFAULTS` einen Eintrag ergänzen (z.B. direkt nach `"last_calendar_sync_at": "",`):
+
+```python
+    "categories": [],
+```
+
+- [ ] **Step 4: `src/sync.py` — Whitelist-Duplikat angleichen**
+
+In `src/sync.py`, in `SYNCED_SETTING_KEYS` (aktuell):
+
+```python
+SYNCED_SETTING_KEYS = (
+    "recipient", "name", "hourly_rate",
+    "mail_subject", "mail_greeting", "mail_content", "mail_closing",
+    "gcal_calendar_id",
+)
+```
+
+ändere zu:
+
+```python
+SYNCED_SETTING_KEYS = (
+    "recipient", "name", "hourly_rate",
+    "mail_subject", "mail_greeting", "mail_content", "mail_closing",
+    "gcal_calendar_id", "categories",
+)
+```
+
+- [ ] **Step 5: Tests laufen lassen — müssen BESTEHEN**
+
+Run: `python -m pytest tests/test_settings.py -q`
+Expected: PASS (inkl. `test_synced_whitelists_in_settings_and_sync_match`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/settings.py src/sync.py tests/test_settings.py
+git commit -m "feat(settings): syncbare categories-Liste (#53)
+
+Neuer Setting-Key categories (list[str], Default []), aufgenommen in
+beide SYNCED_SETTING_KEYS (settings.py + sync.py). _coerce akzeptiert
+Listen-Defaults bereits generisch; per Test fixiert. Teil von AP2.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Sync v3 — Slot-Gleichheit, Konflikt-Resolution, Alt-Client-Guard
+
+**Files:**
+- Modify: `src/sync.py` (`SCHEMA_VERSION`, `_values_equal_entry` + Helfer, Resolution-Apply-Block in `merge`, `resolve_conflict`, `_remote_is_pre_v2` → `_remote_is_pre_v3`)
+- Modify: `src/main.py` (Kompaktierungs-Guard-Aufruf Z. 168 + Kommentar)
+- Test: `tests/test_sync.py` (umfangreiche Anpassung, siehe Steps)
+
+**Interfaces:**
+- Consumes: Storage-Slot-API aus AP1 (`storage.save(date, slots)`, `storage.get(date) -> {"slots": [...]}`, `storage.delete(date)`); Slot-Schema `{start, end, pause, kategorie}`.
+- Produces:
+  - `sync.SCHEMA_VERSION == 3`.
+  - `_values_equal_entry(a, b)` vergleicht Slot-Listen reihenfolge-normalisiert + `deleted`.
+  - `resolve_conflict(...)` (entry-Zweig): `chosen_value = {"slots": [...], "deleted"?: bool}` → schreibt via `storage.save(key, chosen_value["slots"])` bzw. `storage.delete(key)`.
+  - Resolution-Apply in `merge()` schreibt `{"slots": resolution.get("slots", []), modified_at, device_id, deleted}`.
+  - `_remote_is_pre_v3(remote_doc) -> bool`.
+
+### Teil A — `src/sync.py` anpassen
+
+- [ ] **Step 1: `SCHEMA_VERSION` bumpen**
+
+In `src/sync.py`: `SCHEMA_VERSION = 2` → `SCHEMA_VERSION = 3`.
+
+- [ ] **Step 2: Slot-Gleichheit einführen**
+
+Ersetze in `src/sync.py` die Funktion `_values_equal_entry` (aktuell):
+
+```python
+def _values_equal_entry(a, b):
+    return (a.get("start") == b.get("start")
+            and a.get("end") == b.get("end")
+            and a.get("pause") == b.get("pause")
+            and bool(a.get("deleted")) == bool(b.get("deleted")))
+```
+
+durch:
+
+```python
+def _slots_signature(entry):
+    """Reihenfolge-normalisierte Signatur der Slot-Liste eines Eintrags,
+    für den Gleichheitsvergleich im Merge. Sortiert nach den Slot-Feldern,
+    damit eine reine Umordnung der Slots NICHT als Änderung zählt."""
+    return sorted(
+        (s.get("start"), s.get("end"), s.get("pause", 0), s.get("kategorie", ""))
+        for s in (entry.get("slots") or [])
+    )
+
+
+def _values_equal_entry(a, b):
+    return (_slots_signature(a) == _slots_signature(b)
+            and bool(a.get("deleted")) == bool(b.get("deleted")))
+```
+
+- [ ] **Step 3: Resolution-Apply-Block auf Slots umstellen**
+
+In `src/sync.py`, in `merge()`, im Block „Resolutions anwenden", ersetze den `if c["kind"] == "entry":`-Zweig (aktuell):
+
+```python
+        if c["kind"] == "entry":
+            current = merged["entries"].get(c["key"])
+            if current is None or current["modified_at"] < resolved_at:
+                merged["entries"][c["key"]] = {
+                    "start": resolution.get("start"),
+                    "end": resolution.get("end"),
+                    "pause": resolution.get("pause", 0),
+                    "modified_at": resolved_at,
+                    "device_id": resolved_by,
+                    "deleted": bool(resolution.get("deleted", False)),
+                }
+```
+
+durch:
+
+```python
+        if c["kind"] == "entry":
+            current = merged["entries"].get(c["key"])
+            if current is None or current["modified_at"] < resolved_at:
+                merged["entries"][c["key"]] = {
+                    "slots": resolution.get("slots", []),
+                    "modified_at": resolved_at,
+                    "device_id": resolved_by,
+                    "deleted": bool(resolution.get("deleted", False)),
+                }
+```
+
+- [ ] **Step 4: `resolve_conflict` entry-Zweig auf Slots umstellen**
+
+In `src/sync.py`, in `resolve_conflict`, ersetze den `if target["kind"] == "entry":`-Zweig (aktuell):
+
+```python
+    if target["kind"] == "entry":
+        if chosen_value.get("deleted"):
+            storage.delete(target["key"])
+        else:
+            storage.save(
+                target["key"],
+                chosen_value.get("start"),
+                chosen_value.get("end"),
+                chosen_value.get("pause", 0),
+            )
+```
+
+durch:
+
+```python
+    if target["kind"] == "entry":
+        if chosen_value.get("deleted"):
+            storage.delete(target["key"])
+        else:
+            storage.save(target["key"], chosen_value.get("slots", []))
+```
+
+Aktualisiere außerdem den Docstring-Satz von `resolve_conflict` (aktuell „Für entries: {start, end, pause} (und optional deleted).") auf:
+„Für entries: {slots: [...]} (und optional deleted)."
+
+- [ ] **Step 5: `_remote_is_pre_v2` → `_remote_is_pre_v3` ersetzen**
+
+In `src/sync.py`, ersetze die Funktion `_remote_is_pre_v2` (aktuell):
+
+```python
+def _remote_is_pre_v2(remote_doc):
+    """True, wenn das Remote-Doc von einem v1-Gerät stammt (Schema < 2 oder
+    fehlendes/leeres meta ohne gc_watermark-Key) — dann ist gerade ein älteres
+    Gerät aktiv und die Kompaktierung muss abbrechen."""
+    if (remote_doc.get("schema_version") or 1) < 2:
+        return True
+    meta = remote_doc.get("meta")
+    return not (isinstance(meta, dict) and "gc_watermark" in meta)
+```
+
+durch:
+
+```python
+def _remote_is_pre_v3(remote_doc):
+    """True, wenn das Remote-Doc von einem Gerät stammt, das das Multi-Slot-
+    Schema (v3) noch nicht versteht (schema_version < 3). Dann ist ein
+    älteres Gerät aktiv: Kompaktierung muss abbrechen, und ein v2-Remote darf
+    nicht in einen v3-Client gemergt werden (er hätte keine `slots`)."""
+    return (remote_doc.get("schema_version") or 1) < 3
+```
+
+### Teil B — `src/main.py` Kompaktierungs-Guard
+
+- [ ] **Step 6: Guard-Aufruf in `src/main.py` umstellen**
+
+In `src/main.py`, in `_run_compaction_blocking`, ersetze (Z. ~167–168):
+
+```python
+                # v1-Guard auf dem FRISCH gepullten Doc (nie gecacht):
+                if sync._remote_is_pre_v2(remote_doc):
+```
+
+durch:
+
+```python
+                # Alt-Client-Guard auf dem FRISCH gepullten Doc (nie gecacht):
+                if sync._remote_is_pre_v3(remote_doc):
+```
+
+Passe außerdem den Docstring-Satz von `_run_compaction_blocking` an: ersetze
+„ein älteres Gerät ist aktiv (Remote ist pre-v2)" durch
+„ein älteres Gerät ist aktiv (Remote ist pre-v3)".
+
+> Diese `main.py`-Änderung ist Wiring ohne sinnvollen Unit-Test (Drive-I/O + Thread). Die nicht-triviale Entscheidung steckt in `_remote_is_pre_v3` und ist unit-getestet (Teil C). Manuelle Verifikation: `python -c "from src import main, sync"` muss fehlerfrei importieren (Step 12).
+
+### Teil C — `tests/test_sync.py` anpassen
+
+- [ ] **Step 7: `_e`-Helfer auf Slot-Shape umstellen**
+
+In `tests/test_sync.py`, ersetze den Helfer `_e` (Z. 11–15):
+
+```python
+def _e(start, end, pause, modified_at, device_id="d", deleted=False):
+    return {
+        "start": start, "end": end, "pause": pause,
+        "modified_at": modified_at, "device_id": device_id, "deleted": deleted,
+    }
+```
+
+durch:
+
+```python
+def _e(start, end, pause, modified_at, device_id="d", deleted=False):
+    slots = [] if deleted else [{"start": start, "end": end, "pause": pause, "kategorie": ""}]
+    return {
+        "slots": slots,
+        "modified_at": modified_at, "device_id": device_id, "deleted": deleted,
+    }
+
+
+def _slot(start, end, pause=0, kategorie=""):
+    return {"start": start, "end": end, "pause": pause, "kategorie": kategorie}
+```
+
+- [ ] **Step 8: Interne Eintrags-Zugriffe in `tests/test_sync.py` auf Slots umstellen**
+
+Führe diese exakten Ersetzungen durch (jede Zeile genau einmal vorhanden):
+
+- Z. 38: `    assert merged["start"] == "08:00"`
+  → `    assert merged["slots"][0]["start"] == "08:00"`
+- Z. 118: `    assert merged["entries"]["2026-05-14"]["start"] == "09:00"`
+  → `    assert merged["entries"]["2026-05-14"]["slots"][0]["start"] == "09:00"`
+- Z. 137: `    assert merged["entries"]["D"]["start"] == "09:00"`
+  → `    assert merged["entries"]["D"]["slots"][0]["start"] == "09:00"`
+- Z. 559: `    assert merged["entries"]["D"]["start"] == "08:00"`
+  → `    assert merged["entries"]["D"]["slots"][0]["start"] == "08:00"`
+- Z. 571: `    assert merged["entries"]["D"]["start"] == "08:00"`
+  → `    assert merged["entries"]["D"]["slots"][0]["start"] == "08:00"`
+
+- [ ] **Step 9: `storage.save`/`storage.get`-Aufrufe in `tests/test_sync.py` auf Slot-API umstellen**
+
+- `test_build_local_doc_includes_storage_settings_conflicts` (Z. ~277):
+  `    storage.save("2026-05-14", "08:00", "16:00", 30)`
+  → `    storage.save("2026-05-14", [_slot("08:00", "16:00", 30)])`
+- gleicher Test, Z. ~288: `    assert doc["schema_version"] == 2` → `    assert doc["schema_version"] == 3`
+- `test_round_trip_no_loss` (Z. ~293):
+  `    storage.save("2026-05-14", "08:00", "16:00", 30)`
+  → `    storage.save("2026-05-14", [_slot("08:00", "16:00", 30)])`
+- gleicher Test, Z. ~303:
+  `    assert storage.get("2026-05-14") == {"start": "08:00", "end": "16:00", "pause": 30}`
+  → `    assert storage.get("2026-05-14") == {"slots": [_slot("08:00", "16:00", 30)]}`
+- `test_compact_local_strips_stores_and_sets_watermark` (Z. ~596–597):
+  ```python
+      storage.save("LIVE", "08:00", "16:00", 30)
+      storage.save("DEL", "08:00", "16:00", 30)
+  ```
+  →
+  ```python
+      storage.save("LIVE", [_slot("08:00", "16:00", 30)])
+      storage.save("DEL", [_slot("08:00", "16:00", 30)])
+  ```
+
+- [ ] **Step 10: Resolution-/Kandidaten-Dicts in `tests/test_sync.py` auf Slot-Shape umstellen**
+
+- `test_merge_applies_resolved_conflict_to_entry`:
+  - Z. ~243: `resolution={"start": "10:00", "end": "18:00", "pause": 30}`
+    → `resolution={"slots": [_slot("10:00", "18:00", 30)]}`
+  - Z. ~253–254:
+    ```python
+        assert e["start"] == "10:00"
+        assert e["end"] == "18:00"
+    ```
+    →
+    ```python
+        assert e["slots"][0]["start"] == "10:00"
+        assert e["slots"][0]["end"] == "18:00"
+    ```
+- `test_resolve_entry_conflict_updates_storage_and_marks_resolved`:
+  - Kandidaten (Z. ~315–320) ersetzen:
+    ```python
+        "candidates": [
+            {"start": "08:00", "end": "16:00", "pause": 30,
+             "modified_at": "2026-05-14T09:00:00Z", "device_id": "A", "deleted": False},
+            {"start": "09:00", "end": "17:00", "pause": 30,
+             "modified_at": "2026-05-14T10:00:00Z", "device_id": "B", "deleted": False},
+        ],
+    ```
+    →
+    ```python
+        "candidates": [
+            {"slots": [_slot("08:00", "16:00", 30)],
+             "modified_at": "2026-05-14T09:00:00Z", "device_id": "A", "deleted": False},
+            {"slots": [_slot("09:00", "17:00", 30)],
+             "modified_at": "2026-05-14T10:00:00Z", "device_id": "B", "deleted": False},
+        ],
+    ```
+  - chosen (Z. ~326): `    chosen = {"start": "09:00", "end": "17:00", "pause": 30}`
+    → `    chosen = {"slots": [_slot("09:00", "17:00", 30)]}`
+  - Z. ~330: `    assert storage.get("2026-05-14") == {"start": "09:00", "end": "17:00", "pause": 30}`
+    → `    assert storage.get("2026-05-14") == {"slots": [_slot("09:00", "17:00", 30)]}`
+- Übrige entry-Konflikt-Resolutions, die noch `{"start": ...}` nutzen, auf Slot-Shape angleichen (nicht asserted, aber konsistent halten):
+  - `test_merge_conflicts_resolved_wins_over_unresolved` (Z. ~198):
+    `resolution={"start": "08:00", "end": "16:00", "pause": 30}`
+    → `resolution={"slots": [_slot("08:00", "16:00", 30)]}`
+  - `test_merge_conflicts_lww_on_resolved_at_when_both_resolved` (Z. ~210 und ~213):
+    `resolution={"start": "08:00"}` → `resolution={"slots": [_slot("08:00", "16:00", 30)]}`
+    und `resolution={"start": "09:00"}` → `resolution={"slots": [_slot("09:00", "17:00", 30)]}`
+  - `test_compact_local_strips_stores_and_sets_watermark`, Konflikt `c-1` (Z. ~603):
+    `"resolution": {"start": "08:00"}` → `"resolution": {"slots": [_slot("08:00", "16:00", 30)]}`
+
+- [ ] **Step 11: `_remote_is_pre_v2`-Import + -Test auf v3 umstellen, Slot-Tests ergänzen**
+
+- Import (Z. ~591): `from src.sync import compact_local, _remote_is_pre_v2`
+  → `from src.sync import compact_local, _remote_is_pre_v3`
+- Ersetze den Test `test_remote_is_pre_v2` (Z. ~623–627) durch:
+
+```python
+def test_remote_is_pre_v3():
+    assert _remote_is_pre_v3({"schema_version": 1, "entries": {}}) is True
+    assert _remote_is_pre_v3({"schema_version": 2, "entries": {}}) is True
+    assert _remote_is_pre_v3({"schema_version": 3, "entries": {}}) is False
+    assert _remote_is_pre_v3({}) is True  # fehlende schema_version → pre-v3
+```
+
+- Hänge ans Ende von `tests/test_sync.py` zwei neue Tests an:
+
+```python
+def test_merge_slot_reorder_is_not_a_conflict():
+    """Gleiche Slots in unterschiedlicher Reihenfolge zählen als gleich →
+    kein Konflikt, auch wenn beide Seiten seit last_pull geändert haben."""
+    a = {"slots": [_slot("08:00", "12:00", 0, "Büro"), _slot("13:00", "17:00", 0, "HO")],
+         "modified_at": "2026-05-14T10:00:00Z", "device_id": "A", "deleted": False}
+    b = {"slots": [_slot("13:00", "17:00", 0, "HO"), _slot("08:00", "12:00", 0, "Büro")],
+         "modified_at": "2026-05-14T11:00:00Z", "device_id": "B", "deleted": False}
+    local = _doc(entries={"D": a})
+    remote = _doc(entries={"D": b})
+    merged = merge(local, remote, "2026-05-13T00:00:00Z")
+    assert merged["conflicts"] == []
+
+
+def test_merge_different_slots_conflict_candidates_carry_slots():
+    """Unterschiedliche Slot-Listen, beide geändert → Konflikt; die Kandidaten
+    tragen die jeweilige Slot-Liste."""
+    a = {"slots": [_slot("08:00", "16:00", 30, "Büro")],
+         "modified_at": "2026-05-14T09:00:00Z", "device_id": "A", "deleted": False}
+    b = {"slots": [_slot("09:00", "17:00", 30, "HO")],
+         "modified_at": "2026-05-14T10:00:00Z", "device_id": "B", "deleted": False}
+    merged = merge(_doc(entries={"D": a}), _doc(entries={"D": b}), "2026-05-13T00:00:00Z")
+    assert len(merged["conflicts"]) == 1
+    cand_by_dev = {c["device_id"]: c for c in merged["conflicts"][0]["candidates"]}
+    assert cand_by_dev["A"]["slots"] == [_slot("08:00", "16:00", 30, "Büro")]
+    assert cand_by_dev["B"]["slots"] == [_slot("09:00", "17:00", 30, "HO")]
+```
+
+### Teil D — Verifikation
+
+- [ ] **Step 12: Import-Smoke-Test für die `main.py`-Wiring-Änderung**
+
+Run: `python -c "from src import main, sync; print(sync._remote_is_pre_v3({'schema_version': 2}))"`
+Expected: gibt `True` aus, kein ImportError/AttributeError.
+
+- [ ] **Step 13: Sync-Tests laufen lassen — müssen BESTEHEN**
+
+Run: `python -m pytest tests/test_sync.py -q`
+Expected: PASS (alle Tests grün).
+
+- [ ] **Step 14: AP1+AP2-Regressionscheck (kein Rückschritt)**
+
+Run: `python -m pytest tests/test_storage.py tests/test_storage_migration.py tests/test_reservations.py tests/test_reservations_migration.py tests/test_settings.py tests/test_sync.py -q`
+Expected: PASS.
+
+> **Hinweis:** Ein voller `pytest`-Lauf bleibt erwartbar rot (report/share/ui/gcal nutzen noch die alte API). Das ist der harte Schnitt; AP2 verifiziert nur die obigen Dateien.
+
+- [ ] **Step 15: Commit**
+
+```bash
+git add src/sync.py src/main.py tests/test_sync.py
+git commit -m "feat(sync): Schema v3 — Slot-Listen-Merge + Alt-Client-Guard (#53)
+
+_values_equal_entry vergleicht reihenfolge-normalisierte Slot-Listen;
+Konflikt-Resolution (resolve_conflict + merge-Apply) schreibt Slot-Listen.
+SCHEMA_VERSION 2->3. _remote_is_pre_v2 -> _remote_is_pre_v3 (schema<3),
+im Kompaktierungs-Guard verdrahtet. Day-level-LWW unverändert. Teil von AP2.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+**1. Spec-Coverage (AP2-Scope laut Spec-Abschnitt „Sync (sync.py) — SCHEMA_VERSION 2 → 3"):**
+- `SCHEMA_VERSION = 3` → Task 2, Step 1 ✓
+- `_values_equal_entry` vergleicht Slot-Liste reihenfolge-normalisiert + deleted → Task 2, Step 2 (+ Test Step 11 reorder) ✓
+- Konflikt-Kandidaten tragen Slot-Liste; resolve_conflict + Resolution-Apply schreiben Slot-Liste → Task 2, Steps 3–4 (+ Test Step 11 candidates) ✓
+- `_remote_is_pre_v3` + Kompaktierungs-Guard → Task 2, Steps 5–6 (+ Test Step 11) ✓
+- Day-level-LWW/Watermark/Tombstone unverändert → keine Änderung an `_merge_one`/Watermark-Logik ✓
+- Kategorien-Setting in beide `SYNCED_SETTING_KEYS` + Default → Task 1 ✓
+- `_coerce` für Listen → bewusst KEINE Code-Änderung (bereits abgedeckt), per Test fixiert → Task 1, Step 1 (`test_categories_non_list_falls_back_to_default`) ✓
+- Bewusst NICHT in AP2 (dokumentiert): regulärer-Pull-Pre-v3-Guard + UI-Hinweis → AP6; Consumer-Anpassungen (report/share/ui/gcal) → ihre Pakete.
+
+**2. Placeholder-Scan:** Keine TBD/TODO; alle Code- und Test-Edits zeigen exakten Inhalt (old→new). Zeilennummern sind als Orientierung mit „~" markiert, der Match-Text ist eindeutig. ✓
+
+**3. Typ-Konsistenz:**
+- `chosen_value`/`resolution` für entry = `{"slots": [...], "deleted"?: bool}` — konsistent zwischen `resolve_conflict`, Resolution-Apply und den test_sync-Edits. ✓
+- `storage.save(date, slots)` / `storage.get -> {"slots": [...]}` — konsistent zu AP1-Interfaces und den test_sync-Edits. ✓
+- `_remote_is_pre_v3` Name identisch in sync.py, main.py-Aufruf, test-Import und Test. ✓
+- `categories` Key-Name identisch in DEFAULTS, beiden Whitelists und allen Tests. ✓
+- `_slot(...)`-Helfer in test_sync.py liefert `{start,end,pause,kategorie}` wie das AP1-Slot-Schema. ✓

--- a/docs/superpowers/plans/2026-06-19-ap2-sync-v3-kategorien.md
+++ b/docs/superpowers/plans/2026-06-19-ap2-sync-v3-kategorien.md
@@ -435,15 +435,51 @@ Führe diese exakten Ersetzungen durch (jede Zeile genau einmal vorhanden):
     → `    chosen = {"slots": [_slot("09:00", "17:00", 30)]}`
   - Z. ~330: `    assert storage.get("2026-05-14") == {"start": "09:00", "end": "17:00", "pause": 30}`
     → `    assert storage.get("2026-05-14") == {"slots": [_slot("09:00", "17:00", 30)]}`
-- Übrige entry-Konflikt-Resolutions, die noch `{"start": ...}` nutzen, auf Slot-Shape angleichen (nicht asserted, aber konsistent halten):
-  - `test_merge_conflicts_resolved_wins_over_unresolved` (Z. ~198):
-    `resolution={"start": "08:00", "end": "16:00", "pause": 30}`
-    → `resolution={"slots": [_slot("08:00", "16:00", 30)]}`
-  - `test_merge_conflicts_lww_on_resolved_at_when_both_resolved` (Z. ~210 und ~213):
-    `resolution={"start": "08:00"}` → `resolution={"slots": [_slot("08:00", "16:00", 30)]}`
-    und `resolution={"start": "09:00"}` → `resolution={"slots": [_slot("09:00", "17:00", 30)]}`
-  - `test_compact_local_strips_stores_and_sets_watermark`, Konflikt `c-1` (Z. ~603):
-    `"resolution": {"start": "08:00"}` → `"resolution": {"slots": [_slot("08:00", "16:00", 30)]}`
+- **Übrige entry-Konflikt-Resolutions auf Slot-Shape angleichen** (nicht asserted, aber konsistent — und nötig, damit der Resolution-Apply keine Leer-Slot-Einträge erzeugt). **Wichtig:** `resolution={"start": "08:00"}` ist im File NICHT eindeutig; daher jede Ersetzung über den gezeigten Mehr-Zeilen-Kontext verankern (nicht über die nackte `{"start": ...}`-Zeile).
+
+  a) `test_merge_conflicts_resolved_wins_over_unresolved` — diese Zeile ist eindeutig:
+  `                         resolution={"start": "08:00", "end": "16:00", "pause": 30},`
+  → `                         resolution={"slots": [_slot("08:00", "16:00", 30)]},`
+
+  b) `test_merge_conflicts_lww_on_resolved_at_when_both_resolved` — beide Zeilen tragen ihr `resolved_at` und sind dadurch eindeutig:
+  `                    resolution={"start": "08:00"}, resolved_at="2026-05-14T11:00:00Z",`
+  → `                    resolution={"slots": [_slot("08:00", "16:00", 30)]}, resolved_at="2026-05-14T11:00:00Z",`
+  und
+  `                    resolution={"start": "09:00"}, resolved_at="2026-05-14T12:00:00Z",`
+  → `                    resolution={"slots": [_slot("09:00", "17:00", 30)]}, resolved_at="2026-05-14T12:00:00Z",`
+
+  c) `test_merge_drops_settled_resolved_conflict` — über die 2-Zeilen-Folge (`resolved_at` macht sie eindeutig):
+  ```python
+      c = _conflict("c-1", resolved=True, resolution={"start": "08:00"},
+                    resolved_at="2026-05-05T00:00:00Z", resolved_by="A")
+  ```
+  →
+  ```python
+      c = _conflict("c-1", resolved=True, resolution={"slots": [_slot("08:00", "16:00", 30)]},
+                    resolved_at="2026-05-05T00:00:00Z", resolved_by="A")
+  ```
+
+  d) `test_merge_keeps_resolved_conflict_without_resolved_at` — über die 2-Zeilen-Folge (`resolved_at=None` macht sie eindeutig):
+  ```python
+      c = _conflict("c-1", resolved=True, resolution={"start": "08:00"},
+                    resolved_at=None, resolved_by="A")
+  ```
+  →
+  ```python
+      c = _conflict("c-1", resolved=True, resolution={"slots": [_slot("08:00", "16:00", 30)]},
+                    resolved_at=None, resolved_by="A")
+  ```
+
+  e) `test_compact_local_strips_stores_and_sets_watermark`, Konflikt `c-1` — über die 2-Zeilen-Folge mit `"key": "X"` (eindeutig):
+  ```python
+        {"id": "c-1", "kind": "entry", "key": "X", "candidates": [],
+         "detected_at": "...", "resolved": True, "resolution": {"start": "08:00"},
+  ```
+  →
+  ```python
+        {"id": "c-1", "kind": "entry", "key": "X", "candidates": [],
+         "detected_at": "...", "resolved": True, "resolution": {"slots": [_slot("08:00", "16:00", 30)]},
+  ```
 
 - [ ] **Step 11: `_remote_is_pre_v2`-Import + -Test auf v3 umstellen, Slot-Tests ergänzen**
 
@@ -490,6 +526,11 @@ def test_merge_different_slots_conflict_candidates_carry_slots():
 ```
 
 ### Teil D — Verifikation
+
+- [ ] **Step 12a: Grep-Gate — keine alt-geformten Eintrags-Daten mehr in test_sync.py**
+
+Run (PowerShell): `Select-String -Path tests\test_sync.py -Pattern 'resolution.*\{.*"start"', 'chosen.*=.*\{.*"start"', '\["start"\]\s*==', '\["end"\]\s*==' | Select-Object LineNumber, Line`
+Expected: **keine Treffer** für Resolution-/chosen-Dicts mit `"start"` und keine `["start"]==`/`["end"]==`-Assertions auf Einträgen. (Treffer in den NEUEN Slot-Tests wie `_slot("08:00", ...)` sind ok — die matchen das Muster nicht.) Falls Treffer: die entsprechende Stelle wurde in Step 8/10 übersehen → nachziehen.
 
 - [ ] **Step 12: Import-Smoke-Test für die `main.py`-Wiring-Änderung**
 

--- a/docs/superpowers/plans/2026-06-19-ap3-entry-dialog-multislot.md
+++ b/docs/superpowers/plans/2026-06-19-ap3-entry-dialog-multislot.md
@@ -1,0 +1,551 @@
+# AP3 — entry_dialog Multi-Slot + Non-Overlap-Validierung Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Den Tages-Dialog (`src/dialogs/entry_dialog.py`) auf mehrere Timeslots pro Tag (Ist-Zeit und Reservierung) mit Kategorie je Slot umstellen, und die Slot-Validierung (Per-Slot + zeitliche Überlappungsfreiheit) als pure, getestete Funktion in `src/time_utils.py` bereitstellen.
+
+**Architecture:** Die testbare Logik (`validate_slots`) lebt in `time_utils`. Der Dialog ist eine dünne Tkinter-Schicht: dynamische Slot-Zeilen (hinzufügen/entfernen), Kategorie je Zeile, sammelt beim Speichern eine Slot-Liste, ruft `validate_slots` und schreibt via die AP1-Slot-API (`storage.save(date, slots)` / `reservation_store.save(date, slots)`).
+
+**Tech Stack:** Python stdlib, tkinter, pytest. Keine neuen Dependencies.
+
+## Global Constraints
+
+- **Non-Overlap:** Slots eines Blocks dürfen sich **zeitlich nicht überlappen** — getrennt geprüft für Ist-Zeit-Slots bzw. Reservierungs-Slots (die beiden Blöcke dürfen sich gegenseitig überlagern). Angrenzend (Ende == Start des nächsten) ist **erlaubt**.
+- **Slot-Schemata:** Ist-Zeit-Slot `{start, end, pause, kategorie}`; Reservierungs-Slot `{start, end, kategorie}` (kein `pause`).
+- **Kategorie** ist Freitext (String), `""` = keine. Auswahlvorschläge kommen aus `settings.get("categories")`.
+- **Lösch-Modell (CLAUDE.md):** Der Dialog ist auf Win/Linux rein zum Speichern — **kein** Lösch-Button. Entfernen aller Zeilen eines Blocks + Speichern = dieser Block wird gelöscht (`storage.delete` / `reservation_store.delete`) — das ist Editieren, kein zweiter Lösch-Pfad. **macOS-Ausnahme:** behält die expliziten „Löschen"/„Reservierung löschen"-Buttons (`_SHOW_DELETE_IN_DIALOG = platform.system() == "Darwin"`).
+- **AP1-Slot-API:** `storage.save(date, slots)`, `storage.get(date) -> {"slots":[...]}|None`, `storage.delete(date)`; `reservation_store.save(date, slots)`, `reservation_store.get(date) -> {"slots":[{start,end,kategorie}]}|None`, `reservation_store.delete(date)`.
+- **Reservierungs-Slot ohne gcal_event_id im Dialog:** Der Dialog liefert nur `{start,end,kategorie}`. Das Event-Mapping (gcal_event_id) macht der Reconcile (AP7) — der Dialog setzt es nicht.
+- **Datumsformat:** intern ISO; UI deutsch (Dialog-Titel bleibt `%d.%m.%Y`).
+- **Harter Schnitt (laufend):** Nur AP3-Dateien werden angepasst. Consumer außerhalb (report, share, ui, gcal) bleiben rot bis zu ihren Paketen.
+
+## Test-Strategie / Design-Notes (für den Plan-Review)
+
+- **`time_utils.validate_slots` ist voll unit-getestet** (Task 1).
+- **`entry_dialog.py` hat KEINE automatisierten Tests** — bewusst, konsistent mit dem Projekt: Tkinter-Widgets brauchen ein Display und laufen in der CI (ubuntu, `test.yml` ohne xvfb) nicht; es gibt im Repo keine Widget-Tests für Dialoge. Verifikation von Task 2 = (a) Import-Smoke (`python -c "import src.dialogs.entry_dialog"`), (b) Diff-Review, (c) **manueller lokaler Test** durch den Nutzer vor dem PR. Das ist im Plan-Review zur Abnahme markiert.
+- **„Alle Zeilen entfernt + Speichern = Block löschen":** bewusste Save-Semantik (kein zusätzlicher Lösch-Button auf Win/Linux). Im Plan-Review zur Abnahme markiert.
+- **`dark_combo_editable`** ist ein neuer, kleiner Theme-Helfer (editierbare Combobox), nötig weil die Kategorie-Verwaltung erst in AP6 kommt — bis dahin muss man Kategorien im Dialog per Freitext anlegen können.
+
+---
+
+## Dateistruktur
+
+- `src/time_utils.py` — neue pure Helfer `slots_overlap`, `validate_slots`. Verantwortung (Zeit-Mathematik/Validierung) unverändert.
+- `src/theme.py` — neuer Helfer `dark_combo_editable` (editierbare Combobox).
+- `src/dialogs/entry_dialog.py` — komplette Neufassung: dynamische Slot-Zeilen + Kategorie.
+- `tests/test_time_calc.py` — Tests für `validate_slots`/`slots_overlap` (gleiche Datei wie die bestehenden `validate_entry`-Tests).
+
+Task 1 (`time_utils` + Tests) ist unabhängig von Task 2 (Dialog + Theme-Helfer). Task 2 konsumiert `validate_slots` aus Task 1.
+
+---
+
+## Task 1: `time_utils` — `slots_overlap` + `validate_slots`
+
+**Files:**
+- Modify: `src/time_utils.py` (zwei neue Funktionen am Ende)
+- Test: `tests/test_time_calc.py` (neue Tests anhängen)
+
+**Interfaces:**
+- Produces:
+  - `slots_overlap(slots: list[dict]) -> bool` — True, wenn sich zwei Slots zeitlich überlappen. Slots mit unparsbarer Zeit werden übersprungen (separat per `validate_slots` abgefangen). Angrenzend (Ende==Start) ist KEINE Überlappung.
+  - `validate_slots(slots: list[dict], with_pause: bool = True) -> tuple[bool, str]` — validiert jeden Slot (`validate_entry` auf `start`/`end`/`pause`; bei `with_pause=False` wird `pause=0` erzwungen) und die Überlappungsfreiheit. Leere Liste → `(True, "")`. Erste Fehlermeldung gewinnt.
+
+- [ ] **Step 1: Failing-Tests an `tests/test_time_calc.py` anhängen**
+
+Hänge ans Ende von `tests/test_time_calc.py` an:
+
+```python
+
+
+from src.time_utils import slots_overlap, validate_slots
+
+
+def _s(start, end, pause=0, kategorie=""):
+    return {"start": start, "end": end, "pause": pause, "kategorie": kategorie}
+
+
+def test_slots_overlap_false_for_disjoint():
+    assert slots_overlap([_s("08:00", "12:00"), _s("13:00", "17:00")]) is False
+
+
+def test_slots_overlap_false_for_adjacent():
+    # Ende == Start des nächsten ist erlaubt (angrenzend, nicht überlappend)
+    assert slots_overlap([_s("08:00", "12:00"), _s("12:00", "17:00")]) is False
+
+
+def test_slots_overlap_true_for_overlap():
+    assert slots_overlap([_s("08:00", "13:00"), _s("12:00", "17:00")]) is True
+
+
+def test_slots_overlap_detects_unsorted_input():
+    # Reihenfolge egal: zweite Liste ist nicht nach start sortiert
+    assert slots_overlap([_s("13:00", "17:00"), _s("08:00", "13:30")]) is True
+
+
+def test_slots_overlap_ignores_unparsable_times():
+    # Ein Slot mit kaputter Zeit wird übersprungen (validate_slots fängt ihn ab)
+    assert slots_overlap([_s("abc", "xyz"), _s("08:00", "12:00")]) is False
+
+
+def test_slots_overlap_empty_and_single():
+    assert slots_overlap([]) is False
+    assert slots_overlap([_s("08:00", "16:00")]) is False
+
+
+def test_validate_slots_ok_single():
+    ok, msg = validate_slots([_s("08:00", "16:30", 30)])
+    assert ok is True
+    assert msg == ""
+
+
+def test_validate_slots_ok_multiple_disjoint():
+    ok, _ = validate_slots([_s("08:00", "12:00", 0, "Büro"), _s("13:00", "17:00", 30, "HO")])
+    assert ok is True
+
+
+def test_validate_slots_empty_is_ok():
+    assert validate_slots([]) == (True, "")
+
+
+def test_validate_slots_rejects_overlap():
+    ok, msg = validate_slots([_s("08:00", "13:00"), _s("12:00", "17:00")])
+    assert ok is False
+    assert "überlapp" in msg.lower()
+
+
+def test_validate_slots_rejects_bad_slot():
+    ok, msg = validate_slots([_s("17:00", "08:00")])  # Ende vor Start
+    assert ok is False
+
+
+def test_validate_slots_rejects_pause_too_big():
+    ok, msg = validate_slots([_s("08:00", "09:00", 90)])  # Pause > Arbeitszeit
+    assert ok is False
+
+
+def test_validate_slots_without_pause_ignores_pause():
+    # Reservierungs-Slots: pause wird ignoriert (with_pause=False), kein Pausenfehler
+    ok, msg = validate_slots([_s("08:00", "09:00", 999)], with_pause=False)
+    assert ok is True
+```
+
+- [ ] **Step 2: Tests laufen lassen — müssen FEHLSCHLAGEN**
+
+Run: `python -m pytest tests/test_time_calc.py -q`
+Expected: FAIL — `slots_overlap`/`validate_slots` existieren noch nicht (ImportError beim neuen `from src.time_utils import ...`).
+
+- [ ] **Step 3: `src/time_utils.py` — Funktionen ergänzen**
+
+Hänge ans Ende von `src/time_utils.py` an:
+
+```python
+
+
+def slots_overlap(slots):
+    """True, wenn sich zwei Slots zeitlich überlappen.
+
+    `slots`: Liste von Dicts mit 'start'/'end' (HH:MM). Slots mit unparsbarer
+    Zeit werden übersprungen (Format-Fehler fängt validate_slots separat ab).
+    Angrenzend (Ende == Start des nächsten) gilt NICHT als Überlappung.
+    """
+    intervals = []
+    for s in slots:
+        start = parse_time(s.get("start"))
+        end = parse_time(s.get("end"))
+        if start is None or end is None:
+            continue
+        intervals.append((start[0] * 60 + start[1], end[0] * 60 + end[1]))
+    intervals.sort()
+    for (_prev_start, prev_end), (next_start, _next_end) in zip(intervals, intervals[1:]):
+        if next_start < prev_end:
+            return True
+    return False
+
+
+def validate_slots(slots, with_pause=True):
+    """Validiert eine Slot-Liste: jeden Slot einzeln (validate_entry) und die
+    zeitliche Überlappungsfreiheit. Liefert (ok, fehlermeldung).
+
+    with_pause=False (Reservierungen): das Pause-Feld wird ignoriert (als 0
+    behandelt). Eine leere Liste ist gültig (ok, "")."""
+    for s in slots:
+        pause = int(s.get("pause", 0)) if with_pause else 0
+        ok, msg = validate_entry(s.get("start"), s.get("end"), pause_minutes=pause)
+        if not ok:
+            return False, msg
+    if slots_overlap(slots):
+        return False, "Zeitslots dürfen sich zeitlich nicht überlappen."
+    return True, ""
+```
+
+- [ ] **Step 4: Tests laufen lassen — müssen BESTEHEN**
+
+Run: `python -m pytest tests/test_time_calc.py tests/test_time_utils.py -q`
+Expected: PASS (alle Tests grün).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/time_utils.py tests/test_time_calc.py
+git commit -m "feat(time_utils): Slot-Validierung mit Non-Overlap (#53)
+
+slots_overlap + validate_slots: prüfen jeden Slot (validate_entry) und die
+zeitliche Überlappungsfreiheit (angrenzend erlaubt). with_pause=False für
+Reservierungs-Slots. Teil von AP3.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: `entry_dialog` Multi-Slot-Umschreibung (+ Theme-Helfer)
+
+**Files:**
+- Modify: `src/theme.py` (neuer Helfer `dark_combo_editable`, direkt nach `dark_combo`)
+- Modify: `src/dialogs/entry_dialog.py` (komplette Neufassung, siehe Step 3)
+
+**Interfaces:**
+- Consumes: `time_utils.validate_slots` (Task 1); AP1-Slot-API (Storage/ReservationStore); `settings.get("categories")` (AP2).
+- Produces: `dark_combo_editable(parent, textvariable, values, width=14, **kw) -> ttk.Combobox` (editierbar, Freitext + Vorschläge).
+- Signatur von `open_entry_dialog` bleibt unverändert: `open_entry_dialog(parent, date_str, storage, settings, on_change, reservation_store=None, trigger_reconcile=None)`.
+
+> **Keine automatisierten Tests** (Tkinter, kein Display in der CI; Projekt-Norm). Verifikation: Import-Smoke + Diff-Review + manueller lokaler Test.
+
+- [ ] **Step 1: `src/theme.py` — `dark_combo_editable` ergänzen**
+
+Füge in `src/theme.py` direkt **nach** der Funktion `dark_combo` (endet mit der schließenden `)` der `return ttk.Combobox(...)`) ein:
+
+```python
+
+
+def dark_combo_editable(parent, textvariable, values, width=14, **kw):
+    """Wie dark_combo, aber editierbar (state="normal") — Freitext plus
+    Vorschlagsliste. Für die Kategorie-Auswahl je Slot, deren Werte aus
+    settings['categories'] kommen, aber auch frei eingetippt werden dürfen."""
+    return ttk.Combobox(
+        parent, textvariable=textvariable, values=values,
+        width=width, font=FONT, style="Dark.TCombobox", state="normal", **kw,
+    )
+```
+
+- [ ] **Step 2: Import-Smoke nach dem Theme-Helfer**
+
+Run: `python -c "from src.theme import dark_combo_editable; print('ok')"`
+Expected: gibt `ok` aus (kein ImportError).
+
+- [ ] **Step 3: `src/dialogs/entry_dialog.py` neu schreiben**
+
+Ersetze den **kompletten** Inhalt von `src/dialogs/entry_dialog.py` durch:
+
+```python
+import datetime
+import platform
+import tkinter as tk
+from tkinter import messagebox
+
+from src.holidays_de import get_holidays
+from src.settings import WEEKDAY_KEYS
+from src.theme import (
+    BG, FONT, FONT_BOLD, PAUSE_VALUES, TEXT, TEXT_MUTED, TIME_VALUES,
+    apply_app_icon, apply_combobox_style, apply_dark_titlebar,
+    attach_unfocus_on_click, center_dialog_on_parent, dark_combo,
+    dark_combo_editable, disable_min_max, primary_button, secondary_button,
+    themed_askyesno,
+)
+from src.time_utils import validate_slots
+
+
+# Löschen folgt im Kalender dem Muster „Linksklick = speichern, Rechtsklick =
+# löschen". Der Dialog (Linksklick) ist daher rein zum Anlegen/Bearbeiten — die
+# Lösch-Buttons sind dort raus. AUSNAHME macOS: Tkinters Maustasten-Nummerierung
+# macht den Rechtsklick (`<Button-3>`) dort unzuverlässig; damit Löschen auf dem
+# Mac überhaupt erreichbar bleibt, behält der Dialog dort seine Lösch-Buttons.
+_SHOW_DELETE_IN_DIALOG = platform.system() == "Darwin"
+
+
+def open_entry_dialog(parent, date_str, storage, settings, on_change,
+                      reservation_store=None, trigger_reconcile=None):
+    """Modaler Dialog zum Bearbeiten von Ist-Zeit und Reservierung eines Tages.
+
+    Beide Blöcke führen eine Liste von Slot-Zeilen (Start/Ende/Pause/Kategorie
+    bzw. Start/Ende/Kategorie). Speichern sammelt die Zeilen, validiert sie
+    (validate_slots: pro Slot + Überlappungsfreiheit) und schreibt die Slot-
+    Liste. Entfernt man alle Zeilen eines Blocks und speichert, wird der Block
+    gelöscht — kein separater Lösch-Button (außer macOS).
+
+    on_change wird nach erfolgreichem Speichern/Löschen aufgerufen.
+    reservation_store / trigger_reconcile sind optional; ist der Tag
+    heute/zukünftig (oder existiert bereits eine Reservierung), erscheint der
+    Reservierungs-Block. trigger_reconcile() stößt den Kalender-Abgleich an.
+    """
+    entry = storage.get(date_str)
+    day = datetime.date.fromisoformat(date_str)
+    weekday_key = WEEKDAY_KEYS[day.weekday()]
+
+    # Feiertags-Warnung beim Anlegen einer Ist-Zeit (nicht beim Edit).
+    if entry is None:
+        state = settings.get("state")
+        if state:
+            feiertage = get_holidays(state, day.year)
+            if day in feiertage:
+                date_de = day.strftime("%d.%m.%Y")
+                confirm = themed_askyesno(
+                    parent, "Feiertag",
+                    f"Der {date_de} ist {feiertage[day]} (Feiertag).\n\n"
+                    "Trotzdem Eintrag anlegen?",
+                )
+                if not confirm:
+                    return
+
+    existing_reservation = (
+        reservation_store.get(date_str) if reservation_store is not None else None
+    )
+    show_reservation = reservation_store is not None and (
+        day >= datetime.date.today() or existing_reservation is not None
+    )
+
+    categories = settings.get("categories") or []
+    default_start = settings.get(f"default_start_{weekday_key}")
+    default_end = settings.get(f"default_end_{weekday_key}")
+    default_pause = settings.get("default_pause")
+
+    dialog = tk.Toplevel(parent)
+    dialog.title(day.strftime("%d.%m.%Y"))
+    dialog.resizable(False, False)
+    dialog.grab_set()
+    # focus_set() ist nach grab_set() Pflicht, sonst feuern Tastatur-Bindungen
+    # (z.B. Escape) am Dialog nie.
+    dialog.focus_set()
+    dialog.configure(bg=BG)
+    apply_dark_titlebar(dialog)
+    disable_min_max(dialog)
+    apply_app_icon(dialog)
+    apply_combobox_style(dialog)
+    attach_unfocus_on_click(dialog)
+    dialog.bind("<Escape>", lambda _e: dialog.destroy())
+
+    outer = tk.Frame(dialog, bg=BG)
+    outer.pack(padx=12, pady=12)
+
+    # ---------- Ist-Zeit ----------
+    tk.Label(outer, text="Arbeitszeit", font=FONT_BOLD, bg=BG, fg=TEXT).pack(anchor="w")
+    ist_rows_frame = tk.Frame(outer, bg=BG)
+    ist_rows_frame.pack(fill="x")
+    ist_rows = []  # Liste von {frame, start, end, pause, kategorie}
+
+    def add_ist_row(start, end, pause, kategorie):
+        row = tk.Frame(ist_rows_frame, bg=BG)
+        row.pack(fill="x", pady=2)
+        sv = tk.StringVar(value=start)
+        ev = tk.StringVar(value=end)
+        pv = tk.StringVar(value=str(pause))
+        kv = tk.StringVar(value=kategorie)
+        dark_combo(row, sv, TIME_VALUES, width=6).pack(side=tk.LEFT, padx=2)
+        tk.Label(row, text="–", font=FONT, bg=BG, fg=TEXT_MUTED).pack(side=tk.LEFT)
+        dark_combo(row, ev, TIME_VALUES, width=6).pack(side=tk.LEFT, padx=2)
+        dark_combo(row, pv, PAUSE_VALUES, width=4).pack(side=tk.LEFT, padx=2)
+        dark_combo_editable(row, kv, categories, width=14).pack(side=tk.LEFT, padx=2)
+        record = {"frame": row, "start": sv, "end": ev, "pause": pv, "kategorie": kv}
+
+        def remove():
+            row.destroy()
+            ist_rows.remove(record)
+
+        secondary_button(row, "×", remove, padx=8, pady=0).pack(side=tk.LEFT, padx=2)
+        ist_rows.append(record)
+
+    # Vorbelegung: vorhandene Ist-Slots → bestehende Reservierung (erste Slot-
+    # Zeit) → Standardzeit des Wochentags.
+    if entry and entry["slots"]:
+        for s in entry["slots"]:
+            add_ist_row(s["start"], s["end"], s.get("pause", 0), s.get("kategorie", ""))
+    elif existing_reservation and existing_reservation["slots"]:
+        first = existing_reservation["slots"][0]
+        add_ist_row(first["start"], first["end"], default_pause, "")
+    else:
+        add_ist_row(default_start, default_end, default_pause, "")
+
+    ist_btns = tk.Frame(outer, bg=BG)
+    ist_btns.pack(fill="x", pady=(2, 8))
+    secondary_button(
+        ist_btns, "+ Slot",
+        lambda: add_ist_row(default_start, default_end, 0, ""),
+    ).pack(side=tk.LEFT, padx=2)
+
+    def save_ist():
+        slots = [{
+            "start": r["start"].get(),
+            "end": r["end"].get(),
+            "pause": int(r["pause"].get() or 0),
+            "kategorie": r["kategorie"].get().strip(),
+        } for r in ist_rows]
+        if not slots:
+            storage.delete(date_str)
+            dialog.destroy()
+            on_change()
+            return
+        ok, msg = validate_slots(slots, with_pause=True)
+        if not ok:
+            messagebox.showerror("Fehler", msg, parent=dialog)
+            return
+        storage.save(date_str, slots)
+        dialog.destroy()
+        on_change()
+
+    def delete_ist():
+        storage.delete(date_str)
+        dialog.destroy()
+        on_change()
+
+    ist_save = tk.Frame(outer, bg=BG)
+    ist_save.pack(fill="x")
+    primary_button(ist_save, "Speichern", save_ist).pack(side=tk.LEFT, padx=2)
+    if entry is not None and _SHOW_DELETE_IN_DIALOG:
+        secondary_button(ist_save, "Löschen", delete_ist).pack(side=tk.LEFT, padx=2)
+
+    # ---------- Reservierung ----------
+    if show_reservation:
+        tk.Label(
+            outer, text="— Reservierung —", font=FONT_BOLD, bg=BG, fg=TEXT_MUTED,
+        ).pack(anchor="w", pady=(12, 2))
+        res_rows_frame = tk.Frame(outer, bg=BG)
+        res_rows_frame.pack(fill="x")
+        res_rows = []  # Liste von {frame, start, end, kategorie}
+
+        def add_res_row(start, end, kategorie):
+            row = tk.Frame(res_rows_frame, bg=BG)
+            row.pack(fill="x", pady=2)
+            sv = tk.StringVar(value=start)
+            ev = tk.StringVar(value=end)
+            kv = tk.StringVar(value=kategorie)
+            dark_combo(row, sv, TIME_VALUES, width=6).pack(side=tk.LEFT, padx=2)
+            tk.Label(row, text="–", font=FONT, bg=BG, fg=TEXT_MUTED).pack(side=tk.LEFT)
+            dark_combo(row, ev, TIME_VALUES, width=6).pack(side=tk.LEFT, padx=2)
+            dark_combo_editable(row, kv, categories, width=14).pack(side=tk.LEFT, padx=2)
+            record = {"frame": row, "start": sv, "end": ev, "kategorie": kv}
+
+            def remove():
+                row.destroy()
+                res_rows.remove(record)
+
+            secondary_button(row, "×", remove, padx=8, pady=0).pack(side=tk.LEFT, padx=2)
+            res_rows.append(record)
+
+        if existing_reservation and existing_reservation["slots"]:
+            for s in existing_reservation["slots"]:
+                add_res_row(s["start"], s["end"], s.get("kategorie", ""))
+        else:
+            add_res_row(default_start, default_end, "")
+
+        res_btns = tk.Frame(outer, bg=BG)
+        res_btns.pack(fill="x", pady=(2, 8))
+        secondary_button(
+            res_btns, "+ Slot",
+            lambda: add_res_row(default_start, default_end, ""),
+        ).pack(side=tk.LEFT, padx=2)
+
+        def save_reservation():
+            slots = [{
+                "start": r["start"].get(),
+                "end": r["end"].get(),
+                "kategorie": r["kategorie"].get().strip(),
+            } for r in res_rows]
+            if not slots:
+                reservation_store.delete(date_str)
+                dialog.destroy()
+                on_change()
+                if trigger_reconcile is not None:
+                    trigger_reconcile()
+                return
+            ok, msg = validate_slots(slots, with_pause=False)
+            if not ok:
+                messagebox.showerror("Fehler", msg, parent=dialog)
+                return
+            reservation_store.save(date_str, slots)
+            dialog.destroy()
+            on_change()
+            if trigger_reconcile is not None:
+                trigger_reconcile()
+
+        def delete_reservation():
+            reservation_store.delete(date_str)
+            dialog.destroy()
+            on_change()
+            if trigger_reconcile is not None:
+                trigger_reconcile()
+
+        res_save = tk.Frame(outer, bg=BG)
+        res_save.pack(fill="x")
+        primary_button(res_save, "Reservierung speichern",
+                       save_reservation).pack(side=tk.LEFT, padx=2)
+        if existing_reservation is not None and _SHOW_DELETE_IN_DIALOG:
+            secondary_button(res_save, "Reservierung löschen",
+                             delete_reservation).pack(side=tk.LEFT, padx=2)
+
+    center_dialog_on_parent(dialog, parent)
+```
+
+- [ ] **Step 4: Import-Smoke + Byte-Compile**
+
+Run: `python -c "import src.dialogs.entry_dialog; print('ok')"`
+Expected: gibt `ok` aus (kein ImportError, keine SyntaxError).
+
+Run: `python -m py_compile src/dialogs/entry_dialog.py src/theme.py src/time_utils.py`
+Expected: keine Ausgabe, Exit 0.
+
+- [ ] **Step 5: AP1–AP3-Regressionscheck (kein Rückschritt)**
+
+Run: `python -m pytest tests/test_storage.py tests/test_storage_migration.py tests/test_reservations.py tests/test_reservations_migration.py tests/test_settings.py tests/test_sync.py tests/test_time_calc.py tests/test_time_utils.py -q`
+Expected: PASS.
+
+> **Hinweis:** Ein voller `pytest`-Lauf bleibt erwartbar rot (report/share/ui/gcal noch nicht angepasst). `entry_dialog.py` selbst hat keine automatisierten Tests — manueller Test durch den Nutzer vor dem PR.
+
+- [ ] **Step 6: Manuelle Verifikations-Checkliste (für den lokalen Test des Nutzers, NICHT vom Implementer auszuführen)**
+
+In den Report schreiben (als Hinweis an den Nutzer), nicht ausführen:
+- Linksklick auf einen Tag öffnet den Dialog; Ist-Zeit zeigt eine Zeile (Vorbelegung).
+- „+ Slot" fügt eine Zeile hinzu; „×" entfernt sie.
+- Zwei sich überlappende Slots → „Speichern" zeigt Überlappungs-Fehler.
+- Zwei angrenzende Slots (z.B. 08:00–12:00 und 12:00–17:00) speichern ok.
+- Kategorie ist frei eintippbar und bietet `settings['categories']` als Vorschläge.
+- Alle Ist-Zeit-Zeilen entfernen + Speichern löscht die Ist-Zeit des Tages.
+- Reservierungs-Block analog (ohne Pause), nur bei heute/zukünftig bzw. bestehender Reservierung.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/dialogs/entry_dialog.py src/theme.py
+git commit -m "feat(ui): Tages-Dialog mit mehreren Slots + Kategorie je Slot (#53)
+
+entry_dialog führt für Ist-Zeit und Reservierung je eine Liste von Slot-
+Zeilen (hinzufügen/entfernen), Kategorie je Zeile (Freitext + Vorschläge aus
+settings.categories). Speichern validiert via validate_slots (pro Slot +
+Non-Overlap) und schreibt Slot-Listen über die AP1-API; alle Zeilen entfernt
++ Speichern löscht den Block. Neuer Theme-Helfer dark_combo_editable.
+macOS behält seine Lösch-Buttons. Teil von AP3.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+**1. Spec-Coverage (Spec-Abschnitt „entry_dialog.py — dynamische Slot-Zeilen" + Validierung):**
+- Ist-Zeit & Reservierung je Liste von Slot-Zeilen, Start/Ende/Pause/Kategorie bzw. Start/Ende/Kategorie → Task 2, Step 3 ✓
+- „+ Slot hinzufügen" + „×" entfernen je Block → Task 2, Step 3 ✓
+- Kategorie editierbar (Freitext + Vorschläge aus settings.categories) → `dark_combo_editable` + `categories` ✓
+- Speichern validiert (pro Slot + Non-Overlap je Block) und schreibt Slot-Listen via AP1-API → `validate_slots` (Task 1) + `save_ist`/`save_reservation` ✓
+- Non-Overlap getrennt je Block; angrenzend erlaubt → `slots_overlap` (Task 1) + getrennte `validate_slots`-Aufrufe ✓
+- Erster Slot eines neuen Tages aus Per-Wochentag-Defaults; Vorbelegungs-Priorität (Ist → Reservierung → Default) → Task 2, Step 3 ✓
+- Zeile entfernen + Speichern = Editieren (kein zweiter Lösch-Pfad Win/Linux); macOS behält Lösch-Buttons → Save-Semantik + `_SHOW_DELETE_IN_DIALOG` ✓
+- Reservierungs-Slot ohne pause; trigger_reconcile nach Reservierungs-Save → Task 2 ✓
+- Bewusst NICHT in AP3: Kategorie-Verwaltung (AP6), Kalender-Zellen-Mehrslot-Anzeige + Rechtsklick (AP6), report/share/gcal (eigene Pakete).
+
+**2. Placeholder-Scan:** Keine TBD/TODO; vollständiger Code in jedem Code-Step, vollständige Tests in Task 1. ✓
+
+**3. Typ-Konsistenz:**
+- `validate_slots(slots, with_pause)` Signatur identisch in time_utils, Tests und beiden Dialog-Aufrufen. ✓
+- Ist-Zeit-Slot `{start,end,pause,kategorie}` (int pause) vs. Reservierungs-Slot `{start,end,kategorie}` — konsistent zu AP1 und den `storage.save`/`reservation_store.save`-Signaturen. ✓
+- `dark_combo_editable(parent, textvariable, values, width)` — Signatur in theme.py-Definition und Dialog-Aufrufen identisch. ✓
+- `storage.get`/`reservation_store.get` liefern `{"slots":[...]}|None` — der Dialog liest `entry["slots"]` / `existing_reservation["slots"]` entsprechend. ✓

--- a/docs/superpowers/plans/2026-06-19-ap4-report-send-kategorien.md
+++ b/docs/superpowers/plans/2026-06-19-ap4-report-send-kategorien.md
@@ -1,0 +1,913 @@
+# AP4 — Report + Sende-Dialog (Kategorien) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Den Report (`src/report.py`) auf das Multi-Slot-Modell heben — eine Zeile pro Slot mit Kategorie-Spalte, Tages-Subtotal bei mehreren Slots, KW-Summen wie bisher, plus einen „Summe je Kategorie"-Block — und im Sende-Dialog (`src/dialogs/send_dialog.py`) eine Kategorie-Auswahl ergänzen, die in den Versand (Mail/PDF) durchgereicht wird.
+
+**Architecture:** `report.py` rendert aus `{date: {slots: [...]}}` (AP1-Shape). Die HTML-Erzeugung ist pure und voll testbar (Task 1). Der Sende-Dialog ist eine dünne Tkinter-Schicht, die die im Bestand vorhandenen Kategorien als Checkboxen anbietet und die Auswahl an `generate_report`/`generate_pdf` weiterreicht (Task 2).
+
+**Tech Stack:** Python stdlib, xhtml2pdf (lazy import, wie bisher), tkinter, pytest.
+
+## Global Constraints
+
+- **AP1-Shape:** `all_entries` = `{date: {"slots": [{start, end, pause, kategorie}]}}` (Ist-Zeiten). Slots haben `pause` (int) und `kategorie` (str, `""` = keine).
+- **Report-Tabelle:** Spalten `Datum | Tag | Kategorie | Start | Ende | Stunden` (6 Spalten). **Eine Zeile je Slot.** Datum+Tag nur in der ERSTEN Slot-Zeile eines Tages, in Folgezeilen leer. Bei >1 Slot am Tag eine **Tages-Subtotal-Zeile** („Summe TT.MM.JJJJ"). KW-Header + KW-Summe wie bisher. Gesamt-Footer wie bisher.
+- **„Summe je Kategorie"-Block:** eigene Tabelle nach der Haupttabelle (`Kategorie | Stunden`), Summe je Kategorie über den (gefilterten) Zeitraum. `""` → Label „(ohne Kategorie)", einsortiert ans Ende.
+- **Kategorie-Filter:** `generate_report`/`generate_pdf` bekommen Parameter `categories=None`. `None` = alle. Sonst Menge von Kategorie-Strings (`""` = ohne Kategorie); Slots mit nicht-enthaltener Kategorie werden verworfen; Tage ohne verbleibende Slots fallen weg. Werden dadurch (oder durch Datum) keine Slots übrig → `(None, 0)` bzw. `None`.
+- **HTML-Escaping:** `kategorie` ist **freier Nutzertext** und MUSS escaped werden (`_esc`). `start`/`end`/Datum/KW bleiben strukturell sicher (wie der bestehende Kommentar in report.py erklärt).
+- **Stundenlogik:** Slot-Stunden = `calculate_hours(start, end, pause)`. Tages-/Wochen-/Gesamt-/Kategorie-Summe = Summe über Slots, je `round(…, 2)`.
+- **Backwards-Compat der Signaturen:** `categories=None` ist der Default → bestehende Aufrufer ohne Filter verhalten sich unverändert.
+- **Datumsformat:** intern ISO; UI/Anzeige deutsch (`%d.%m.%Y`).
+- **Harter Schnitt (laufend):** Nur AP4-Dateien. Consumer außerhalb (share, ui, gcal) bleiben rot bis zu ihren Paketen.
+
+## Test-Strategie / Design-Notes (für den Plan-Review)
+
+- **`report.py` ist voll unit-getestet** (Task 1) — `test_report.py` wird auf die Slot-Shape umgestellt (bestehende Assertions bleiben gültig, da ein 1-Slot-Tag weiter Datum/Start/Ende/Stunden rendert) und um Kategorie-/Multi-Slot-/Filter-Tests erweitert.
+- **`send_dialog.py` hat KEINE automatisierten Tests** (Tkinter/CI ohne Display, Projekt-Norm). Verifikation Task 2 = Import-Smoke + Diff-Review + manueller lokaler Test. Im Plan-Review zur Abnahme markiert.
+- **Filter-Default „alle":** Sind alle Checkboxen gesetzt, übergibt der Dialog `categories=None` (kein Filter) — semantisch identisch zu „alle ausgewählt", aber günstiger und robust.
+
+---
+
+## Dateistruktur
+
+- `src/report.py` — komplette Neufassung der Tabellen-/Render-Logik (Slot-Zeilen, Kategorie-Spalte, Tages-Subtotal, Kategorie-Summen-Block, Filter). Verantwortung unverändert.
+- `src/dialogs/send_dialog.py` — Kategorie-Checkbox-Sektion + Durchreichen von `categories`.
+- `tests/test_report.py` — auf Slot-Shape umgestellt + Kategorie-/Filter-Tests.
+
+Task 1 (report + Tests) ist unabhängig testbar. Task 2 (send_dialog) konsumiert die neue `categories`-Signatur.
+
+---
+
+## Task 1: `report.py` — Multi-Slot-Tabelle + Kategorie-Summen + Filter
+
+**Files:**
+- Modify: `src/report.py` (komplette Neufassung, siehe Step 3)
+- Test: `tests/test_report.py` (Neufassung, siehe Step 1)
+
+**Interfaces:**
+- Consumes: AP1-Shape `{date: {"slots":[{start,end,pause,kategorie}]}}`.
+- Produces:
+  - `generate_report(date_from, date_to, all_entries, greeting="", content="", closing="", categories=None) -> (html|None, total)`.
+  - `generate_pdf(date_from, date_to, all_entries, name="", categories=None) -> bytes|None`.
+  - Interne Helfer: `_slot_hours(slot)`, `_entry_hours(entry)` (Summe über Slots), `_apply_category_filter(entries, categories)`, `_build_category_summary(range_entries, style)`.
+
+- [ ] **Step 1: `tests/test_report.py` neu schreiben**
+
+Ersetze den **kompletten** Inhalt von `tests/test_report.py` durch:
+
+```python
+import datetime
+from unittest.mock import patch, MagicMock
+
+from src.report import generate_report
+
+
+def _e(start, end, pause=0, kategorie=""):
+    """Eintrag mit genau einem Slot."""
+    return {"slots": [{"start": start, "end": end, "pause": pause, "kategorie": kategorie}]}
+
+
+def _slot(start, end, pause=0, kategorie=""):
+    return {"start": start, "end": end, "pause": pause, "kategorie": kategorie}
+
+
+def test_empty_entries():
+    html, total = generate_report(datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), {})
+    assert html is None
+    assert total == 0
+
+
+def test_single_entry():
+    entries = {"2026-03-23": _e("08:00", "16:30", 30)}
+    html, total = generate_report(datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries)
+    assert "23.03.2026" in html
+    assert "Mo" in html
+    assert "08:00" in html
+    assert "16:30" in html
+    assert "8.0h" in html
+    assert "<table" in html
+    assert "#0f172a" in html
+    assert "#00D8A7" in html
+
+
+def test_kategorie_column_present():
+    entries = {"2026-03-23": _e("08:00", "16:00", 0, "Büro")}
+    html, _ = generate_report(datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries)
+    assert "Kategorie" in html   # Spaltenkopf
+    assert "Büro" in html        # Wert
+
+
+def test_multiple_entries_sorted():
+    entries = {"2026-03-25": _e("09:00", "17:00", 30), "2026-03-23": _e("08:00", "16:30", 30)}
+    html, total = generate_report(datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries)
+    assert html.index("23.03.2026") < html.index("25.03.2026")
+
+
+def test_total_hours():
+    entries = {"2026-03-23": _e("08:00", "16:30", 30), "2026-03-24": _e("09:00", "17:00", 60)}
+    html, total = generate_report(datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries)
+    assert "15.0h" in html
+    assert total == 15.0
+
+
+def test_multi_slot_day_rows_and_subtotal():
+    """Ein Tag mit zwei Slots: beide Slots als Zeilen + Tages-Subtotal."""
+    entries = {"2026-03-23": {"slots": [
+        _slot("08:00", "12:00", 0, "Büro"),
+        _slot("13:00", "17:00", 0, "Homeoffice"),
+    ]}}
+    html, total = generate_report(datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries)
+    assert "08:00" in html and "12:00" in html
+    assert "13:00" in html and "17:00" in html
+    assert "Büro" in html and "Homeoffice" in html
+    assert "Summe 23.03.2026" in html   # Tages-Subtotal bei >1 Slot
+    assert total == 8.0
+
+
+def test_single_slot_day_has_no_subtotal():
+    entries = {"2026-03-23": _e("08:00", "16:00")}
+    html, _ = generate_report(datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries)
+    assert "Summe 23.03.2026" not in html
+
+
+def test_category_summary_block():
+    entries = {
+        "2026-03-23": {"slots": [_slot("08:00", "12:00", 0, "Büro"),
+                                  _slot("13:00", "17:00", 0, "Homeoffice")]},
+        "2026-03-24": _e("08:00", "12:00", 0, "Büro"),
+    }
+    html, _ = generate_report(datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries)
+    # Büro: 4h (Di) + 4h (Mo) = 8h; Homeoffice: 4h
+    assert "Büro" in html
+    assert "Homeoffice" in html
+    assert "8.0h" in html
+    assert "4.0h" in html
+
+
+def test_category_summary_uncategorized_label():
+    entries = {"2026-03-23": _e("08:00", "16:00")}  # kategorie ""
+    html, _ = generate_report(datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries)
+    assert "(ohne Kategorie)" in html
+
+
+def test_category_filter_includes_only_selected():
+    entries = {"2026-03-23": {"slots": [_slot("08:00", "12:00", 0, "Büro"),
+                                         _slot("13:00", "17:00", 0, "Homeoffice")]}}
+    html, total = generate_report(
+        datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries, categories={"Büro"})
+    assert "Büro" in html
+    assert "Homeoffice" not in html
+    assert total == 4.0
+
+
+def test_category_filter_uncategorized_via_empty_string():
+    entries = {"2026-03-23": {"slots": [_slot("08:00", "12:00", 0, ""),
+                                         _slot("13:00", "17:00", 0, "Büro")]}}
+    html, total = generate_report(
+        datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries, categories={""})
+    assert total == 4.0
+    assert "Büro" not in html
+
+
+def test_category_filter_empty_result_returns_none():
+    entries = {"2026-03-23": _e("08:00", "16:00", 0, "Büro")}
+    html, total = generate_report(
+        datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries, categories={"Nichtvorhanden"})
+    assert html is None
+    assert total == 0
+
+
+def test_filters_outside_range():
+    entries = {"2026-03-23": _e("08:00", "16:30"), "2026-04-01": _e("09:00", "17:00")}
+    html, total = generate_report(datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries)
+    assert "23.03.2026" in html
+    assert "01.04.2026" not in html
+
+
+def test_legacy_entry_no_pause():
+    # Slot ohne pause-Key (Default 0)
+    entries = {"2026-03-23": {"slots": [{"start": "08:00", "end": "16:30", "kategorie": ""}]}}
+    html, total = generate_report(datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries)
+    assert "8.5h" in html
+
+
+def test_cross_month_range():
+    entries = {
+        "2026-02-20": _e("08:00", "16:00"), "2026-03-05": _e("09:00", "17:00"),
+        "2026-03-20": _e("08:00", "16:00"),
+    }
+    html, total = generate_report(datetime.date(2026, 2, 15), datetime.date(2026, 3, 14), entries)
+    assert "20.02.2026" in html
+    assert "05.03.2026" in html
+    assert "20.03.2026" not in html
+
+
+def test_inclusive_boundaries():
+    entries = {
+        "2026-03-01": _e("08:00", "16:00"), "2026-03-15": _e("08:00", "16:00"),
+        "2026-03-16": _e("08:00", "16:00"),
+    }
+    html, total = generate_report(datetime.date(2026, 3, 1), datetime.date(2026, 3, 15), entries)
+    assert "01.03.2026" in html
+    assert "15.03.2026" in html
+    assert "16.03.2026" not in html
+
+
+def test_alternating_row_colors():
+    entries = {"2026-03-23": _e("08:00", "16:00"), "2026-03-24": _e("08:00", "16:00")}
+    html, total = generate_report(datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries)
+    assert "#1e293b" in html
+    assert "#243347" in html
+
+
+def test_greeting_content_closing_in_html():
+    entries = {"2026-03-23": _e("08:00", "16:00")}
+    html, total = generate_report(
+        datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries,
+        greeting="Hallo Welt,", content="hier die Zeiten für {zeitraum}.", closing="Grüße\nMax")
+    assert "Hallo Welt," in html
+    assert "hier die Zeiten für 01.03.2026 – 31.03.2026." in html
+    assert "Grüße" in html
+    assert "Max" in html
+
+
+def test_placeholders_replaced():
+    entries = {"2026-03-23": _e("08:00", "16:00")}
+    html, total = generate_report(
+        datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries, content="Gesamt: {gesamt}")
+    assert "Gesamt: 8.0h" in html
+
+
+def test_week_header_and_sum_present():
+    entries = {"2026-03-23": _e("08:00", "16:00")}
+    html, total = generate_report(datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries)
+    assert "KW 13" in html
+    assert "Summe KW 13" in html
+    assert "8.0h" in html
+
+
+def test_multiple_weeks_each_have_header_and_sum():
+    entries = {
+        "2026-03-23": _e("08:00", "16:00"), "2026-03-24": _e("09:00", "17:00"),
+        "2026-03-30": _e("08:00", "17:00", 60),
+    }
+    html, total = generate_report(datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries)
+    assert "KW 13" in html
+    assert "KW 14" in html
+    assert "Summe KW 13" in html
+    assert "Summe KW 14" in html
+    assert html.index("KW 13") < html.index("KW 14")
+
+
+def test_week_sum_equals_sum_of_days():
+    entries = {"2026-03-23": _e("08:00", "16:00"), "2026-03-24": _e("09:00", "17:00")}
+    html, total = generate_report(datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries)
+    assert "16.0h" in html
+    assert total == 16.0
+
+
+def test_iso_week_across_year_boundary():
+    entries = {"2025-12-29": _e("08:00", "16:00")}
+    html, total = generate_report(datetime.date(2025, 12, 1), datetime.date(2026, 1, 31), entries)
+    assert "KW 1" in html
+
+
+# --- HTML-Escaping ---
+
+
+def test_greeting_with_ampersand_is_escaped():
+    entries = {"2026-03-23": _e("08:00", "16:00")}
+    html, _ = generate_report(
+        datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries, greeting="Mayer & Söhne,")
+    assert "Mayer &amp; Söhne," in html
+    assert "Mayer & Söhne" not in html
+
+
+def test_greeting_with_html_tag_is_escaped():
+    entries = {"2026-03-23": _e("08:00", "16:00")}
+    html, _ = generate_report(
+        datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries,
+        greeting="<script>alert(1)</script>")
+    assert "&lt;script&gt;alert(1)&lt;/script&gt;" in html
+    assert "<script>alert(1)</script>" not in html
+
+
+def test_kategorie_is_escaped():
+    """Kategorie ist freier Nutzertext und muss escaped werden."""
+    entries = {"2026-03-23": _e("08:00", "16:00", 0, "Mayer & <b>Co</b>")}
+    html, _ = generate_report(datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries)
+    assert "Mayer &amp; &lt;b&gt;Co&lt;/b&gt;" in html
+    assert "<b>Co</b>" not in html
+
+
+def test_content_newline_becomes_br():
+    entries = {"2026-03-23": _e("08:00", "16:00")}
+    html, _ = generate_report(
+        datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries, content="Zeile1\nZeile2")
+    assert "Zeile1<br>Zeile2" in html
+
+
+def test_closing_with_lt_and_newline_escaped_with_br():
+    entries = {"2026-03-23": _e("08:00", "16:00")}
+    html, _ = generate_report(
+        datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries, closing="A < B\nFreundlich")
+    assert "A &lt; B<br>Freundlich" in html
+    assert "&lt;br&gt;" not in html
+
+
+def test_placeholder_zeitraum_replaced_after_escape():
+    entries = {"2026-03-23": _e("08:00", "16:00")}
+    html, _ = generate_report(
+        datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries, content="Zeitraum: {zeitraum}")
+    assert "Zeitraum: 01.03.2026 – 31.03.2026" in html
+
+
+def test_pdf_name_is_escaped():
+    """generate_pdf escaped name; xhtml2pdf wird gemockt (CI ohne Lib)."""
+    from src import report as report_mod
+    entries = {"2026-03-23": _e("08:00", "16:00")}
+    captured_html = {}
+
+    class FakePisa:
+        @staticmethod
+        def CreatePDF(html_str, dest):
+            captured_html["html"] = html_str
+            return MagicMock(err=0)
+
+    fake_xhtml2pdf = MagicMock()
+    fake_xhtml2pdf.pisa = FakePisa
+
+    with patch.dict("sys.modules", {"xhtml2pdf": fake_xhtml2pdf}):
+        report_mod.generate_pdf(
+            datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries, name="Müller & Co")
+
+    assert "Müller &amp; Co" in captured_html["html"]
+    assert "Müller & Co" not in captured_html["html"]
+
+
+def test_pdf_category_filter_applied():
+    """generate_pdf respektiert den categories-Filter."""
+    from src import report as report_mod
+    entries = {"2026-03-23": {"slots": [{"start": "08:00", "end": "12:00", "pause": 0, "kategorie": "Büro"},
+                                         {"start": "13:00", "end": "17:00", "pause": 0, "kategorie": "HO"}]}}
+    captured_html = {}
+
+    class FakePisa:
+        @staticmethod
+        def CreatePDF(html_str, dest):
+            captured_html["html"] = html_str
+            return MagicMock(err=0)
+
+    fake_xhtml2pdf = MagicMock()
+    fake_xhtml2pdf.pisa = FakePisa
+
+    with patch.dict("sys.modules", {"xhtml2pdf": fake_xhtml2pdf}):
+        report_mod.generate_pdf(
+            datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries, categories={"Büro"})
+
+    assert "Büro" in captured_html["html"]
+    assert "HO" not in captured_html["html"]
+```
+
+- [ ] **Step 2: Tests laufen lassen — müssen FEHLSCHLAGEN**
+
+Run: `python -m pytest tests/test_report.py -q`
+Expected: FAIL — `report.py` liest noch `entry["start"]` (KeyError, da Einträge jetzt `{"slots": [...]}`), und der `categories`-Parameter / Kategorie-Spalte / Summen-Block existieren noch nicht.
+
+- [ ] **Step 3: `src/report.py` neu schreiben**
+
+Ersetze den **kompletten** Inhalt von `src/report.py` durch:
+
+```python
+import datetime
+import html
+import io
+from collections import OrderedDict
+
+from src.time_utils import DAYS_DE, calculate_hours, get_week_label
+
+
+def _esc(text):
+    return html.escape(text or "", quote=True)
+
+
+def _esc_multiline(text):
+    return _esc(text).replace("\n", "<br>")
+
+
+COLUMN_LABELS = ["Datum", "Tag", "Kategorie", "Start", "Ende", "Stunden"]
+
+# Style-Dict pro Render-Ziel. Felder werden direkt als CSS-Strings in die
+# Inline-Styles der Zellen geschrieben.
+HTML_STYLE = {
+    "table_extra": "border-radius:8px;overflow:hidden;",
+    "th_row":      "background:#1e293b;",
+    "th_cell":     "padding:10px 14px;text-align:left;color:#94a3b8;font-size:12px;font-weight:600;text-transform:uppercase;letter-spacing:0.05em;",
+    "kw_row":      "background:#334155;",
+    "kw_cell":     "padding:10px 14px;color:#ffffff;font-weight:600;font-size:13px;letter-spacing:0.03em;",
+    "row_a":       "background:#1e293b;",
+    "row_b":       "background:#243347;",
+    "td_base":     "padding:10px 14px;border-bottom:1px solid rgba(255,255,255,0.08);",
+    "c_date":      "color:#cbd5e1;",
+    "c_day":       "color:#94a3b8;",
+    "c_kat":       "color:#94a3b8;",
+    "c_time":      "color:#cbd5e1;",
+    "c_hours":     "color:#00D8A7;font-weight:600;",
+    "sum_row":     "background:#263244;",
+    "sum_lbl":     "padding:10px 14px;color:#cbd5e1;font-weight:600;",
+    "sum_hrs":     "padding:10px 14px;color:#00D8A7;font-weight:700;",
+    "total_row":   "background:#334155;",
+    "total_lbl":   "padding:12px 14px;color:#ffffff;font-weight:700;",
+    "total_hrs":   "padding:12px 14px;color:#00D8A7;font-weight:700;font-size:15px;",
+}
+
+PDF_STYLE = {
+    "table_extra": "",
+    "th_row":      "background:#1e293b;",
+    "th_cell":     "padding:8px 12px;text-align:left;color:#ffffff;font-size:11px;font-weight:600;text-transform:uppercase;",
+    "kw_row":      "background:#e2e8f0;",
+    "kw_cell":     "padding:8px 12px;color:#111827;font-weight:700;font-size:12px;",
+    "row_a":       "background:#ffffff;",
+    "row_b":       "background:#f1f5f9;",
+    "td_base":     "padding:8px 12px;border-bottom:1px solid #d1d5db;",
+    "c_date":      "color:#111827;",
+    "c_day":       "color:#4b5563;",
+    "c_kat":       "color:#4b5563;",
+    "c_time":      "color:#111827;",
+    "c_hours":     "color:#111827;font-weight:600;",
+    "sum_row":     "background:#cbd5e1;",
+    "sum_lbl":     "padding:8px 12px;color:#111827;font-weight:700;",
+    "sum_hrs":     "padding:8px 12px;color:#111827;font-weight:700;",
+    "total_row":   "background:#1e293b;",
+    "total_lbl":   "padding:10px 12px;color:#ffffff;font-weight:700;",
+    "total_hrs":   "padding:10px 12px;color:#ffffff;font-weight:700;",
+}
+
+
+def _slot_hours(slot):
+    return round(calculate_hours(slot["start"], slot["end"], pause_minutes=slot.get("pause", 0)), 2)
+
+
+def _entry_hours(entry):
+    """Summe der Stunden über alle Slots eines Tages."""
+    return round(sum(_slot_hours(s) for s in entry.get("slots", [])), 2)
+
+
+def _group_by_week(range_entries):
+    """Group entries by ISO week, chronologically.
+
+    Returns OrderedDict keyed by (iso_year, iso_week), value is list of
+    (date_str, entry) tuples sorted by date.
+    """
+    groups = OrderedDict()
+    for date_str in sorted(range_entries.keys()):
+        entry = range_entries[date_str]
+        dt = datetime.date.fromisoformat(date_str)
+        iso = dt.isocalendar()
+        key = (iso.year, iso.week)
+        groups.setdefault(key, []).append((date_str, entry))
+    return groups
+
+
+def _filter_entries(date_from, date_to, all_entries):
+    from_str = date_from.isoformat()
+    to_str = date_to.isoformat()
+    range_entries = {
+        k: v for k, v in all_entries.items() if from_str <= k <= to_str
+    }
+    return range_entries if range_entries else None
+
+
+def _apply_category_filter(entries, categories):
+    """categories=None → unverändert. Sonst werden je Tag nur Slots behalten,
+    deren Kategorie (oder "" für ohne) in `categories` liegt; Tage ohne
+    verbleibende Slots fallen weg. Liefert ein neues Dict."""
+    if categories is None:
+        return entries
+    cats = set(categories)
+    out = {}
+    for date_str, entry in entries.items():
+        kept = [s for s in entry["slots"] if (s.get("kategorie") or "") in cats]
+        if kept:
+            out[date_str] = {"slots": kept}
+    return out
+
+
+def _apply_placeholders(text, label, total):
+    return text.replace("{zeitraum}", _esc(label)).replace("{gesamt}", _esc(f"{total}h"))
+
+
+# _week_block / _build_table / _build_category_summary rendern Werte aus dem
+# Storage. start/end/Datum/KW sind strukturell auf [0-9:.-] beschränkt (kein
+# Escape nötig). `kategorie` ist FREIER Nutzertext → wird mit _esc() escaped.
+def _week_block(iso_year, iso_week, week_entries, style):
+    """Render einen Wochen-Block: KW-Header, je Slot eine Zeile, Tages-Subtotal
+    bei >1 Slot, Wochensumme. Returns (rows_html, week_total)."""
+    s = style
+    rows = [
+        f"<tr style='{s['kw_row']}'>"
+        f"<td colspan='6' style='{s['kw_cell']}'>{get_week_label(iso_year, iso_week)}</td>"
+        f"</tr>"
+    ]
+
+    week_total = 0.0
+    for idx, (date_str, entry) in enumerate(week_entries):
+        dt = datetime.date.fromisoformat(date_str)
+        weekday = DAYS_DE[dt.weekday()]
+        day_fmt = dt.strftime("%d.%m.%Y")
+        row_bg = s["row_a"] if idx % 2 == 0 else s["row_b"]
+        td = s["td_base"]
+        slots = entry["slots"]
+        day_total = 0.0
+        for sidx, slot in enumerate(slots):
+            hours = _slot_hours(slot)
+            day_total += hours
+            week_total += hours
+            date_cell = day_fmt if sidx == 0 else ""
+            day_cell = weekday if sidx == 0 else ""
+            rows.append(
+                f"<tr style='{row_bg}'>"
+                f"<td style='{td}{s['c_date']}'>{date_cell}</td>"
+                f"<td style='{td}{s['c_day']}'>{day_cell}</td>"
+                f"<td style='{td}{s['c_kat']}'>{_esc(slot.get('kategorie') or '')}</td>"
+                f"<td style='{td}{s['c_time']}'>{slot['start']}</td>"
+                f"<td style='{td}{s['c_time']}'>{slot['end']}</td>"
+                f"<td style='{td}{s['c_hours']}'>{hours}h</td>"
+                f"</tr>"
+            )
+        if len(slots) > 1:
+            day_total = round(day_total, 2)
+            rows.append(
+                f"<tr style='{row_bg}'>"
+                f"<td colspan='5' style='{td}{s['c_day']}'>Summe {day_fmt}</td>"
+                f"<td style='{td}{s['c_hours']}'>{day_total}h</td>"
+                f"</tr>"
+            )
+
+    week_total = round(week_total, 2)
+    rows.append(
+        f"<tr style='{s['sum_row']}'>"
+        f"<td colspan='5' style='{s['sum_lbl']}'>Summe KW {iso_week}</td>"
+        f"<td style='{s['sum_hrs']}'>{week_total}h</td>"
+        f"</tr>"
+    )
+    return "\n".join(rows), week_total
+
+
+def _build_table(groups, style):
+    """Bauen die komplette Stundentabelle. Returns (table_html, total)."""
+    s = style
+    week_blocks = []
+    total = 0.0
+    for (iso_year, iso_week), week_entries in groups.items():
+        block_html, week_total = _week_block(iso_year, iso_week, week_entries, s)
+        week_blocks.append(block_html)
+        total += week_total
+    total = round(total, 2)
+
+    th_cells = "".join(
+        f'<th style="{s["th_cell"]}">{label}</th>' for label in COLUMN_LABELS
+    )
+
+    table = (
+        f'<table style="border-collapse:collapse;width:100%;{s["table_extra"]}">'
+        f'<tr style="{s["th_row"]}">{th_cells}</tr>'
+        f'{"".join(week_blocks)}'
+        f'<tr style="{s["total_row"]}">'
+        f'<td colspan="5" style="{s["total_lbl"]}">Gesamt</td>'
+        f'<td style="{s["total_hrs"]}">{total}h</td>'
+        f'</tr>'
+        f'</table>'
+    )
+    return table, total
+
+
+def _build_category_summary(range_entries, style):
+    """„Summe je Kategorie"-Tabelle über den (gefilterten) Zeitraum. Leerer
+    String ('' = keine Kategorie) wird als '(ohne Kategorie)' ans Ende
+    sortiert. Liefert '' wenn keine Slots vorhanden."""
+    s = style
+    totals = {}
+    for entry in range_entries.values():
+        for slot in entry["slots"]:
+            kat = slot.get("kategorie") or ""
+            totals[kat] = totals.get(kat, 0.0) + _slot_hours(slot)
+    if not totals:
+        return ""
+
+    td = s["td_base"]
+    rows = []
+    for idx, kat in enumerate(sorted(totals, key=lambda k: (k == "", k.lower()))):
+        label = kat if kat else "(ohne Kategorie)"
+        hours = round(totals[kat], 2)
+        row_bg = s["row_a"] if idx % 2 == 0 else s["row_b"]
+        rows.append(
+            f"<tr style='{row_bg}'>"
+            f"<td style='{td}{s['c_day']}'>{_esc(label)}</td>"
+            f"<td style='{td}{s['c_hours']}'>{hours}h</td>"
+            f"</tr>"
+        )
+
+    return (
+        f'<table style="border-collapse:collapse;width:100%;margin-top:16px;{s["table_extra"]}">'
+        f'<tr style="{s["th_row"]}">'
+        f'<th style="{s["th_cell"]}">Kategorie</th>'
+        f'<th style="{s["th_cell"]}">Stunden</th>'
+        f'</tr>'
+        f'{"".join(rows)}'
+        f'</table>'
+    )
+
+
+def generate_report(date_from, date_to, all_entries, greeting="", content="",
+                    closing="", categories=None):
+    """Generate an HTML email report with greeting, content, table, category
+    summary, and closing.
+
+    categories: None = alle; sonst Menge von Kategorie-Strings ('' = ohne).
+    Returns (html, total) tuple, or (None, 0) if no entries.
+    """
+    range_entries = _filter_entries(date_from, date_to, all_entries)
+    if range_entries:
+        range_entries = _apply_category_filter(range_entries, categories)
+    if not range_entries:
+        return None, 0
+
+    label = f"{date_from.strftime('%d.%m.%Y')} – {date_to.strftime('%d.%m.%Y')}"
+    groups = _group_by_week(range_entries)
+    table, total = _build_table(groups, HTML_STYLE)
+    category_summary = _build_category_summary(range_entries, HTML_STYLE)
+
+    greeting_filled = _apply_placeholders(_esc_multiline(greeting), label, total)
+    content_filled = _apply_placeholders(_esc_multiline(content), label, total)
+    closing_filled = _apply_placeholders(_esc_multiline(closing), label, total)
+
+    text_style = "color:#cbd5e1;font-size:14px;line-height:1.6;margin:0 0 16px 0;"
+    greeting_html = f'<p style="{text_style}">{greeting_filled}</p>' if greeting_filled else ""
+    content_html = f'<p style="{text_style}">{content_filled}</p>' if content_filled else ""
+    closing_html = f'<p style="{text_style}margin-top:24px;white-space:pre-line;">{closing_filled}</p>' if closing_filled else ""
+
+    html_out = f"""<html><head><meta charset="utf-8"><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head>
+<body style="margin:0;padding:0;background:#0f172a;font-family:'Segoe UI',Arial,sans-serif;">
+<div style="max-width:640px;margin:0 auto;padding:32px 24px;">
+{greeting_html}
+{content_html}
+{table}
+{category_summary}
+{closing_html}
+</div>
+</body></html>"""
+
+    return html_out, total
+
+
+def generate_pdf(date_from, date_to, all_entries, name="", categories=None):
+    """Generate a PDF of the time tracking table. Returns PDF bytes, or None if no entries."""
+    from xhtml2pdf import pisa
+
+    range_entries = _filter_entries(date_from, date_to, all_entries)
+    if range_entries:
+        range_entries = _apply_category_filter(range_entries, categories)
+    if not range_entries:
+        return None
+
+    label = f"{date_from.strftime('%d.%m.%Y')} – {date_to.strftime('%d.%m.%Y')}"
+    groups = _group_by_week(range_entries)
+    table, _ = _build_table(groups, PDF_STYLE)
+    category_summary = _build_category_summary(range_entries, PDF_STYLE)
+
+    name_html = (
+        f"<p style='color:#111827;font-size:13px;margin:0 0 2px 0;font-weight:600;'>{_esc(name)}</p>"
+        if name else ""
+    )
+
+    pdf_html = f"""<html><head><meta charset="utf-8"></head>
+<body style="margin:0;padding:20px;font-family:Arial,sans-serif;font-size:12px;color:#111827;">
+<h2 style="font-size:18px;margin:0 0 4px 0;color:#111827;">Zeiterfassung</h2>
+{name_html}
+<p style="color:#4b5563;font-size:12px;margin:0 0 16px 0;">{_esc(label)}</p>
+{table}
+{category_summary}
+</body></html>"""
+
+    buffer = io.BytesIO()
+    pisa.CreatePDF(pdf_html, dest=buffer)
+    return buffer.getvalue()
+```
+
+- [ ] **Step 4: Tests laufen lassen — müssen BESTEHEN**
+
+Run: `python -m pytest tests/test_report.py -q`
+Expected: PASS (alle Tests grün).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/report.py tests/test_report.py
+git commit -m "feat(report): Zeile pro Slot + Kategorie-Spalte/-Summen + Filter (#53)
+
+report rendert je Slot eine Zeile (Datum/Tag nur in erster Slot-Zeile),
+Tages-Subtotal bei >1 Slot, plus 'Summe je Kategorie'-Block. generate_report/
+generate_pdf bekommen categories-Filter (None=alle). Kategorie wird escaped.
+Teil von AP4.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: `send_dialog` — Kategorie-Auswahl
+
+**Files:**
+- Modify: `src/dialogs/send_dialog.py` (Import `CELL_BG`, Kategorie-Checkbox-Sektion, `categories` an `generate_report`/`generate_pdf` durchreichen, Button-Zeile verschieben)
+
+**Interfaces:**
+- Consumes: `generate_report(..., categories=...)` / `generate_pdf(..., categories=...)` (Task 1); `storage.get_all() -> {date: {"slots":[{...}]}}`.
+
+> **Keine automatisierten Tests** (Tkinter). Verifikation: Import-Smoke + Diff-Review + manueller lokaler Test.
+
+- [ ] **Step 1: Import `CELL_BG` ergänzen**
+
+In `src/dialogs/send_dialog.py`, im `from src.theme import (...)`-Block, ändere die Zeile
+
+```python
+    BG, FONT, TEXT,
+```
+
+zu
+
+```python
+    BG, CELL_BG, FONT, TEXT,
+```
+
+- [ ] **Step 2: Kategorie-Checkbox-Sektion + Button-Zeile verschieben**
+
+In `open_send_dialog`, ersetze den Abschnitt von `from_day, from_month, from_year = ...` bis vor `def do_send():` (aktuell):
+
+```python
+    from_day, from_month, from_year = build_date_row(0, "Von:", from_default)
+    to_day, to_month, to_year = build_date_row(1, "Bis:", today)
+
+    def do_send():
+```
+
+durch:
+
+```python
+    from_day, from_month, from_year = build_date_row(0, "Von:", from_default)
+    to_day, to_month, to_year = build_date_row(1, "Bis:", today)
+
+    # --- Kategorie-Auswahl ---
+    # Vorhandene Kategorien aus dem Bestand sammeln ("" = ohne Kategorie). Alle
+    # standardmäßig ausgewählt; sind alle ausgewählt, wird kein Filter gesetzt.
+    all_entries = storage.get_all()
+    present_categories = sorted(
+        {(s.get("kategorie") or "") for e in all_entries.values() for s in e["slots"]},
+        key=lambda k: (k == "", k.lower()),
+    )
+    category_vars = {}  # rohe Kategorie -> BooleanVar
+    if present_categories:
+        tk.Label(dialog, text="Kategorien:", font=FONT, bg=BG, fg=TEXT).grid(
+            row=2, column=0, padx=(10, 5), pady=(4, 8), sticky="nw")
+        cat_frame = tk.Frame(dialog, bg=BG)
+        cat_frame.grid(row=2, column=1, columnspan=5, padx=(0, 10), pady=(4, 8), sticky="w")
+        for kat in present_categories:
+            var = tk.BooleanVar(value=True)
+            category_vars[kat] = var
+            label = kat if kat else "(ohne Kategorie)"
+            tk.Checkbutton(
+                cat_frame, text=label, variable=var,
+                font=FONT, bg=BG, fg=TEXT, selectcolor=CELL_BG,
+                activebackground=BG, activeforeground=TEXT,
+                highlightthickness=0, bd=0, anchor="w",
+            ).pack(anchor="w")
+
+    def _selected_categories():
+        """None, wenn keine Kategorien existieren oder alle ausgewählt sind
+        (= kein Filter). Sonst die Menge der ausgewählten rohen Kategorien."""
+        if not category_vars:
+            return None
+        selected = {kat for kat, var in category_vars.items() if var.get()}
+        if len(selected) == len(category_vars):
+            return None
+        return selected
+
+    def do_send():
+```
+
+- [ ] **Step 3: `do_send` — `entries` wiederverwenden + `categories` durchreichen**
+
+In `do_send`, ersetze (aktuell):
+
+```python
+        entries = storage.get_all()
+
+        html, total = generate_report(
+            date_from, date_to, entries,
+            greeting=settings.get("mail_greeting"),
+            content=settings.get("mail_content"),
+            closing=settings.get("mail_closing"),
+        )
+```
+
+durch:
+
+```python
+        entries = all_entries
+        categories = _selected_categories()
+
+        html, total = generate_report(
+            date_from, date_to, entries,
+            greeting=settings.get("mail_greeting"),
+            content=settings.get("mail_content"),
+            closing=settings.get("mail_closing"),
+            categories=categories,
+        )
+```
+
+Und ersetze die PDF-Zeile (aktuell):
+
+```python
+            pdf_bytes = generate_pdf(date_from, date_to, entries, name=settings.get("name"))
+```
+
+durch:
+
+```python
+            pdf_bytes = generate_pdf(date_from, date_to, entries, name=settings.get("name"),
+                                     categories=categories)
+```
+
+- [ ] **Step 4: Button-Zeile von row=2 auf row=3 verschieben**
+
+In `open_send_dialog`, ändere (aktuell):
+
+```python
+    btn_frame = tk.Frame(dialog, bg=BG)
+    btn_frame.grid(row=2, column=0, columnspan=6, pady=12)
+```
+
+zu:
+
+```python
+    btn_frame = tk.Frame(dialog, bg=BG)
+    btn_frame.grid(row=3, column=0, columnspan=6, pady=12)
+```
+
+- [ ] **Step 5: Import-Smoke + Byte-Compile**
+
+Run: `python -c "import src.dialogs.send_dialog; print('ok')"`
+Expected: gibt `ok` aus.
+
+Run: `python -m py_compile src/dialogs/send_dialog.py`
+Expected: keine Ausgabe, Exit 0.
+
+- [ ] **Step 6: AP1–AP4-Regressionscheck**
+
+Run: `python -m pytest tests/test_storage.py tests/test_storage_migration.py tests/test_reservations.py tests/test_reservations_migration.py tests/test_settings.py tests/test_sync.py tests/test_time_calc.py tests/test_time_utils.py tests/test_report.py -q`
+Expected: PASS.
+
+> **Hinweis:** Voller `pytest`-Lauf bleibt erwartbar rot (share/ui/gcal offen). `send_dialog.py` hat keine Auto-Tests — manueller Test durch den Nutzer.
+
+- [ ] **Step 7: Manuelle Verifikations-Checkliste (in den Report, NICHT ausführen)**
+
+- Sende-Dialog zeigt unter Von/Bis eine „Kategorien:"-Sektion mit je einer Checkbox pro vorhandener Kategorie (+ „(ohne Kategorie)"), alle gesetzt.
+- Gibt es keine Kategorien im Bestand, fehlt die Sektion (kein leerer Block).
+- Eine Kategorie abwählen → PDF/Mail enthält nur die gewählten Kategorien.
+- Alle gewählt → unverändertes Verhalten (kein Filter).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/dialogs/send_dialog.py
+git commit -m "feat(ui): Kategorie-Auswahl im Sende-Dialog (#53)
+
+Checkbox je vorhandener Kategorie (+ '(ohne Kategorie)'), alle vorgewählt;
+die Auswahl wird als categories-Filter an generate_report/generate_pdf
+durchgereicht (alle gewählt = kein Filter). Teil von AP4.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+**1. Spec-Coverage (Spec-Abschnitt „Report (report.py)" + „send_dialog"):**
+- Zeile je Slot mit Spalten Datum/Tag/Kategorie/Start/Ende/Stunden → Task 1, `_week_block` ✓
+- Tages-Subtotal bei >1 Slot; KW-Summen + Gesamt wie bisher → Task 1 ✓
+- „Summe je Kategorie"-Block über den Zeitraum; „(ohne Kategorie)" → Task 1, `_build_category_summary` ✓
+- Kategorie-Filter in `generate_report`/`generate_pdf` (Slot-Ebene, Default alle) → Task 1, `_apply_category_filter` ✓
+- Tages-/KW-/Gesamt-Summen über Slots → `_slot_hours`/`_entry_hours`/`_week_block`/`_build_table` ✓
+- HTML + PDF konsistent (beide Pfade Kategorie-Spalte + Summen-Block + Filter) → Task 1 ✓
+- Kategorie escaped (freier Text) → `_esc(slot.kategorie)` + Test `test_kategorie_is_escaped` ✓
+- Sende-Dialog: Mehrfachauswahl der Kategorien, Default alle, Auswahl fließt in den Report → Task 2 ✓
+- Bewusst NICHT in AP4: Kategorie-Verwaltung (AP6), Share-Export-Filter (AP5), Kalender-Zellen (AP6).
+
+**2. Placeholder-Scan:** Keine TBD/TODO; vollständiger Code in jedem Step. ✓
+
+**3. Typ-Konsistenz:**
+- `generate_report(..., categories=None)` / `generate_pdf(..., categories=None)` — Signaturen in report.py, Tests und send_dialog identisch. ✓
+- `categories` = `set[str]|None`, `""` = ohne Kategorie — konsistent in `_apply_category_filter`, `_build_category_summary`, send_dialog `_selected_categories`. ✓
+- AP1-Shape `{date:{"slots":[{start,end,pause,kategorie}]}}` — gelesen in `_week_block`/`_build_category_summary`/`_apply_category_filter` und send_dialog `present_categories`. ✓
+- `CELL_BG` existiert in theme.py (verwendet in `apply_combobox_style`/`dark_entry`) und wird in send_dialog importiert. ✓

--- a/docs/superpowers/plans/2026-06-19-ap4-report-send-kategorien.md
+++ b/docs/superpowers/plans/2026-06-19-ap4-report-send-kategorien.md
@@ -758,11 +758,16 @@ durch:
     to_day, to_month, to_year = build_date_row(1, "Bis:", today)
 
     # --- Kategorie-Auswahl ---
-    # Vorhandene Kategorien aus dem Bestand sammeln ("" = ohne Kategorie). Alle
-    # standardmäßig ausgewählt; sind alle ausgewählt, wird kein Filter gesetzt.
+    # Kategorien aus dem Bestand UND der Settings-Pickliste sammeln ("" = ohne
+    # Kategorie). Alle standardmäßig ausgewählt; sind alle ausgewählt, wird kein
+    # Filter gesetzt. Bewusste Vereinfachung: die Liste wird NICHT auf den
+    # gewählten Zeitraum eingeschränkt (das bräuchte dynamisches Neu-Aufbauen bei
+    # Datumswechsel) — eine im Zeitraum nicht vorkommende Kategorie bleibt
+    # wirkungslos, daher unkritisch.
     all_entries = storage.get_all()
     present_categories = sorted(
-        {(s.get("kategorie") or "") for e in all_entries.values() for s in e["slots"]},
+        {(s.get("kategorie") or "") for e in all_entries.values() for s in e["slots"]}
+        | {c for c in (settings.get("categories") or [])},
         key=lambda k: (k == "", k.lower()),
     )
     category_vars = {}  # rohe Kategorie -> BooleanVar

--- a/docs/superpowers/plans/2026-06-19-ap5-share-v3.md
+++ b/docs/superpowers/plans/2026-06-19-ap5-share-v3.md
@@ -1,0 +1,1109 @@
+# AP5 — Share v3 (Slot-Format) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Das Teilen-/Import-Format (`src/share.py`) auf das Multi-Slot-Modell heben (Wire-Schema v3 mit Slot-Listen, Export-Kategorie-Filter), v1/v2-Dateien beim Lesen abwärtskompatibel in Slots wrappen, und die Import-/Export-UI (`import_dialog.py`, `share_dialog.py`) entsprechend anpassen.
+
+**Architecture:** `share.py` ist pure Logik (parse/validate/build/diff/apply) und voll testbar (Task 1). Das v3-Wire-Format führt je Tag eine Slot-Liste; v1/v2-Dateien werden beim Parsen in 1-Slot-Listen normalisiert, sodass die nachgelagerte Pipeline (Diff/Apply/UI) immer Slot-Records sieht. Die Dialoge sind dünne Tkinter-Schichten (Task 2).
+
+**Tech Stack:** Python stdlib, tkinter, pytest.
+
+## Global Constraints
+
+- **Wire-Format v3** (`SCHEMA_VERSION = 3`):
+  - `entries`: `{ "YYYY-MM-DD": {"slots": [{"start","end","pause","kategorie"}]} }`
+  - `reservations`: `{ "YYYY-MM-DD": {"slots": [{"start","end","kategorie"}]} }` (kein `pause`)
+- **Abwärtskompatibilität (Pflicht):** v1-Dateien (`entries` = `{start,end,pause}`, Pflichtfeld) und v2-Dateien (`entries`/`reservations` optional, alte Shape) bleiben importierbar. Beim Parsen werden ihre Records in **1-Slot-Listen** gewrappt (`kategorie=""`), sodass `parse_share_doc` immer Slot-Records liefert. v1/v2-**Validierung** bleibt unverändert (alte Shape wird wie bisher geprüft).
+- **`parse_share_doc`** lehnt `schema_version > 3` ab („neueren Version"), `schema_version < 1` ab. Der zurückgegebene `doc["schema_version"]` bleibt der Original-Wert (1/2/3); nur `entries`/`reservations` werden normalisiert.
+- **v3-Validierung:** je Record genau `{"slots": [...]}`; je Entry-Slot exakt die Keys `{start,end,pause,kategorie}` (pause int ≥ 0, kein bool; kategorie str); je Reservierungs-Slot exakt `{start,end,kategorie}`. Mind. eines von `entries`/`reservations` nicht-leer.
+- **Export-Kategorie-Filter:** `build_share_doc(..., categories=None)`. `None` = alle. Sonst werden je Tag nur Slots mit Kategorie (oder `""`) aus der Menge behalten; Tage ohne verbleibende Slots fallen weg. Gilt für `entries` UND `reservations`.
+- **Diff/Apply auf Slot-Ebene:** Gleichheit vergleicht reihenfolge-normalisierte Slot-Listen. `apply_import` schreibt `storage.save_many({date: {"slots":[...]}})`; `apply_reservation_import` schreibt `reservation_store.save(date, slots)`.
+- **AP1/AP4-Shapes:** `storage.get_all()` / `reservation_store.get_all()` liefern bereits Slot-Records; `storage.save_many`/`reservation_store.save` erwarten Slot-Listen.
+- **Datumsformat:** intern ISO; UI deutsch.
+- **Harter Schnitt (laufend):** Nur AP5-Dateien. Consumer außerhalb (ui, gcal) bleiben rot bis zu ihren Paketen.
+
+## Forward-Dependencies / Design-Notes (für den Plan-Review)
+
+- **Zwei Reservierungs-Import-Tests entfallen in AP5 und wandern nach AP7:** `test_apply_reservation_import_integration_keeps_event_id` und `test_apply_reservation_import_then_reconcile_plans_update`. Sie prüfen `gcal_event_id`-Erhalt über `save()` und die Integration mit `reservations_sync.merge_reservations` — beides hat AP1 verändert (save bewahrt keine event_ids mehr) bzw. ist noch nicht slot-fähig (gehört zu AP7). AP5 testet stattdessen, dass `apply_reservation_import` `save(date, slots)` korrekt aufruft. *(Zur Abnahme markiert.)*
+- **`import_dialog.py` ist die einzige record-shape-abhängige UI-Stelle:** nur `_PerDayDialog._fmt(rec)` liest `rec['start']/['end']/['pause']` — wird auf Slot-Rendering umgestellt. Diff-Counts/Decisions/Apply reichen Records transparent durch.
+- **Dialoge ohne Auto-Tests** (Tkinter/CI). Verifikation Task 2 = Import-Smoke + Diff-Review + manueller Test.
+
+---
+
+## Dateistruktur
+
+- `src/share.py` — komplette Neufassung (v3-Validatoren, v1/v2-Wrapping, build mit Filter, Slot-Diff/Apply). Verantwortung unverändert.
+- `tests/test_share.py` — auf v3 umgestellt; v1/v2-Accept-Tests prüfen gewrappte Slots; neue v3-/Filter-Tests; zwei AP7-Tests entfernt.
+- `src/dialogs/import_dialog.py` — `_PerDayDialog._fmt` rendert Slots.
+- `src/dialogs/share_dialog.py` — Kategorie-Auswahl beim Export, an `build_share_doc(categories=...)` durchgereicht.
+
+Task 1 (share.py + Tests) ist unabhängig testbar. Task 2 (Dialoge) konsumiert die neuen Signaturen/Shapes.
+
+---
+
+## Task 1: `share.py` v3 + Tests
+
+**Files:**
+- Modify: `src/share.py` (komplette Neufassung, siehe Step 3)
+- Test: `tests/test_share.py` (Neufassung, siehe Step 1)
+
+**Interfaces:**
+- Produces:
+  - `parse_share_doc(raw_bytes) -> doc` (entries/reservations als Slot-Records; v1/v2 gewrappt).
+  - `build_share_doc(storage, sender_email, *, reservation_store=None, include_entries=True, include_reservations=False, categories=None) -> doc`.
+  - `serialize_share_doc(doc) -> bytes` (unverändert).
+  - `diff_share_against_local(share_entries, storage, date_from=None, date_to=None)` / `diff_reservations_against_local(...)` (Slot-Records).
+  - `apply_import(storage, decisions)` (decisions `entry` = `{"slots":[...]}`); `apply_reservation_import(reservation_store, decisions)` (ruft `save(date, slots)`).
+
+- [ ] **Step 1: `tests/test_share.py` neu schreiben**
+
+Ersetze den **kompletten** Inhalt von `tests/test_share.py` durch:
+
+```python
+import datetime as _dt
+import json
+
+import pytest
+
+from src.share import (
+    KIND,
+    SCHEMA_VERSION,
+    ShareValidationError,
+    apply_import,
+    apply_reservation_import,
+    build_share_doc,
+    diff_reservations_against_local,
+    diff_share_against_local,
+    parse_share_doc,
+    serialize_share_doc,
+)
+
+
+def _bytes(obj):
+    return json.dumps(obj).encode("utf-8")
+
+
+def _eslot(start, end, pause=0, kategorie=""):
+    return {"start": start, "end": end, "pause": pause, "kategorie": kategorie}
+
+
+def _rslot(start, end, kategorie=""):
+    return {"start": start, "end": end, "kategorie": kategorie}
+
+
+def _erec(*slots):
+    return {"slots": list(slots)}
+
+
+def _v1(**fields):
+    base = {"kind": "zeiterfassung-share", "schema_version": 1}
+    base.update(fields)
+    return _bytes(base)
+
+
+def _v2(**fields):
+    base = {"kind": "zeiterfassung-share", "schema_version": 2}
+    base.update(fields)
+    return _bytes(base)
+
+
+def _v3(**fields):
+    base = {"kind": "zeiterfassung-share", "schema_version": 3}
+    base.update(fields)
+    return _bytes(base)
+
+
+# --- generische Header-Validierung ---
+
+
+def test_parse_rejects_broken_json():
+    with pytest.raises(ShareValidationError, match="JSON"):
+        parse_share_doc(b"{not json")
+
+
+def test_parse_rejects_non_object_toplevel():
+    with pytest.raises(ShareValidationError, match="JSON-Objekt"):
+        parse_share_doc(_bytes(["array", "instead"]))
+
+
+def test_parse_rejects_wrong_kind():
+    with pytest.raises(ShareValidationError, match="geteilte Zeiterfassung"):
+        parse_share_doc(_bytes({"kind": "something-else", "schema_version": 1, "entries": {}}))
+
+
+def test_parse_rejects_missing_kind():
+    with pytest.raises(ShareValidationError, match="geteilte Zeiterfassung"):
+        parse_share_doc(_bytes({"schema_version": 1, "entries": {}}))
+
+
+def test_parse_rejects_missing_schema_version():
+    with pytest.raises(ShareValidationError, match="schema_version"):
+        parse_share_doc(_bytes({"kind": "zeiterfassung-share", "entries": {}}))
+
+
+def test_parse_rejects_future_schema_version():
+    with pytest.raises(ShareValidationError, match="neueren Version"):
+        parse_share_doc(_bytes({"kind": "zeiterfassung-share", "schema_version": 4, "entries": {}}))
+
+
+def test_parse_rejects_past_schema_version():
+    with pytest.raises(ShareValidationError, match="schema_version"):
+        parse_share_doc(_bytes({"kind": "zeiterfassung-share", "schema_version": 0, "entries": {}}))
+
+
+# --- v1: alte Shape, beim Lesen in Slots gewrappt ---
+
+
+def test_parse_v1_entries_only_wrapped_into_slots():
+    doc = parse_share_doc(_v1(entries={"2026-05-14": {"start": "08:00", "end": "16:00", "pause": 0}}))
+    assert doc["schema_version"] == 1
+    assert doc["entries"] == {"2026-05-14": _erec(_eslot("08:00", "16:00", 0, ""))}
+
+
+def test_parse_v1_rejects_missing_entries():
+    with pytest.raises(ShareValidationError, match="entries"):
+        parse_share_doc(_v1())
+
+
+def test_parse_v1_rejects_bad_date_key():
+    with pytest.raises(ShareValidationError, match="Datum"):
+        parse_share_doc(_v1(entries={"not-a-date": {"start": "08:00", "end": "16:00", "pause": 0}}))
+
+
+def test_parse_v1_rejects_extra_entry_field():
+    with pytest.raises(ShareValidationError, match="unbekannt"):
+        parse_share_doc(_v1(entries={"2026-05-14": {"start": "08:00", "end": "16:00", "pause": 0, "deleted": True}}))
+
+
+def test_parse_v1_rejects_missing_entry_field():
+    with pytest.raises(ShareValidationError, match="fehlend"):
+        parse_share_doc(_v1(entries={"2026-05-14": {"start": "08:00", "end": "16:00"}}))
+
+
+def test_parse_v1_rejects_bad_time_format():
+    with pytest.raises(ShareValidationError, match="Startzeit"):
+        parse_share_doc(_v1(entries={"2026-05-14": {"start": "8:00", "end": "16:00", "pause": 0}}))
+
+
+def test_parse_v1_rejects_negative_pause():
+    with pytest.raises(ShareValidationError, match="Pause"):
+        parse_share_doc(_v1(entries={"2026-05-14": {"start": "08:00", "end": "16:00", "pause": -5}}))
+
+
+def test_parse_v1_rejects_bool_as_pause():
+    with pytest.raises(ShareValidationError, match="Pause"):
+        parse_share_doc(_v1(entries={"2026-05-14": {"start": "08:00", "end": "16:00", "pause": True}}))
+
+
+def test_parse_v1_rejects_bad_end_time():
+    with pytest.raises(ShareValidationError, match="Endzeit"):
+        parse_share_doc(_v1(entries={"2026-05-14": {"start": "08:00", "end": "16:0", "pause": 0}}))
+
+
+def test_parse_v1_rejects_unreal_time():
+    with pytest.raises(ShareValidationError, match="Startzeit"):
+        parse_share_doc(_v1(entries={"2026-05-14": {"start": "25:00", "end": "16:00", "pause": 0}}))
+
+
+# --- v2: alte Shape (entries+reservations), beim Lesen gewrappt ---
+
+
+def test_parse_v2_entries_only_wrapped():
+    doc = parse_share_doc(_v2(entries={"2026-05-14": {"start": "08:00", "end": "16:00", "pause": 0}}))
+    assert doc["entries"] == {"2026-05-14": _erec(_eslot("08:00", "16:00", 0, ""))}
+
+
+def test_parse_v2_reservations_only_wrapped():
+    doc = parse_share_doc(_v2(reservations={"2026-05-14": {"start": "08:00", "end": "12:00"}}))
+    assert doc["reservations"] == {"2026-05-14": _erec(_rslot("08:00", "12:00", ""))}
+
+
+def test_parse_v2_both_wrapped():
+    doc = parse_share_doc(_v2(
+        entries={"2026-05-14": {"start": "08:00", "end": "16:00", "pause": 0}},
+        reservations={"2026-05-15": {"start": "09:00", "end": "12:00"}},
+    ))
+    assert doc["entries"] == {"2026-05-14": _erec(_eslot("08:00", "16:00", 0, ""))}
+    assert doc["reservations"] == {"2026-05-15": _erec(_rslot("09:00", "12:00", ""))}
+
+
+def test_parse_v2_empty_entries_with_reservations_ok():
+    doc = parse_share_doc(_v2(entries={}, reservations={"2026-05-14": {"start": "08:00", "end": "12:00"}}))
+    assert doc["reservations"] == {"2026-05-14": _erec(_rslot("08:00", "12:00", ""))}
+
+
+def test_parse_v2_rejects_both_missing():
+    with pytest.raises(ShareValidationError, match="weder"):
+        parse_share_doc(_v2())
+
+
+def test_parse_v2_rejects_both_empty():
+    with pytest.raises(ShareValidationError, match="weder"):
+        parse_share_doc(_v2(entries={}, reservations={}))
+
+
+def test_parse_v2_reservation_rejects_pause_field():
+    with pytest.raises(ShareValidationError, match="unbekannt"):
+        parse_share_doc(_v2(reservations={"2026-05-14": {"start": "08:00", "end": "12:00", "pause": 0}}))
+
+
+def test_parse_v2_reservation_rejects_missing_field():
+    with pytest.raises(ShareValidationError, match="fehlend"):
+        parse_share_doc(_v2(reservations={"2026-05-14": {"start": "08:00"}}))
+
+
+def test_parse_v2_reservation_rejects_bad_time():
+    with pytest.raises(ShareValidationError, match="Startzeit"):
+        parse_share_doc(_v2(reservations={"2026-05-14": {"start": "25:00", "end": "12:00"}}))
+
+
+def test_parse_v2_reservation_rejects_bad_date_key():
+    with pytest.raises(ShareValidationError, match="Datum"):
+        parse_share_doc(_v2(reservations={"not-a-date": {"start": "08:00", "end": "12:00"}}))
+
+
+# --- v3: Slot-Format ---
+
+
+def test_parse_v3_entries_slots():
+    doc = parse_share_doc(_v3(entries={"2026-05-14": _erec(_eslot("08:00", "12:00", 0, "Büro"),
+                                                           _eslot("13:00", "17:00", 30, "HO"))}))
+    assert doc["entries"]["2026-05-14"]["slots"][0] == _eslot("08:00", "12:00", 0, "Büro")
+    assert doc["entries"]["2026-05-14"]["slots"][1] == _eslot("13:00", "17:00", 30, "HO")
+
+
+def test_parse_v3_reservations_slots():
+    doc = parse_share_doc(_v3(reservations={"2026-05-14": _erec(_rslot("09:00", "12:00", "Termin"))}))
+    assert doc["reservations"]["2026-05-14"]["slots"][0] == _rslot("09:00", "12:00", "Termin")
+
+
+def test_parse_v3_both():
+    doc = parse_share_doc(_v3(
+        entries={"2026-05-14": _erec(_eslot("08:00", "16:00", 0, ""))},
+        reservations={"2026-05-15": _erec(_rslot("09:00", "12:00", ""))},
+    ))
+    assert doc["entries"] and doc["reservations"]
+
+
+def test_parse_v3_rejects_both_missing():
+    with pytest.raises(ShareValidationError, match="weder"):
+        parse_share_doc(_v3())
+
+
+def test_parse_v3_rejects_record_without_slots_key():
+    with pytest.raises(ShareValidationError, match="slots"):
+        parse_share_doc(_v3(entries={"2026-05-14": {"start": "08:00", "end": "16:00", "pause": 0}}))
+
+
+def test_parse_v3_rejects_entry_slot_extra_field():
+    with pytest.raises(ShareValidationError, match="unbekannt"):
+        parse_share_doc(_v3(entries={"2026-05-14": {"slots": [
+            {"start": "08:00", "end": "16:00", "pause": 0, "kategorie": "", "x": 1}]}}))
+
+
+def test_parse_v3_rejects_entry_slot_missing_field():
+    with pytest.raises(ShareValidationError, match="fehlend"):
+        parse_share_doc(_v3(entries={"2026-05-14": {"slots": [
+            {"start": "08:00", "end": "16:00", "pause": 0}]}}))
+
+
+def test_parse_v3_rejects_entry_slot_bad_time():
+    with pytest.raises(ShareValidationError, match="Startzeit"):
+        parse_share_doc(_v3(entries={"2026-05-14": {"slots": [_eslot("25:00", "16:00", 0, "")]}}))
+
+
+def test_parse_v3_rejects_entry_slot_negative_pause():
+    with pytest.raises(ShareValidationError, match="Pause"):
+        parse_share_doc(_v3(entries={"2026-05-14": {"slots": [_eslot("08:00", "16:00", -1, "")]}}))
+
+
+def test_parse_v3_rejects_entry_slot_bool_pause():
+    with pytest.raises(ShareValidationError, match="Pause"):
+        parse_share_doc(_v3(entries={"2026-05-14": {"slots": [
+            {"start": "08:00", "end": "16:00", "pause": True, "kategorie": ""}]}}))
+
+
+def test_parse_v3_rejects_reservation_slot_with_pause():
+    with pytest.raises(ShareValidationError, match="unbekannt"):
+        parse_share_doc(_v3(reservations={"2026-05-14": {"slots": [
+            {"start": "08:00", "end": "12:00", "pause": 0, "kategorie": ""}]}}))
+
+
+def test_parse_v3_rejects_bad_date_key():
+    with pytest.raises(ShareValidationError, match="Datum"):
+        parse_share_doc(_v3(entries={"not-a-date": _erec(_eslot("08:00", "16:00", 0, ""))}))
+
+
+# --- build_share_doc ---
+
+
+class _FakeStorage:
+    def __init__(self, entries):
+        self._entries = entries
+
+    def get_all(self):
+        return dict(self._entries)
+
+
+class _FakeResStore:
+    def __init__(self, data):
+        self._d = data
+
+    def get_all(self):
+        return dict(self._d)
+
+
+def test_build_share_doc_basic():
+    storage = _FakeStorage({"2026-05-14": _erec(_eslot("08:00", "16:00", 30, "Büro"))})
+    doc = build_share_doc(storage, "alice@example.com")
+    assert doc["kind"] == KIND
+    assert doc["schema_version"] == SCHEMA_VERSION == 3
+    assert doc["exported_by"] == "alice@example.com"
+    assert doc["entries"] == {"2026-05-14": _erec(_eslot("08:00", "16:00", 30, "Büro"))}
+    assert "exported_at" in doc and doc["exported_at"].endswith("Z")
+
+
+def test_build_share_doc_none_sender_becomes_empty_string():
+    doc = build_share_doc(_FakeStorage({}), None)
+    assert doc["exported_by"] == ""
+
+
+def test_build_doc_entries_only_omits_reservations():
+    doc = build_share_doc(_FakeStorage({"2026-05-14": _erec(_eslot("08:00", "16:00", 0, ""))}), "a@b.de")
+    assert "entries" in doc
+    assert "reservations" not in doc
+    assert doc["schema_version"] == 3
+
+
+def test_build_doc_reservations_only():
+    storage = _FakeStorage({"2026-05-14": _erec(_eslot("08:00", "16:00", 0, ""))})
+    res = _FakeResStore({"2026-05-15": _erec(_rslot("09:00", "12:00", ""))})
+    doc = build_share_doc(storage, "a@b.de", reservation_store=res,
+                          include_entries=False, include_reservations=True)
+    assert "entries" not in doc
+    assert doc["reservations"] == {"2026-05-15": _erec(_rslot("09:00", "12:00", ""))}
+
+
+def test_build_doc_category_filter_entries():
+    storage = _FakeStorage({"2026-05-14": _erec(_eslot("08:00", "12:00", 0, "Büro"),
+                                                _eslot("13:00", "17:00", 0, "HO"))})
+    doc = build_share_doc(storage, "a@b.de", categories={"Büro"})
+    assert doc["entries"] == {"2026-05-14": _erec(_eslot("08:00", "12:00", 0, "Büro"))}
+
+
+def test_build_doc_category_filter_drops_empty_days():
+    storage = _FakeStorage({"2026-05-14": _erec(_eslot("08:00", "12:00", 0, "Büro"))})
+    doc = build_share_doc(storage, "a@b.de", categories={"Nichtvorhanden"})
+    assert doc["entries"] == {}
+
+
+def test_round_trip_build_serialize_parse():
+    storage = _FakeStorage({
+        "2026-05-14": _erec(_eslot("08:00", "16:00", 30, "Büro")),
+        "2026-05-15": _erec(_eslot("09:00", "17:30", 45, "")),
+    })
+    doc = build_share_doc(storage, "alice@example.com")
+    parsed = parse_share_doc(serialize_share_doc(doc))
+    assert parsed["entries"] == doc["entries"]
+    assert parsed["schema_version"] == SCHEMA_VERSION
+
+
+def test_serialize_utf8_umlauts():
+    doc = build_share_doc(_FakeStorage({"2026-05-14": _erec(_eslot("08:00", "16:00", 0, "Büro"))}),
+                          "äöü@example.com")
+    payload = serialize_share_doc(doc)
+    assert b"\\u" not in payload
+    assert parse_share_doc(payload)["exported_by"] == "äöü@example.com"
+
+
+# --- diff (Arbeitszeiten) ---
+
+
+def test_diff_only_additions():
+    share = {"2026-05-14": _erec(_eslot("08:00", "16:00", 30, ""))}
+    diff = diff_share_against_local(share, _FakeStorage({}))
+    assert diff["additions"] == [("2026-05-14", _erec(_eslot("08:00", "16:00", 30, "")))]
+    assert diff["conflicts"] == []
+    assert diff["untouched"] == []
+
+
+def test_diff_only_untouched():
+    local = {"2026-05-14": _erec(_eslot("08:00", "16:00", 30, ""))}
+    share = {"2026-05-14": _erec(_eslot("08:00", "16:00", 30, ""))}
+    diff = diff_share_against_local(share, _FakeStorage(local))
+    assert diff["untouched"] == ["2026-05-14"]
+    assert diff["conflicts"] == []
+
+
+def test_diff_slot_reorder_is_untouched():
+    local = {"2026-05-14": _erec(_eslot("08:00", "12:00", 0, "A"), _eslot("13:00", "17:00", 0, "B"))}
+    share = {"2026-05-14": _erec(_eslot("13:00", "17:00", 0, "B"), _eslot("08:00", "12:00", 0, "A"))}
+    diff = diff_share_against_local(share, _FakeStorage(local))
+    assert diff["untouched"] == ["2026-05-14"]
+
+
+def test_diff_category_difference_is_conflict():
+    local = {"2026-05-14": _erec(_eslot("08:00", "16:00", 30, "Büro"))}
+    share = {"2026-05-14": _erec(_eslot("08:00", "16:00", 30, "HO"))}
+    diff = diff_share_against_local(share, _FakeStorage(local))
+    assert len(diff["conflicts"]) == 1
+    assert diff["untouched"] == []
+
+
+def test_diff_pause_difference_is_conflict():
+    local = {"2026-05-14": _erec(_eslot("08:00", "16:00", 30, ""))}
+    share = {"2026-05-14": _erec(_eslot("08:00", "16:00", 45, ""))}
+    diff = diff_share_against_local(share, _FakeStorage(local))
+    assert len(diff["conflicts"]) == 1
+
+
+def test_diff_range_filter_inclusive_bounds():
+    share = {"2026-05-10": _erec(_eslot("08:00", "16:00", 0, "")),
+             "2026-05-15": _erec(_eslot("08:00", "16:00", 0, ""))}
+    diff = diff_share_against_local(share, _FakeStorage({}),
+                                    date_from=_dt.date(2026, 5, 10), date_to=_dt.date(2026, 5, 15))
+    assert len(diff["additions"]) == 2
+    assert diff["out_of_range"] == 0
+
+
+def test_diff_range_filter_excludes_outside():
+    share = {"2026-05-10": _erec(_eslot("08:00", "16:00", 0, "")),
+             "2026-05-15": _erec(_eslot("08:00", "16:00", 0, ""))}
+    diff = diff_share_against_local(share, _FakeStorage({}), date_from=_dt.date(2026, 5, 12))
+    assert [d for d, _ in diff["additions"]] == ["2026-05-15"]
+    assert diff["out_of_range"] == 1
+
+
+# --- apply (Arbeitszeiten) ---
+
+
+class _RecordingStorage:
+    def __init__(self):
+        self.save_many_calls = []
+
+    def save_many(self, updates):
+        self.save_many_calls.append(dict(updates))
+
+
+def test_apply_import_single_call_for_all_decisions():
+    s = _RecordingStorage()
+    apply_import(s, [
+        {"date": "2026-05-14", "entry": _erec(_eslot("08:00", "16:00", 30, "Büro"))},
+        {"date": "2026-05-15", "entry": _erec(_eslot("09:00", "17:00", 0, ""))},
+    ])
+    assert len(s.save_many_calls) == 1
+    assert s.save_many_calls[0] == {
+        "2026-05-14": _erec(_eslot("08:00", "16:00", 30, "Büro")),
+        "2026-05-15": _erec(_eslot("09:00", "17:00", 0, "")),
+    }
+
+
+def test_apply_import_integration_with_real_storage(tmp_path):
+    from src.storage import Storage
+    s = Storage(str(tmp_path / "z.json"), device_id="dev1")
+    s.save("2026-05-14", [_eslot("08:00", "16:00", 30, "")])
+    apply_import(s, [
+        {"date": "2026-05-15", "entry": _erec(_eslot("09:00", "17:00", 0, ""))},
+        {"date": "2026-05-14", "entry": _erec(_eslot("10:00", "18:00", 45, "Büro"))},
+    ])
+    entries = s.get_all()
+    assert entries["2026-05-14"] == _erec(_eslot("10:00", "18:00", 45, "Büro"))
+    assert entries["2026-05-15"] == _erec(_eslot("09:00", "17:00", 0, ""))
+
+
+# --- diff + apply (Reservierungen) ---
+
+
+def test_diff_reservations_additions_and_conflicts():
+    store = _FakeResStore({"2026-05-14": _erec(_rslot("08:00", "12:00", ""))})
+    share = {
+        "2026-05-14": _erec(_rslot("09:00", "12:00", "")),  # conflict
+        "2026-05-16": _erec(_rslot("10:00", "14:00", "")),  # addition
+    }
+    diff = diff_reservations_against_local(share, store)
+    assert [d for d, _ in diff["additions"]] == ["2026-05-16"]
+    assert [d for d, _l, _s in diff["conflicts"]] == ["2026-05-14"]
+
+
+def test_diff_reservations_untouched():
+    store = _FakeResStore({"2026-05-14": _erec(_rslot("08:00", "12:00", ""))})
+    share = {"2026-05-14": _erec(_rslot("08:00", "12:00", ""))}
+    diff = diff_reservations_against_local(share, store)
+    assert diff["untouched"] == ["2026-05-14"]
+
+
+class _RecordingResStore:
+    def __init__(self):
+        self.saved = []
+
+    def save(self, date_str, slots):
+        self.saved.append((date_str, slots))
+
+
+def test_apply_reservation_import_calls_save_with_slots():
+    store = _RecordingResStore()
+    apply_reservation_import(store, [
+        {"date": "2026-05-14", "entry": _erec(_rslot("08:00", "12:00", "Termin"))},
+        {"date": "2026-05-15", "entry": _erec(_rslot("09:00", "13:00", ""))},
+    ])
+    assert store.saved == [
+        ("2026-05-14", [_rslot("08:00", "12:00", "Termin")]),
+        ("2026-05-15", [_rslot("09:00", "13:00", "")]),
+    ]
+
+
+def test_apply_reservation_import_empty_is_noop():
+    store = _RecordingResStore()
+    apply_reservation_import(store, [])
+    assert store.saved == []
+```
+
+- [ ] **Step 2: Tests laufen lassen — müssen FEHLSCHLAGEN**
+
+Run: `python -m pytest tests/test_share.py -q`
+Expected: FAIL — `SCHEMA_VERSION` ist noch 2, v3-Validatoren / Wrapping / `categories`-Param / Slot-Diff existieren nicht; `apply_reservation_import` ruft noch `save(date, start, end)`.
+
+- [ ] **Step 3: `src/share.py` neu schreiben**
+
+Ersetze den **kompletten** Inhalt von `src/share.py` durch:
+
+```python
+"""Arbeitszeiten teilen + importieren — pure functions, kein UI-Import.
+
+Wire-Format v3 (Slot-Listen):
+{
+  "schema_version": 3,
+  "kind": "zeiterfassung-share",
+  "exported_at": "<UTC-ISO>",
+  "exported_by": "<email or empty>",
+  "entries":      {"YYYY-MM-DD": {"slots": [{"start","end","pause":int>=0,"kategorie":str}]}},
+  "reservations": {"YYYY-MM-DD": {"slots": [{"start","end","kategorie":str}]}}
+}
+
+Beide Felder sind optional, aber mind. eines muss nicht-leer sein.
+v1-Dateien ({start,end,pause}/Tag, Pflichtfeld) und v2-Dateien (entries +
+reservations, alte Shape) werden beim Lesen weiterhin akzeptiert und in
+1-Slot-Listen (kategorie="") gewrappt (Abwärtskompatibilität).
+"""
+
+import datetime
+import json
+import re
+
+
+SCHEMA_VERSION = 3
+KIND = "zeiterfassung-share"
+
+_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+_TIME_RE = re.compile(r"^\d{2}:\d{2}$")
+
+# Alte (v1/v2) Record-Keys:
+_LEGACY_ENTRY_KEYS = frozenset({"start", "end", "pause"})
+_LEGACY_RESERVATION_KEYS = frozenset({"start", "end"})
+# v3-Slot-Keys:
+_ENTRY_SLOT_KEYS = frozenset({"start", "end", "pause", "kategorie"})
+_RESERVATION_SLOT_KEYS = frozenset({"start", "end", "kategorie"})
+
+
+def _utc_now_iso():
+    return datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+class ShareValidationError(Exception):
+    """Datei kann nicht importiert werden. `.reason` enthält den deutschen Grund."""
+
+    def __init__(self, reason):
+        super().__init__(reason)
+        self.reason = reason
+
+
+def _validate_time(date_str, label, value):
+    if not isinstance(value, str) or not _TIME_RE.match(value):
+        raise ShareValidationError(f"Eintrag {date_str}: ungültige {label} {value!r}")
+    try:
+        datetime.time.fromisoformat(value)
+    except ValueError:
+        raise ShareValidationError(f"Eintrag {date_str}: ungültige {label} {value!r}")
+
+
+def _validate_date_key(date_str):
+    if not isinstance(date_str, str) or not _DATE_RE.match(date_str):
+        raise ShareValidationError(f"Ungültiger Datums-Key: {date_str!r}")
+    try:
+        datetime.date.fromisoformat(date_str)
+    except ValueError:
+        raise ShareValidationError(f"Ungültiges Datum: {date_str!r}")
+
+
+def _check_keys(date_str, obj, expected_keys, label="Eintrag"):
+    if not isinstance(obj, dict):
+        raise ShareValidationError(f"{label} {date_str} ist kein Objekt.")
+    keys = set(obj.keys())
+    if keys != expected_keys:
+        extras = sorted(keys - expected_keys)
+        missing = sorted(expected_keys - keys)
+        parts = []
+        if extras:
+            parts.append(f"unbekannte Felder: {extras}")
+        if missing:
+            parts.append(f"fehlende Felder: {missing}")
+        raise ShareValidationError(f"{label} {date_str}: {'; '.join(parts)}")
+
+
+def _validate_pause(date_str, pause):
+    if not isinstance(pause, int) or isinstance(pause, bool) or pause < 0:
+        raise ShareValidationError(f"Eintrag {date_str}: ungültige Pause {pause!r}")
+
+
+def _validate_kategorie(date_str, kategorie):
+    if not isinstance(kategorie, str):
+        raise ShareValidationError(f"Eintrag {date_str}: ungültige Kategorie {kategorie!r}")
+
+
+# --- v1/v2 (alte Shape) ---
+
+def _validate_legacy_entries(entries):
+    for date_str, entry in entries.items():
+        _validate_date_key(date_str)
+        _check_keys(date_str, entry, _LEGACY_ENTRY_KEYS)
+        _validate_time(date_str, "Startzeit", entry["start"])
+        _validate_time(date_str, "Endzeit", entry["end"])
+        _validate_pause(date_str, entry["pause"])
+
+
+def _validate_legacy_reservations(reservations):
+    for date_str, entry in reservations.items():
+        _validate_date_key(date_str)
+        _check_keys(date_str, entry, _LEGACY_RESERVATION_KEYS, label="Reservierung")
+        _validate_time(date_str, "Startzeit", entry["start"])
+        _validate_time(date_str, "Endzeit", entry["end"])
+
+
+def _wrap_legacy_entries(entries):
+    return {
+        d: {"slots": [{"start": e["start"], "end": e["end"],
+                       "pause": e["pause"], "kategorie": ""}]}
+        for d, e in entries.items()
+    }
+
+
+def _wrap_legacy_reservations(reservations):
+    return {
+        d: {"slots": [{"start": r["start"], "end": r["end"], "kategorie": ""}]}
+        for d, r in reservations.items()
+    }
+
+
+# --- v3 (Slot-Shape) ---
+
+def _validate_slot_record(date_str, record, slot_keys, has_pause):
+    if not isinstance(record, dict) or set(record.keys()) != {"slots"}:
+        raise ShareValidationError(f"Eintrag {date_str}: erwartet {{\"slots\": [...]}}.")
+    if not isinstance(record["slots"], list):
+        raise ShareValidationError(f"Eintrag {date_str}: 'slots' ist keine Liste.")
+    for slot in record["slots"]:
+        _check_keys(date_str, slot, slot_keys, label="Slot")
+        _validate_time(date_str, "Startzeit", slot["start"])
+        _validate_time(date_str, "Endzeit", slot["end"])
+        if has_pause:
+            _validate_pause(date_str, slot["pause"])
+        _validate_kategorie(date_str, slot["kategorie"])
+
+
+def _validate_v3_entries(entries):
+    for date_str, record in entries.items():
+        _validate_date_key(date_str)
+        _validate_slot_record(date_str, record, _ENTRY_SLOT_KEYS, has_pause=True)
+
+
+def _validate_v3_reservations(reservations):
+    for date_str, record in reservations.items():
+        _validate_date_key(date_str)
+        _validate_slot_record(date_str, record, _RESERVATION_SLOT_KEYS, has_pause=False)
+
+
+def parse_share_doc(raw_bytes):
+    """Parst und validiert Share-File-Inhalt. Wirft ShareValidationError bei
+    jeder Schema-Verletzung. Der zurückgegebene doc hat entries/reservations
+    immer als Slot-Records (v1/v2 werden gewrappt)."""
+    try:
+        doc = json.loads(raw_bytes)
+    except (ValueError, TypeError) as e:
+        raise ShareValidationError(f"Datei ist kein gültiges JSON: {e}")
+
+    if not isinstance(doc, dict):
+        raise ShareValidationError("Datei-Inhalt ist kein JSON-Objekt.")
+
+    if doc.get("kind") != KIND:
+        raise ShareValidationError("Diese Datei ist keine geteilte Zeiterfassung.")
+
+    schema_version = doc.get("schema_version")
+    if not isinstance(schema_version, int) or isinstance(schema_version, bool):
+        raise ShareValidationError("Fehlende oder ungültige schema_version.")
+    if schema_version > SCHEMA_VERSION:
+        raise ShareValidationError(
+            "Diese Datei wurde mit einer neueren Version erstellt. "
+            "Bitte App aktualisieren."
+        )
+    if schema_version < 1:
+        raise ShareValidationError(f"Unbekannte schema_version: {schema_version}")
+
+    entries = doc.get("entries")
+    reservations = doc.get("reservations")
+
+    if schema_version == 1:
+        # v1: nur entries, Pflichtfeld, alte Shape → wrappen.
+        if not isinstance(entries, dict):
+            raise ShareValidationError("Feld 'entries' fehlt oder ist kein Objekt.")
+        _validate_legacy_entries(entries)
+        doc["entries"] = _wrap_legacy_entries(entries)
+        return doc
+
+    if schema_version == 2:
+        # v2: entries + reservations optional, alte Shape → wrappen.
+        if entries is not None:
+            if not isinstance(entries, dict):
+                raise ShareValidationError("Feld 'entries' ist kein Objekt.")
+            _validate_legacy_entries(entries)
+        if reservations is not None:
+            if not isinstance(reservations, dict):
+                raise ShareValidationError("Feld 'reservations' ist kein Objekt.")
+            _validate_legacy_reservations(reservations)
+        if not entries and not reservations:
+            raise ShareValidationError("Datei enthält weder Arbeitszeiten noch Reservierungen.")
+        if entries is not None:
+            doc["entries"] = _wrap_legacy_entries(entries)
+        if reservations is not None:
+            doc["reservations"] = _wrap_legacy_reservations(reservations)
+        return doc
+
+    # v3: Slot-Shape.
+    if entries is not None:
+        if not isinstance(entries, dict):
+            raise ShareValidationError("Feld 'entries' ist kein Objekt.")
+        _validate_v3_entries(entries)
+    if reservations is not None:
+        if not isinstance(reservations, dict):
+            raise ShareValidationError("Feld 'reservations' ist kein Objekt.")
+        _validate_v3_reservations(reservations)
+    if not entries and not reservations:
+        raise ShareValidationError("Datei enthält weder Arbeitszeiten noch Reservierungen.")
+    return doc
+
+
+def _filter_records_by_category(records, categories):
+    """categories=None → unverändert. Sonst je Tag nur Slots behalten, deren
+    Kategorie (oder "") in `categories` liegt; leere Tage fallen weg."""
+    if categories is None:
+        return records
+    cats = set(categories)
+    out = {}
+    for date_str, record in records.items():
+        kept = [s for s in record["slots"] if (s.get("kategorie") or "") in cats]
+        if kept:
+            out[date_str] = {"slots": kept}
+    return out
+
+
+def build_share_doc(storage, sender_email, *, reservation_store=None,
+                    include_entries=True, include_reservations=False, categories=None):
+    """Baut das v3-Share-Doc aus den Slot-Records von Storage/ReservationStore.
+
+    include_entries / include_reservations steuern die Typen. categories=None →
+    alle; sonst werden Slots auf die Kategorie-Menge gefiltert ('' = ohne)."""
+    doc = {
+        "schema_version": SCHEMA_VERSION,
+        "kind": KIND,
+        "exported_at": _utc_now_iso(),
+        "exported_by": sender_email or "",
+    }
+    if include_entries:
+        doc["entries"] = _filter_records_by_category(dict(storage.get_all()), categories)
+    if include_reservations and reservation_store is not None:
+        doc["reservations"] = _filter_records_by_category(
+            dict(reservation_store.get_all()), categories)
+    return doc
+
+
+def serialize_share_doc(doc):
+    """Stabiles UTF-8-JSON, sortierte Keys (deterministisch für Tests)."""
+    return json.dumps(doc, indent=2, ensure_ascii=False, sort_keys=True).encode("utf-8")
+
+
+def _slot_signature(slots, keys):
+    """Reihenfolge-normalisierte Signatur einer Slot-Liste über `keys`."""
+    return sorted(tuple(s.get(k) for k in keys) for s in (slots or []))
+
+
+def _entries_equal(a, b):
+    return (_slot_signature(a.get("slots"), ("start", "end", "pause", "kategorie"))
+            == _slot_signature(b.get("slots"), ("start", "end", "pause", "kategorie")))
+
+
+def _reservations_equal(a, b):
+    return (_slot_signature(a.get("slots"), ("start", "end", "kategorie"))
+            == _slot_signature(b.get("slots"), ("start", "end", "kategorie")))
+
+
+def _diff_records(share_records, local_snapshot, equal_fn, date_from=None, date_to=None):
+    """Typ-neutraler Diff zwischen Share-Records und lokalem Snapshot.
+
+    Rückgabe: additions / conflicts / untouched / out_of_range.
+    """
+    additions = []
+    conflicts = []
+    untouched = []
+    out_of_range = 0
+
+    for date_str in sorted(share_records.keys()):
+        try:
+            d = datetime.date.fromisoformat(date_str)
+        except ValueError:
+            continue
+        if date_from is not None and d < date_from:
+            out_of_range += 1
+            continue
+        if date_to is not None and d > date_to:
+            out_of_range += 1
+            continue
+
+        share_rec = share_records[date_str]
+        local_rec = local_snapshot.get(date_str)
+        if local_rec is None:
+            additions.append((date_str, share_rec))
+        elif equal_fn(local_rec, share_rec):
+            untouched.append(date_str)
+        else:
+            conflicts.append((date_str, local_rec, share_rec))
+
+    return {
+        "additions": additions,
+        "conflicts": conflicts,
+        "untouched": untouched,
+        "out_of_range": out_of_range,
+    }
+
+
+def diff_share_against_local(share_entries, storage, date_from=None, date_to=None):
+    """Arbeitszeiten-Diff (Slot-Records)."""
+    return _diff_records(
+        share_entries, storage.get_all(), _entries_equal, date_from, date_to)
+
+
+def diff_reservations_against_local(share_reservations, reservation_store,
+                                    date_from=None, date_to=None):
+    """Reservierungs-Diff gegen den ReservationStore-Snapshot (Slot-Records)."""
+    return _diff_records(
+        share_reservations, reservation_store.get_all(),
+        _reservations_equal, date_from, date_to)
+
+
+def apply_reservation_import(reservation_store, decisions):
+    """Schreibt importierte Reservierungen (Slot-Records) in den Store.
+
+    decisions: list of {"date": "YYYY-MM-DD", "entry": {"slots": [...]}}.
+    Der gcal_event_id-Erhalt / Reconcile-Abgleich passiert separat im
+    Kalender-Reconcile (nicht hier)."""
+    for d in decisions:
+        reservation_store.save(d["date"], d["entry"]["slots"])
+
+
+def apply_import(storage, decisions):
+    """Wendet Import-Decisions atomar an (ein save_many-Aufruf).
+
+    decisions: list of {"date": "YYYY-MM-DD", "entry": {"slots": [...]}}.
+    """
+    updates = {d["date"]: d["entry"] for d in decisions}
+    storage.save_many(updates)
+```
+
+- [ ] **Step 4: Tests laufen lassen — müssen BESTEHEN**
+
+Run: `python -m pytest tests/test_share.py -q`
+Expected: PASS (alle Tests grün).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/share.py tests/test_share.py
+git commit -m "feat(share): Wire-Format v3 (Slot-Listen) + v1/v2-Wrap + Kategorie-Filter (#53)
+
+share v3: entries/reservations als Slot-Listen; v1/v2-Dateien beim Parsen in
+1-Slot-Listen gewrappt (Abwärtskompat). build_share_doc(categories=...) filtert
+beim Export; Diff vergleicht reihenfolge-normalisierte Slots; apply_*_import
+schreiben Slot-Listen. Teil von AP5.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Import-/Export-Dialog auf Slots
+
+**Files:**
+- Modify: `src/dialogs/import_dialog.py` (`_PerDayDialog._fmt` rendert Slots)
+- Modify: `src/dialogs/share_dialog.py` (Kategorie-Auswahl beim Export, `categories` durchreichen)
+
+**Interfaces:**
+- Consumes: v3-`share.py` (Task 1); `storage.get_all()`/`reservation_store.get_all()` (Slot-Records); `settings.get("categories")`.
+
+> **Keine automatisierten Tests** (Tkinter). Verifikation: Import-Smoke + Diff-Review + manueller Test.
+
+- [ ] **Step 1: `import_dialog.py` — `_PerDayDialog._fmt` auf Slots umstellen**
+
+In `src/dialogs/import_dialog.py`, ersetze die Methode `_fmt` (aktuell):
+
+```python
+    def _fmt(self, rec):
+        if self.has_pause:
+            return f"{rec['start']}—{rec['end']} (P{rec.get('pause', 0)})"
+        return f"{rec['start']}—{rec['end']}"
+```
+
+durch:
+
+```python
+    def _fmt(self, rec):
+        parts = []
+        for s in rec.get("slots", []):
+            kat = f" {s['kategorie']}" if s.get("kategorie") else ""
+            if self.has_pause:
+                parts.append(f"{s['start']}—{s['end']} (P{s.get('pause', 0)}){kat}")
+            else:
+                parts.append(f"{s['start']}—{s['end']}{kat}")
+        return ", ".join(parts) if parts else "—"
+```
+
+- [ ] **Step 2: `share_dialog.py` — `CELL_BG` importieren**
+
+In `src/dialogs/share_dialog.py`, im `from src.theme import (...)`-Block, ändere
+
+```python
+    BG, FONT, TEXT,
+```
+
+zu
+
+```python
+    BG, CELL_BG, FONT, TEXT,
+```
+
+- [ ] **Step 3: `share_dialog.py` — Kategorie-Auswahl ergänzen**
+
+In `open_share_dialog`, direkt **nach** dem `include_res`-Block (der mit `cb_res.grid(...)` und `row += 1` endet) und **vor** dem `tk.Label(... text="Empfänger:" ...)`, füge ein:
+
+```python
+    # --- Kategorie-Auswahl (optional) ---
+    # Kategorien aus Arbeitszeiten + Reservierungen + settings.categories.
+    present_categories = sorted(
+        {(s.get("kategorie") or "")
+         for rec in list(entries.values()) + list(reservations.values())
+         for s in rec["slots"]}
+        | set(settings.get("categories") or []),
+        key=lambda k: (k == "", k.lower()),
+    )
+    category_vars = {}
+    if present_categories:
+        tk.Label(
+            dialog, text="Kategorien:", font=FONT, bg=BG, fg=TEXT,
+        ).grid(row=row, column=0, padx=(20, 6), pady=(0, 4), sticky="nw")
+        cat_frame = tk.Frame(dialog, bg=BG)
+        cat_frame.grid(row=row, column=1, padx=(0, 20), pady=(0, 4), sticky="w")
+        for kat in present_categories:
+            var = tk.BooleanVar(value=True)
+            category_vars[kat] = var
+            tk.Checkbutton(
+                cat_frame, text=(kat if kat else "(ohne Kategorie)"), variable=var,
+                font=FONT, bg=BG, fg=TEXT, selectcolor=CELL_BG,
+                activebackground=BG, activeforeground=TEXT,
+                highlightthickness=0, bd=0, anchor="w",
+            ).pack(anchor="w")
+        row += 1
+
+    def _selected_categories():
+        if not category_vars:
+            return None
+        selected = {kat for kat, var in category_vars.items() if var.get()}
+        if len(selected) == len(category_vars):
+            return None
+        return selected
+```
+
+- [ ] **Step 4: `share_dialog.py` — `categories` an `build_share_doc` durchreichen**
+
+In `do_send`, ersetze (aktuell):
+
+```python
+            doc = build_share_doc(
+                storage, sender_email,
+                reservation_store=reservation_store,
+                include_entries=want_entries,
+                include_reservations=want_res,
+            )
+```
+
+durch:
+
+```python
+            doc = build_share_doc(
+                storage, sender_email,
+                reservation_store=reservation_store,
+                include_entries=want_entries,
+                include_reservations=want_res,
+                categories=_selected_categories(),
+            )
+```
+
+- [ ] **Step 5: Import-Smoke + Byte-Compile**
+
+Run: `python -c "import src.dialogs.import_dialog, src.dialogs.share_dialog; print('ok')"`
+Expected: gibt `ok` aus.
+
+Run: `python -m py_compile src/dialogs/import_dialog.py src/dialogs/share_dialog.py`
+Expected: keine Ausgabe, Exit 0.
+
+- [ ] **Step 6: AP1–AP5-Regressionscheck**
+
+Run: `python -m pytest tests/test_storage.py tests/test_storage_migration.py tests/test_reservations.py tests/test_reservations_migration.py tests/test_settings.py tests/test_sync.py tests/test_time_calc.py tests/test_time_utils.py tests/test_report.py tests/test_share.py -q`
+Expected: PASS.
+
+> **Hinweis:** Voller `pytest`-Lauf bleibt erwartbar rot (ui/gcal offen). Dialoge ohne Auto-Tests — manueller Test durch den Nutzer.
+
+- [ ] **Step 7: Manuelle Verifikations-Checkliste (in den Report, NICHT ausführen)**
+
+- Teilen-Dialog: „Kategorien:"-Sektion mit Checkbox je vorhandener Kategorie (+ „(ohne Kategorie)"), alle gesetzt. Eine abwählen → exportierte Datei enthält nur die gewählten Kategorien.
+- Import einer v3-Datei: Pro-Tag-Konflikt-Dialog zeigt je Tag alle Slots („08:00—12:00 (P0) Büro, 13:00—17:00 (P30) HO").
+- Import einer alten v1/v2-Datei: wird akzeptiert, Slots erscheinen mit leerer Kategorie.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/dialogs/import_dialog.py src/dialogs/share_dialog.py
+git commit -m "feat(ui): Import-/Teilen-Dialog auf Slots + Export-Kategorie-Filter (#53)
+
+import_dialog rendert je Tag alle Slots (inkl. Kategorie); share_dialog bietet
+eine Kategorie-Auswahl, die als categories-Filter an build_share_doc geht.
+Teil von AP5.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+**1. Spec-Coverage (Spec-Abschnitt „Teilen (share.py) — Schema v3"):**
+- v3-Wire-Format entries/reservations als Slot-Listen → Task 1 ✓
+- Export respektiert Kategorie-Auswahl → `build_share_doc(categories=...)` (Task 1) + share_dialog-UI (Task 2) ✓
+- Import mit Diff/Konflikt auf Slot-Listen-Ebene → `_entries_equal`/`_reservations_equal` (Slot-Signatur), import_dialog `_fmt` (Task 2) ✓
+- Abwärtskompat: v1/v2 importierbar, in 1-Slot-Listen gewrappt → `_wrap_legacy_*` + parse-Pfade ✓
+- v3-Validierung Slot-Records → `_validate_v3_*` ✓
+- Bewusst NICHT in AP5 (dokumentiert): gcal_event_id-Erhalt/Reconcile-Integration (AP7); Kategorie-Verwaltung (AP6).
+
+**2. Placeholder-Scan:** Keine TBD/TODO; vollständiger Code in jedem Step. ✓
+
+**3. Typ-Konsistenz:**
+- `SCHEMA_VERSION == 3`; `parse_share_doc` liefert Slot-Records; `build_share_doc(categories=None)`; `apply_reservation_import` ruft `save(date, slots)` — konsistent zwischen share.py, Tests und Dialogen. ✓
+- Entry-Slot `{start,end,pause,kategorie}` vs. Reservierungs-Slot `{start,end,kategorie}` — durchgängig getrennt (Validatoren, Wrapping, Diff-Keys). ✓
+- Record-Form `{"slots":[...]}` — in build/parse/diff/apply und import_dialog `_fmt`/share_dialog `present_categories`. ✓
+- `CELL_BG` existiert in theme.py, in share_dialog importiert. ✓

--- a/docs/superpowers/plans/2026-06-19-ap6-ui-kategorien-guard.md
+++ b/docs/superpowers/plans/2026-06-19-ap6-ui-kategorien-guard.md
@@ -1,0 +1,617 @@
+# AP6 — UI Multi-Slot + Kategorie-Verwaltung + Pull-Guard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Die Kalender-Zellen (`src/ui.py`) auf das Multi-Slot-Modell heben (Tagessumme über Slots, kompakte Zellen-Darstellung, Slot-Tooltips), eine Kategorie-Verwaltung als eigenen Modal-Dialog (`src/dialogs/category_dialog.py`) bereitstellen (Button im Settings-Dialog), und den aus AP2 verschobenen Regulär-Sync-Pre-v3-Guard in `src/main.py` verdrahten.
+
+**Architecture:** ui.py ist eine dünne Tkinter-Schicht (Task 1, manuell verifiziert). Die Kategorie-Listen-Logik (anlegen/umbenennen/entfernen) wird als **pure, getestete Funktionen** in `category_dialog.py` ausgelagert; der Modal nutzt sie (Task 2). Der Pull-Guard nutzt die in AP2 bereits getestete `sync._remote_is_pre_v3` und überspringt den Merge bei einem pre-v3-Remote (Task 3).
+
+**Tech Stack:** Python stdlib, tkinter, pytest.
+
+## Global Constraints
+
+- **AP1-Shape:** Ist-Zeit-Eintrag = `{"slots":[{start,end,pause,kategorie}]}`; Reservierung (user-shape) = `{"slots":[{start,end,kategorie}]}`. `storage.get(date)`/`reservation_store.get(date)` liefern das oder `None`.
+- **Tagessumme** = Summe `calculate_hours(start,end,pause)` über alle Slots, `round(…,2)`.
+- **Zellen-Darstellung:** kompakt — erste Slot-Zeit `HH:MM-HH:MM`, bei >1 Slot `+N` (N = weitere Slots). Tooltip listet bei >1 Slot alle Arbeitszeit-Slots (inkl. Kategorie); Reservierungs-/Feiertags-Infos im selben (einzigen) Tooltip kombiniert.
+- **Genau ein `attach_tooltip` pro Zelle** (Mehrfach = überlappende Tooltips, s. bestehender Docstring).
+- **Rechtsklick-Löschen (`_delete_day`) bleibt unverändert** — es arbeitet bereits typweise (Arbeitszeit/Reservierung, nur was existiert) und liest die Slot-Shape nicht.
+- **Kategorie-Verwaltung** als eigener Modal `open_category_dialog(parent, settings, on_change=None)`; speichert via `settings.set_synced("categories", liste)`. Reine Listen-Logik (`add_category`/`remove_category`/`rename_category`) ist pure + getestet.
+- **Pull-Guard:** `sync._remote_is_pre_v3(remote_doc)` in `_run_pull_in_background` (nur im real-heruntergeladenen Zweig, NICHT im synthetischen No-File-Fall) und im `_run_push_blocking`-Retry; bei pre-v3-Remote Merge überspringen + `sync.OLD_REMOTE_VERSION_MSG` melden (freundlicher Info-Dialog via `_friendly_sync_message`).
+- **Datumsformat:** intern ISO; UI deutsch.
+- **Harter Schnitt — Ziel: nach AP6 ist die App lauffähig.** Nach AP6 sind alle bisher umgestellten Pfade konsistent; nur `gcal`/`reservations_sync` (AP7) bleiben offen, betreffen aber nur den (optionalen) Google-Kalender-Abgleich.
+
+## Test-Strategie / Design-Notes (für den Plan-Review)
+
+- **`category_dialog.py` Pure-Helfer sind voll unit-getestet** (Task 2). Der Tkinter-Modal selbst: Import-Smoke + manuell.
+- **`ui.py` und `settings_dialog.py` und `main.py`-Wiring: keine Auto-Tests** (Tkinter/Threads). Verifikation: Import-Smoke + Diff-Review + manueller Test + bestehende `test_ui_*`-Tests bleiben grün (sie berühren die Zellen-Logik nicht).
+- **`sync._remote_is_pre_v3` ist seit AP2 getestet**; AP6 fügt nur die Wiring + eine String-Konstante hinzu.
+
+---
+
+## Dateistruktur
+
+- `src/ui.py` — `_entry_hours` (Slot-Summe), `_build_entry_cell` (kompakte Multi-Slot-Zeit), `_build_day_cell` (kombinierter Slot-Tooltip), neuer Helfer `_fmt_slot_line`; plus `_friendly_sync_message`-Branch (Task 3).
+- `src/dialogs/category_dialog.py` — **neu**: pure Listen-Helfer + Modal.
+- `tests/test_category_dialog.py` — **neu**: Tests der Pure-Helfer.
+- `src/dialogs/settings_dialog.py` — Button „Kategorien verwalten…".
+- `src/main.py` — Pull-Guard (2 Stellen).
+- `src/sync.py` — Konstante `OLD_REMOTE_VERSION_MSG`.
+
+Task 1 (ui-Zellen) und Task 2 (Kategorie-Dialog) sind unabhängig. Task 3 (Guard) ist unabhängig von 1/2.
+
+---
+
+## Task 1: `ui.py` — Multi-Slot-Zellen
+
+**Files:**
+- Modify: `src/ui.py` (`_entry_hours`, `_build_entry_cell`, `_build_day_cell`, neuer Helfer `_fmt_slot_line`)
+
+**Interfaces:**
+- Consumes: AP1-Shape (`entry["slots"]`, `reservation["slots"]`).
+
+> Keine Auto-Tests (Tkinter). Verifikation: Import-Smoke + `test_ui_*` grün + manuell.
+
+- [ ] **Step 1: `_entry_hours` auf Slot-Summe umstellen**
+
+In `src/ui.py`, ersetze (aktuell):
+
+```python
+    def _entry_hours(self, entry):
+        return calculate_hours(
+            entry["start"], entry["end"], pause_minutes=entry.get("pause", 0),
+        )
+```
+
+durch:
+
+```python
+    def _entry_hours(self, entry):
+        return round(sum(
+            calculate_hours(s["start"], s["end"], pause_minutes=s.get("pause", 0))
+            for s in entry.get("slots", [])
+        ), 2)
+```
+
+- [ ] **Step 2: `_fmt_slot_line`-Helfer ergänzen**
+
+In `src/ui.py`, direkt **vor** `def _add_reservation_marker(self, cell):`, füge ein:
+
+```python
+    @staticmethod
+    def _fmt_slot_line(slot):
+        """Eine Tooltip-Zeile für einen Slot: 'HH:MM-HH:MM  Kategorie'
+        (Kategorie weggelassen, wenn leer)."""
+        kat = f"  {slot['kategorie']}" if slot.get("kategorie") else ""
+        return f"{slot['start']}-{slot['end']}{kat}"
+
+```
+
+- [ ] **Step 3: `_build_entry_cell` — kompakte Multi-Slot-Zeit**
+
+In `src/ui.py`, in `_build_entry_cell`, ersetze (aktuell):
+
+```python
+        time_lbl = tk.Label(
+            cell, text=f"{entry['start']}-{entry['end']}",
+            font=time_font, bg=bg, fg=TEXT_MUTED, cursor="hand2",
+        )
+```
+
+durch:
+
+```python
+        slots = entry.get("slots", [])
+        if slots:
+            first = slots[0]
+            time_text = f"{first['start']}-{first['end']}"
+            if len(slots) > 1:
+                time_text += f"  +{len(slots) - 1}"
+        else:
+            time_text = ""
+        time_lbl = tk.Label(
+            cell, text=time_text,
+            font=time_font, bg=bg, fg=TEXT_MUTED, cursor="hand2",
+        )
+```
+
+- [ ] **Step 4: `_build_day_cell` — kombinierter Slot-Tooltip**
+
+In `src/ui.py`, in `_build_day_cell`, ersetze den Tooltip-Block (aktuell):
+
+```python
+        # Reservierung ist ein reiner Overlay-Marker (Eck-Punkt) — sie ändert
+        # den Zelltyp nicht. Genau ein attach_tooltip pro Zelle: Mehrfachaufruf
+        # erzeugt überlappende Tooltips (s. attach_tooltip-Docstring).
+        if reservation is not None:
+            self._add_reservation_marker(cell)
+            tip = f"Reservierung: {reservation['start']}-{reservation['end']}"
+            if is_holiday:
+                tip += f"\nFeiertag: {holidays_map[day_date]}"
+            attach_tooltip(cell, tip)
+        elif entry and is_holiday:
+            attach_tooltip(cell, f"Feiertag: {holidays_map[day_date]}")
+```
+
+durch:
+
+```python
+        # Reservierung ist ein reiner Overlay-Marker (Eck-Punkt) — sie ändert
+        # den Zelltyp nicht. Genau EIN attach_tooltip pro Zelle (Mehrfachaufruf
+        # erzeugt überlappende Tooltips); deshalb alle relevanten Infos
+        # (mehrere Arbeitszeit-Slots, Reservierung, Feiertag) in einen
+        # kombinierten Tooltip. Ein Feiertag-OHNE-Eintrag/-Reservierung zeigt
+        # seinen Namen weiterhin als Zelltext (Holiday-Zelle) bzw. eigenen
+        # Tooltip (name_tooltip) und kommt hier NICHT rein.
+        tip_parts = []
+        if entry and len(entry.get("slots", [])) > 1:
+            tip_parts.append(
+                "Arbeitszeit:\n"
+                + "\n".join(self._fmt_slot_line(s) for s in entry["slots"]))
+        if reservation is not None:
+            self._add_reservation_marker(cell)
+            tip_parts.append(
+                "Reservierung:\n"
+                + "\n".join(self._fmt_slot_line(s) for s in reservation.get("slots", [])))
+        if is_holiday and (reservation is not None or entry):
+            tip_parts.append(f"Feiertag: {holidays_map[day_date]}")
+        if tip_parts:
+            attach_tooltip(cell, "\n".join(tip_parts))
+```
+
+- [ ] **Step 5: Import-Smoke + Byte-Compile + `test_ui_*`**
+
+Run: `python -c "import src.ui; print('ok')"`
+Expected: `ok`.
+
+Run: `python -m py_compile src/ui.py`
+Expected: keine Ausgabe, Exit 0.
+
+Run: `python -m pytest tests/test_ui_sync_errors.py tests/test_ui_autostart_target.py tests/test_click_guard.py -q`
+Expected: PASS (unverändert grün — die Zellen-Logik wird dort nicht berührt).
+
+- [ ] **Step 6: Manuelle Verifikations-Checkliste (in den Report, NICHT ausführen)**
+
+- Tag mit einem Slot: Zelle zeigt „HH:MM-HH:MM" wie bisher, Tagessumme korrekt.
+- Tag mit zwei Slots: Zelle zeigt „erste Zeit  +1"; Tooltip listet beide Slots inkl. Kategorie; Footer-Summe = Summe beider Slots.
+- Tag mit Reservierung: violetter Punkt + Tooltip listet Reservierungs-Slots.
+- Feiertag ohne Eintrag: Name als Text/Tooltip wie bisher (kein Doppel-Tooltip).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/ui.py
+git commit -m "feat(ui): Kalenderzellen mit mehreren Slots + Slot-Tooltips (#53)
+
+_entry_hours summiert über Slots; _build_entry_cell zeigt erste Slot-Zeit
++N; _build_day_cell baut einen kombinierten Tooltip (Arbeitszeit-Slots,
+Reservierung, Feiertag). Rechtsklick-Löschen unverändert. Teil von AP6.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Kategorie-Verwaltung (`category_dialog.py` + Settings-Button)
+
+**Files:**
+- Create: `src/dialogs/category_dialog.py`
+- Create: `tests/test_category_dialog.py`
+- Modify: `src/dialogs/settings_dialog.py` (Import + Button im btn_frame)
+
+**Interfaces:**
+- Produces:
+  - `add_category(categories, name) -> list` / `remove_category(categories, name) -> list` / `rename_category(categories, old, new) -> list` (pure; trimmen, dedupen, neue Liste).
+  - `open_category_dialog(parent, settings, on_change=None) -> None` (Modal; speichert via `settings.set_synced("categories", ...)`).
+
+- [ ] **Step 1: `tests/test_category_dialog.py` anlegen (Failing)**
+
+Lege `tests/test_category_dialog.py` mit folgendem Inhalt an:
+
+```python
+from src.dialogs.category_dialog import add_category, remove_category, rename_category
+
+
+def test_add_category():
+    assert add_category([], "Büro") == ["Büro"]
+
+
+def test_add_strips_whitespace():
+    assert add_category([], "  Büro  ") == ["Büro"]
+
+
+def test_add_empty_is_ignored():
+    assert add_category(["A"], "   ") == ["A"]
+
+
+def test_add_duplicate_is_ignored():
+    assert add_category(["Büro"], "Büro") == ["Büro"]
+
+
+def test_add_returns_new_list():
+    orig = ["A"]
+    result = add_category(orig, "B")
+    assert orig == ["A"]            # Original unverändert
+    assert result == ["A", "B"]
+
+
+def test_remove_category():
+    assert remove_category(["A", "B"], "A") == ["B"]
+
+
+def test_remove_absent_is_noop():
+    assert remove_category(["A"], "X") == ["A"]
+
+
+def test_rename_category():
+    assert rename_category(["A", "B"], "A", "C") == ["C", "B"]
+
+
+def test_rename_strips_whitespace():
+    assert rename_category(["A"], "A", "  C  ") == ["C"]
+
+
+def test_rename_empty_new_is_ignored():
+    assert rename_category(["A"], "A", "   ") == ["A"]
+
+
+def test_rename_absent_old_is_noop():
+    assert rename_category(["A"], "X", "C") == ["A"]
+
+
+def test_rename_to_existing_other_is_ignored():
+    assert rename_category(["A", "B"], "A", "B") == ["A", "B"]
+
+
+def test_rename_to_same_name_keeps_list():
+    assert rename_category(["A", "B"], "A", "A") == ["A", "B"]
+```
+
+- [ ] **Step 2: Tests laufen lassen — müssen FEHLSCHLAGEN**
+
+Run: `python -m pytest tests/test_category_dialog.py -q`
+Expected: FAIL — `src/dialogs/category_dialog.py` existiert noch nicht (ImportError).
+
+- [ ] **Step 3: `src/dialogs/category_dialog.py` anlegen**
+
+Lege `src/dialogs/category_dialog.py` mit folgendem Inhalt an:
+
+```python
+"""Modal zum Verwalten der Kategorie-Pickliste. Die Listen-Logik
+(add/remove/rename) ist pure und getestet; der Tkinter-Teil ist nur Wiring.
+Speichert via settings.set_synced('categories', ...)."""
+
+import tkinter as tk
+
+from src.theme import (
+    ACCENT, BG, CELL_BG, FONT, FONT_BOLD, TEXT,
+    apply_app_icon, apply_dark_titlebar, attach_unfocus_on_click,
+    center_dialog_on_parent, dark_entry, disable_min_max,
+    primary_button, secondary_button,
+)
+
+
+def add_category(categories, name):
+    """Fügt `name` (getrimmt) hinzu, falls nicht leer und nicht vorhanden.
+    Liefert IMMER eine neue Liste (Original bleibt unangetastet)."""
+    name = name.strip()
+    if not name or name in categories:
+        return list(categories)
+    return list(categories) + [name]
+
+
+def remove_category(categories, name):
+    """Entfernt `name`. Liefert eine neue Liste."""
+    return [c for c in categories if c != name]
+
+
+def rename_category(categories, old, new):
+    """Benennt `old` in `new` (getrimmt) um. No-op, wenn `new` leer ist, `old`
+    nicht existiert, oder `new` bereits eine ANDERE Kategorie ist."""
+    new = new.strip()
+    if not new or old not in categories:
+        return list(categories)
+    if new in categories and new != old:
+        return list(categories)
+    return [new if c == old else c for c in categories]
+
+
+def open_category_dialog(parent, settings, on_change=None):
+    categories = list(settings.get("categories") or [])
+
+    dialog = tk.Toplevel(parent)
+    dialog.title("Kategorien verwalten")
+    dialog.resizable(False, False)
+    dialog.grab_set()
+    dialog.focus_set()
+    dialog.configure(bg=BG)
+    apply_dark_titlebar(dialog)
+    disable_min_max(dialog)
+    apply_app_icon(dialog)
+    attach_unfocus_on_click(dialog)
+    dialog.bind("<Escape>", lambda _e: dialog.destroy())
+
+    outer = tk.Frame(dialog, bg=BG)
+    outer.pack(padx=12, pady=12)
+
+    tk.Label(outer, text="Kategorien", font=FONT_BOLD, bg=BG, fg=TEXT).pack(anchor="w")
+
+    listbox = tk.Listbox(
+        outer, height=8, width=30, font=FONT, bg=CELL_BG, fg=TEXT,
+        selectbackground=ACCENT, selectforeground="#ffffff",
+        highlightthickness=0, bd=0, activestyle="none",
+    )
+    listbox.pack(fill="x", pady=(4, 8))
+
+    def refresh():
+        listbox.delete(0, tk.END)
+        for c in categories:
+            listbox.insert(tk.END, c)
+
+    refresh()
+
+    def _selected():
+        sel = listbox.curselection()
+        return categories[sel[0]] if sel else None
+
+    name_var = tk.StringVar()
+
+    def on_add():
+        nonlocal categories
+        categories = add_category(categories, name_var.get())
+        name_var.set("")
+        refresh()
+
+    def on_rename():
+        nonlocal categories
+        current = _selected()
+        if current is None:
+            return
+        categories = rename_category(categories, current, name_var.get())
+        name_var.set("")
+        refresh()
+
+    def on_remove():
+        nonlocal categories
+        current = _selected()
+        if current is None:
+            return
+        categories = remove_category(categories, current)
+        refresh()
+
+    edit_row = tk.Frame(outer, bg=BG)
+    edit_row.pack(fill="x", pady=(0, 8))
+    dark_entry(edit_row, name_var, width=18).pack(side=tk.LEFT, padx=(0, 4))
+    secondary_button(edit_row, "Hinzufügen", on_add).pack(side=tk.LEFT, padx=2)
+    secondary_button(edit_row, "Umbenennen", on_rename).pack(side=tk.LEFT, padx=2)
+    secondary_button(edit_row, "Entfernen", on_remove).pack(side=tk.LEFT, padx=2)
+
+    def on_save():
+        settings.set_synced("categories", categories)
+        if on_change is not None:
+            on_change()
+        dialog.destroy()
+
+    save_row = tk.Frame(outer, bg=BG)
+    save_row.pack(fill="x")
+    primary_button(save_row, "Speichern", on_save).pack(side=tk.LEFT, padx=2)
+    secondary_button(save_row, "Schließen", dialog.destroy).pack(side=tk.LEFT, padx=2)
+
+    center_dialog_on_parent(dialog, parent)
+```
+
+- [ ] **Step 4: Tests laufen lassen — müssen BESTEHEN**
+
+Run: `python -m pytest tests/test_category_dialog.py -q`
+Expected: PASS.
+
+Run: `python -c "import src.dialogs.category_dialog; print('ok')"`
+Expected: `ok`.
+
+- [ ] **Step 5: `settings_dialog.py` — Button „Kategorien verwalten…"**
+
+In `src/dialogs/settings_dialog.py`, ergänze den Import (z.B. direkt nach den bestehenden `from src.dialogs...`-Imports am Dateianfang — oder, falls keine vorhanden, nach den `from src.theme import (...)`-Imports):
+
+```python
+from src.dialogs.category_dialog import open_category_dialog
+```
+
+Und ersetze den Button-Block (aktuell):
+
+```python
+    primary_button(btn_frame, "Speichern", save_settings).pack(side=tk.LEFT, padx=5)
+    secondary_button(btn_frame, "Abbrechen", dialog.destroy).pack(side=tk.LEFT, padx=5)
+```
+
+durch:
+
+```python
+    secondary_button(
+        btn_frame, "Kategorien verwalten…",
+        lambda: open_category_dialog(dialog, settings),
+    ).pack(side=tk.LEFT, padx=5)
+    primary_button(btn_frame, "Speichern", save_settings).pack(side=tk.LEFT, padx=5)
+    secondary_button(btn_frame, "Abbrechen", dialog.destroy).pack(side=tk.LEFT, padx=5)
+```
+
+> Hinweis: Der Kategorie-Dialog speichert eigenständig via `set_synced` — unabhängig vom „Speichern"/„Abbrechen" des Settings-Dialogs. Das ist gewollt.
+
+- [ ] **Step 6: Import-Smoke + Byte-Compile**
+
+Run: `python -c "import src.dialogs.settings_dialog, src.dialogs.category_dialog; print('ok')"`
+Expected: `ok`.
+
+Run: `python -m py_compile src/dialogs/settings_dialog.py src/dialogs/category_dialog.py`
+Expected: keine Ausgabe, Exit 0.
+
+- [ ] **Step 7: Manuelle Verifikations-Checkliste (in den Report, NICHT ausführen)**
+
+- Settings-Dialog: Button „Kategorien verwalten…" öffnet den Modal.
+- Hinzufügen/Umbenennen/Entfernen ändern die Liste; Speichern persistiert sie; im Tages-Dialog erscheinen die Kategorien als Vorschläge.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/dialogs/category_dialog.py tests/test_category_dialog.py src/dialogs/settings_dialog.py
+git commit -m "feat(ui): Kategorie-Verwaltung als Modal-Dialog (#53)
+
+Neuer category_dialog mit pure, getesteten Listen-Helfern (add/remove/
+rename) + Tkinter-Modal; speichert via set_synced('categories'). Button
+'Kategorien verwalten…' im Settings-Dialog. Teil von AP6.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Regulär-Sync Pre-v3-Guard (aus AP2 verschoben)
+
+**Files:**
+- Modify: `src/sync.py` (Konstante `OLD_REMOTE_VERSION_MSG`)
+- Modify: `src/main.py` (Guard in `_run_pull_in_background` + `_run_push_blocking`-Retry)
+- Modify: `src/ui.py` (`_friendly_sync_message`-Branch)
+
+**Interfaces:**
+- Consumes: `sync._remote_is_pre_v3` (seit AP2 getestet).
+- Produces: `sync.OLD_REMOTE_VERSION_MSG` (str).
+
+> Wiring ohne Unit-Test (Drive-I/O/Threads). `_remote_is_pre_v3` ist getestet. Verifikation: Import-Smoke + Regression + manuell.
+
+- [ ] **Step 1: `sync.py` — Konstante ergänzen**
+
+In `src/sync.py`, direkt **nach** `SCHEMA_VERSION = 3`, füge ein:
+
+```python
+
+
+OLD_REMOTE_VERSION_MSG = (
+    "Ein anderes Gerät nutzt eine ältere App-Version, die das neue Format "
+    "(Mehrfach-Slots/Kategorien) noch nicht versteht.\n\n"
+    "Bitte aktualisiere die App auf dem anderen Gerät, bevor du dort "
+    "synchronisierst. Bis dahin pausiert die Synchronisation, damit keine "
+    "Daten verloren gehen."
+)
+```
+
+- [ ] **Step 2: `main.py` — Guard im Startup-Pull**
+
+In `src/main.py`, in `_run_pull_in_background`, ersetze (aktuell):
+
+```python
+            remote_doc = _parse_remote_or_quarantine(content, file_id, _quarantine)
+        local_doc = sync.build_local_doc(storage, settings, conflicts_store)
+```
+
+durch:
+
+```python
+            remote_doc = _parse_remote_or_quarantine(content, file_id, _quarantine)
+            if sync._remote_is_pre_v3(remote_doc):
+                # Älteres Gerät aktiv: nicht mergen (ein v2-Eintrag hat kein
+                # 'slots' → würde apply_merge verletzen / Daten plätten).
+                ui_callback(ok=False, error=sync.OLD_REMOTE_VERSION_MSG, tb="")
+                return
+        local_doc = sync.build_local_doc(storage, settings, conflicts_store)
+```
+
+> Der synthetische No-File-Fall (`file_id is None` → `{"schema_version": 1, "entries": {}}`) liegt im `if`-Zweig DAVOR und wird vom Guard NICHT erfasst — ein Erstsync ohne Drive-Datei merged korrekt (leeres Remote).
+
+- [ ] **Step 3: `main.py` — Guard im Push-Retry**
+
+In `src/main.py`, in `_run_push_blocking`, im `except drive.DriveConflictError:`-Block, ersetze (aktuell):
+
+```python
+                    remote_bytes, _ = drive.download(service, file_id)
+                    remote_doc = json.loads(remote_bytes)
+```
+
+durch:
+
+```python
+                    remote_bytes, _ = drive.download(service, file_id)
+                    remote_doc = json.loads(remote_bytes)
+                    if sync._remote_is_pre_v3(remote_doc):
+                        result["ok"] = False
+                        result["error"] = sync.OLD_REMOTE_VERSION_MSG
+                        result["tb"] = ""
+                        return
+```
+
+- [ ] **Step 4: `ui.py` — freundliche Meldung in `_friendly_sync_message`**
+
+In `src/ui.py`, in `_friendly_sync_message`, ersetze den Anfang (aktuell):
+
+```python
+    kind = _classify_sync_error(error)
+
+    if kind == "auth":
+```
+
+durch:
+
+```python
+    from src.sync import OLD_REMOTE_VERSION_MSG
+    if str(error) == OLD_REMOTE_VERSION_MSG:
+        return ("Anderes Gerät veraltet", OLD_REMOTE_VERSION_MSG, True)
+
+    kind = _classify_sync_error(error)
+
+    if kind == "auth":
+```
+
+- [ ] **Step 5: Import-Smoke + Byte-Compile + Regression**
+
+Run: `python -c "import src.main, src.ui, src.sync; print(src.sync.OLD_REMOTE_VERSION_MSG[:10])"`
+Expected: gibt `Ein andere` aus (kein ImportError).
+
+Run: `python -m py_compile src/main.py src/ui.py src/sync.py`
+Expected: keine Ausgabe, Exit 0.
+
+Run: `python -m pytest tests/test_sync.py -q`
+Expected: PASS (Konstante bricht nichts).
+
+- [ ] **Step 6: AP1–AP6-Gesamtregression**
+
+Run: `python -m pytest tests/ -q --ignore=tests/test_gcal.py --ignore=tests/test_reservations_sync.py`
+Expected: PASS.
+
+> **Hinweis:** `test_gcal.py` und `test_reservations_sync.py` bleiben rot bis AP7 (gcal/reservations_sync noch nicht slot-fähig). Alle übrigen Tests müssen grün sein.
+
+- [ ] **Step 7: Manuelle Verifikations-Checkliste (in den Report, NICHT ausführen)**
+
+- Bei aktivem Sync gegen ein altes (pre-v3) Remote-Doc: Startup-Pull und manueller Sync zeigen den freundlichen „Anderes Gerät veraltet"-Hinweis und ändern lokale Daten NICHT.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/sync.py src/main.py src/ui.py
+git commit -m "feat(sync): Regulär-Pull/Push-Guard gegen pre-v3-Remote (#53)
+
+_remote_is_pre_v3 in _run_pull_in_background + _run_push_blocking-Retry:
+bei älterem Remote Merge überspringen (kein apply_merge-Crash/Datenverlust)
+und freundlichen Hinweis zeigen (sync.OLD_REMOTE_VERSION_MSG +
+_friendly_sync_message-Branch). Schließt die aus AP2 verschobene Lücke.
+Teil von AP6.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+**1. Spec-Coverage (Spec „UI (ui.py)" + „settings_dialog" + AP2-Guard-Verschiebung):**
+- Kalenderzelle mehrere Slots kompakt + Tooltip + Tagessumme über Slots → Task 1 ✓
+- Rechtsklick-Löschen zeigt nur vorhandene Arten (unverändert korrekt) → keine Änderung nötig ✓
+- settings_dialog Kategorie-Verwaltung (anlegen/umbenennen/entfernen) → Task 2 (eigener Modal) ✓
+- Regulär-Pull-Pre-v3-Guard + Hinweis (aus AP2) → Task 3 ✓
+- Bewusst NICHT in AP6: gcal Multi-Event / reservations_sync (AP7).
+
+**2. Placeholder-Scan:** Keine TBD/TODO; vollständiger Code/Tests in jedem Step. ✓
+
+**3. Typ-Konsistenz:**
+- `_fmt_slot_line(slot)` liest `{start,end,kategorie}` — passt für Ist-Zeit- UND Reservierungs-Slots (pause ignoriert). ✓
+- `_entry_hours` summiert `entry["slots"]`; `_build_entry_cell`/`_build_day_cell` lesen `entry["slots"]`/`reservation["slots"]` — konsistent zu AP1. ✓
+- `add/remove/rename_category` Signaturen identisch in category_dialog, Tests und Modal-Aufrufen. ✓
+- `open_category_dialog(parent, settings, on_change=None)` — Aufruf in settings_dialog passt. ✓
+- `sync.OLD_REMOTE_VERSION_MSG` — definiert in sync.py, referenziert in main.py (2×) und ui.py. ✓
+- `sync._remote_is_pre_v3` — seit AP2 vorhanden/getestet. ✓

--- a/docs/superpowers/plans/2026-06-19-ap7-gcal-multi-event.md
+++ b/docs/superpowers/plans/2026-06-19-ap7-gcal-multi-event.md
@@ -1,0 +1,873 @@
+# AP7 — gcal Multi-Event + reservations_sync (Slots) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Den Google-Kalender-Abgleich der Reservierungen auf das Multi-Slot-Modell heben: jeder Reservierungs-Slot ↔ ein Kalender-Event (mit Kategorie im Titel/Marker), `gcal_event_id` pro Slot; `merge_reservations`/`reconcile_reservations` rechnen auf Slot-Ebene (Matching über `gcal_event_id`, Datum-Level-LWW).
+
+**Architecture:** `gcal.py`-Pure-Helfer (`event_payload`/`parse_event`) und `reservations_sync.py` (`merge_reservations`) sind reine Funktionen → voll unit-getestet. Der `reconcile_reservations`-Orchestrator wird mit gemockten gcal-I/O-Funktionen getestet. Damit schließt AP7 auch die zwei in AP5 verschobenen Reservierungs-Import-Tests (Reconcile-Pfad).
+
+**Tech Stack:** Python stdlib, pytest. gcal-Google-Imports bleiben lazy (CI ohne requirements.txt).
+
+## Global Constraints
+
+- **Reservierungs-Record (AP1):** `{date: {slots: [{start, end, kategorie, gcal_event_id}], modified_at, deleted}}`. `gcal_event_id` ist `None`, bis der Slot erstmals als Event gepusht wurde.
+- **Ein Event pro Slot.** Matching lokaler Slot ↔ Remote-Event über `gcal_event_id` / `event_id`.
+- **Kategorie im Event:** `event_payload` setzt `summary = "{EVENT_SUMMARY} — {kategorie}"` (ohne Kategorie nur `EVENT_SUMMARY`) und `extendedProperties.private["kategorie"]`. `parse_event` liefert `kategorie` mit zurück.
+- **gcal-Signaturen:** `event_payload(date, start, end, kategorie, modified_at)`, `parse_event(event) -> {date,start,end,kategorie,modified_at,event_id}`, `create_event(service, cal, date, start, end, kategorie, modified_at)`, `update_event(service, cal, event_id, date, start, end, kategorie, modified_at)`. `list_app_events`/`delete_event` unverändert in der Signatur.
+- **Datum-Level-LWW:** Pro Datum entscheidet `modified_at` (App ist bei Gleichstand autoritativ), wie bisher. Gewinnt lokal → Slots gegen Remote-Events diffen (create/update/delete pro Slot). Gewinnt remote → die Remote-Events des Tages werden als Slots übernommen (`_adopt_remote`).
+- **Plan-Format:** `create: {date, slot_index, start, end, kategorie, modified_at}`; `update: {event_id, date, start, end, kategorie, modified_at}`; `delete: {event_id}`. `slot_index` zeigt in `merged[date]["slots"]`, damit der Reconcile die neue `event_id` zurückschreibt.
+- **Rebase (concurrent local save)** bleibt: Datum, das seit dem Snapshot lokal jünger wurde, überschreibt das Merge-Ergebnis.
+- **Mehrere Events/Tag sind normal** — die alte „Duplikat-Event-Selbstheilung pro Tag" entfällt (mehrere Events = mehrere Slots).
+- **Datumsformat:** intern ISO; UI deutsch.
+- **Ziel:** Nach AP7 ist die GESAMTE Test-Suite grün und das Feature komplett.
+
+## Forward-Dependencies / Notes (für den Plan-Review)
+
+- AP5 hatte zwei Reservierungs-Import-Tests nach AP7 verschoben (gcal_event_id-Erhalt + Reconcile-Plan-Update). AP7 deckt deren Kern ab: ein importiertes Reservierungs-Update wird beim nächsten Reconcile als `update` (gleiche event_id) geplant — Test `test_reconcile_imported_update_plans_update` in Task 2.
+- `event_payload` neue Arg-Position: `kategorie` kommt VOR `modified_at` (analog zu create/update). Alle Aufrufer (gcal.create_event/update_event, reconcile) übergeben sie.
+
+---
+
+## Dateistruktur
+
+- `src/gcal.py` — `event_payload`/`parse_event`/`create_event`/`update_event` um `kategorie` erweitert. Rest unverändert.
+- `tests/test_gcal.py` — auf neue Signaturen + Kategorie umgestellt.
+- `src/reservations_sync.py` — `merge_reservations`/`_merge_one_date`/`reconcile_reservations` slot-fähig (Neufassung).
+- `tests/test_reservations_sync.py` — auf Slot-Records umgestellt + Reconcile-Tests.
+
+Task 1 (gcal) ist unabhängig. Task 2 (reservations_sync) konsumiert die neuen gcal-Signaturen.
+
+---
+
+## Task 1: `gcal.py` — Kategorie in Events
+
+**Files:**
+- Modify: `src/gcal.py` (`event_payload`, `parse_event`, `create_event`, `update_event`)
+- Test: `tests/test_gcal.py` (Neufassung)
+
+**Interfaces:**
+- Produces: `event_payload(date, start, end, kategorie, modified_at)`, `parse_event -> {…, kategorie, …}`, `create_event(service, cal, date, start, end, kategorie, modified_at) -> id`, `update_event(service, cal, event_id, date, start, end, kategorie, modified_at)`.
+
+- [ ] **Step 1: `tests/test_gcal.py` neu schreiben**
+
+Ersetze den **kompletten** Inhalt von `tests/test_gcal.py` durch:
+
+```python
+from src import gcal
+
+
+def test_event_payload_has_summary_and_marker():
+    body = gcal.event_payload("2026-06-01", "09:00", "17:00", "", "2026-05-20T10:00:00Z")
+    assert body["summary"] == gcal.EVENT_SUMMARY
+    private = body["extendedProperties"]["private"]
+    assert private[gcal.APP_MARKER_KEY] == gcal.APP_MARKER_VALUE
+    assert private["kategorie"] == ""
+    assert private["modified_at"] == "2026-05-20T10:00:00Z"
+
+
+def test_event_payload_summary_includes_kategorie():
+    body = gcal.event_payload("2026-06-01", "09:00", "17:00", "Büro", "2026-05-20T10:00:00Z")
+    assert body["summary"] == f"{gcal.EVENT_SUMMARY} — Büro"
+    assert body["extendedProperties"]["private"]["kategorie"] == "Büro"
+
+
+def test_event_payload_datetime_encodes_date_and_time():
+    body = gcal.event_payload("2026-06-01", "09:30", "17:45", "", "2026-05-20T10:00:00Z")
+    assert body["start"]["dateTime"].startswith("2026-06-01T09:30:00")
+    assert body["end"]["dateTime"].startswith("2026-06-01T17:45:00")
+
+
+def test_parse_event_roundtrips_payload_with_kategorie():
+    body = gcal.event_payload("2026-06-01", "09:00", "17:00", "Büro", "2026-05-20T10:00:00Z")
+    body["id"] = "ev-42"
+    parsed = gcal.parse_event(body)
+    assert parsed == {
+        "date": "2026-06-01", "start": "09:00", "end": "17:00",
+        "kategorie": "Büro", "modified_at": "2026-05-20T10:00:00Z", "event_id": "ev-42",
+    }
+
+
+def test_parse_event_missing_kategorie_defaults_empty():
+    # Event ohne kategorie-Property (z.B. von einer älteren App-Version)
+    body = {
+        "id": "ev-1",
+        "start": {"dateTime": "2026-06-01T09:00:00+02:00"},
+        "end": {"dateTime": "2026-06-01T17:00:00+02:00"},
+        "extendedProperties": {"private": {
+            gcal.APP_MARKER_KEY: gcal.APP_MARKER_VALUE,
+            "modified_at": "2026-05-20T10:00:00Z",
+        }},
+    }
+    assert gcal.parse_event(body)["kategorie"] == ""
+
+
+def test_parse_event_ignores_non_app_events():
+    foreign = {"id": "x", "start": {"dateTime": "2026-06-01T09:00:00+02:00"},
+               "end": {"dateTime": "2026-06-01T17:00:00+02:00"}}
+    assert gcal.parse_event(foreign) is None
+
+
+def test_parse_event_ignores_all_day_events():
+    all_day = {
+        "id": "x",
+        "start": {"date": "2026-06-01"}, "end": {"date": "2026-06-02"},
+        "extendedProperties": {"private": {gcal.APP_MARKER_KEY: gcal.APP_MARKER_VALUE}},
+    }
+    assert gcal.parse_event(all_day) is None
+
+
+def test_parse_event_ignores_event_with_null_extended_properties():
+    ev = {"id": "x", "extendedProperties": None,
+          "start": {"dateTime": "2026-06-01T09:00:00+02:00"},
+          "end": {"dateTime": "2026-06-01T17:00:00+02:00"}}
+    assert gcal.parse_event(ev) is None
+
+
+class _FakeExec:
+    def __init__(self, result):
+        self._result = result
+
+    def execute(self):
+        return self._result
+
+
+class _FakeEvents:
+    def __init__(self, recorder, list_result):
+        self._recorder = recorder
+        self._list_result = list_result
+
+    def list(self, **kwargs):
+        self._recorder.append(("list", kwargs))
+        return _FakeExec(self._list_result)
+
+    def insert(self, **kwargs):
+        self._recorder.append(("insert", kwargs))
+        return _FakeExec({"id": "created-id"})
+
+    def update(self, **kwargs):
+        self._recorder.append(("update", kwargs))
+        return _FakeExec({"id": kwargs.get("eventId")})
+
+    def delete(self, **kwargs):
+        self._recorder.append(("delete", kwargs))
+        return _FakeExec({})
+
+
+class _FakeService:
+    def __init__(self, recorder, list_result=None):
+        self._recorder = recorder
+        self._events = _FakeEvents(recorder, list_result or {"items": []})
+
+    def events(self):
+        return self._events
+
+
+def test_list_app_events_filters_and_parses():
+    body = gcal.event_payload("2026-06-01", "09:00", "17:00", "", "2026-05-20T10:00:00Z")
+    body["id"] = "ev-1"
+    foreign = {"id": "ev-2", "start": {"dateTime": "2026-06-02T09:00:00+02:00"},
+               "end": {"dateTime": "2026-06-02T17:00:00+02:00"}}
+    recorder = []
+    service = _FakeService(recorder, {"items": [body, foreign]})
+
+    events = gcal.list_app_events(service, "cal-1")
+
+    assert len(events) == 1
+    assert events[0]["event_id"] == "ev-1"
+    _, kwargs = recorder[0]
+    assert kwargs["privateExtendedProperty"] == "zeiterfassung=reservation"
+    assert kwargs["calendarId"] == "cal-1"
+
+
+def test_create_event_returns_event_id():
+    recorder = []
+    service = _FakeService(recorder)
+    event_id = gcal.create_event(
+        service, "cal-1", "2026-06-01", "09:00", "17:00", "Büro", "2026-05-20T10:00:00Z")
+    assert event_id == "created-id"
+    assert recorder[0][0] == "insert"
+    assert recorder[0][1]["body"]["extendedProperties"]["private"]["kategorie"] == "Büro"
+
+
+def test_update_event_sends_kategorie():
+    recorder = []
+    service = _FakeService(recorder)
+    gcal.update_event(
+        service, "cal-1", "ev-1", "2026-06-01", "09:00", "17:00", "HO", "2026-05-20T10:00:00Z")
+    assert recorder[0][0] == "update"
+    assert recorder[0][1]["eventId"] == "ev-1"
+    assert recorder[0][1]["body"]["extendedProperties"]["private"]["kategorie"] == "HO"
+
+
+def test_delete_event_swallows_already_gone():
+    class _GoneResp:
+        status = 410
+
+    class _GoneService:
+        def events(self):
+            class _E:
+                def delete(self, **kwargs):
+                    class _Boom:
+                        def execute(self_):
+                            err = Exception("gone")
+                            err.resp = _GoneResp()
+                            raise err
+                    return _Boom()
+            return _E()
+
+    gcal.delete_event(_GoneService(), "cal-1", "ev-x")
+```
+
+- [ ] **Step 2: Tests laufen lassen — müssen FEHLSCHLAGEN**
+
+Run: `python -m pytest tests/test_gcal.py -q`
+Expected: FAIL — `event_payload`/`create_event`/`update_event` haben den `kategorie`-Parameter noch nicht; `parse_event` liefert kein `kategorie`.
+
+- [ ] **Step 3: `src/gcal.py` anpassen**
+
+In `src/gcal.py`, ersetze `event_payload` (aktuell):
+
+```python
+def event_payload(date_str, start, end, modified_at):
+    """Baut den Calendar-API-Event-Body aus einer Reservierung.
+
+    date_str ISO ('YYYY-MM-DD'), start/end 'HH:MM'. Die dateTime-Werte tragen
+    den lokalen UTC-Offset (`astimezone()`) — kein IANA-Zeitzonenname nötig.
+    """
+    day = datetime.date.fromisoformat(date_str)
+    sh, sm = (int(p) for p in start.split(":"))
+    eh, em = (int(p) for p in end.split(":"))
+    start_dt = datetime.datetime(day.year, day.month, day.day, sh, sm).astimezone()
+    end_dt = datetime.datetime(day.year, day.month, day.day, eh, em).astimezone()
+    return {
+        "summary": EVENT_SUMMARY,
+        "description": EVENT_DESCRIPTION,
+        "start": {"dateTime": start_dt.isoformat()},
+        "end": {"dateTime": end_dt.isoformat()},
+        "extendedProperties": {
+            "private": {
+                APP_MARKER_KEY: APP_MARKER_VALUE,
+                "modified_at": modified_at,
+            },
+        },
+    }
+```
+
+durch:
+
+```python
+def event_payload(date_str, start, end, kategorie, modified_at):
+    """Baut den Calendar-API-Event-Body aus einem Reservierungs-Slot.
+
+    date_str ISO ('YYYY-MM-DD'), start/end 'HH:MM'. Die dateTime-Werte tragen
+    den lokalen UTC-Offset (`astimezone()`) — kein IANA-Zeitzonenname nötig.
+    Die Kategorie steht im Titel (für die Kalender-Anzeige) UND als private
+    Property (damit parse_event sie verlustfrei zurückliest).
+    """
+    day = datetime.date.fromisoformat(date_str)
+    sh, sm = (int(p) for p in start.split(":"))
+    eh, em = (int(p) for p in end.split(":"))
+    start_dt = datetime.datetime(day.year, day.month, day.day, sh, sm).astimezone()
+    end_dt = datetime.datetime(day.year, day.month, day.day, eh, em).astimezone()
+    summary = f"{EVENT_SUMMARY} — {kategorie}" if kategorie else EVENT_SUMMARY
+    return {
+        "summary": summary,
+        "description": EVENT_DESCRIPTION,
+        "start": {"dateTime": start_dt.isoformat()},
+        "end": {"dateTime": end_dt.isoformat()},
+        "extendedProperties": {
+            "private": {
+                APP_MARKER_KEY: APP_MARKER_VALUE,
+                "kategorie": kategorie,
+                "modified_at": modified_at,
+            },
+        },
+    }
+```
+
+Ersetze in `parse_event` den Return (aktuell):
+
+```python
+    return {
+        "date": start_dt.date().isoformat(),
+        "start": start_dt.strftime("%H:%M"),
+        "end": end_dt.strftime("%H:%M"),
+        "modified_at": private.get("modified_at", ""),
+        "event_id": event.get("id", ""),
+    }
+```
+
+durch:
+
+```python
+    return {
+        "date": start_dt.date().isoformat(),
+        "start": start_dt.strftime("%H:%M"),
+        "end": end_dt.strftime("%H:%M"),
+        "kategorie": private.get("kategorie", ""),
+        "modified_at": private.get("modified_at", ""),
+        "event_id": event.get("id", ""),
+    }
+```
+
+Ersetze `create_event` (aktuell):
+
+```python
+def create_event(service, calendar_id, date_str, start, end, modified_at):
+    """Legt ein Event an und liefert dessen event_id."""
+    body = event_payload(date_str, start, end, modified_at)
+    created = service.events().insert(calendarId=calendar_id, body=body).execute()
+    return created["id"]
+```
+
+durch:
+
+```python
+def create_event(service, calendar_id, date_str, start, end, kategorie, modified_at):
+    """Legt ein Event an und liefert dessen event_id."""
+    body = event_payload(date_str, start, end, kategorie, modified_at)
+    created = service.events().insert(calendarId=calendar_id, body=body).execute()
+    return created["id"]
+```
+
+Ersetze `update_event` (aktuell):
+
+```python
+def update_event(service, calendar_id, event_id, date_str, start, end, modified_at):
+    """Überschreibt ein bestehendes Event mit den Reservierungs-Werten."""
+    body = event_payload(date_str, start, end, modified_at)
+    service.events().update(
+        calendarId=calendar_id, eventId=event_id, body=body,
+    ).execute()
+```
+
+durch:
+
+```python
+def update_event(service, calendar_id, event_id, date_str, start, end, kategorie, modified_at):
+    """Überschreibt ein bestehendes Event mit den Reservierungs-Werten."""
+    body = event_payload(date_str, start, end, kategorie, modified_at)
+    service.events().update(
+        calendarId=calendar_id, eventId=event_id, body=body,
+    ).execute()
+```
+
+- [ ] **Step 4: Tests laufen lassen — müssen BESTEHEN**
+
+Run: `python -m pytest tests/test_gcal.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/gcal.py tests/test_gcal.py
+git commit -m "feat(gcal): Kategorie in Kalender-Events (Titel + Property) (#53)
+
+event_payload/parse_event/create_event/update_event tragen die Kategorie
+(Summary 'Arbeitszeit (reserviert) — <Kat>' + extendedProperties.private).
+Teil von AP7.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: `reservations_sync.py` — Slot↔Event-Merge
+
+**Files:**
+- Modify: `src/reservations_sync.py` (komplette Neufassung der Merge-/Reconcile-Logik)
+- Test: `tests/test_reservations_sync.py` (Neufassung)
+
+**Interfaces:**
+- Consumes: gcal-Signaturen aus Task 1; AP1-Reservierungs-Records.
+- Produces:
+  - `merge_reservations(local_raw, remote_events, watermark) -> {"merged": {...}, "plan": {...}}` auf Slot-Ebene.
+  - `reconcile_reservations(service, calendar_id, store, settings)` (führt Plan aus, schreibt event_ids pro Slot zurück).
+
+- [ ] **Step 1: `tests/test_reservations_sync.py` neu schreiben**
+
+Ersetze den **kompletten** Inhalt von `tests/test_reservations_sync.py` durch:
+
+```python
+from src.reservations_sync import merge_reservations
+
+
+def _lslot(start="09:00", end="17:00", kategorie="", event_id=None):
+    return {"start": start, "end": end, "kategorie": kategorie, "gcal_event_id": event_id}
+
+
+def _local(slots=None, modified_at="2026-05-20T10:00:00Z", deleted=False):
+    return {
+        "slots": slots if slots is not None else [_lslot()],
+        "modified_at": modified_at, "deleted": deleted,
+    }
+
+
+def _remote(date="2026-06-01", start="09:00", end="17:00", kategorie="",
+            modified_at="2026-05-20T10:00:00Z", event_id="ev1"):
+    return {"date": date, "start": start, "end": end, "kategorie": kategorie,
+            "modified_at": modified_at, "event_id": event_id}
+
+
+def test_local_only_new_creates_event_per_slot():
+    res = merge_reservations(
+        {"2026-06-01": _local(slots=[_lslot(kategorie="Büro")],
+                              modified_at="2026-05-20T10:00:00Z")},
+        [], "2026-05-19T00:00:00Z")
+    assert res["plan"]["create"] == [{
+        "date": "2026-06-01", "slot_index": 0, "start": "09:00", "end": "17:00",
+        "kategorie": "Büro", "modified_at": "2026-05-20T10:00:00Z"}]
+    assert "2026-06-01" in res["merged"]
+
+
+def test_local_only_stale_is_dropped():
+    res = merge_reservations(
+        {"2026-06-01": _local(modified_at="2026-05-10T10:00:00Z")},
+        [], "2026-05-19T00:00:00Z")
+    assert res["merged"] == {}
+    assert res["plan"]["create"] == []
+
+
+def test_local_only_exactly_at_watermark_is_dropped():
+    res = merge_reservations(
+        {"2026-06-01": _local(modified_at="2026-05-19T00:00:00Z")},
+        [], "2026-05-19T00:00:00Z")
+    assert res["merged"] == {}
+    assert res["plan"]["create"] == []
+
+
+def test_remote_only_is_imported_as_slots():
+    res = merge_reservations({}, [_remote(kategorie="HO")], "2026-05-19T00:00:00Z")
+    slots = res["merged"]["2026-06-01"]["slots"]
+    assert slots == [{"start": "09:00", "end": "17:00", "kategorie": "HO", "gcal_event_id": "ev1"}]
+    assert res["plan"] == {"create": [], "update": [], "delete": []}
+
+
+def test_remote_only_multiple_events_become_multiple_slots():
+    res = merge_reservations(
+        {},
+        [_remote(start="08:00", end="12:00", event_id="a"),
+         _remote(start="13:00", end="17:00", event_id="b")],
+        "2026-05-19T00:00:00Z")
+    ids = sorted(s["gcal_event_id"] for s in res["merged"]["2026-06-01"]["slots"])
+    assert ids == ["a", "b"]
+    assert res["plan"] == {"create": [], "update": [], "delete": []}
+
+
+def test_local_wins_updates_matched_slot():
+    res = merge_reservations(
+        {"2026-06-01": _local(slots=[_lslot(start="08:00", event_id="ev1")],
+                              modified_at="2026-05-21T10:00:00Z")},
+        [_remote(start="09:00", modified_at="2026-05-20T10:00:00Z", event_id="ev1")],
+        "2026-05-19T00:00:00Z")
+    assert res["plan"]["update"] == [{
+        "event_id": "ev1", "date": "2026-06-01", "start": "08:00", "end": "17:00",
+        "kategorie": "", "modified_at": "2026-05-21T10:00:00Z"}]
+    assert res["merged"]["2026-06-01"]["slots"][0]["gcal_event_id"] == "ev1"
+
+
+def test_local_wins_category_change_updates():
+    res = merge_reservations(
+        {"2026-06-01": _local(slots=[_lslot(kategorie="HO", event_id="ev1")],
+                              modified_at="2026-05-21T10:00:00Z")},
+        [_remote(kategorie="Büro", modified_at="2026-05-20T10:00:00Z", event_id="ev1")],
+        "2026-05-19T00:00:00Z")
+    assert len(res["plan"]["update"]) == 1
+    assert res["plan"]["update"][0]["kategorie"] == "HO"
+
+
+def test_local_wins_equal_values_no_update():
+    res = merge_reservations(
+        {"2026-06-01": _local(slots=[_lslot(event_id="ev1")],
+                              modified_at="2026-05-21T10:00:00Z")},
+        [_remote(modified_at="2026-05-20T10:00:00Z", event_id="ev1")],
+        "2026-05-19T00:00:00Z")
+    assert res["plan"]["update"] == []
+    assert res["merged"]["2026-06-01"]["slots"][0]["gcal_event_id"] == "ev1"
+
+
+def test_local_wins_new_slot_creates_extra_event():
+    res = merge_reservations(
+        {"2026-06-01": _local(
+            slots=[_lslot(start="08:00", end="12:00", event_id="ev1"),
+                   _lslot(start="13:00", end="17:00", event_id=None)],
+            modified_at="2026-05-21T10:00:00Z")},
+        [_remote(start="08:00", end="12:00", modified_at="2026-05-20T10:00:00Z", event_id="ev1")],
+        "2026-05-19T00:00:00Z")
+    assert res["plan"]["update"] == []
+    assert res["plan"]["create"] == [{
+        "date": "2026-06-01", "slot_index": 1, "start": "13:00", "end": "17:00",
+        "kategorie": "", "modified_at": "2026-05-21T10:00:00Z"}]
+    assert res["plan"]["delete"] == []
+
+
+def test_local_wins_removed_slot_deletes_orphan_event():
+    res = merge_reservations(
+        {"2026-06-01": _local(slots=[_lslot(start="08:00", end="12:00", event_id="ev1")],
+                              modified_at="2026-05-21T10:00:00Z")},
+        [_remote(start="08:00", end="12:00", modified_at="2026-05-20T10:00:00Z", event_id="ev1"),
+         _remote(start="13:00", end="17:00", modified_at="2026-05-20T10:00:00Z", event_id="ev2")],
+        "2026-05-19T00:00:00Z")
+    assert res["plan"]["delete"] == [{"event_id": "ev2"}]
+    assert [s["gcal_event_id"] for s in res["merged"]["2026-06-01"]["slots"]] == ["ev1"]
+
+
+def test_remote_wins_adopts_remote_slots():
+    res = merge_reservations(
+        {"2026-06-01": _local(slots=[_lslot(start="08:00", event_id="ev1")],
+                              modified_at="2026-05-20T10:00:00Z")},
+        [_remote(start="09:00", modified_at="2026-05-21T10:00:00Z", event_id="ev1")],
+        "2026-05-19T00:00:00Z")
+    assert res["merged"]["2026-06-01"]["slots"][0]["start"] == "09:00"
+    assert res["plan"]["update"] == []
+
+
+def test_tombstone_newer_deletes_all_events():
+    res = merge_reservations(
+        {"2026-06-01": _local(slots=[], deleted=True, modified_at="2026-05-21T10:00:00Z")},
+        [_remote(modified_at="2026-05-20T10:00:00Z", event_id="ev1"),
+         _remote(start="13:00", modified_at="2026-05-20T10:00:00Z", event_id="ev2")],
+        "2026-05-19T00:00:00Z")
+    deleted = sorted(d["event_id"] for d in res["plan"]["delete"])
+    assert deleted == ["ev1", "ev2"]
+    assert "2026-06-01" not in res["merged"]
+
+
+def test_tombstone_older_than_remote_is_dropped():
+    res = merge_reservations(
+        {"2026-06-01": _local(slots=[], deleted=True, modified_at="2026-05-20T10:00:00Z")},
+        [_remote(modified_at="2026-05-21T10:00:00Z", event_id="ev1")],
+        "2026-05-19T00:00:00Z")
+    assert res["plan"]["delete"] == []
+    assert res["merged"]["2026-06-01"]["slots"][0]["start"] == "09:00"
+
+
+def test_tombstone_without_remote_is_noop():
+    res = merge_reservations(
+        {"2026-06-01": _local(slots=[], deleted=True, modified_at="2026-05-21T10:00:00Z")},
+        [], "2026-05-19T00:00:00Z")
+    assert res["merged"] == {}
+    assert res["plan"] == {"create": [], "update": [], "delete": []}
+
+
+# --- reconcile (mit gemockten gcal-I/O) ---
+
+
+def test_reconcile_creates_event_and_persists_event_id_per_slot(tmp_path, monkeypatch):
+    from src import gcal, reservations_sync
+    from src.reservations import ReservationStore
+    from src.settings import Settings
+
+    store = ReservationStore(str(tmp_path / "res.json"))
+    store.save("2026-06-01", [{"start": "09:00", "end": "17:00", "kategorie": "Büro"}])
+    settings = Settings(str(tmp_path / "set.json"))
+
+    monkeypatch.setattr(gcal, "list_app_events", lambda s, c: [])
+    monkeypatch.setattr(gcal, "update_event", lambda *a: None)
+    monkeypatch.setattr(gcal, "delete_event", lambda *a: None)
+    monkeypatch.setattr(
+        gcal, "create_event",
+        lambda s, c, date, start, end, kategorie, modified_at: "new-event-id")
+
+    reservations_sync.reconcile_reservations(object(), "cal-1", store, settings)
+
+    raw = store.get_all_raw()["2026-06-01"]
+    assert raw["slots"][0]["gcal_event_id"] == "new-event-id"
+    assert settings.get("last_calendar_sync_at") != ""
+
+
+def test_reconcile_imported_update_plans_update(tmp_path, monkeypatch):
+    """AP5-Forward-Test: ein lokal geändertes (jüngeres) Slot mit bestehender
+    event_id wird beim Reconcile als update geplant (kein Duplikat)."""
+    from src import gcal, reservations_sync
+    from src.reservations import ReservationStore
+    from src.settings import Settings
+
+    store = ReservationStore(str(tmp_path / "res.json"))
+    # Slot mit bereits bekannter event_id (wie nach einem früheren Reconcile).
+    store.save("2026-06-01", [{"start": "10:00", "end": "14:00",
+                               "kategorie": "", "gcal_event_id": "evt-1"}])
+    settings = Settings(str(tmp_path / "set.json"))
+
+    updated = []
+    remote = {"date": "2026-06-01", "start": "08:00", "end": "12:00",
+              "kategorie": "", "modified_at": "2020-01-01T00:00:00Z", "event_id": "evt-1"}
+    monkeypatch.setattr(gcal, "list_app_events", lambda s, c: [remote])
+    monkeypatch.setattr(gcal, "create_event", lambda *a: "x")
+    monkeypatch.setattr(gcal, "delete_event", lambda *a: None)
+    monkeypatch.setattr(
+        gcal, "update_event",
+        lambda s, c, event_id, *a: updated.append(event_id))
+
+    reservations_sync.reconcile_reservations(object(), "cal-1", store, settings)
+
+    assert updated == ["evt-1"]
+    assert store.get_all_raw()["2026-06-01"]["slots"][0]["start"] == "10:00"
+
+
+def test_reconcile_preserves_concurrent_local_save(tmp_path, monkeypatch):
+    from src import gcal, reservations_sync
+    from src.reservations import ReservationStore
+    from src.settings import Settings
+
+    store = ReservationStore(str(tmp_path / "res.json"))
+    settings = Settings(str(tmp_path / "set.json"))
+
+    def fake_list(s, c):
+        store.save("2026-07-01", [{"start": "10:00", "end": "18:00", "kategorie": ""}])
+        return []
+
+    monkeypatch.setattr(gcal, "list_app_events", fake_list)
+    monkeypatch.setattr(gcal, "create_event", lambda *a: "ev")
+    monkeypatch.setattr(gcal, "update_event", lambda *a: None)
+    monkeypatch.setattr(gcal, "delete_event", lambda *a: None)
+
+    reservations_sync.reconcile_reservations(object(), "cal-1", store, settings)
+
+    assert store.get("2026-07-01") == {"slots": [{"start": "10:00", "end": "18:00", "kategorie": ""}]}
+```
+
+- [ ] **Step 2: Tests laufen lassen — müssen FEHLSCHLAGEN**
+
+Run: `python -m pytest tests/test_reservations_sync.py -q`
+Expected: FAIL — `merge_reservations` rechnet noch per-Datum auf der alten Shape.
+
+- [ ] **Step 3: `src/reservations_sync.py` neu schreiben**
+
+Ersetze den **kompletten** Inhalt von `src/reservations_sync.py` durch:
+
+```python
+# src/reservations_sync.py
+"""Reservierungs-Abgleich mit dem Google Kalender (Slot-Modell).
+
+Jeder Reservierungs-Slot ↔ ein Kalender-Event (Matching über gcal_event_id).
+`merge_reservations()` ist eine pure LWW-Merge-Funktion (kein I/O): pro Datum
+entscheidet `modified_at` (App autoritativ bei Gleichstand), ob die lokalen
+Slots oder die Remote-Events gewinnen. `reconcile_reservations()` orchestriert
+pull → merge → push und schreibt neue event_ids pro Slot zurück.
+"""
+
+import datetime
+
+
+def _utc_now_iso():
+    return datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _slot_from_event(ev):
+    """Reservierungs-Slot aus einem geparsten Kalender-Event."""
+    return {
+        "start": ev["start"], "end": ev["end"],
+        "kategorie": ev.get("kategorie", ""), "gcal_event_id": ev["event_id"],
+    }
+
+
+def _adopt_remote(date, remotes, merged):
+    """Remote gewinnt: die Slots des Tages = die Remote-Events."""
+    merged[date] = {
+        "slots": [_slot_from_event(ev) for ev in remotes],
+        "modified_at": max(ev["modified_at"] for ev in remotes),
+        "deleted": False,
+    }
+
+
+def _merge_one_date(date, local, remotes, watermark, merged, plan):
+    """Mergt einen einzelnen Tag (Slot-Ebene). Mutiert `merged`/`plan`.
+
+    local   — Reservierungs-Record {slots, modified_at, deleted} oder None
+    remotes — Liste geparster Kalender-Events dieses Tages (evtl. leer)
+    """
+    is_tombstone = local is not None and local.get("deleted")
+    local_mod = local["modified_at"] if local is not None else None
+    remote_mod = max((ev["modified_at"] for ev in remotes), default=None)
+
+    # Fall 1: nichts vorhanden.
+    if local is None and not remotes:
+        return
+
+    # Fall 2: nur remote → als Slots übernehmen.
+    if local is None:
+        _adopt_remote(date, remotes, merged)
+        return
+
+    # Fall 3: lokaler Tombstone.
+    if is_tombstone:
+        if not remotes:
+            return  # Tombstone fällt weg.
+        if local_mod >= remote_mod:
+            for ev in remotes:
+                plan["delete"].append({"event_id": ev["event_id"]})
+            return  # Löschung gewinnt.
+        _adopt_remote(date, remotes, merged)  # Remote-Update jünger.
+        return
+
+    # Fall 4: lokal (echt), keine Remote-Events.
+    if not remotes:
+        if local_mod > watermark:
+            merged[date] = {
+                "slots": [dict(s) for s in local["slots"]],
+                "modified_at": local_mod, "deleted": False,
+            }
+            for i, s in enumerate(local["slots"]):
+                plan["create"].append({
+                    "date": date, "slot_index": i,
+                    "start": s["start"], "end": s["end"],
+                    "kategorie": s.get("kategorie", ""), "modified_at": local_mod,
+                })
+        # sonst: war beim letzten Sync da, remote jetzt weg → verwerfen.
+        return
+
+    # Fall 5: lokal (echt) + Remote-Events.
+    if remote_mod > local_mod:
+        _adopt_remote(date, remotes, merged)
+        return
+
+    # Lokal gewinnt (inkl. Gleichstand — App autoritativ): Slots ↔ Events über
+    # gcal_event_id matchen.
+    remote_by_id = {ev["event_id"]: ev for ev in remotes}
+    matched_ids = set()
+    merged_slots = []
+    for i, s in enumerate(local["slots"]):
+        eid = s.get("gcal_event_id")
+        slot_copy = dict(s)
+        if eid and eid in remote_by_id:
+            matched_ids.add(eid)
+            ev = remote_by_id[eid]
+            if (s["start"] != ev["start"] or s["end"] != ev["end"]
+                    or s.get("kategorie", "") != ev.get("kategorie", "")):
+                plan["update"].append({
+                    "event_id": eid, "date": date,
+                    "start": s["start"], "end": s["end"],
+                    "kategorie": s.get("kategorie", ""), "modified_at": local_mod,
+                })
+        else:
+            # Neuer Slot (noch kein Event oder verwaiste id) → create.
+            slot_copy["gcal_event_id"] = None
+            plan["create"].append({
+                "date": date, "slot_index": i,
+                "start": s["start"], "end": s["end"],
+                "kategorie": s.get("kategorie", ""), "modified_at": local_mod,
+            })
+        merged_slots.append(slot_copy)
+
+    # Remote-Events ohne lokalen Slot → löschen.
+    for ev in remotes:
+        if ev["event_id"] not in matched_ids:
+            plan["delete"].append({"event_id": ev["event_id"]})
+
+    merged[date] = {"slots": merged_slots, "modified_at": local_mod, "deleted": False}
+
+
+def merge_reservations(local_raw, remote_events, watermark):
+    """Pure Merge zwischen lokalen Reservierungs-Records und Kalender-Events.
+
+    local_raw:     {date: {slots: [{start,end,kategorie,gcal_event_id}],
+                           modified_at, deleted}}
+    remote_events: Liste von {date, start, end, kategorie, modified_at, event_id}
+    watermark:     last_calendar_sync_at (ISO-String, "" beim Erststart)
+
+    Liefert {"merged": {...}, "plan": {"create": [...], "update": [...],
+    "delete": [...]}}.
+    """
+    plan = {"create": [], "update": [], "delete": []}
+
+    remote_by_date = {}
+    for ev in remote_events:
+        remote_by_date.setdefault(ev["date"], []).append(ev)
+
+    merged = {}
+    for date in set(local_raw.keys()) | set(remote_by_date.keys()):
+        _merge_one_date(
+            date, local_raw.get(date), remote_by_date.get(date, []),
+            watermark, merged, plan,
+        )
+    return {"merged": merged, "plan": plan}
+
+
+def reconcile_reservations(service, calendar_id, store, settings):
+    """Voller Kalender-Abgleich: pull → merge → push.
+
+    Mutiert store und settings. Wirft bei Netz-/API-Fehlern weiter — der Caller
+    entscheidet, ob still geloggt oder als Messagebox gezeigt wird.
+    """
+    from src import gcal
+
+    watermark = settings.get("last_calendar_sync_at") or ""
+    local_snapshot = store.get_all_raw()
+    remote_events = gcal.list_app_events(service, calendar_id)
+    result = merge_reservations(local_snapshot, remote_events, watermark)
+    merged, plan = result["merged"], result["plan"]
+
+    for item in plan["delete"]:
+        gcal.delete_event(service, calendar_id, item["event_id"])
+
+    for item in plan["update"]:
+        gcal.update_event(
+            service, calendar_id, item["event_id"],
+            item["date"], item["start"], item["end"],
+            item["kategorie"], item["modified_at"],
+        )
+
+    for item in plan["create"]:
+        event_id = gcal.create_event(
+            service, calendar_id,
+            item["date"], item["start"], item["end"],
+            item["kategorie"], item["modified_at"],
+        )
+        merged[item["date"]]["slots"][item["slot_index"]]["gcal_event_id"] = event_id
+
+    # Rebase: Reservierungen, die seit dem Snapshot lokal gespeichert/geändert
+    # wurden (paralleler Reconcile / User-Save während des Netzwerkteils),
+    # dürfen nicht durch den apply_reconciled-Replace verloren gehen.
+    for date, entry in store.get_all_raw().items():
+        snap = local_snapshot.get(date)
+        if snap is None or entry.get("modified_at", "") > snap.get("modified_at", ""):
+            merged[date] = entry
+
+    store.apply_reconciled(merged)
+    settings.set("last_calendar_sync_at", _utc_now_iso())
+```
+
+- [ ] **Step 4: Tests laufen lassen — müssen BESTEHEN**
+
+Run: `python -m pytest tests/test_reservations_sync.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: GESAMT-Regression (ganze Suite muss grün sein)**
+
+Run: `python -m pytest tests/ -q`
+Expected: PASS (alle Tests grün — AP7 schließt die letzten roten Dateien).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/reservations_sync.py tests/test_reservations_sync.py
+git commit -m "feat(gcal): Reservierungs-Reconcile auf Slot↔Event-Mapping (#53)
+
+merge_reservations rechnet auf Slot-Ebene: pro Slot ein Event, Matching über
+gcal_event_id, Datum-Level-LWW. reconcile schreibt neue event_ids pro Slot
+zurück. Schließt die ganze Suite (inkl. der aus AP5 verschobenen Tests).
+Teil von AP7.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+**1. Spec-Coverage (Spec „gcal (gcal.py) + reservations_sync.py — mehrere Events pro Tag"):**
+- Pro Reservierungs-Slot ein Event, `gcal_event_id` pro Slot → Task 2 (`_merge_one_date` create/update/delete pro Slot) ✓
+- Event-Titel trägt Kategorie → Task 1 (`event_payload` summary + property) ✓
+- merge/reconcile von „pro Tag" auf „pro Slot im Tag", Matching über event_id → Task 2 ✓
+- `list_app_events`/`parse_event` liefern weiter pro Event ein Dict (jetzt inkl. kategorie) → Task 1 ✓
+- AP5-verschobene Tests (gcal_event_id-Erhalt/Reconcile-Update) → `test_reconcile_imported_update_plans_update` ✓
+- Ziel „ganze Suite grün" → Task 2 Step 5 ✓
+
+**2. Placeholder-Scan:** Keine TBD/TODO; vollständiger Code + Tests in jedem Step. ✓
+
+**3. Typ-Konsistenz:**
+- `event_payload(date,start,end,kategorie,modified_at)` / `create_event(...,kategorie,modified_at)` / `update_event(...,kategorie,modified_at)` — identisch in gcal.py, test_gcal, reconcile-Aufrufen. ✓
+- Plan `create`-Item `{date,slot_index,start,end,kategorie,modified_at}`; `slot_index` indexiert `merged[date]["slots"]` — reconcile schreibt event_id dorthin zurück. ✓
+- Reservierungs-Record `{slots:[{start,end,kategorie,gcal_event_id}],modified_at,deleted}` — konsistent zu AP1 + apply_reconciled-Pflichtkeys. ✓
+- `parse_event` liefert `{date,start,end,kategorie,modified_at,event_id}` — von `_slot_from_event` und dem Matching gelesen. ✓

--- a/docs/superpowers/plans/2026-06-20-macos-delete-button-cell.md
+++ b/docs/superpowers/plans/2026-06-20-macos-delete-button-cell.md
@@ -13,7 +13,8 @@
 - macOS-exklusiv: alle Verhaltensänderungen gegated über `platform.system() == "Darwin"`. Win/Linux bleiben unverändert (Rechtsklick bleibt einziger Lösch-Pfad).
 - Datumsformat intern ISO, UI deutsch (hier nicht betroffen — Button trägt kein Datum).
 - Tkinter-Widget-Aufbau wird nicht automatisiert getestet (CI ohne Display). Auto-Tests nur für reine Logik; UI-Schicht per `py_compile`-Smoke + manuellem macOS-Test.
-- CI installiert nur `pytest` + `holidays` (kein `requirements.txt`): Test-Code darf **nicht** `src.ui` importieren. Reine Helfer in `src/theme.py` ansiedeln.
+- CI (`.github/workflows/test.yml`) installiert `pytest`, `holidays`, `google-api-python-client`, `google-auth`, `google-auth-oauthlib`; `src.ui` IST in Tests importierbar (s. `tests/test_ui_delete.py`, das `_delete_action` direkt importiert). Der `lint`-Job läuft `ruff check .` — keine unbenutzten Imports/Namen zurücklassen.
+- Reine UI-Entscheidungs-Helfer leben gebündelt in `src/theme.py` (vgl. `_stray_click_suppressed`, `_click_keeps_focus`) — dep-leicht und in jeder Umgebung (auch lokal ohne Google-Libs) importierbar. Die neue Sichtbarkeitslogik folgt diesem Muster.
 - Lösch-*Mechanismus* (`App._delete_day`, `_delete_action`, `themed_ask_delete_choice`) bleibt unverändert — der Button ist nur ein weiterer Auslöser.
 - Theme: keine neuen Tokens; nur vorhandene `TEXT_MUTED`/`ACCENT`/`FONT_TINY`.
 - Shell ist PowerShell 5.1: keine `&&`-Verkettung (mit `;` trennen). Git-Commits enden mit `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`.
@@ -181,6 +182,12 @@ ergänzen zu:
 ```
 
 - [ ] **Step 4: `_cell_hover` um `_delete_button` erweitern**
+
+Hinweis: `_cell_hover` deckt sowohl Entry-Zellen (`ui.py:854-855`) als auch
+Feiertags-Zellen ab — `_build_holiday_cell` bindet seinen Hover ebenfalls auf
+`self._cell_hover` (`ui.py:1232-1235`), keinen eigenen Pfad. Diese eine
+Erweiterung färbt also den ✕-Hintergrund auf Entry- UND Feiertags-Zellen mit;
+`_empty_hover` (Step 5) deckt die reinen Reservierungstage (Empty-Zellen) ab.
 
 In `src/ui.py` die Methode `_cell_hover` (Zeile 1244-1252). Vorhandenen Body:
 

--- a/docs/superpowers/plans/2026-06-20-macos-delete-button-cell.md
+++ b/docs/superpowers/plans/2026-06-20-macos-delete-button-cell.md
@@ -1,0 +1,458 @@
+# macOS-Lösch-Button in der Tageszelle — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Auf macOS ein kleines ✕-Overlay oben links in jeder Tageszelle mit löschbaren Einträgen, das denselben Lösch-Pfad wie der Win/Linux-Rechtsklick auslöst, und die bisherige macOS-Dialog-Lösch-Ausnahme entfernen.
+
+**Architecture:** Reine, testbare Sichtbarkeits-Funktion in `src/theme.py` (dep-frei, CI-sicher wie `_stray_click_suppressed`). Tkinter-Verdrahtung im Zell-Dispatcher `App._build_day_cell` über einen neuen `_add_delete_button`-Helfer (spiegelt das vorhandene `_add_reservation_marker`-Overlay-Muster). Hover-Repaint analog zum Reservierungs-Marker. macOS-Dialog-Ausnahme in `entry_dialog.py` entfällt.
+
+**Tech Stack:** Python, Tkinter; pytest. Keine neuen Dependencies.
+
+## Global Constraints
+
+- macOS-exklusiv: alle Verhaltensänderungen gegated über `platform.system() == "Darwin"`. Win/Linux bleiben unverändert (Rechtsklick bleibt einziger Lösch-Pfad).
+- Datumsformat intern ISO, UI deutsch (hier nicht betroffen — Button trägt kein Datum).
+- Tkinter-Widget-Aufbau wird nicht automatisiert getestet (CI ohne Display). Auto-Tests nur für reine Logik; UI-Schicht per `py_compile`-Smoke + manuellem macOS-Test.
+- CI installiert nur `pytest` + `holidays` (kein `requirements.txt`): Test-Code darf **nicht** `src.ui` importieren. Reine Helfer in `src/theme.py` ansiedeln.
+- Lösch-*Mechanismus* (`App._delete_day`, `_delete_action`, `themed_ask_delete_choice`) bleibt unverändert — der Button ist nur ein weiterer Auslöser.
+- Theme: keine neuen Tokens; nur vorhandene `TEXT_MUTED`/`ACCENT`/`FONT_TINY`.
+- Shell ist PowerShell 5.1: keine `&&`-Verkettung (mit `;` trennen). Git-Commits enden mit `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`.
+
+---
+
+### Task 1: Reine Sichtbarkeits-Funktion `_should_show_delete_button`
+
+**Files:**
+- Modify: `src/theme.py` (neue Funktion neben `_stray_click_suppressed`)
+- Test: `tests/test_delete_button.py` (neu)
+
+**Interfaces:**
+- Produces: `_should_show_delete_button(is_macos: bool, has_entry: bool, has_reservation: bool) -> bool` in `src/theme.py`. Wahr genau dann, wenn `is_macos and (has_entry or has_reservation)`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_delete_button.py`:
+
+```python
+"""Sichtbarkeit des macOS-Lösch-Buttons in der Tageszelle.
+
+Reine Entscheidungslogik `_should_show_delete_button`. Die Tk-Verdrahtung
+(_add_delete_button, Aufruf in _build_day_cell, Hover-Repaint) ist UI-Schicht
+und wird wie üblich manuell auf macOS verifiziert.
+"""
+from src.theme import _should_show_delete_button
+
+
+def test_not_macos_never_shows():
+    assert _should_show_delete_button(False, True, True) is False
+    assert _should_show_delete_button(False, True, False) is False
+    assert _should_show_delete_button(False, False, True) is False
+
+
+def test_macos_without_deletable_units_hidden():
+    assert _should_show_delete_button(True, False, False) is False
+
+
+def test_macos_with_entry_shows():
+    assert _should_show_delete_button(True, True, False) is True
+
+
+def test_macos_with_reservation_only_shows():
+    assert _should_show_delete_button(True, False, True) is True
+
+
+def test_macos_with_both_shows():
+    assert _should_show_delete_button(True, True, True) is True
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_delete_button.py -v`
+Expected: FAIL mit `ImportError: cannot import name '_should_show_delete_button' from 'src.theme'`
+
+- [ ] **Step 3: Add the implementation**
+
+In `src/theme.py`, direkt nach der Funktion `_stray_click_suppressed` einfügen:
+
+```python
+def _should_show_delete_button(is_macos, has_entry, has_reservation):
+    """macOS-only Lösch-Button (✕) in der Tageszelle: nur auf macOS und nur,
+    wenn der Tag löschbare Einheiten hat — Ist-Zeit ODER aktive Reservierung.
+    Reine Logik, damit aus den Tests ohne Tk/UI-Deps prüfbar (vgl.
+    _stray_click_suppressed)."""
+    return is_macos and (has_entry or has_reservation)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_delete_button.py -v`
+Expected: PASS (5 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/theme.py tests/test_delete_button.py
+git commit -m "feat(theme): reine Sichtbarkeitslogik fuer macOS-Loesch-Button
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: `_add_delete_button`-Helfer + Verdrahtung in `_build_day_cell` + Hover-Repaint
+
+**Files:**
+- Modify: `src/ui.py` — Import aus `src.theme`; neuer Helfer `App._add_delete_button`; Aufruf in `App._build_day_cell`; `_cell_hover` und `_empty_hover` um `_delete_button` erweitern.
+
+**Interfaces:**
+- Consumes: `_should_show_delete_button` aus `src.theme` (Task 1); `App._delete_day(date_str)`, `App._add_reservation_marker` (bestehend).
+- Produces: `App._add_delete_button(self, cell, date_str) -> None` — setzt ein `tk.Label` „✕" oben links, bindet Klick auf `_delete_day`, taggt `cell._delete_button`.
+
+- [ ] **Step 1: Import der Sichtbarkeitslogik ergänzen**
+
+In `src/ui.py` den `from src.theme import (...)`-Block (beginnt bei Zeile 35) um `_should_show_delete_button` erweitern. Konkret die vorhandene Zeile
+
+```python
+    BG, CELL_BG, WEEKEND_BG, ACCENT, ACCENT_HOVER, TEXT, TEXT_MUTED,
+```
+
+ersetzen durch:
+
+```python
+    BG, CELL_BG, WEEKEND_BG, ACCENT, ACCENT_HOVER, TEXT, TEXT_MUTED,
+    _should_show_delete_button,
+```
+
+(`platform`, `ACCENT`, `TEXT_MUTED`, `FONT_TINY` sind in `ui.py` bereits importiert.)
+
+- [ ] **Step 2: Helfer `_add_delete_button` hinzufügen**
+
+In `src/ui.py` direkt **nach** der Methode `_add_reservation_marker` (endet mit `cell._reservation_marker = marker`, Zeile 883) einfügen:
+
+```python
+    def _add_delete_button(self, cell, date_str):
+        """macOS-only: kleines ✕ oben links, das den Lösch-Pfad auslöst.
+
+        <Button-3> ist auf macOS unzuverlässig (Sekundärklick je nach Tk-Version
+        <Button-2>/Control-Klick); dieser Button gibt dort einen verlässlichen
+        Lösch-Auslöser, ohne den Linksklick-Dialog mit Lösch-Buttons zu belasten.
+        Klick ruft denselben _delete_day-Pfad wie der Win/Linux-Rechtsklick
+        (Ja/Nein bzw. Slot-Auswahl). Getaggt als cell._delete_button, damit
+        _cell_hover/_empty_hover seinen Hintergrund beim Hover mitfärben."""
+        bg = cell.cget("bg")
+        btn = tk.Label(
+            cell, text="✕", font=FONT_TINY, bg=bg, fg=TEXT_MUTED, cursor="hand2",
+        )
+        btn.place(relx=0.0, x=3, y=2, anchor="nw")
+        # "break" stoppt jede Propagation, damit der Klick nicht zusätzlich als
+        # Zell-Linksklick (Bearbeiten-Dialog) durchschlägt.
+        btn.bind("<Button-1>",
+                 lambda e, d=date_str: (self._delete_day(d), "break")[1])
+        # fg-Hover (rot als Lösch-Affordance) steuert der Button selbst; den bg
+        # färbt _cell_hover/_empty_hover mit der Zelle.
+        btn.bind("<Enter>", lambda e: btn.config(fg=ACCENT))
+        btn.bind("<Leave>", lambda e: btn.config(fg=TEXT_MUTED))
+        cell._delete_button = btn
+```
+
+- [ ] **Step 3: Aufruf in `_build_day_cell` ergänzen**
+
+In `src/ui.py` in `_build_day_cell` am Ende des Tooltip-Blocks. Vorhandene Stelle (Zeile 971-972):
+
+```python
+        if tip_parts:
+            attach_tooltip(cell, "\n".join(tip_parts))
+```
+
+ergänzen zu:
+
+```python
+        if tip_parts:
+            attach_tooltip(cell, "\n".join(tip_parts))
+
+        # macOS-only Lösch-Button (✕) oben links, sobald der Tag löschbare
+        # Einheiten hat (Ist-Zeit ODER aktive Reservierung). reservation wird
+        # nur bei aktivem Kalender-Sync übergeben (vgl. _add_reservation_marker),
+        # daher deckt `reservation is not None` die aktive Reservierung ab.
+        if _should_show_delete_button(
+            platform.system() == "Darwin", bool(entry), reservation is not None
+        ):
+            self._add_delete_button(cell, date_str)
+```
+
+- [ ] **Step 4: `_cell_hover` um `_delete_button` erweitern**
+
+In `src/ui.py` die Methode `_cell_hover` (Zeile 1244-1252). Vorhandenen Body:
+
+```python
+    def _cell_hover(frame, day_lbl, time_lbl, bg):
+        frame.config(bg=bg)
+        day_lbl.config(bg=bg)
+        time_lbl.config(bg=bg)
+        # Eck-Marker (nur auf Entry-Zellen mit zusätzlicher Reservierung)
+        # mitfärben, sonst bleibt beim Hover ein andersfarbiges Rechteck stehen.
+        marker = getattr(frame, "_reservation_marker", None)
+        if marker is not None:
+            marker.config(bg=bg)
+```
+
+ersetzen durch:
+
+```python
+    def _cell_hover(frame, day_lbl, time_lbl, bg):
+        frame.config(bg=bg)
+        day_lbl.config(bg=bg)
+        time_lbl.config(bg=bg)
+        # Eck-Overlays (Reservierungs-Marker, macOS-Lösch-Button) mitfärben,
+        # sonst bleibt beim Hover ein andersfarbiges Rechteck stehen. Nur bg —
+        # die fg des Lösch-Buttons steuert dessen eigener Enter/Leave-Handler.
+        marker = getattr(frame, "_reservation_marker", None)
+        if marker is not None:
+            marker.config(bg=bg)
+        del_btn = getattr(frame, "_delete_button", None)
+        if del_btn is not None:
+            del_btn.config(bg=bg)
+```
+
+- [ ] **Step 5: `_empty_hover` um `_delete_button` erweitern**
+
+In `src/ui.py` die Methode `_empty_hover` (Zeile 1254-1263). Vorhandenen Body:
+
+```python
+    @staticmethod
+    def _empty_hover(frame, day_lbl, bg):
+        frame.config(bg=bg)
+        day_lbl.config(bg=bg)
+        # Reservierungs-Eck-Punkt mitfärben — Nur-Reservierungs-Tage sind
+        # Empty-Zellen mit Marker; sonst bliebe beim Hover ein andersfarbiges
+        # Rechteck hinter dem Punkt stehen.
+        marker = getattr(frame, "_reservation_marker", None)
+        if marker is not None:
+            marker.config(bg=bg)
+```
+
+ersetzen durch:
+
+```python
+    @staticmethod
+    def _empty_hover(frame, day_lbl, bg):
+        frame.config(bg=bg)
+        day_lbl.config(bg=bg)
+        # Eck-Overlays mitfärben — Nur-Reservierungs-Tage sind Empty-Zellen mit
+        # Marker (und auf macOS zusätzlich dem Lösch-Button); sonst bliebe beim
+        # Hover ein andersfarbiges Rechteck dahinter stehen. Nur bg.
+        marker = getattr(frame, "_reservation_marker", None)
+        if marker is not None:
+            marker.config(bg=bg)
+        del_btn = getattr(frame, "_delete_button", None)
+        if del_btn is not None:
+            del_btn.config(bg=bg)
+```
+
+- [ ] **Step 6: Syntax-Smoke**
+
+Run: `python -m py_compile src/ui.py`
+Expected: kein Output, Exit 0 (importiert keine schweren Deps, prüft nur Syntax).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/ui.py
+git commit -m "feat(ui): macOS-Loesch-Button (X) oben links in der Tageszelle
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: macOS-Dialog-Lösch-Ausnahme in `entry_dialog.py` entfernen
+
+**Files:**
+- Modify: `src/dialogs/entry_dialog.py` — `import platform` raus, `_SHOW_DELETE_IN_DIALOG` + Kommentarblock raus, `delete_ist`/`delete_reservation` + zugehörige Buttons raus, Docstring anpassen.
+
+**Interfaces:**
+- Consumes: nichts Neues. `secondary_button` bleibt importiert (an anderen Stellen genutzt: Zeilen 113, 129, 190, 201).
+
+- [ ] **Step 1: `import platform` entfernen**
+
+In `src/dialogs/entry_dialog.py` Zeile 2 löschen:
+
+```python
+import platform
+```
+
+(Wird nach Entfernen von `_SHOW_DELETE_IN_DIALOG` nirgends mehr genutzt.)
+
+- [ ] **Step 2: Kommentarblock + Konstante entfernen**
+
+In `src/dialogs/entry_dialog.py` die Zeilen 17-22 löschen:
+
+```python
+# Löschen folgt im Kalender dem Muster „Linksklick = speichern, Rechtsklick =
+# löschen". Der Dialog (Linksklick) ist daher rein zum Anlegen/Bearbeiten — die
+# Lösch-Buttons sind dort raus. AUSNAHME macOS: Tkinters Maustasten-Nummerierung
+# macht den Rechtsklick (`<Button-3>`) dort unzuverlässig; damit Löschen auf dem
+# Mac überhaupt erreichbar bleibt, behält der Dialog dort seine Lösch-Buttons.
+_SHOW_DELETE_IN_DIALOG = platform.system() == "Darwin"
+```
+
+- [ ] **Step 3: Docstring anpassen**
+
+In `src/dialogs/entry_dialog.py` (Docstring von `open_entry_dialog`) die Zeile
+
+```python
+    Liste. Entfernt man alle Zeilen eines Blocks und speichert, wird der Block
+    gelöscht — kein separater Lösch-Button (außer macOS).
+```
+
+ersetzen durch:
+
+```python
+    Liste. Entfernt man alle Zeilen eines Blocks und speichert, wird der Block
+    gelöscht — der Dialog hat keinen Lösch-Button (Löschen läuft im Kalender:
+    Rechtsklick auf Win/Linux, ✕-Button in der Zelle auf macOS).
+```
+
+- [ ] **Step 4: `delete_ist` + Ist-Lösch-Button entfernen**
+
+In `src/dialogs/entry_dialog.py` die Funktion `delete_ist` (Zeilen 154-157) löschen:
+
+```python
+    def delete_ist():
+        storage.delete(date_str)
+        dialog.destroy()
+        on_change()
+```
+
+Und im Ist-Save-Block (Zeilen 159-163) die beiden Lösch-Zeilen löschen, sodass aus
+
+```python
+    ist_save = tk.Frame(outer, bg=BG)
+    ist_save.pack(fill="x")
+    primary_button(ist_save, "Speichern", save_ist).pack(side=tk.LEFT, padx=2)
+    if entry is not None and _SHOW_DELETE_IN_DIALOG:
+        secondary_button(ist_save, "Löschen", delete_ist).pack(side=tk.LEFT, padx=2)
+```
+
+wird:
+
+```python
+    ist_save = tk.Frame(outer, bg=BG)
+    ist_save.pack(fill="x")
+    primary_button(ist_save, "Speichern", save_ist).pack(side=tk.LEFT, padx=2)
+```
+
+- [ ] **Step 5: `delete_reservation` + Reservierungs-Lösch-Button entfernen**
+
+In `src/dialogs/entry_dialog.py` die Funktion `delete_reservation` (Zeilen 229-234) löschen:
+
+```python
+        def delete_reservation():
+            reservation_store.delete(date_str)
+            dialog.destroy()
+            on_change()
+            if trigger_reconcile is not None:
+                trigger_reconcile()
+```
+
+Und im Reservierungs-Save-Block (Zeilen 236-242) die Lösch-Zeilen löschen, sodass aus
+
+```python
+        res_save = tk.Frame(outer, bg=BG)
+        res_save.pack(fill="x")
+        primary_button(res_save, "Reservierung speichern",
+                       save_reservation).pack(side=tk.LEFT, padx=2)
+        if existing_reservation is not None and _SHOW_DELETE_IN_DIALOG:
+            secondary_button(res_save, "Reservierung löschen",
+                             delete_reservation).pack(side=tk.LEFT, padx=2)
+```
+
+wird:
+
+```python
+        res_save = tk.Frame(outer, bg=BG)
+        res_save.pack(fill="x")
+        primary_button(res_save, "Reservierung speichern",
+                       save_reservation).pack(side=tk.LEFT, padx=2)
+```
+
+- [ ] **Step 6: Syntax-Smoke + bestehende Tests**
+
+Run: `python -m py_compile src/dialogs/entry_dialog.py`
+Expected: kein Output, Exit 0.
+
+Run: `pytest -q`
+Expected: alle Tests grün (inkl. `tests/test_delete_button.py`); keine Regression durch den Umbau (die Lösch-Logik selbst ist unverändert).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/dialogs/entry_dialog.py
+git commit -m "refactor(ui): macOS-Dialog-Loeschbuttons entfernen (Zell-Button ersetzt sie)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Doku in `CLAUDE.md` aktualisieren
+
+**Files:**
+- Modify: `CLAUDE.md` — Abschnitt „Plattform-Ausnahme macOS".
+
+**Interfaces:** keine.
+
+- [ ] **Step 1: Abschnitt anpassen**
+
+In `CLAUDE.md` den Absatz unter „Kalender-Interaktion: Linksklick speichert, Rechtsklick löscht". Vorhandenen Text:
+
+```markdown
+**Plattform-Ausnahme macOS:** Tkinters Maustasten-Nummerierung macht den
+Rechtsklick (`<Button-3>`) auf macOS unzuverlässig (Sekundärklick ist je nach
+Tk-Version `<Button-2>` bzw. Control-Klick). Damit Löschen auf dem Mac
+überhaupt erreichbar bleibt, behält der Dialog **dort** seine Lösch-Buttons
+(„Löschen" / „Reservierung löschen"). Gesteuert über
+`_SHOW_DELETE_IN_DIALOG = platform.system() == "Darwin"` in `entry_dialog.py`.
+Auf Windows/Linux ist Löschen ausschließlich der Rechtsklick.
+```
+
+ersetzen durch:
+
+```markdown
+**Plattform-Ausnahme macOS:** Tkinters Maustasten-Nummerierung macht den
+Rechtsklick (`<Button-3>`) auf macOS unzuverlässig (Sekundärklick ist je nach
+Tk-Version `<Button-2>` bzw. Control-Klick). Damit Löschen auf dem Mac
+erreichbar bleibt, zeigt die Tageszelle **dort** ein kleines ✕ oben links,
+sobald der Tag löschbare Einheiten hat (Ist-Zeit oder aktive Reservierung).
+Der ✕-Button löst denselben Lösch-Pfad wie der Rechtsklick aus
+(`App._delete_day` inkl. Bestätigung/Slot-Auswahl). Gesteuert über
+`_should_show_delete_button` (`theme.py`) + `App._add_delete_button` (`ui.py`).
+Der Tages-Dialog hat auf **allen** Plattformen keine Lösch-Buttons. Auf
+Windows/Linux ist Löschen ausschließlich der Rechtsklick.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: macOS-Loeschen ueber Zell-Button statt Dialog-Buttons
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Manuelle Verifikation (macOS, nach allen Tasks)
+
+Auf einem Mac (`python -m src.main`) prüfen — kann auf Windows nicht automatisiert werden:
+
+1. Tag mit Ist-Zeit: ✕ oben links sichtbar; Klick → „Arbeitszeit löschen?"-Ja/Nein; Bestätigen löscht.
+2. Tag mit mehreren Slots: Klick auf ✕ → Checkbox-Auswahldialog (600 ms-Lock), nicht-gewählte Slots bleiben.
+3. Reiner Reservierungstag (leere/Feiertags-Zelle mit violettem Punkt): ✕ sichtbar; löscht die Reservierung.
+4. Tag mit Ist-Zeit **und** Reservierung: ✕ links + violetter Punkt rechts; Auswahldialog bietet beide.
+5. Leerer Tag: **kein** ✕.
+6. ✕ färbt sich beim Hover über das Symbol rot; Zell-Hover lässt **kein** andersfarbiges Rechteck hinter dem ✕ stehen. Falls beim Hover über das ✕ die Zelle kurz ihre Hervorhebung verliert (Tk `<Leave>` mit `NotifyInferior` beim Eintritt in das Kind-Widget): als Detail notieren — kein Blocker, ggf. Folge-Fix.
+7. Linksklick auf die Zelle (nicht auf das ✕) öffnet weiterhin den Bearbeiten-Dialog; Klick auf das ✕ öffnet den Dialog **nicht**.
+8. Tages-Dialog hat keine Lösch-Buttons mehr.
+
+Win/Linux-Regressionscheck: keine ✕ in den Zellen; Rechtsklick löscht wie bisher; Dialog ohne Lösch-Buttons.

--- a/docs/superpowers/specs/2026-06-19-multi-timeslots-kategorien-design.md
+++ b/docs/superpowers/specs/2026-06-19-multi-timeslots-kategorien-design.md
@@ -1,0 +1,272 @@
+# Mehrere Timeslots pro Tag mit benutzerdefinierten Kategorien
+
+**Issue:** margenheld/Zeiterfassung#53
+**Datum:** 2026-06-19
+**Status:** Design abgenommen, bereit für Implementierungsplan
+
+## Ziel
+
+Pro Tag sollen statt genau **einer** Arbeitszeit **mehrere Timeslots** erfassbar sein,
+jeder einer **benutzerdefinierten Kategorie** zugeordnet (z.B. „Büro", „Homeoffice",
+„Kundentermin"). Gleiches gilt für **Reservierungen** (geplante Soll-Zeiten). Kategorien
+pflegt der Nutzer selbst in den Settings. Über einen Zeitraum lässt sich gezielt nach
+Kategorie aufsummieren, und beim Senden/Teilen können Kategorien gefiltert werden.
+
+**Backwards-Compatibility ist Pflicht.** Hatte der Nutzer vorher keine Kategorien/mehreren
+Slots, verhält sich alles wie vor der Migration: ein Tag = ein Slot mit leerer Kategorie.
+
+## Leitentscheidungen (abgenommen)
+
+1. **Sync-Granularität:** Der **Tag bleibt die Sync-/Konflikt-Einheit.** Der Eintragswert
+   wird eine Slot-Liste. LWW-Merge vergleicht die ganze Liste; ein Konflikt ist weiterhin
+   ein Tages-Konflikt. Kein Slot-level-Sync (bewusst YAGNI — vervielfachte Komplexität ohne
+   realen Nutzen für ein persönliches Tool mit wenigen Geräten).
+2. **Kategorie-Modell:** Der Slot speichert den Kategorie-**Namen als String**. Die
+   Settings-Liste ist nur die Pickliste/Vorschlagsliste. Folgen: leer (`""`) = keine
+   Kategorie = Verhalten wie heute; der Name reist mit dem Slot, daher kann „Kategorie
+   existiert auf Gerät X nicht" konstruktiv nicht auftreten; ein Slot bleibt lesbar, auch
+   wenn die Kategorie später aus der Pickliste entfernt wird.
+3. **Pause** wird **pro Slot** geführt (jeder Ist-Zeit-Slot hat eigene Pause).
+4. **Report:** voller Kategorie-Nutzen — Zeile pro Slot mit Kategorie-Spalte, Tages-Subtotal,
+   KW-Summen, plus „Summe je Kategorie"-Block; Kategorie-Filter im Sende-/Teilen-Dialog.
+5. **Non-Overlap:** Slots eines Tages dürfen sich **zeitlich nicht überlappen** — getrennt
+   geprüft innerhalb der Ist-Zeit-Slots bzw. innerhalb der Reservierungs-Slots. Ist-Zeit und
+   Reservierung dürfen sich (wie heute) am selben Tag überlagern. Gleiche Kategorie mehrfach
+   zu verschiedenen, nicht-überlappenden Zeiten ist erlaubt und summiert sich.
+6. **Löschen:** Rechtsklick auf eine Tageszelle bleibt das Lösch-Modell (CLAUDE.md).
+   Der Bestätigungs-/Auswahl-Dialog zeigt **nur die am Tag tatsächlich vorhandenen Arten**
+   (Arbeitszeit / Reservierung), differenziert wie heute. Einzelne Slots entfernt man im
+   Links-Klick-Dialog durch Entfernen der Slot-Zeile + Speichern (Editieren, kein zweiter
+   Löschpfad auf Win/Linux).
+7. **Umfang:** Ein Branch, ein PR, intern in eigenständig verifizierte Arbeitspakete
+   zerlegt. Reservierungen + Multi-Event-gcal sind **enthalten** (nicht abgespalten).
+
+## Datenmodell
+
+### Storage (`src/storage.py`)
+
+Tag bleibt Sync-Einheit, Wert wird eine Slot-Liste:
+
+```jsonc
+"2026-06-19": {
+  "slots": [
+    {"start": "08:00", "end": "12:00", "pause": 0,  "kategorie": "Büro"},
+    {"start": "13:00", "end": "17:00", "pause": 30, "kategorie": "Homeoffice"}
+  ],
+  "modified_at": "...", "device_id": "...", "deleted": false
+}
+```
+
+- Slot-Schema: `{start, end, pause, kategorie}`. `kategorie` ist ein String, `""` = keine.
+- `_REQUIRED_ENTRY_KEYS` → `{slots, modified_at, device_id, deleted}`.
+- `_user_shape(entry)` → `{slots: [...]}` (Liste der reinen Slot-Dicts ohne Metadaten).
+- `save(date, slots)` ersetzt die Tages-Signatur (`start, end, pause` → `slots`).
+- `save_many(updates)`: `updates = {date: {slots: [...]}}`.
+- `delete(date)`: Tombstone mit `slots: []`, `deleted: True`.
+- `apply_merge`: Required-Key-Validierung auf neues Schema.
+
+### Reservierungen (`src/reservations.py`)
+
+Analog, **`gcal_event_id` pro Slot**:
+
+```jsonc
+"2026-06-25": {
+  "slots": [
+    {"start": "09:00", "end": "17:00", "kategorie": "Kundentermin", "gcal_event_id": null}
+  ],
+  "modified_at": "...", "deleted": false
+}
+```
+
+- Slot-Schema: `{start, end, kategorie, gcal_event_id}` (kein `pause` bei Reservierungen,
+  wie heute).
+- `_REQUIRED_RESERVATION_KEYS`, `save`, `delete`, `apply_reconciled` analog zu Storage.
+
+### Migration (idempotent)
+
+Beim Laden, analog zu `Storage._migrate_legacy_entries` / dem Settings-Migrationsmuster:
+
+- **Erkennung:** Hat ein Eintrag bereits einen `"slots"`-Key → schon migriert, unberührt.
+- **Lebender Alt-Eintrag** `{start, end, pause, ...}` → `{slots: [{start, end, pause,
+  kategorie: ""}], ...}` (Metadaten bleiben).
+- **Alt-Tombstone** (`deleted: true`, `start: null`) → `{slots: [], deleted: true, ...}`.
+- **Reservierungen:** Alt `{start, end, gcal_event_id, ...}` → `{slots: [{start, end,
+  kategorie: "", gcal_event_id}], ...}`; Alt-Tombstone → `{slots: []}`.
+
+Migration läuft rein lokal beim Laden; sie schreibt nicht selbst auf Platte, sondern wird
+beim nächsten regulären Save persistiert (wie das bestehende Muster).
+
+## Kategorien (Settings)
+
+- Neuer Setting-Key `categories` = `list[str]`, Default `[]`. Reine Pickliste/Vorschläge,
+  keine Stundensätze o.ä.
+- In den Drive-Sync aufgenommen: `categories` zu `SYNCED_SETTING_KEYS` in **beiden** Stellen
+  (`src/settings.py` *und* dem Duplikat in `src/sync.py`). Der Wert ist ein String-Array →
+  `_values_equal_setting` (Vergleich per `==`) funktioniert ohne Änderung.
+- `_coerce` in `settings.py` muss einen `list`-Default unterstützen (Listen-Typ als neuer
+  Coerce-Fall; Nicht-Listen → Default).
+- Verwaltung im `settings_dialog.py`: anlegen / umbenennen / entfernen. Umbenennen ändert
+  **nicht** rückwirkend Slots (Slots tragen den Namen-String; Umbenennen passt nur die
+  Pickliste an). Das ist akzeptiert und konsistent mit dem Name-am-Slot-Modell.
+
+## Validierung (`src/time_utils.py`)
+
+- Pro Slot wie heute: `validate_entry(start, end, pause)` — Ende > Start, Pause < Dauer.
+- **Neu:** Hilfsfunktion, die eine Slot-Liste auf **zeitliche Überlappungsfreiheit** prüft
+  (nach Start sortieren, benachbarte Paare vergleichen). Getrennt für Ist-Zeit-Slots und
+  Reservierungs-Slots aufgerufen. Liefert (ok, Fehlermeldung) für die Dialog-Anzeige.
+- Stundenberechnung: `calculate_hours` bleibt pro Slot; Tagessumme = Summe über Slots.
+
+## Sync (`src/sync.py`) — `SCHEMA_VERSION` 2 → 3
+
+- `_values_equal_entry(a, b)`: vergleicht statt `start/end/pause` jetzt die **Slot-Liste**
+  (reihenfolge-normalisiert, z.B. nach `start` sortiert, Feld-für-Feld) **und** `deleted`.
+- Day-level-LWW (`_merge_one`), Konflikt-Dedup, Watermark/Tombstone-Kompaktierung,
+  Self-Heal (Regel 1/2) bleiben **strukturell unverändert** — sie operieren weiter pro Datum.
+- **Konflikte (bewusst minimal gehalten):** Kandidaten (`_strip_for_candidate`) tragen die
+  Slot-Liste. `resolve_conflict` (kind=`entry`) und der Resolution-Apply-Block in `merge()`
+  schreiben eine **Slot-Liste** statt `{start, end, pause}`. `chosen_value` für Entry-Konflikte
+  wird `{slots: [...], deleted?}`.
+  > **Hinweis:** Der Konflikt-Auflösungs-Flow wird voraussichtlich demnächst überarbeitet.
+  > Deshalb hier nur die minimal nötige Anpassung (Slot-Liste durchreichen), **keine** neuen
+  > tiefen Annahmen über Konflikt-UI/-Granularität verankern.
+- **Alt-Client-Schutz (Issue-Frage 5):** Neue Funktion `_remote_is_pre_v3(remote_doc)`
+  analog zum bestehenden `_remote_is_pre_v2`. Sieht ein v3-Client ein v2-(oder älteres)-
+  Remote-Doc — also ist gerade ein noch nicht aktualisiertes Gerät aktiv —, wird **die
+  Kompaktierung ausgesetzt** und der Sync-Pfad zeigt einen Hinweis: „Ein anderes Gerät nutzt
+  eine ältere Version — bitte dort aktualisieren, bevor Mehrfach-Slots verwendet werden."
+  1-Slot-Tage bleiben dabei wire-lesbar; Multi-Slot-Tage versteht ein Alt-Client nicht
+  korrekt. Voller bidirektionaler Cross-Version-Erhalt ist **bewusst nicht** Ziel
+  (Over-Engineering für ein persönliches Tool) — die Empfehlung lautet: alle Geräte updaten.
+- `build_local_doc` / `apply_merged_doc` unverändert in der Struktur (sie reichen
+  `storage.get_all_raw()` bzw. das Merge-Ergebnis durch).
+
+## Dialoge
+
+### `src/dialogs/entry_dialog.py` — dynamische Slot-Zeilen
+
+- Ist-Zeit **und** Reservierung werden je eine **Liste von Slot-Zeilen**.
+- Slot-Zeile (Ist-Zeit): Start / Ende / Pause / **Kategorie** (editierbare Combobox, Werte
+  aus `settings.categories` + Freitext) / „× entfernen".
+- Slot-Zeile (Reservierung): Start / Ende / **Kategorie** / „× entfernen".
+- „+ Slot hinzufügen"-Button je Block.
+- Speichern: validiert alle Slots (pro Slot + Non-Overlap je Block) und schreibt die Liste
+  via `storage.save(date, slots)` bzw. `reservation_store.save(date, slots)`; danach
+  `trigger_reconcile()` für Reservierungen wie heute.
+- Slot-Zeile entfernen + Speichern = Editieren (kein zweiter Löschpfad → CLAUDE.md-konform).
+- Der erste Slot eines neuen Tages füllt Start/Ende/Pause aus den Per-Wochentag-Defaults
+  (`default_start_{day}` etc.) wie heute.
+- macOS (`_SHOW_DELETE_IN_DIALOG`) behält seine Lösch-Buttons; diese löschen die jeweilige
+  **Art komplett** (alle Ist-Zeit-Slots bzw. alle Reservierungs-Slots).
+
+### `src/dialogs/send_dialog.py` — Kategorie-Filter
+
+- Zusätzlich zur Von/Bis-Auswahl eine **Mehrfachauswahl der Kategorien** (Default: alle
+  ausgewählt; Quelle = im Zeitraum vorkommende Kategorien + `settings.categories`).
+- Die Auswahl wird an `generate_report` / `generate_pdf` durchgereicht (Filter auf Slot-Ebene).
+
+### `src/dialogs/settings_dialog.py` — Kategorie-Verwaltung
+
+- Neue Sektion (eigene collapsible Section, analog „Mail-Vorlage") zum Pflegen der
+  `categories`-Liste: Hinzufügen (Eingabe + Button), Umbenennen, Entfernen.
+
+## Report (`src/report.py`)
+
+- Tabelle: **eine Zeile je Slot** mit Spalten `Datum | Tag | Kategorie | Start | Ende |
+  Stunden`. Bei einem Tag mit >1 Slot eine **Tages-Subtotal-Zeile**; KW-Summen wie heute.
+- Am Ende ein **„Summe je Kategorie"-Block** über den ausgewählten Zeitraum (Kategorie →
+  Gesamtstunden), `""`/keine Kategorie als „(ohne Kategorie)".
+- **Kategorie-Filter:** `generate_report` / `generate_pdf` nehmen eine optionale
+  Kategorie-Auswahl; `_filter_entries` filtert zusätzlich Slots, deren Kategorie nicht in der
+  Auswahl ist (Default: alle Kategorien).
+- `_entry_hours` / Tages- und KW-Summen summieren über (gefilterte) Slots.
+- Beide Pfade (HTML `generate_report`, PDF `generate_pdf`) konsistent.
+
+## Teilen (`src/share.py`) — Schema v3
+
+- Neues Wire-Format v3:
+  ```jsonc
+  {
+    "schema_version": 3, "kind": "zeiterfassung-share", "exported_at": "...", "exported_by": "...",
+    "entries":      {"YYYY-MM-DD": {"slots": [{"start","end","pause","kategorie"}]}},
+    "reservations": {"YYYY-MM-DD": {"slots": [{"start","end","kategorie"}]}}
+  }
+  ```
+- **Export:** respektiert die Kategorie-Auswahl (nur passende Slots), `include_entries` /
+  `include_reservations` wie heute.
+- **Import:** Diff/Konflikt-Anzeige wie heute, aber auf Slot-Listen-Ebene
+  (`_entries_equal` / `_reservations_equal` vergleichen Slot-Listen).
+- **Abwärtskompat:** v1/v2-Dateien bleiben importierbar — beim Lesen werden ihre
+  `{start,end,pause}` / `{start,end}` in 1-Slot-Listen (`kategorie:""`) gewrappt. v3-Validierung
+  prüft Slot-Listen (`_validate_entries` / `_validate_reservations` angepasst).
+
+## UI (`src/ui.py`)
+
+- `_build_entry_cell`: bei mehreren Slots **kompakte Darstellung** — Tagessumme bleibt
+  führend; angezeigt wird z.B. die erste Zeit plus „+N" (N = weitere Slots), der **Tooltip**
+  listet alle Slots inkl. Kategorie. `_entry_hours` summiert über Slots.
+- `_refresh_month` / Footer-Summen summieren über Slots.
+- `_delete_day` (Rechtsklick): erweiterter Auswahl-Dialog, der **nur die am Tag vorhandenen
+  Arten** zeigt (Arbeitszeit / Reservierung), differenziert wie heute (`themed_ask_delete_choice`
+  bzw. einfacher Ja/Nein, wenn nur eine Art existiert). Löscht die gewählte(n) Art(en) komplett
+  (= ganze Slot-Liste der Art).
+- Reservierungs-Marker (violetter Eckpunkt) bleibt; Tooltip listet die Reservierungs-Slots.
+
+## gcal (`src/gcal.py` + `src/reservations_sync.py`) — mehrere Events pro Tag
+
+- Pro Reservierungs-Slot **ein** Kalender-Event, identifiziert über `gcal_event_id` **pro Slot**.
+- `event_payload`: Event-Titel trägt die Kategorie, z.B. „Arbeitszeit (reserviert) — {Kategorie}"
+  (ohne Kategorie wie heute „Arbeitszeit (reserviert)"). App-Marker (`extendedProperties.private`)
+  unverändert.
+- `merge_reservations` / `reconcile_reservations` rechnen von „pro Tag" auf „pro Slot im Tag" um:
+  - **Matching** lokaler Slots ↔ Remote-Events über `gcal_event_id`.
+  - Neuer Slot (event_id `null`) → `create_event`, gesetzte event_id zurückschreiben.
+  - Entfernter Slot (lokal weg, Event noch da) → `delete_event`.
+  - Geänderter Slot (Zeit/Kategorie) → `update_event`.
+  - LWW pro Slot über `modified_at` des Tages (Tag bleibt Zeitstempel-Träger; Slot-Änderungen
+    aktualisieren `modified_at` des Tages, wie heute der Save).
+- `list_app_events` / `parse_event` unverändert in der Form (liefern weiter pro Event ein
+  `{date, start, end, modified_at, event_id}`); die Zuordnung mehrerer Events zum selben Datum
+  übernimmt der Reconcile.
+
+## Arbeitspakete
+
+Ein Branch (`feat/multi-timeslots-kategorien`), ein PR. Intern in eigenständig verifizierte
+Pakete zerlegt; jedes Paket endet mit grünen Tests. Lokaler Test vor dem PR.
+
+1. **Datenmodell + Migration** — `storage.py`, `reservations.py` + Tests.
+2. **Sync v3 + Kategorien-Setting** — `sync.py` (`SCHEMA_VERSION`, `_values_equal_entry`,
+   Konflikt-Durchreichung, `_remote_is_pre_v3`), `settings.py` (+ Duplikat `SYNCED_SETTING_KEYS`,
+   `categories`-Default, list-Coerce) + Tests.
+3. **entry_dialog Multi-Slot** + `time_utils`-Validierung (Non-Overlap) + Tests.
+4. **report + send_dialog** (Kategorie-Spalte, Tages-Subtotal, „Summe je Kategorie", Filter) + Tests.
+5. **share v3** (Export/Import + Filter, v1/v2-Kompat) + Tests.
+6. **ui.py** (Zellen-Rendering, Rechtsklick-Löschen) + **settings_dialog** (Kategorie-Verwaltung) + Tests.
+7. **gcal + reservations_sync** (Multi-Event pro Tag, Slot-Event-Mapping) + Tests.
+
+Reihenfolge ist die Default-Abfolge (Fundament → außen); der Implementierungsplan kann sie
+verfeinern. Pakete 1–2 sind harte Voraussetzung für die übrigen.
+
+## Tests
+
+Alle betroffenen Pfade haben Tests, die heute auf dem Ein-Eintrag-Modell beruhen
+(`tests/`). Pro Paket:
+
+- Bestehende Tests auf das Slot-Schema umstellen (nicht löschen — anpassen).
+- **Migrations-Tests:** Alt-Eintrag/Alt-Tombstone → 1-Slot; idempotent bei erneutem Laden.
+- **Non-Overlap-Tests:** überlappende Slots werden abgelehnt; angrenzende (Ende==Start) erlaubt.
+- **Sync-Tests:** Slot-Listen-Gleichheit, Tages-Konflikt mit Slot-Kandidaten, `_remote_is_pre_v3`
+  setzt Kompaktierung aus.
+- **Report-Tests:** Zeile/Slot, Tages-Subtotal, Kategorie-Summen, Kategorie-Filter.
+- **Share-Tests:** v3-Roundtrip, v1/v2-Import wird zu 1-Slot gewrappt.
+- **gcal-Tests:** mehrere Events/Tag erzeugen/aktualisieren/löschen, Matching über event_id.
+
+CI installiert weiter nur `pytest`+`holidays` (kein `requirements.txt`); `xhtml2pdf`-Import in
+`report.py` bleibt lazy.
+
+## Offene Punkte / bewusst nicht gelöst
+
+- **Cross-Version-Sync** mit Alt-Clients: nur Schutz (Kompaktierung aussetzen + Hinweis), kein
+  bidirektionaler Multi-Slot-Erhalt. Empfehlung „alle Geräte updaten".
+- **Konflikt-Flow** wird voraussichtlich überarbeitet — Multi-Slot greift dort minimal ein.
+- **Kategorie-Umbenennen** wirkt nicht rückwirkend auf bestehende Slots (Name-am-Slot-Modell).

--- a/docs/superpowers/specs/2026-06-20-macos-delete-button-cell-design.md
+++ b/docs/superpowers/specs/2026-06-20-macos-delete-button-cell-design.md
@@ -1,0 +1,137 @@
+# Design: macOS-Lösch-Button in der Tageszelle (✕ oben links)
+
+Datum: 2026-06-20
+Branch: `feat/multi-timeslots-kategorien`
+
+## Problem
+
+Das Kalender-Modell ist „Linksklick = anlegen/bearbeiten, Rechtsklick = löschen".
+Auf macOS ist `<Button-3>` unzuverlässig (Sekundärklick je nach Tk-Version
+`<Button-2>` bzw. Control-Klick). Damit Löschen auf dem Mac erreichbar bleibt,
+zeigt der Tages-Dialog dort als Ausnahme zusätzliche Lösch-Buttons
+(`_SHOW_DELETE_IN_DIALOG = platform.system() == "Darwin"` in
+`src/dialogs/entry_dialog.py`).
+
+Mit dem Multi-Slot-Feature ist Löschen über den Linksklick-Dialog konzeptionell
+unsauber: Der Dialog ist auf Win/Linux bewusst rein zum Speichern, und das
+Slot-Modell macht „was genau löschen" zu einer eigenen Auswahl (siehe
+`App._delete_day`). Die macOS-Dialog-Buttons löschen dagegen den ganzen Block.
+
+## Ziel
+
+Die macOS-Dialog-Lösch-Buttons durch einen kleinen ✕-Button **oben links** in
+der Tageszelle ersetzen. Der Button triggert exakt denselben Lösch-Pfad wie der
+Rechtsklick auf Win/Linux (`App._delete_day`), inklusive Bestätigung und
+Mehr-Slot-Auswahldialog. Damit gilt auf allen drei Plattformen derselbe
+Lösch-*Mechanismus*; nur der *Auslöser* unterscheidet sich (Rechtsklick vs.
+Button), weil macOS-Rechtsklick unzuverlässig ist.
+
+Design-Regel des Projekts: „bestmöglich gleich auf allen drei Plattformen; wenn
+nicht möglich, exklusive Anpassung." Dies ist eine saubere macOS-exklusive
+Ergänzung — Win/Linux bleiben unverändert.
+
+## Verhalten
+
+- **Nur macOS.** Gegated über `platform.system() == "Darwin"`. Auf Win/Linux
+  ändert sich nichts; Rechtsklick bleibt der einzige Lösch-Pfad.
+- **Sichtbarkeit:** Der Button ist dauerhaft sichtbar (kein Hover-Reveal),
+  sobald ein Tag löschbare Einheiten hat — also Ist-Zeit-Slots **oder** eine
+  aktive Reservierung (`_reservations_active()`). Auf Tagen ohne löschbare
+  Einheiten erscheint er nicht.
+- **Abdeckung:** Volle Parität zum Rechtsklick. Erscheint auch auf reinen
+  Reservierungstagen (optisch leere/Feiertags-Zellen mit violettem Eckpunkt).
+- **Klick:** ruft `App._delete_day(date_str)` auf — bei genau einer löschbaren
+  Einheit Ja/Nein-Abfrage, bei mehreren der Checkbox-Auswahldialog
+  (`themed_ask_delete_choice`) mit 600 ms Button-Lock. Identisch zum
+  Win/Linux-Rechtsklick.
+- **Kein Doppel-Effekt:** Ein Klick auf den Button öffnet **nicht** zusätzlich
+  den Bearbeiten-Dialog. Der Button ist ein eigenes, über den Zell-Bindings
+  liegendes Widget; Tk liefert das Event an das oberste Widget (den Button), die
+  Zell-`<Button-1>`-Bindung feuert nicht. Defensiv gibt der Handler `"break"`
+  zurück.
+
+## Optik
+
+- Umsetzung als `tk.Label` (kein `tk.Button` — der bringt auf macOS native
+  Chrome/Rahmen mit). Spiegelt das vorhandene `_add_reservation_marker`-Muster
+  (Overlay via `place()`).
+- Glyph: `✕`, Font `FONT_TINY`.
+- Platzierung: oben links, `place(relx=0.0, x=3, y=2, anchor="nw")`. Kollidiert
+  nicht mit dem Reservierungs-Eckpunkt (oben rechts, `anchor="ne"`).
+- Farbe: Ruhezustand `TEXT_MUTED` (grau); beim Hover über das ✕-Symbol selbst
+  `ACCENT` (rot) als Lösch-Affordance. `cursor="hand2"`.
+- Hintergrund folgt der Zellfarbe und wird beim Zell-Hover mitgefärbt (siehe
+  Hover-Integration).
+- Kein runder Badge/Hintergrundkreis — die Zelle ist pixel-fixiert und eng.
+- Kein neuer Theme-Token; vorhandene `TEXT_MUTED`/`ACCENT` aus `theme.py`.
+
+## Architektur / betroffene Stellen
+
+Einziger funktionaler Einhängepunkt ist der Zell-Dispatcher `App._build_day_cell`
+(`src/ui.py`), die einzige Stelle, die sowohl `entry` als auch `reservation`
+kennt und bereits `_add_reservation_marker` aufruft.
+
+1. **`src/ui.py` — neuer Helfer `App._add_delete_button(cell, date_str)`**
+   Baut das ✕-`tk.Label`, platziert es oben links, bindet `<Button-1>` →
+   `self._delete_day(date_str)` (mit `return "break"`), bindet `<Enter>`/
+   `<Leave>` für die Rot-Hover-Färbung des Glyphs, und taggt es als
+   `cell._delete_button` (analog `cell._reservation_marker`).
+
+2. **`src/ui.py` — `App._build_day_cell`**
+   Nach dem Aufbau der Zelle und dem optionalen `_add_reservation_marker`: wenn
+   macOS **und** (`entry` vorhanden **oder** `reservation` aktiv vorhanden),
+   `self._add_delete_button(cell, date_str)` aufrufen.
+   - macOS-Erkennung über ein Modul-Konstanten-Flag (z. B. `_IS_MACOS =
+     platform.system() == "Darwin"`); `platform` ist in `ui.py` zu importieren,
+     falls noch nicht vorhanden.
+   - Die Reservierungs-Bedingung muss zur bereits im Dispatcher verwendeten
+     `reservation`-Logik passen (der `reservation`-Parameter wird nur bei
+     aktivem Kalender-Sync übergeben — siehe vorhandener Marker-Pfad).
+
+3. **`src/ui.py` — `_cell_hover` und `_empty_hover`**
+   Zusätzlich zu `_reservation_marker` auch `_delete_button` einsammeln und beim
+   Hover dessen `bg` mitfärben (sonst bleibt ein andersfarbiges Rechteck hinter
+   dem Glyph stehen). Wichtig: nur `bg` setzen, **nicht** `fg` — die `fg` steuert
+   der eigene `<Enter>`/`<Leave>`-Handler des Buttons (Rot beim Symbol-Hover).
+
+4. **`src/dialogs/entry_dialog.py` — macOS-Ausnahme entfernen**
+   `_SHOW_DELETE_IN_DIALOG` auf `False` setzen bzw. die Konstante und die beiden
+   davon abhängigen Lösch-Button-Blöcke (`delete_ist`, `delete_reservation`)
+   entfernen. Der Dialog ist dann auf **allen** Plattformen rein zum Speichern.
+   Die zugehörigen Kommentare/Docstrings (Dialog „außer macOS") anpassen.
+
+5. **`CLAUDE.md` — Doku aktualisieren**
+   Abschnitt „Kalender-Interaktion / Plattform-Ausnahme macOS" anpassen: Die
+   macOS-Ausnahme ist nicht mehr „Lösch-Buttons im Dialog", sondern „✕-Button
+   oben links in der Tageszelle".
+
+## Fehlerbehandlung / Edge Cases
+
+- **Stray-Click nach Dialog-Schluss:** `_delete_day` ist bereits über
+  `_stray_click_suppressed` abgesichert — der Button erbt diesen Schutz, da er
+  denselben Pfad nutzt. Keine zusätzliche Behandlung nötig.
+- **Hover-Rechteck:** Durch die `_delete_button`-Behandlung in den Hover-Helfern
+  vermieden (siehe Punkt 3).
+- **Zerstörte Widgets / after-Callbacks:** unverändert; der Button hängt am
+  Zell-Lebenszyklus wie der Marker.
+
+## Tests
+
+- Die Lösch-*Logik* (`_delete_action`, Auswahl, Slot-Erhalt) ist bereits durch
+  bestehende Tests (`tests/test_click_guard.py` u. a.) abgedeckt und wird nicht
+  verändert — der Button ist nur ein weiterer Auslöser desselben Pfads.
+- Tkinter-Widget-Aufbau wird im Projekt nicht automatisiert getestet (CI ohne
+  Display). Verifikation des Buttons: Import-Smoke (Modul lädt) + **manueller
+  Test auf macOS** (Sichtbarkeit nur bei löschbaren Tagen, Position, Hover-Farbe,
+  Klick löst Auswahl-/Bestätigungsdialog aus, kein paralleler Bearbeiten-Dialog).
+- Falls eine kleine pure Prüfung sinnvoll ist: die Sichtbarkeitsbedingung
+  (`macOS and (entry or aktive reservation)`) ließe sich als reine Funktion
+  auslagern und testen; optional, da trivial.
+
+## Bewusst nicht enthalten (YAGNI)
+
+- Kein Hover-Reveal (Button ist immer sichtbar, wenn löschbar).
+- Kein eigener Lösch-Button pro Slot direkt in der Zelle — die Slot-Auswahl
+  bleibt im bestehenden `themed_ask_delete_choice`-Dialog.
+- Keine Änderung am Win/Linux-Verhalten.
+- Kein neuer Theme-Token, kein Badge-Hintergrund.

--- a/docs/superpowers/specs/2026-06-21-kategorie-standardzeiten-design.md
+++ b/docs/superpowers/specs/2026-06-21-kategorie-standardzeiten-design.md
@@ -54,12 +54,24 @@ def remove_category_times(times, name):
 ## UI — Kategorien-Dialog (`src/dialogs/category_dialog.py`)
 
 Unter der Kategorie-Liste erscheinen drei Combos **Start / Ende / Pause** für die
-aktuell selektierte Kategorie. Jede Combo hat eine Leer-Option **„(Standard)"**
-= globaler Fallback (leerer gespeicherter Wert).
+aktuell selektierte Kategorie. Jede Combo hat als **ersten** Eintrag die Option **„(Standard)"** — ein
+literaler Combo-Wert, der beim Speichern als **leerer String** im Eintrag
+landet (bzw. das Feld weglässt) und so den Per-Feld-Fallback auf global
+auslöst. Beim Laden eines leeren/fehlenden Feldes wird „(Standard)" angezeigt.
+`TIME_VALUES` / `PAUSE_VALUES` (theme.py, reine String-Listen) werden NICHT
+global mutiert — „(Standard)" wird nur lokal in diesen Dialog-Combos
+vorangestellt (`["(Standard)", *TIME_VALUES]`).
 
-- Listbox-Auswahl wechselt → Felder aus dem In-Memory-`category_times` laden.
-- Vor dem Wechsel: aktuelle Feldwerte in das In-Memory-Dict der vorher
-  selektierten Kategorie zurückschreiben.
+- Eine `category_times`-Kopie wird beim Öffnen geladen:
+  `category_times = dict(settings.get("category_times") or {})` — parallel zur
+  bestehenden lokalen `categories`-Liste, im selben `nonlocal`-Scope mutiert.
+- Listbox-Auswahl wechselt (`<<ListboxSelect>>`-Binding, existiert noch nicht)
+  → Felder aus dem In-Memory-`category_times` laden.
+- **Vorherige Auswahl** wird in einem Holder (`prev_sel = [None]`) gemerkt, weil
+  Tk im Select-Event nur die NEUE Auswahl liefert. Der Handler schreibt zuerst
+  die aktuellen Feldwerte in den Eintrag der `prev_sel`-Kategorie zurück, lädt
+  dann die neue und setzt `prev_sel[0]` auf die neue Kategorie. Auch `on_save`
+  schreibt die Felder der aktuell selektierten Kategorie final zurück.
 - Sind alle drei Felder „(Standard)" → Kategorie-Eintrag wird entfernt
   (komplett globaler Fallback).
 - **Speichern** persistiert `categories` UND `category_times` via `set_synced`.
@@ -69,8 +81,16 @@ aktuell selektierte Kategorie. Jede Combo hat eine Leer-Option **„(Standard)"*
 ## UI — Tages-Dialog (`src/dialogs/entry_dialog.py`)
 
 Pro Slot-Zeile wird die zuletzt automatisch gesetzte Default-Basis gemerkt
-(`base_start/base_end/base_pause`), initial die globalen Standardzeiten des
-Wochentags (bzw. die Werte, mit denen die Zeile angelegt wurde).
+(`base_start/base_end/base_pause`). **Die Basis sind exakt die Werte, mit denen
+die Zeile angelegt wurde** — NICHT pauschal die globalen Standardzeiten:
+- Erste/aus Reservierung übernommene Ist-Zeile: globaler Start/Ende +
+  `default_pause` (entry_dialog.py:115/117).
+- „+ Slot"-Ist-Zeile: globaler Start/Ende, **`pause=0`** (entry_dialog.py:123).
+- Geladene bestehende Zeile: die gespeicherten Slot-Werte.
+
+Die Basis wird in `add_ist_row` / `add_res_row` aus den übergebenen
+Start/Ende/Pause-Argumenten gesetzt, damit jede Zeile ihre eigene korrekte
+Basis hat.
 
 Bei **Kategorie-Wechsel** (Trace auf der `kategorie`-StringVar der Zeile):
 1. Zielwerte via `resolve_slot_defaults(...)` bestimmen.

--- a/docs/superpowers/specs/2026-06-21-kategorie-standardzeiten-design.md
+++ b/docs/superpowers/specs/2026-06-21-kategorie-standardzeiten-design.md
@@ -33,45 +33,51 @@ Liste von Strings — Report, Send-Dialog und die Combos lesen sie weiter direkt
   Ganzes, wie bei `categories`.
 - `_coerce` lässt Dicts unverändert durch (wie die `categories`-Liste).
 
-## Pure Logik — `src/category_defaults.py` (neu, testbar)
+## Pure Logik
+
+`src/category_defaults.py` (neu, testbar):
 
 ```python
 def resolve_slot_defaults(category_times, kategorie, g_start, g_end, g_pause):
     """(start, end, pause) mit Per-Feld-Fallback auf die globalen Werte."""
-
-def rename_category_times(times, old, new):
-    """Verschiebt den Time-Eintrag old→new. Liefert neues Dict."""
-
-def remove_category_times(times, name):
-    """Entfernt den Time-Eintrag. Liefert neues Dict."""
 ```
 
 - Leere Strings / fehlende Keys im Eintrag → Fallback pro Feld.
 - `pause`: leer/None → globale Pause; sonst int.
-- `rename`: No-op wenn `old` keinen Eintrag hat; überschreibt vorhandenen
-  `new`-Eintrag nicht (konsistent zur `rename_category`-Semantik).
+
+`src/dialogs/category_dialog.py::collect_categories(rows)` (pure, testbar):
+
+```python
+def collect_categories(rows):
+    """rows: [{name, start, end, pause}] (Roh-Strings der Zeilen-Widgets)
+    → (categories, category_times).
+    Namen getrimmt, ohne Leere, dedupliziert (erstes Vorkommen gewinnt).
+    STANDARD/leere Felder entfallen → Per-Feld-Fallback. pause → int."""
+```
 
 ## UI — Kategorien-Dialog (`src/dialogs/category_dialog.py`)
 
-Unter der Kategorie-Liste erscheinen drei Combos **Start / Ende / Pause** für die
-aktuell selektierte Kategorie. Jede Combo hat als **ersten** Eintrag die Option **„(Standard)"** — ein
-literaler Combo-Wert, der beim Speichern als **leerer String** im Eintrag
-landet (bzw. das Feld weglässt) und so den Per-Feld-Fallback auf global
-auslöst. Beim Laden eines leeren/fehlenden Feldes wird „(Standard)" angezeigt.
-`TIME_VALUES` / `PAUSE_VALUES` (theme.py, reine String-Listen) werden NICHT
-global mutiert — „(Standard)" wird nur lokal in diesen Dialog-Combos
-vorangestellt (`["(Standard)", *TIME_VALUES]`).
+**Inline-Zeilen-Modell wie der Tages-Dialog** (Entscheidung 2026-06-21): keine
+separate Listbox + Detail-Sektion mehr, sondern **eine Zeile pro Kategorie** mit
+allen Feldern direkt drin:
 
-- Eine `category_times`-Kopie wird beim Öffnen geladen:
-  `category_times = dict(settings.get("category_times") or {})` — parallel zur
-  bestehenden lokalen `categories`-Liste, im selben `nonlocal`-Scope mutiert.
-- Listbox-Auswahl wechselt (`<<ListboxSelect>>`-Binding, existiert noch nicht)
-  → Felder aus dem In-Memory-`category_times` laden.
-- **Vorherige Auswahl** wird in einem Holder (`prev_sel = [None]`) gemerkt, weil
-  Tk im Select-Event nur die NEUE Auswahl liefert. Der Handler schreibt zuerst
-  die aktuellen Feldwerte in den Eintrag der `prev_sel`-Kategorie zurück, lädt
-  dann die neue und setzt `prev_sel[0]` auf die neue Kategorie. Auch `on_save`
-  schreibt die Felder der aktuell selektierten Kategorie final zurück.
+```
+[Name-Entry] [Start-Combo] – [Ende-Combo] [Pause-Combo] [×]
+```
+
+Darunter ein **„+ Kategorie"**-Button (legt leere Zeile an) und Speichern/
+Schließen. Umbenennen = Name-Feld editieren, Entfernen = ×-Button. Die früheren
+`add/rename/remove_category`-Helfer und die Listbox/`prev_sel`-Logik entfallen.
+
+- Beim Öffnen werden `categories` + `category_times` geladen und je Kategorie
+  eine vorbefüllte Zeile erzeugt (Zeit-Felder aus `category_times`, sonst
+  „(Standard)"). Ohne Kategorien: eine leere Startzeile.
+- Jede Zeit-Combo hat als **ersten** Eintrag **„(Standard)"** — ein literaler
+  Wert, der beim Speichern als fehlendes Feld abgelegt wird (Per-Feld-Fallback
+  auf global). `TIME_VALUES` / `PAUSE_VALUES` werden NICHT global mutiert —
+  „(Standard)" nur lokal vorangestellt (`["(Standard)", *TIME_VALUES]`).
+- **Speichern** liest alle Zeilen-Widgets in Roh-Dicts, ruft `collect_categories`
+  und persistiert `categories` + `category_times` via `set_synced`.
 - Sind alle drei Felder „(Standard)" → Kategorie-Eintrag wird entfernt
   (komplett globaler Fallback).
 - **Speichern** persistiert `categories` UND `category_times` via `set_synced`.
@@ -110,7 +116,9 @@ bekannten Kategorie.
 ## Tests
 
 - `tests/test_category_defaults.py`: Per-Feld-Fallback, leere Felder, unbekannte
-  Kategorie, rename/remove der Time-Keys, pause-Coercion.
+  Kategorie, pause-Coercion, Nicht-Dict-Eintrag.
+- `tests/test_category_dialog.py`: `collect_categories` — Dedup, Reihenfolge,
+  leere/getrimmte Namen, partielle Zeilen, pause=0, mehrere Kategorien.
 - Settings/Sync: `category_times` ist whitelisted und synct (Smoke).
 
 ## Bewusst nicht enthalten (YAGNI)

--- a/docs/superpowers/specs/2026-06-21-kategorie-standardzeiten-design.md
+++ b/docs/superpowers/specs/2026-06-21-kategorie-standardzeiten-design.md
@@ -1,0 +1,99 @@
+# Standardzeiten & Pause pro Kategorie
+
+**Datum:** 2026-06-21
+**Branch / PR:** `feat/multi-timeslots-kategorien` (PR #60)
+
+## Ziel
+
+Pro Kategorie konfigurierbare Standard-Start-/Endzeit und Pause. Die globalen
+Standardzeiten bleiben bestehen und gelten weiterhin, wenn ein Slot **keine**
+Kategorie hat oder die Kategorie für das jeweilige Feld nichts konfiguriert hat.
+Manuell geänderte Felder im Tages-Dialog werden nie überschrieben.
+
+Granularität: **ein Satz (Start/Ende/Pause) pro Kategorie**, nicht pro Wochentag.
+
+## Datenmodell
+
+Neuer synchronisierter Settings-Key `category_times` (Dict), parallel zur
+bestehenden `categories`-Liste. Die `categories`-Liste bleibt unverändert eine
+Liste von Strings — Report, Send-Dialog und die Combos lesen sie weiter direkt.
+
+```json
+"category_times": {
+  "Office":     {"start": "08:00", "end": "16:30", "pause": 30},
+  "Homeoffice": {"start": "09:00", "end": "17:00", "pause": 0}
+}
+```
+
+- **Per-Feld-Fallback:** Fehlt/leer ein Feld → globaler Standard für genau
+  dieses Feld. Kategorie nicht im Dict → komplett global.
+- `DEFAULTS["category_times"] = {}`.
+- Aufgenommen in `SYNCED_SETTING_KEYS` in **`src/settings.py` und `src/sync.py`**
+  (das Duplikat muss konsistent bleiben). LWW-Merge behandelt den Dict-Wert als
+  Ganzes, wie bei `categories`.
+- `_coerce` lässt Dicts unverändert durch (wie die `categories`-Liste).
+
+## Pure Logik — `src/category_defaults.py` (neu, testbar)
+
+```python
+def resolve_slot_defaults(category_times, kategorie, g_start, g_end, g_pause):
+    """(start, end, pause) mit Per-Feld-Fallback auf die globalen Werte."""
+
+def rename_category_times(times, old, new):
+    """Verschiebt den Time-Eintrag old→new. Liefert neues Dict."""
+
+def remove_category_times(times, name):
+    """Entfernt den Time-Eintrag. Liefert neues Dict."""
+```
+
+- Leere Strings / fehlende Keys im Eintrag → Fallback pro Feld.
+- `pause`: leer/None → globale Pause; sonst int.
+- `rename`: No-op wenn `old` keinen Eintrag hat; überschreibt vorhandenen
+  `new`-Eintrag nicht (konsistent zur `rename_category`-Semantik).
+
+## UI — Kategorien-Dialog (`src/dialogs/category_dialog.py`)
+
+Unter der Kategorie-Liste erscheinen drei Combos **Start / Ende / Pause** für die
+aktuell selektierte Kategorie. Jede Combo hat eine Leer-Option **„(Standard)"**
+= globaler Fallback (leerer gespeicherter Wert).
+
+- Listbox-Auswahl wechselt → Felder aus dem In-Memory-`category_times` laden.
+- Vor dem Wechsel: aktuelle Feldwerte in das In-Memory-Dict der vorher
+  selektierten Kategorie zurückschreiben.
+- Sind alle drei Felder „(Standard)" → Kategorie-Eintrag wird entfernt
+  (komplett globaler Fallback).
+- **Speichern** persistiert `categories` UND `category_times` via `set_synced`.
+- **Umbenennen** zieht den `category_times`-Key per `rename_category_times` nach,
+  **Entfernen** per `remove_category_times`.
+
+## UI — Tages-Dialog (`src/dialogs/entry_dialog.py`)
+
+Pro Slot-Zeile wird die zuletzt automatisch gesetzte Default-Basis gemerkt
+(`base_start/base_end/base_pause`), initial die globalen Standardzeiten des
+Wochentags (bzw. die Werte, mit denen die Zeile angelegt wurde).
+
+Bei **Kategorie-Wechsel** (Trace auf der `kategorie`-StringVar der Zeile):
+1. Zielwerte via `resolve_slot_defaults(...)` bestimmen.
+2. Pro Feld (Start/Ende/Pause): **nur überschreiben, wenn aktueller Feldwert ==
+   gemerkte Basis** (unverändert). Dann Feldwert setzen UND Basis auf den neuen
+   Zielwert nachziehen.
+3. Weicht ein Feld ab (manuell) → unangetastet; Basis bleibt, Feld bleibt
+   dauerhaft manuell.
+
+Gilt für **Ist-Slots** (Start/Ende/Pause). **Reservierungs-Slots** analog, aber
+nur Start/Ende (Reservierungen haben keine Pause).
+
+Der Trace wird erst **nach** dem initialen `kv.set(...)` registriert, damit die
+Vorbelegung nicht selbst triggert. Auto-Anwenden nur bei exaktem Treffer einer
+bekannten Kategorie.
+
+## Tests
+
+- `tests/test_category_defaults.py`: Per-Feld-Fallback, leere Felder, unbekannte
+  Kategorie, rename/remove der Time-Keys, pause-Coercion.
+- Settings/Sync: `category_times` ist whitelisted und synct (Smoke).
+
+## Bewusst nicht enthalten (YAGNI)
+
+- Keine Per-Wochentag-Zeiten pro Kategorie.
+- Kein Auto-Anwenden beim Tippen abseits exakter Kategorie-Treffer.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,3 +15,33 @@ select = ["E4", "E7", "E9", "F"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+
+[tool.pyright]
+# Wird sowohl von der Pyright-CLI als auch von Pylance (VS Code) gelesen —
+# eine einzige Quelle. Bewusst KEINE separate pyrightconfig.json, die wuerde
+# diesen Block ueberstimmen.
+typeCheckingMode = "basic"       # gleicht dem Pylance-Default an
+pythonVersion = "3.10"
+include = ["src", "tests"]
+# Repo-Root in den Import-Suchpfad: sonst findet pyright das `src`-Paket aus
+# den Test-Dateien (`from src.foo import ...`) nicht -> reportMissingImports.
+extraPaths = ["."]
+
+# Tkinter-typisches Rauschen: viele Widgets/Vars werden mit None initialisiert
+# und erst spaeter gesetzt; pyright kann dieses Narrowing nicht nachvollziehen.
+# Reiner False-Positive -> ganz aus.
+reportOptionalMemberAccess = "none"
+# Gemischt: teils Monkeypatch-FP (z.B. _was_in_grid), teils echte Fragilitaet
+# (Lib-Internals, build-generierte Importe). Sichtbar lassen, aber entschaerfen.
+reportAttributeAccessIssue = "warning"
+
+# Tests werden weiter geprueft, aber das Mock-/MagicMock-typische Rauschen
+# (Operatoren & Member-Zugriffe auf Mocks) wird dort unterdrueckt.
+[[tool.pyright.executionEnvironments]]
+root = "tests"
+reportOperatorIssue = "none"
+reportOptionalSubscript = "none"
+reportOptionalMemberAccess = "none"
+reportAttributeAccessIssue = "none"
+reportCallIssue = "none"
+reportArgumentType = "none"

--- a/src/category_defaults.py
+++ b/src/category_defaults.py
@@ -1,0 +1,57 @@
+"""Pure Logik für Per-Kategorie-Standardzeiten (Start/Ende/Pause).
+
+`category_times` ist ein Dict `{kategorie: {"start", "end", "pause"}}`, parallel
+zur `categories`-Liste in den Settings. Fehlt eine Kategorie oder ein einzelnes
+Feld (leer/None), gilt der globale Standardwert für genau dieses Feld — so
+bleiben die globalen Standardzeiten wirksam, wenn eine Kategorie nichts
+konfiguriert hat. Rein, ohne Tkinter/IO, daher direkt testbar.
+"""
+
+
+def resolve_slot_defaults(category_times, kategorie, g_start, g_end, g_pause):
+    """(start, end, pause) für einen Slot der gegebenen Kategorie.
+
+    Per-Feld-Fallback auf die globalen Werte (g_start/g_end/g_pause), wenn die
+    Kategorie unbekannt ist, keinen Eintrag hat oder das jeweilige Feld leer
+    bzw. ungültig ist. `pause=0` ist ein gültiger Wert und bleibt erhalten.
+    """
+    entry = category_times.get(kategorie) if isinstance(category_times, dict) else None
+    if not isinstance(entry, dict):
+        return g_start, g_end, g_pause
+
+    start = entry.get("start") or g_start
+    end = entry.get("end") or g_end
+
+    pause = entry.get("pause")
+    if pause is None or pause == "":
+        pause = g_pause
+    else:
+        try:
+            pause = int(pause)
+        except (TypeError, ValueError):
+            pause = g_pause
+
+    return start, end, pause
+
+
+def rename_category_times(times, old, new):
+    """Verschiebt den Zeit-Eintrag `old`→`new`. Liefert ein neues Dict.
+
+    No-op (unveränderte Kopie), wenn `new` leer ist, `old` keinen Eintrag hat,
+    oder `new` bereits ein ANDERER vorhandener Eintrag ist — konsistent zur
+    Semantik von `category_dialog.rename_category`.
+    """
+    new = (new or "").strip()
+    result = dict(times)
+    if not new or old not in result:
+        return result
+    if new in result and new != old:
+        return result
+    if new != old:
+        result[new] = result.pop(old)
+    return result
+
+
+def remove_category_times(times, name):
+    """Entfernt den Zeit-Eintrag `name`. Liefert ein neues Dict."""
+    return {k: v for k, v in times.items() if k != name}

--- a/src/category_defaults.py
+++ b/src/category_defaults.py
@@ -32,26 +32,3 @@ def resolve_slot_defaults(category_times, kategorie, g_start, g_end, g_pause):
             pause = g_pause
 
     return start, end, pause
-
-
-def rename_category_times(times, old, new):
-    """Verschiebt den Zeit-Eintrag `old`→`new`. Liefert ein neues Dict.
-
-    No-op (unveränderte Kopie), wenn `new` leer ist, `old` keinen Eintrag hat,
-    oder `new` bereits ein ANDERER vorhandener Eintrag ist — konsistent zur
-    Semantik von `category_dialog.rename_category`.
-    """
-    new = (new or "").strip()
-    result = dict(times)
-    if not new or old not in result:
-        return result
-    if new in result and new != old:
-        return result
-    if new != old:
-        result[new] = result.pop(old)
-    return result
-
-
-def remove_category_times(times, name):
-    """Entfernt den Zeit-Eintrag `name`. Liefert ein neues Dict."""
-    return {k: v for k, v in times.items() if k != name}

--- a/src/dialogs/category_dialog.py
+++ b/src/dialogs/category_dialog.py
@@ -1,45 +1,65 @@
-"""Modal zum Verwalten der Kategorie-Pickliste. Die Listen-Logik
-(add/remove/rename) ist pure und getestet; der Tkinter-Teil ist nur Wiring.
-Speichert via settings.set_synced('categories', ...)."""
+"""Modal zum Verwalten der Kategorien samt ihrer Standardzeiten.
+
+Jede Kategorie ist eine Zeile (wie die Slot-Zeilen im Tages-Dialog): Name +
+Start/Ende/Pause. „(Standard)" in einem Zeit-Feld bedeutet „kein eigener Wert,
+globale Standardzeit gilt" und landet beim Speichern als fehlendes Feld. Die
+Listen-Logik (`collect_categories`) ist pure und getestet; der Tkinter-Teil ist
+nur Wiring. Speichert `categories` (Liste) und `category_times` (Dict) via
+settings.set_synced.
+"""
 
 import tkinter as tk
 
-from src.category_defaults import remove_category_times, rename_category_times
 from src.theme import (
-    ACCENT, BG, CELL_BG, FONT, FONT_BOLD, PAUSE_VALUES, TEXT, TEXT_MUTED,
-    TIME_VALUES, apply_app_icon, apply_dark_titlebar, attach_unfocus_on_click,
+    BG, FONT, FONT_BOLD, PAUSE_VALUES, TEXT, TEXT_MUTED, TIME_VALUES,
+    apply_app_icon, apply_dark_titlebar, attach_unfocus_on_click,
     center_dialog_on_parent, dark_combo, dark_entry, disable_min_max,
     primary_button, secondary_button,
 )
 
-# Sentinel-Eintrag in den Zeit-Combos: bedeutet "kein eigener Wert, globaler
-# Standard gilt". Wird beim Speichern als fehlendes/leeres Feld abgelegt.
+# Sentinel-Eintrag in den Zeit-Combos: „kein eigener Wert, globaler Standard
+# gilt". Wird beim Speichern als fehlendes/leeres Feld abgelegt.
 STANDARD = "(Standard)"
 
 
-def add_category(categories, name):
-    """Fügt `name` (getrimmt) hinzu, falls nicht leer und nicht vorhanden.
-    Liefert IMMER eine neue Liste (Original bleibt unangetastet)."""
-    name = name.strip()
-    if not name or name in categories:
-        return list(categories)
-    return list(categories) + [name]
+def _clean_field(value):
+    """STANDARD/leer → None, sonst der getrimmte Wert."""
+    value = (value or "").strip()
+    return None if value in ("", STANDARD) else value
 
 
-def remove_category(categories, name):
-    """Entfernt `name`. Liefert eine neue Liste."""
-    return [c for c in categories if c != name]
+def collect_categories(rows):
+    """Baut (categories, category_times) aus den Roh-Zeilen.
 
+    `rows` ist eine Liste von Dicts mit den Roh-Strings der Combos/Entries:
+    `{"name", "start", "end", "pause"}`.
 
-def rename_category(categories, old, new):
-    """Benennt `old` in `new` (getrimmt) um. No-op, wenn `new` leer ist, `old`
-    nicht existiert, oder `new` bereits eine ANDERE Kategorie ist."""
-    new = new.strip()
-    if not new or old not in categories:
-        return list(categories)
-    if new in categories and new != old:
-        return list(categories)
-    return [new if c == old else c for c in categories]
+    - `categories`: Namen in Eingabereihenfolge, getrimmt, ohne Leere,
+      dedupliziert (erstes Vorkommen gewinnt).
+    - `category_times`: `{name: {start?, end?, pause?}}` nur für Namen mit
+      mindestens einem gesetzten (Nicht-Standard-)Feld. Leere/STANDARD-Felder
+      entfallen → Per-Feld-Fallback auf die globalen Standardzeiten.
+    """
+    categories = []
+    category_times = {}
+    for row in rows:
+        name = (row.get("name") or "").strip()
+        if not name or name in categories:
+            continue
+        categories.append(name)
+        entry = {}
+        start = _clean_field(row.get("start"))
+        end = _clean_field(row.get("end"))
+        pause = _clean_field(row.get("pause"))
+        if start is not None:
+            entry["start"] = start
+        if end is not None:
+            entry["end"] = end
+        if pause is not None:
+            entry["pause"] = int(pause)
+        if entry:
+            category_times[name] = entry
+    return categories, category_times
 
 
 def open_category_dialog(parent, settings, on_change=None):
@@ -62,128 +82,76 @@ def open_category_dialog(parent, settings, on_change=None):
     outer.pack(padx=12, pady=12)
 
     tk.Label(outer, text="Kategorien", font=FONT_BOLD, bg=BG, fg=TEXT).pack(anchor="w")
-
-    listbox = tk.Listbox(
-        outer, height=8, width=30, font=FONT, bg=CELL_BG, fg=TEXT,
-        selectbackground=ACCENT, selectforeground="#ffffff",
-        highlightthickness=0, bd=0, activestyle="none",
-    )
-    listbox.pack(fill="x", pady=(4, 8))
-
-    def refresh():
-        listbox.delete(0, tk.END)
-        for c in categories:
-            listbox.insert(tk.END, c)
-
-    refresh()
-
-    def _selected():
-        sel = listbox.curselection()
-        return categories[sel[0]] if sel else None
-
-    name_var = tk.StringVar()
-
-    # --- Zeit-Felder für die aktuell selektierte Kategorie ---
-    start_var = tk.StringVar(value=STANDARD)
-    end_var = tk.StringVar(value=STANDARD)
-    pause_var = tk.StringVar(value=STANDARD)
-    prev_sel = [None]  # zuletzt selektierte Kategorie (Tk liefert nur die neue)
-
-    def _load_fields(cat):
-        entry = category_times.get(cat) or {}
-        start_var.set(entry.get("start") or STANDARD)
-        end_var.set(entry.get("end") or STANDARD)
-        p = entry.get("pause")
-        pause_var.set(str(p) if p not in (None, "") else STANDARD)
-
-    def _store_fields(cat):
-        """Schreibt die angezeigten Felder in den Eintrag von `cat` zurück.
-        STANDARD/leer → Feld entfällt; bleibt nichts übrig, verschwindet der
-        Kategorie-Eintrag ganz (komplett globaler Fallback)."""
-        if cat is None:
-            return
-        entry = {}
-        if start_var.get() not in ("", STANDARD):
-            entry["start"] = start_var.get()
-        if end_var.get() not in ("", STANDARD):
-            entry["end"] = end_var.get()
-        if pause_var.get() not in ("", STANDARD):
-            entry["pause"] = int(pause_var.get())
-        if entry:
-            category_times[cat] = entry
-        else:
-            category_times.pop(cat, None)
-
-    def on_select(_e=None):
-        _store_fields(prev_sel[0])
-        cat = _selected()
-        if cat is None:
-            return
-        _load_fields(cat)
-        prev_sel[0] = cat
-
-    listbox.bind("<<ListboxSelect>>", on_select)
-
-    def on_add():
-        nonlocal categories
-        categories = add_category(categories, name_var.get())
-        name_var.set("")
-        refresh()
-
-    def on_rename():
-        nonlocal categories, category_times
-        current = _selected()
-        if current is None:
-            return
-        _store_fields(current)
-        new = name_var.get()
-        categories = rename_category(categories, current, new)
-        category_times = rename_category_times(category_times, current, new)
-        name_var.set("")
-        prev_sel[0] = None
-        refresh()
-
-    def on_remove():
-        nonlocal categories, category_times
-        current = _selected()
-        if current is None:
-            return
-        categories = remove_category(categories, current)
-        category_times = remove_category_times(category_times, current)
-        prev_sel[0] = None
-        refresh()
-
-    edit_row = tk.Frame(outer, bg=BG)
-    edit_row.pack(fill="x", pady=(0, 8))
-    dark_entry(edit_row, name_var, width=18).pack(side=tk.LEFT, padx=(0, 4))
-    secondary_button(edit_row, "Hinzufügen", on_add).pack(side=tk.LEFT, padx=2)
-    secondary_button(edit_row, "Umbenennen", on_rename).pack(side=tk.LEFT, padx=2)
-    secondary_button(edit_row, "Entfernen", on_remove).pack(side=tk.LEFT, padx=2)
-
     tk.Label(
-        outer, text="Standardzeiten der gewählten Kategorie",
-        font=FONT_BOLD, bg=BG, fg=TEXT,
-    ).pack(anchor="w", pady=(4, 0))
-    tk.Label(
-        outer, text='„(Standard)" = globale Standardzeit verwenden',
+        outer, text='Pro Kategorie: Name + Standardzeiten. '
+                    '„(Standard)" = globale Standardzeit verwenden.',
         font=FONT, bg=BG, fg=TEXT_MUTED,
-    ).pack(anchor="w")
-    time_row = tk.Frame(outer, bg=BG)
-    time_row.pack(fill="x", pady=(4, 8))
-    tk.Label(time_row, text="Start", font=FONT, bg=BG, fg=TEXT_MUTED).pack(side=tk.LEFT)
-    dark_combo(time_row, start_var, [STANDARD, *TIME_VALUES],
-               width=8).pack(side=tk.LEFT, padx=(2, 8))
-    tk.Label(time_row, text="Ende", font=FONT, bg=BG, fg=TEXT_MUTED).pack(side=tk.LEFT)
-    dark_combo(time_row, end_var, [STANDARD, *TIME_VALUES],
-               width=8).pack(side=tk.LEFT, padx=(2, 8))
-    tk.Label(time_row, text="Pause", font=FONT, bg=BG, fg=TEXT_MUTED).pack(side=tk.LEFT)
-    dark_combo(time_row, pause_var, [STANDARD, *PAUSE_VALUES],
-               width=10).pack(side=tk.LEFT, padx=2)
+    ).pack(anchor="w", pady=(0, 6))
+
+    # Spaltenüberschriften
+    head = tk.Frame(outer, bg=BG)
+    head.pack(fill="x")
+    tk.Label(head, text="Name", font=FONT, bg=BG, fg=TEXT_MUTED,
+             width=15, anchor="w").pack(side=tk.LEFT, padx=2)
+    tk.Label(head, text="Start", font=FONT, bg=BG, fg=TEXT_MUTED,
+             width=9, anchor="w").pack(side=tk.LEFT, padx=2)
+    tk.Label(head, text="Ende", font=FONT, bg=BG, fg=TEXT_MUTED,
+             width=10, anchor="w").pack(side=tk.LEFT, padx=2)
+    tk.Label(head, text="Pause", font=FONT, bg=BG, fg=TEXT_MUTED,
+             width=9, anchor="w").pack(side=tk.LEFT, padx=2)
+
+    rows_frame = tk.Frame(outer, bg=BG)
+    rows_frame.pack(fill="x")
+    rows = []  # Liste von {frame, name, start, end, pause}
+
+    def add_row(name="", start=STANDARD, end=STANDARD, pause=STANDARD):
+        row = tk.Frame(rows_frame, bg=BG)
+        row.pack(fill="x", pady=2)
+        nv = tk.StringVar(value=name)
+        sv = tk.StringVar(value=start)
+        ev = tk.StringVar(value=end)
+        pv = tk.StringVar(value=pause)
+        dark_entry(row, nv, width=15).pack(side=tk.LEFT, padx=2)
+        dark_combo(row, sv, [STANDARD, *TIME_VALUES], width=8).pack(side=tk.LEFT, padx=2)
+        tk.Label(row, text="–", font=FONT, bg=BG, fg=TEXT_MUTED).pack(side=tk.LEFT)
+        dark_combo(row, ev, [STANDARD, *TIME_VALUES], width=8).pack(side=tk.LEFT, padx=2)
+        dark_combo(row, pv, [STANDARD, *PAUSE_VALUES], width=8).pack(side=tk.LEFT, padx=2)
+        record = {"frame": row, "name": nv, "start": sv, "end": ev, "pause": pv}
+
+        def remove():
+            row.destroy()
+            rows.remove(record)
+
+        secondary_button(row, "×", remove, padx=8, pady=0).pack(side=tk.LEFT, padx=2)
+        rows.append(record)
+
+    if categories:
+        for c in categories:
+            t = category_times.get(c) or {}
+            p = t.get("pause")
+            add_row(
+                c,
+                t.get("start") or STANDARD,
+                t.get("end") or STANDARD,
+                str(p) if p not in (None, "") else STANDARD,
+            )
+    else:
+        add_row()  # eine leere Startzeile
+
+    btns = tk.Frame(outer, bg=BG)
+    btns.pack(fill="x", pady=(2, 8))
+    secondary_button(btns, "+ Kategorie", lambda: add_row()).pack(side=tk.LEFT, padx=2)
 
     def on_save():
-        _store_fields(prev_sel[0])
-        settings.set_synced("categories", categories)
-        settings.set_synced("category_times", category_times)
+        raw = [{
+            "name": r["name"].get(),
+            "start": r["start"].get(),
+            "end": r["end"].get(),
+            "pause": r["pause"].get(),
+        } for r in rows]
+        cats, times = collect_categories(raw)
+        settings.set_synced("categories", cats)
+        settings.set_synced("category_times", times)
         if on_change is not None:
             on_change()
         dialog.destroy()

--- a/src/dialogs/category_dialog.py
+++ b/src/dialogs/category_dialog.py
@@ -10,6 +10,7 @@ settings.set_synced.
 
 import tkinter as tk
 
+from src.settings import WEEKDAY_KEYS
 from src.theme import (
     BG, FONT, FONT_BOLD, PAUSE_VALUES, TEXT, TEXT_MUTED, TIME_VALUES,
     apply_app_icon, apply_dark_titlebar, attach_unfocus_on_click,
@@ -94,15 +95,45 @@ def open_category_dialog(parent, settings, on_change=None):
     tk.Label(head, text="Name", font=FONT, bg=BG, fg=TEXT_MUTED,
              width=15, anchor="w").pack(side=tk.LEFT, padx=2)
     tk.Label(head, text="Start", font=FONT, bg=BG, fg=TEXT_MUTED,
-             width=9, anchor="w").pack(side=tk.LEFT, padx=2)
+             width=11, anchor="w").pack(side=tk.LEFT, padx=2)
     tk.Label(head, text="Ende", font=FONT, bg=BG, fg=TEXT_MUTED,
-             width=10, anchor="w").pack(side=tk.LEFT, padx=2)
+             width=13, anchor="w").pack(side=tk.LEFT, padx=2)
     tk.Label(head, text="Pause", font=FONT, bg=BG, fg=TEXT_MUTED,
-             width=9, anchor="w").pack(side=tk.LEFT, padx=2)
+             width=11, anchor="w").pack(side=tk.LEFT, padx=2)
 
     rows_frame = tk.Frame(outer, bg=BG)
     rows_frame.pack(fill="x")
     rows = []  # Liste von {frame, name, start, end, pause}
+    _keep = []  # haltet StringVars der read-only Zeile am Leben
+
+    # Read-only Referenzzeile: die globalen Standardzeiten, damit der Nutzer
+    # direkt sieht, worauf „(Standard)" hinausläuft. Start/Ende sind pro
+    # Wochentag konfigurierbar — sind alle Tage gleich, zeigen wir den Wert,
+    # sonst „variabel". Pause ist global. Nicht editierbar, nicht in `rows`.
+    starts = {settings.get(f"default_start_{d}") for d in WEEKDAY_KEYS}
+    ends = {settings.get(f"default_end_{d}") for d in WEEKDAY_KEYS}
+    std_start = next(iter(starts)) if len(starts) == 1 else "variabel"
+    std_end = next(iter(ends)) if len(ends) == 1 else "variabel"
+    std_pause = str(settings.get("default_pause"))
+
+    std_row = tk.Frame(rows_frame, bg=BG)
+    std_row.pack(fill="x", pady=2)
+    std_name = tk.StringVar(value="Standard")
+    _keep.append(std_name)
+    std_name_e = dark_entry(std_row, std_name, width=15)
+    std_name_e.configure(state="disabled")
+    std_name_e.pack(side=tk.LEFT, padx=2)
+
+    def _ro_combo(val, width):
+        c = dark_combo(std_row, None, [val], width=width)
+        c.set(val)
+        c.configure(state="disabled")
+        return c
+
+    _ro_combo(std_start, 11).pack(side=tk.LEFT, padx=2)
+    tk.Label(std_row, text="–", font=FONT, bg=BG, fg=TEXT_MUTED).pack(side=tk.LEFT)
+    _ro_combo(std_end, 11).pack(side=tk.LEFT, padx=2)
+    _ro_combo(std_pause, 11).pack(side=tk.LEFT, padx=2)
 
     def add_row(name="", start=STANDARD, end=STANDARD, pause=STANDARD):
         row = tk.Frame(rows_frame, bg=BG)
@@ -112,10 +143,10 @@ def open_category_dialog(parent, settings, on_change=None):
         ev = tk.StringVar(value=end)
         pv = tk.StringVar(value=pause)
         dark_entry(row, nv, width=15).pack(side=tk.LEFT, padx=2)
-        dark_combo(row, sv, [STANDARD, *TIME_VALUES], width=8).pack(side=tk.LEFT, padx=2)
+        dark_combo(row, sv, [STANDARD, *TIME_VALUES], width=11).pack(side=tk.LEFT, padx=2)
         tk.Label(row, text="–", font=FONT, bg=BG, fg=TEXT_MUTED).pack(side=tk.LEFT)
-        dark_combo(row, ev, [STANDARD, *TIME_VALUES], width=8).pack(side=tk.LEFT, padx=2)
-        dark_combo(row, pv, [STANDARD, *PAUSE_VALUES], width=8).pack(side=tk.LEFT, padx=2)
+        dark_combo(row, ev, [STANDARD, *TIME_VALUES], width=11).pack(side=tk.LEFT, padx=2)
+        dark_combo(row, pv, [STANDARD, *PAUSE_VALUES], width=11).pack(side=tk.LEFT, padx=2)
         record = {"frame": row, "name": nv, "start": sv, "end": ev, "pause": pv}
 
         def remove():

--- a/src/dialogs/category_dialog.py
+++ b/src/dialogs/category_dialog.py
@@ -1,0 +1,121 @@
+"""Modal zum Verwalten der Kategorie-Pickliste. Die Listen-Logik
+(add/remove/rename) ist pure und getestet; der Tkinter-Teil ist nur Wiring.
+Speichert via settings.set_synced('categories', ...)."""
+
+import tkinter as tk
+
+from src.theme import (
+    ACCENT, BG, CELL_BG, FONT, FONT_BOLD, TEXT,
+    apply_app_icon, apply_dark_titlebar, attach_unfocus_on_click,
+    center_dialog_on_parent, dark_entry, disable_min_max,
+    primary_button, secondary_button,
+)
+
+
+def add_category(categories, name):
+    """Fügt `name` (getrimmt) hinzu, falls nicht leer und nicht vorhanden.
+    Liefert IMMER eine neue Liste (Original bleibt unangetastet)."""
+    name = name.strip()
+    if not name or name in categories:
+        return list(categories)
+    return list(categories) + [name]
+
+
+def remove_category(categories, name):
+    """Entfernt `name`. Liefert eine neue Liste."""
+    return [c for c in categories if c != name]
+
+
+def rename_category(categories, old, new):
+    """Benennt `old` in `new` (getrimmt) um. No-op, wenn `new` leer ist, `old`
+    nicht existiert, oder `new` bereits eine ANDERE Kategorie ist."""
+    new = new.strip()
+    if not new or old not in categories:
+        return list(categories)
+    if new in categories and new != old:
+        return list(categories)
+    return [new if c == old else c for c in categories]
+
+
+def open_category_dialog(parent, settings, on_change=None):
+    categories = list(settings.get("categories") or [])
+
+    dialog = tk.Toplevel(parent)
+    dialog.title("Kategorien verwalten")
+    dialog.resizable(False, False)
+    dialog.grab_set()
+    dialog.focus_set()
+    dialog.configure(bg=BG)
+    apply_dark_titlebar(dialog)
+    disable_min_max(dialog)
+    apply_app_icon(dialog)
+    attach_unfocus_on_click(dialog)
+    dialog.bind("<Escape>", lambda _e: dialog.destroy())
+
+    outer = tk.Frame(dialog, bg=BG)
+    outer.pack(padx=12, pady=12)
+
+    tk.Label(outer, text="Kategorien", font=FONT_BOLD, bg=BG, fg=TEXT).pack(anchor="w")
+
+    listbox = tk.Listbox(
+        outer, height=8, width=30, font=FONT, bg=CELL_BG, fg=TEXT,
+        selectbackground=ACCENT, selectforeground="#ffffff",
+        highlightthickness=0, bd=0, activestyle="none",
+    )
+    listbox.pack(fill="x", pady=(4, 8))
+
+    def refresh():
+        listbox.delete(0, tk.END)
+        for c in categories:
+            listbox.insert(tk.END, c)
+
+    refresh()
+
+    def _selected():
+        sel = listbox.curselection()
+        return categories[sel[0]] if sel else None
+
+    name_var = tk.StringVar()
+
+    def on_add():
+        nonlocal categories
+        categories = add_category(categories, name_var.get())
+        name_var.set("")
+        refresh()
+
+    def on_rename():
+        nonlocal categories
+        current = _selected()
+        if current is None:
+            return
+        categories = rename_category(categories, current, name_var.get())
+        name_var.set("")
+        refresh()
+
+    def on_remove():
+        nonlocal categories
+        current = _selected()
+        if current is None:
+            return
+        categories = remove_category(categories, current)
+        refresh()
+
+    edit_row = tk.Frame(outer, bg=BG)
+    edit_row.pack(fill="x", pady=(0, 8))
+    dark_entry(edit_row, name_var, width=18).pack(side=tk.LEFT, padx=(0, 4))
+    secondary_button(edit_row, "Hinzufügen", on_add).pack(side=tk.LEFT, padx=2)
+    secondary_button(edit_row, "Umbenennen", on_rename).pack(side=tk.LEFT, padx=2)
+    secondary_button(edit_row, "Entfernen", on_remove).pack(side=tk.LEFT, padx=2)
+
+    def on_save():
+        settings.set_synced("categories", categories)
+        if on_change is not None:
+            on_change()
+        dialog.destroy()
+
+    save_row = tk.Frame(outer, bg=BG)
+    save_row.pack(fill="x")
+    primary_button(save_row, "Speichern", on_save).pack(side=tk.LEFT, padx=2)
+    secondary_button(save_row, "Schließen", dialog.destroy).pack(side=tk.LEFT, padx=2)
+
+    center_dialog_on_parent(dialog, parent)

--- a/src/dialogs/category_dialog.py
+++ b/src/dialogs/category_dialog.py
@@ -64,49 +64,6 @@ def collect_categories(rows):
     return categories, category_times
 
 
-def _open_standard_times(parent, settings):
-    """Read-only Popup mit den globalen Standardzeiten je Wochentag.
-
-    Nur zur Ansicht — editiert wird in den Einstellungen. Wird vom „Pro Tag…"-
-    Button der Standard-Zeile geöffnet, wenn die Zeiten nicht an allen Tagen
-    gleich sind.
-    """
-    pop = tk.Toplevel(parent)
-    pop.title("Standardzeiten pro Tag")
-    pop.resizable(False, False)
-    pop.grab_set()
-    pop.focus_set()
-    pop.configure(bg=BG)
-    apply_dark_titlebar(pop)
-    disable_min_max(pop)
-    apply_app_icon(pop)
-    pop.bind("<Escape>", lambda _e: pop.destroy())
-
-    box = tk.Frame(pop, bg=BG)
-    box.pack(padx=16, pady=14)
-
-    tk.Label(box, text="Start", font=FONT, bg=BG, fg=TEXT_MUTED).grid(
-        row=0, column=1, padx=8)
-    tk.Label(box, text="Ende", font=FONT, bg=BG, fg=TEXT_MUTED).grid(
-        row=0, column=2, padx=8)
-    for i, (key, lbl) in enumerate(zip(WEEKDAY_KEYS, DAYS_DE), start=1):
-        tk.Label(box, text=lbl, font=FONT, bg=BG, fg=TEXT,
-                 width=4, anchor="w").grid(row=i, column=0, padx=(0, 8),
-                                           pady=2, sticky="w")
-        tk.Label(box, text=settings.get(f"default_start_{key}"),
-                 font=FONT, bg=BG, fg=TEXT).grid(row=i, column=1, padx=8, pady=2)
-        tk.Label(box, text=settings.get(f"default_end_{key}"),
-                 font=FONT, bg=BG, fg=TEXT).grid(row=i, column=2, padx=8, pady=2)
-
-    tk.Label(box, text=f"Pause: {settings.get('default_pause')} Min (global)",
-             font=FONT, bg=BG, fg=TEXT_MUTED).grid(
-        row=8, column=0, columnspan=3, pady=(10, 0), sticky="w")
-    secondary_button(box, "Schließen", pop.destroy).grid(
-        row=9, column=0, columnspan=3, pady=(12, 0))
-
-    center_dialog_on_parent(pop, parent)
-
-
 def open_category_dialog(parent, settings, on_change=None):
     categories = list(settings.get("categories") or [])
     category_times = dict(settings.get("category_times") or {})
@@ -172,14 +129,37 @@ def open_category_dialog(parent, settings, on_change=None):
         tk.Label(std_row, text=text, font=FONT, bg=BG, fg=fg,
                  width=w, anchor="w").pack(side=tk.LEFT, padx=2)
 
-    # Bei abweichenden Wochentagen zeigen Start/Ende „variabel" — ein kleiner
-    # Button blendet die echten Zeiten je Tag ein (read-only, vgl. Settings).
+    # Bei abweichenden Wochentagen zeigen Start/Ende „variabel". Ein Toggle
+    # klappt — wie in den Einstellungen — die echten Zeiten je Tag inline aus
+    # (read-only); das Fenster passt seine Höhe automatisch an.
     if is_variable:
-        secondary_button(
-            std_row, "Pro Tag…",
-            lambda: _open_standard_times(dialog, settings),
-            padx=8, pady=0,
-        ).pack(side=tk.LEFT, padx=2)
+        daygrid = tk.Frame(rows_frame, bg=BG)
+        tk.Label(daygrid, text="Start", font=FONT, bg=BG, fg=TEXT_MUTED).grid(
+            row=0, column=1, padx=6)
+        tk.Label(daygrid, text="Ende", font=FONT, bg=BG, fg=TEXT_MUTED).grid(
+            row=0, column=2, padx=6)
+        for i, (key, lbl) in enumerate(zip(WEEKDAY_KEYS, DAYS_DE), start=1):
+            tk.Label(daygrid, text=lbl, font=FONT, bg=BG, fg=TEXT,
+                     width=4, anchor="w").grid(row=i, column=0, padx=(2, 8),
+                                               pady=1, sticky="w")
+            tk.Label(daygrid, text=settings.get(f"default_start_{key}"),
+                     font=FONT, bg=BG, fg=TEXT).grid(row=i, column=1, padx=6, pady=1)
+            tk.Label(daygrid, text=settings.get(f"default_end_{key}"),
+                     font=FONT, bg=BG, fg=TEXT).grid(row=i, column=2, padx=6, pady=1)
+
+        toggle_holder = {}
+
+        def _toggle_daygrid():
+            if daygrid.winfo_ismapped():
+                daygrid.pack_forget()
+                toggle_holder["btn"]._label.config(text="Pro Tag ▶")
+            else:
+                daygrid.pack(after=std_row, anchor="w", pady=(0, 4))
+                toggle_holder["btn"]._label.config(text="Pro Tag ▼")
+
+        toggle_holder["btn"] = secondary_button(
+            std_row, "Pro Tag ▶", _toggle_daygrid, padx=8, pady=0)
+        toggle_holder["btn"].pack(side=tk.LEFT, padx=2)
 
     def add_row(name="", start=STANDARD, end=STANDARD, pause=STANDARD):
         row = tk.Frame(rows_frame, bg=BG)

--- a/src/dialogs/category_dialog.py
+++ b/src/dialogs/category_dialog.py
@@ -104,12 +104,12 @@ def open_category_dialog(parent, settings, on_change=None):
     rows_frame = tk.Frame(outer, bg=BG)
     rows_frame.pack(fill="x")
     rows = []  # Liste von {frame, name, start, end, pause}
-    _keep = []  # haltet StringVars der read-only Zeile am Leben
 
     # Read-only Referenzzeile: die globalen Standardzeiten, damit der Nutzer
-    # direkt sieht, worauf „(Standard)" hinausläuft. Start/Ende sind pro
-    # Wochentag konfigurierbar — sind alle Tage gleich, zeigen wir den Wert,
-    # sonst „variabel". Pause ist global. Nicht editierbar, nicht in `rows`.
+    # direkt sieht, worauf „(Standard)" hinausläuft. Als schlichte Labels (kein
+    # Eingabefeld) — eindeutig nicht editierbar. Start/Ende sind pro Wochentag
+    # konfigurierbar: sind alle Tage gleich, zeigen wir den Wert, sonst
+    # „variabel"; Pause ist global. Spaltenbreiten = die der Überschriften.
     starts = {settings.get(f"default_start_{d}") for d in WEEKDAY_KEYS}
     ends = {settings.get(f"default_end_{d}") for d in WEEKDAY_KEYS}
     std_start = next(iter(starts)) if len(starts) == 1 else "variabel"
@@ -118,22 +118,14 @@ def open_category_dialog(parent, settings, on_change=None):
 
     std_row = tk.Frame(rows_frame, bg=BG)
     std_row.pack(fill="x", pady=2)
-    std_name = tk.StringVar(value="Standard")
-    _keep.append(std_name)
-    std_name_e = dark_entry(std_row, std_name, width=15)
-    std_name_e.configure(state="disabled")
-    std_name_e.pack(side=tk.LEFT, padx=2)
-
-    def _ro_combo(val, width):
-        c = dark_combo(std_row, None, [val], width=width)
-        c.set(val)
-        c.configure(state="disabled")
-        return c
-
-    _ro_combo(std_start, 11).pack(side=tk.LEFT, padx=2)
-    tk.Label(std_row, text="–", font=FONT, bg=BG, fg=TEXT_MUTED).pack(side=tk.LEFT)
-    _ro_combo(std_end, 11).pack(side=tk.LEFT, padx=2)
-    _ro_combo(std_pause, 11).pack(side=tk.LEFT, padx=2)
+    tk.Label(std_row, text="Standard", font=FONT, bg=BG, fg=TEXT_MUTED,
+             width=15, anchor="w").pack(side=tk.LEFT, padx=2)
+    tk.Label(std_row, text=std_start, font=FONT, bg=BG, fg=TEXT,
+             width=11, anchor="w").pack(side=tk.LEFT, padx=2)
+    tk.Label(std_row, text=std_end, font=FONT, bg=BG, fg=TEXT,
+             width=13, anchor="w").pack(side=tk.LEFT, padx=2)
+    tk.Label(std_row, text=std_pause, font=FONT, bg=BG, fg=TEXT,
+             width=11, anchor="w").pack(side=tk.LEFT, padx=2)
 
     def add_row(name="", start=STANDARD, end=STANDARD, pause=STANDARD):
         row = tk.Frame(rows_frame, bg=BG)

--- a/src/dialogs/category_dialog.py
+++ b/src/dialogs/category_dialog.py
@@ -4,12 +4,17 @@ Speichert via settings.set_synced('categories', ...)."""
 
 import tkinter as tk
 
+from src.category_defaults import remove_category_times, rename_category_times
 from src.theme import (
-    ACCENT, BG, CELL_BG, FONT, FONT_BOLD, TEXT,
-    apply_app_icon, apply_dark_titlebar, attach_unfocus_on_click,
-    center_dialog_on_parent, dark_entry, disable_min_max,
+    ACCENT, BG, CELL_BG, FONT, FONT_BOLD, PAUSE_VALUES, TEXT, TEXT_MUTED,
+    TIME_VALUES, apply_app_icon, apply_dark_titlebar, attach_unfocus_on_click,
+    center_dialog_on_parent, dark_combo, dark_entry, disable_min_max,
     primary_button, secondary_button,
 )
+
+# Sentinel-Eintrag in den Zeit-Combos: bedeutet "kein eigener Wert, globaler
+# Standard gilt". Wird beim Speichern als fehlendes/leeres Feld abgelegt.
+STANDARD = "(Standard)"
 
 
 def add_category(categories, name):
@@ -39,6 +44,7 @@ def rename_category(categories, old, new):
 
 def open_category_dialog(parent, settings, on_change=None):
     categories = list(settings.get("categories") or [])
+    category_times = dict(settings.get("category_times") or {})
 
     dialog = tk.Toplevel(parent)
     dialog.title("Kategorien verwalten")
@@ -77,6 +83,47 @@ def open_category_dialog(parent, settings, on_change=None):
 
     name_var = tk.StringVar()
 
+    # --- Zeit-Felder für die aktuell selektierte Kategorie ---
+    start_var = tk.StringVar(value=STANDARD)
+    end_var = tk.StringVar(value=STANDARD)
+    pause_var = tk.StringVar(value=STANDARD)
+    prev_sel = [None]  # zuletzt selektierte Kategorie (Tk liefert nur die neue)
+
+    def _load_fields(cat):
+        entry = category_times.get(cat) or {}
+        start_var.set(entry.get("start") or STANDARD)
+        end_var.set(entry.get("end") or STANDARD)
+        p = entry.get("pause")
+        pause_var.set(str(p) if p not in (None, "") else STANDARD)
+
+    def _store_fields(cat):
+        """Schreibt die angezeigten Felder in den Eintrag von `cat` zurück.
+        STANDARD/leer → Feld entfällt; bleibt nichts übrig, verschwindet der
+        Kategorie-Eintrag ganz (komplett globaler Fallback)."""
+        if cat is None:
+            return
+        entry = {}
+        if start_var.get() not in ("", STANDARD):
+            entry["start"] = start_var.get()
+        if end_var.get() not in ("", STANDARD):
+            entry["end"] = end_var.get()
+        if pause_var.get() not in ("", STANDARD):
+            entry["pause"] = int(pause_var.get())
+        if entry:
+            category_times[cat] = entry
+        else:
+            category_times.pop(cat, None)
+
+    def on_select(_e=None):
+        _store_fields(prev_sel[0])
+        cat = _selected()
+        if cat is None:
+            return
+        _load_fields(cat)
+        prev_sel[0] = cat
+
+    listbox.bind("<<ListboxSelect>>", on_select)
+
     def on_add():
         nonlocal categories
         categories = add_category(categories, name_var.get())
@@ -84,20 +131,26 @@ def open_category_dialog(parent, settings, on_change=None):
         refresh()
 
     def on_rename():
-        nonlocal categories
+        nonlocal categories, category_times
         current = _selected()
         if current is None:
             return
-        categories = rename_category(categories, current, name_var.get())
+        _store_fields(current)
+        new = name_var.get()
+        categories = rename_category(categories, current, new)
+        category_times = rename_category_times(category_times, current, new)
         name_var.set("")
+        prev_sel[0] = None
         refresh()
 
     def on_remove():
-        nonlocal categories
+        nonlocal categories, category_times
         current = _selected()
         if current is None:
             return
         categories = remove_category(categories, current)
+        category_times = remove_category_times(category_times, current)
+        prev_sel[0] = None
         refresh()
 
     edit_row = tk.Frame(outer, bg=BG)
@@ -107,8 +160,30 @@ def open_category_dialog(parent, settings, on_change=None):
     secondary_button(edit_row, "Umbenennen", on_rename).pack(side=tk.LEFT, padx=2)
     secondary_button(edit_row, "Entfernen", on_remove).pack(side=tk.LEFT, padx=2)
 
+    tk.Label(
+        outer, text="Standardzeiten der gewählten Kategorie",
+        font=FONT_BOLD, bg=BG, fg=TEXT,
+    ).pack(anchor="w", pady=(4, 0))
+    tk.Label(
+        outer, text='„(Standard)" = globale Standardzeit verwenden',
+        font=FONT, bg=BG, fg=TEXT_MUTED,
+    ).pack(anchor="w")
+    time_row = tk.Frame(outer, bg=BG)
+    time_row.pack(fill="x", pady=(4, 8))
+    tk.Label(time_row, text="Start", font=FONT, bg=BG, fg=TEXT_MUTED).pack(side=tk.LEFT)
+    dark_combo(time_row, start_var, [STANDARD, *TIME_VALUES],
+               width=8).pack(side=tk.LEFT, padx=(2, 8))
+    tk.Label(time_row, text="Ende", font=FONT, bg=BG, fg=TEXT_MUTED).pack(side=tk.LEFT)
+    dark_combo(time_row, end_var, [STANDARD, *TIME_VALUES],
+               width=8).pack(side=tk.LEFT, padx=(2, 8))
+    tk.Label(time_row, text="Pause", font=FONT, bg=BG, fg=TEXT_MUTED).pack(side=tk.LEFT)
+    dark_combo(time_row, pause_var, [STANDARD, *PAUSE_VALUES],
+               width=10).pack(side=tk.LEFT, padx=2)
+
     def on_save():
+        _store_fields(prev_sel[0])
         settings.set_synced("categories", categories)
+        settings.set_synced("category_times", category_times)
         if on_change is not None:
             on_change()
         dialog.destroy()

--- a/src/dialogs/category_dialog.py
+++ b/src/dialogs/category_dialog.py
@@ -154,7 +154,7 @@ def open_category_dialog(parent, settings, on_change=None):
                 daygrid.pack_forget()
                 toggle_holder["btn"]._label.config(text="Pro Tag ▶")
             else:
-                daygrid.pack(after=std_row, anchor="w", pady=(0, 4))
+                daygrid.pack(after=std_row, anchor="center", pady=(0, 4))
                 toggle_holder["btn"]._label.config(text="Pro Tag ▼")
 
         toggle_holder["btn"] = secondary_button(

--- a/src/dialogs/category_dialog.py
+++ b/src/dialogs/category_dialog.py
@@ -17,10 +17,7 @@ from src.theme import (
     center_dialog_on_parent, dark_combo, dark_entry, disable_min_max,
     primary_button, secondary_button,
 )
-from src.tooltip import attach_tooltip
-
-# Deutsche Wochentags-Kürzel, indexgleich zu WEEKDAY_KEYS (Mo=mon … So=sun).
-_WEEKDAY_LABELS_DE = ("Mo", "Di", "Mi", "Do", "Fr", "Sa", "So")
+from src.time_utils import DAYS_DE
 
 # Sentinel-Eintrag in den Zeit-Combos: „kein eigener Wert, globaler Standard
 # gilt". Wird beim Speichern als fehlendes/leeres Feld abgelegt.
@@ -65,6 +62,49 @@ def collect_categories(rows):
         if entry:
             category_times[name] = entry
     return categories, category_times
+
+
+def _open_standard_times(parent, settings):
+    """Read-only Popup mit den globalen Standardzeiten je Wochentag.
+
+    Nur zur Ansicht — editiert wird in den Einstellungen. Wird vom „Pro Tag…"-
+    Button der Standard-Zeile geöffnet, wenn die Zeiten nicht an allen Tagen
+    gleich sind.
+    """
+    pop = tk.Toplevel(parent)
+    pop.title("Standardzeiten pro Tag")
+    pop.resizable(False, False)
+    pop.grab_set()
+    pop.focus_set()
+    pop.configure(bg=BG)
+    apply_dark_titlebar(pop)
+    disable_min_max(pop)
+    apply_app_icon(pop)
+    pop.bind("<Escape>", lambda _e: pop.destroy())
+
+    box = tk.Frame(pop, bg=BG)
+    box.pack(padx=16, pady=14)
+
+    tk.Label(box, text="Start", font=FONT, bg=BG, fg=TEXT_MUTED).grid(
+        row=0, column=1, padx=8)
+    tk.Label(box, text="Ende", font=FONT, bg=BG, fg=TEXT_MUTED).grid(
+        row=0, column=2, padx=8)
+    for i, (key, lbl) in enumerate(zip(WEEKDAY_KEYS, DAYS_DE), start=1):
+        tk.Label(box, text=lbl, font=FONT, bg=BG, fg=TEXT,
+                 width=4, anchor="w").grid(row=i, column=0, padx=(0, 8),
+                                           pady=2, sticky="w")
+        tk.Label(box, text=settings.get(f"default_start_{key}"),
+                 font=FONT, bg=BG, fg=TEXT).grid(row=i, column=1, padx=8, pady=2)
+        tk.Label(box, text=settings.get(f"default_end_{key}"),
+                 font=FONT, bg=BG, fg=TEXT).grid(row=i, column=2, padx=8, pady=2)
+
+    tk.Label(box, text=f"Pause: {settings.get('default_pause')} Min (global)",
+             font=FONT, bg=BG, fg=TEXT_MUTED).grid(
+        row=8, column=0, columnspan=3, pady=(10, 0), sticky="w")
+    secondary_button(box, "Schließen", pop.destroy).grid(
+        row=9, column=0, columnspan=3, pady=(12, 0))
+
+    center_dialog_on_parent(pop, parent)
 
 
 def open_category_dialog(parent, settings, on_change=None):
@@ -123,26 +163,23 @@ def open_category_dialog(parent, settings, on_change=None):
 
     std_row = tk.Frame(rows_frame, bg=BG)
     std_row.pack(fill="x", pady=2)
-    std_labels = [std_row]
     for text, w, fg in (
         ("Standard", 15, TEXT_MUTED),
         (std_start, 11, TEXT),
         (std_end, 13, TEXT),
         (std_pause, 11, TEXT),
     ):
-        lbl = tk.Label(std_row, text=text, font=FONT, bg=BG, fg=fg,
-                       width=w, anchor="w")
-        lbl.pack(side=tk.LEFT, padx=2)
-        std_labels.append(lbl)
+        tk.Label(std_row, text=text, font=FONT, bg=BG, fg=fg,
+                 width=w, anchor="w").pack(side=tk.LEFT, padx=2)
 
-    # Bei abweichenden Wochentagen sind die echten Zeiten im "variabel" nicht
-    # ablesbar — per Hover die Zeiten je Tag zeigen.
+    # Bei abweichenden Wochentagen zeigen Start/Ende „variabel" — ein kleiner
+    # Button blendet die echten Zeiten je Tag ein (read-only, vgl. Settings).
     if is_variable:
-        lines = [
-            f"{lbl}: {s}–{e}"
-            for lbl, s, e in zip(_WEEKDAY_LABELS_DE, day_starts, day_ends)
-        ]
-        attach_tooltip(std_labels, "Standardzeiten je Wochentag:\n" + "\n".join(lines))
+        secondary_button(
+            std_row, "Pro Tag…",
+            lambda: _open_standard_times(dialog, settings),
+            padx=8, pady=0,
+        ).pack(side=tk.LEFT, padx=2)
 
     def add_row(name="", start=STANDARD, end=STANDARD, pause=STANDARD):
         row = tk.Frame(rows_frame, bg=BG)

--- a/src/dialogs/category_dialog.py
+++ b/src/dialogs/category_dialog.py
@@ -17,6 +17,10 @@ from src.theme import (
     center_dialog_on_parent, dark_combo, dark_entry, disable_min_max,
     primary_button, secondary_button,
 )
+from src.tooltip import attach_tooltip
+
+# Deutsche Wochentags-Kürzel, indexgleich zu WEEKDAY_KEYS (Mo=mon … So=sun).
+_WEEKDAY_LABELS_DE = ("Mo", "Di", "Mi", "Do", "Fr", "Sa", "So")
 
 # Sentinel-Eintrag in den Zeit-Combos: „kein eigener Wert, globaler Standard
 # gilt". Wird beim Speichern als fehlendes/leeres Feld abgelegt.
@@ -110,22 +114,35 @@ def open_category_dialog(parent, settings, on_change=None):
     # Eingabefeld) — eindeutig nicht editierbar. Start/Ende sind pro Wochentag
     # konfigurierbar: sind alle Tage gleich, zeigen wir den Wert, sonst
     # „variabel"; Pause ist global. Spaltenbreiten = die der Überschriften.
-    starts = {settings.get(f"default_start_{d}") for d in WEEKDAY_KEYS}
-    ends = {settings.get(f"default_end_{d}") for d in WEEKDAY_KEYS}
-    std_start = next(iter(starts)) if len(starts) == 1 else "variabel"
-    std_end = next(iter(ends)) if len(ends) == 1 else "variabel"
+    day_starts = [settings.get(f"default_start_{d}") for d in WEEKDAY_KEYS]
+    day_ends = [settings.get(f"default_end_{d}") for d in WEEKDAY_KEYS]
+    is_variable = len(set(day_starts)) > 1 or len(set(day_ends)) > 1
+    std_start = "variabel" if len(set(day_starts)) > 1 else day_starts[0]
+    std_end = "variabel" if len(set(day_ends)) > 1 else day_ends[0]
     std_pause = str(settings.get("default_pause"))
 
     std_row = tk.Frame(rows_frame, bg=BG)
     std_row.pack(fill="x", pady=2)
-    tk.Label(std_row, text="Standard", font=FONT, bg=BG, fg=TEXT_MUTED,
-             width=15, anchor="w").pack(side=tk.LEFT, padx=2)
-    tk.Label(std_row, text=std_start, font=FONT, bg=BG, fg=TEXT,
-             width=11, anchor="w").pack(side=tk.LEFT, padx=2)
-    tk.Label(std_row, text=std_end, font=FONT, bg=BG, fg=TEXT,
-             width=13, anchor="w").pack(side=tk.LEFT, padx=2)
-    tk.Label(std_row, text=std_pause, font=FONT, bg=BG, fg=TEXT,
-             width=11, anchor="w").pack(side=tk.LEFT, padx=2)
+    std_labels = [std_row]
+    for text, w, fg in (
+        ("Standard", 15, TEXT_MUTED),
+        (std_start, 11, TEXT),
+        (std_end, 13, TEXT),
+        (std_pause, 11, TEXT),
+    ):
+        lbl = tk.Label(std_row, text=text, font=FONT, bg=BG, fg=fg,
+                       width=w, anchor="w")
+        lbl.pack(side=tk.LEFT, padx=2)
+        std_labels.append(lbl)
+
+    # Bei abweichenden Wochentagen sind die echten Zeiten im "variabel" nicht
+    # ablesbar — per Hover die Zeiten je Tag zeigen.
+    if is_variable:
+        lines = [
+            f"{lbl}: {s}–{e}"
+            for lbl, s, e in zip(_WEEKDAY_LABELS_DE, day_starts, day_ends)
+        ]
+        attach_tooltip(std_labels, "Standardzeiten je Wochentag:\n" + "\n".join(lines))
 
     def add_row(name="", start=STANDARD, end=STANDARD, pause=STANDARD):
         row = tk.Frame(rows_frame, bg=BG)

--- a/src/dialogs/conflicts_dialog.py
+++ b/src/dialogs/conflicts_dialog.py
@@ -7,13 +7,25 @@ from src.theme import apply_app_icon
 from src.time_utils import format_iso_datetime
 
 
+def _fmt_slot(slot):
+    kat = f" {slot['kategorie']}" if slot.get("kategorie") else ""
+    return f"{slot.get('start', '')}—{slot.get('end', '')} (P{slot.get('pause', 0)}){kat}"
+
+
+def _entry_chosen(cand):
+    """Baut den chosen-Wert für sync.resolve_conflict aus einem Entry-Kandidaten:
+    die Slot-Liste + das deleted-Flag (kein Top-Level start/end/pause mehr)."""
+    return {"slots": cand.get("slots", []), "deleted": cand.get("deleted", False)}
+
+
 def _fmt_entry_candidate(cand):
     when = format_iso_datetime(cand.get("modified_at", ""), fallback="")
+    dev = cand.get("device_id", "?")[:8]
     if cand.get("deleted"):
-        return f"GELÖSCHT (von {cand.get('device_id', '?')[:8]}…, {when})"
-    return (f"{cand.get('start', '')}—{cand.get('end', '')} "
-            f"(Pause {cand.get('pause', 0)} min, von "
-            f"{cand.get('device_id', '?')[:8]}…, {when})")
+        return f"GELÖSCHT (von {dev}…, {when})"
+    slots = cand.get("slots", [])
+    body = ", ".join(_fmt_slot(s) for s in slots) if slots else "(leer)"
+    return f"{body} (von {dev}…, {when})"
 
 
 def _fmt_setting_candidate(cand):
@@ -96,12 +108,7 @@ class ConflictsDialog:
         c = self._selected
         cand = c["candidates"][idx]
         if c["kind"] == "entry":
-            chosen = {
-                "start": cand.get("start"),
-                "end": cand.get("end"),
-                "pause": cand.get("pause", 0),
-                "deleted": cand.get("deleted", False),
-            }
+            chosen = _entry_chosen(cand)
         else:
             chosen = {"value": cand.get("value")}
         device_id = self.settings.get("device_id") or ""

--- a/src/dialogs/entry_dialog.py
+++ b/src/dialogs/entry_dialog.py
@@ -131,15 +131,14 @@ def open_entry_dialog(parent, date_str, storage, settings, on_change,
         ist_rows.append(record)
 
     # Vorbelegung: vorhandene Ist-Slots → bestehende Reservierung (erste Slot-
-    # Zeit) → Standardzeit des Wochentags.
+    # Zeit). Gibt es weder Ist-Zeit noch Reservierung, bleibt der Block leer —
+    # nur der „+ Slot"-Button erscheint, keine Default-Zeile.
     if entry and entry["slots"]:
         for s in entry["slots"]:
             add_ist_row(s["start"], s["end"], s.get("pause", 0), s.get("kategorie", ""))
     elif existing_reservation and existing_reservation["slots"]:
         first = existing_reservation["slots"][0]
         add_ist_row(first["start"], first["end"], default_pause, "")
-    else:
-        add_ist_row(default_start, default_end, default_pause, "")
 
     ist_btns = tk.Frame(outer, bg=BG)
     ist_btns.pack(fill="x", pady=(2, 8))
@@ -216,11 +215,11 @@ def open_entry_dialog(parent, date_str, storage, settings, on_change,
             secondary_button(row, "×", remove, padx=8, pady=0).pack(side=tk.LEFT, padx=2)
             res_rows.append(record)
 
+        # Bestehende Reservierung → Zeilen. Sonst leer: nur der „+ Slot"-Button
+        # (an der Stelle, wo sonst die Default-Zeile stünde), keine Vorbelegung.
         if existing_reservation and existing_reservation["slots"]:
             for s in existing_reservation["slots"]:
                 add_res_row(s["start"], s["end"], s.get("kategorie", ""))
-        else:
-            add_res_row(default_start, default_end, "")
 
         res_btns = tk.Frame(outer, bg=BG)
         res_btns.pack(fill="x", pady=(2, 8))

--- a/src/dialogs/entry_dialog.py
+++ b/src/dialogs/entry_dialog.py
@@ -1,7 +1,6 @@
 import datetime
 import platform
 import tkinter as tk
-from tkinter import messagebox
 
 from src.holidays_de import get_holidays
 from src.settings import WEEKDAY_KEYS
@@ -10,7 +9,7 @@ from src.theme import (
     apply_app_icon, apply_combobox_style, apply_dark_titlebar,
     attach_unfocus_on_click, center_dialog_on_parent, dark_combo,
     dark_combo_editable, disable_min_max, primary_button, secondary_button,
-    themed_askyesno,
+    themed_askyesno, themed_showerror,
 )
 from src.time_utils import validate_slots
 
@@ -146,7 +145,7 @@ def open_entry_dialog(parent, date_str, storage, settings, on_change,
             return
         ok, msg = validate_slots(slots, with_pause=True)
         if not ok:
-            messagebox.showerror("Fehler", msg, parent=dialog)
+            themed_showerror(dialog, "Fehler", msg)
             return
         storage.save(date_str, slots)
         dialog.destroy()
@@ -219,7 +218,7 @@ def open_entry_dialog(parent, date_str, storage, settings, on_change,
                 return
             ok, msg = validate_slots(slots, with_pause=False)
             if not ok:
-                messagebox.showerror("Fehler", msg, parent=dialog)
+                themed_showerror(dialog, "Fehler", msg)
                 return
             reservation_store.save(date_str, slots)
             dialog.destroy()

--- a/src/dialogs/entry_dialog.py
+++ b/src/dialogs/entry_dialog.py
@@ -9,7 +9,7 @@ from src.theme import (
     apply_app_icon, apply_combobox_style, apply_dark_titlebar,
     attach_unfocus_on_click, center_dialog_on_parent, dark_combo,
     dark_combo_editable, disable_min_max, primary_button, secondary_button,
-    themed_askyesno, themed_showerror,
+    themed_askyesno, themed_showinfo,
 )
 from src.time_utils import validate_slots
 
@@ -145,7 +145,7 @@ def open_entry_dialog(parent, date_str, storage, settings, on_change,
             return
         ok, msg = validate_slots(slots, with_pause=True)
         if not ok:
-            themed_showerror(dialog, "Fehler", msg)
+            themed_showinfo(dialog, "Hinweis", msg)
             return
         storage.save(date_str, slots)
         dialog.destroy()
@@ -218,7 +218,7 @@ def open_entry_dialog(parent, date_str, storage, settings, on_change,
                 return
             ok, msg = validate_slots(slots, with_pause=False)
             if not ok:
-                themed_showerror(dialog, "Fehler", msg)
+                themed_showinfo(dialog, "Hinweis", msg)
                 return
             reservation_store.save(date_str, slots)
             dialog.destroy()

--- a/src/dialogs/entry_dialog.py
+++ b/src/dialogs/entry_dialog.py
@@ -1,5 +1,4 @@
 import datetime
-import platform
 import tkinter as tk
 
 from src.holidays_de import get_holidays
@@ -14,14 +13,6 @@ from src.theme import (
 from src.time_utils import validate_slots
 
 
-# Löschen folgt im Kalender dem Muster „Linksklick = speichern, Rechtsklick =
-# löschen". Der Dialog (Linksklick) ist daher rein zum Anlegen/Bearbeiten — die
-# Lösch-Buttons sind dort raus. AUSNAHME macOS: Tkinters Maustasten-Nummerierung
-# macht den Rechtsklick (`<Button-3>`) dort unzuverlässig; damit Löschen auf dem
-# Mac überhaupt erreichbar bleibt, behält der Dialog dort seine Lösch-Buttons.
-_SHOW_DELETE_IN_DIALOG = platform.system() == "Darwin"
-
-
 def open_entry_dialog(parent, date_str, storage, settings, on_change,
                       reservation_store=None, trigger_reconcile=None):
     """Modaler Dialog zum Bearbeiten von Ist-Zeit und Reservierung eines Tages.
@@ -30,7 +21,8 @@ def open_entry_dialog(parent, date_str, storage, settings, on_change,
     bzw. Start/Ende/Kategorie). Speichern sammelt die Zeilen, validiert sie
     (validate_slots: pro Slot + Überlappungsfreiheit) und schreibt die Slot-
     Liste. Entfernt man alle Zeilen eines Blocks und speichert, wird der Block
-    gelöscht — kein separater Lösch-Button (außer macOS).
+    gelöscht — der Dialog hat keinen Lösch-Button (Löschen läuft im Kalender:
+    Rechtsklick auf Win/Linux, ✕-Button in der Zelle auf macOS).
 
     on_change wird nach erfolgreichem Speichern/Löschen aufgerufen.
     reservation_store / trigger_reconcile sind optional; ist der Tag
@@ -151,16 +143,9 @@ def open_entry_dialog(parent, date_str, storage, settings, on_change,
         dialog.destroy()
         on_change()
 
-    def delete_ist():
-        storage.delete(date_str)
-        dialog.destroy()
-        on_change()
-
     ist_save = tk.Frame(outer, bg=BG)
     ist_save.pack(fill="x")
     primary_button(ist_save, "Speichern", save_ist).pack(side=tk.LEFT, padx=2)
-    if entry is not None and _SHOW_DELETE_IN_DIALOG:
-        secondary_button(ist_save, "Löschen", delete_ist).pack(side=tk.LEFT, padx=2)
 
     # ---------- Reservierung ----------
     if show_reservation:
@@ -226,19 +211,9 @@ def open_entry_dialog(parent, date_str, storage, settings, on_change,
             if trigger_reconcile is not None:
                 trigger_reconcile()
 
-        def delete_reservation():
-            reservation_store.delete(date_str)
-            dialog.destroy()
-            on_change()
-            if trigger_reconcile is not None:
-                trigger_reconcile()
-
         res_save = tk.Frame(outer, bg=BG)
         res_save.pack(fill="x")
         primary_button(res_save, "Reservierung speichern",
                        save_reservation).pack(side=tk.LEFT, padx=2)
-        if existing_reservation is not None and _SHOW_DELETE_IN_DIALOG:
-            secondary_button(res_save, "Reservierung löschen",
-                             delete_reservation).pack(side=tk.LEFT, padx=2)
 
     center_dialog_on_parent(dialog, parent)

--- a/src/dialogs/entry_dialog.py
+++ b/src/dialogs/entry_dialog.py
@@ -8,10 +8,11 @@ from src.settings import WEEKDAY_KEYS
 from src.theme import (
     BG, FONT, FONT_BOLD, PAUSE_VALUES, TEXT, TEXT_MUTED, TIME_VALUES,
     apply_app_icon, apply_combobox_style, apply_dark_titlebar,
-    attach_unfocus_on_click, center_dialog_on_parent, disable_min_max,
-    dark_combo, primary_button, secondary_button, themed_askyesno,
+    attach_unfocus_on_click, center_dialog_on_parent, dark_combo,
+    dark_combo_editable, disable_min_max, primary_button, secondary_button,
+    themed_askyesno,
 )
-from src.time_utils import validate_entry
+from src.time_utils import validate_slots
 
 
 # Löschen folgt im Kalender dem Muster „Linksklick = speichern, Rechtsklick =
@@ -26,15 +27,20 @@ def open_entry_dialog(parent, date_str, storage, settings, on_change,
                       reservation_store=None, trigger_reconcile=None):
     """Modaler Dialog zum Bearbeiten von Ist-Zeit und Reservierung eines Tages.
 
-    on_change wird nach erfolgreichem Speichern/Löschen aufgerufen, damit der
-    Aufrufer den Kalender neu rendert.
-    reservation_store / trigger_reconcile sind optional; sind sie gesetzt und
-    ist der Tag heute/zukünftig (oder existiert bereits eine Reservierung),
-    wird der Reservierungs-Block angezeigt. trigger_reconcile() stößt nach
-    einer Reservierungsänderung den Kalender-Abgleich an.
+    Beide Blöcke führen eine Liste von Slot-Zeilen (Start/Ende/Pause/Kategorie
+    bzw. Start/Ende/Kategorie). Speichern sammelt die Zeilen, validiert sie
+    (validate_slots: pro Slot + Überlappungsfreiheit) und schreibt die Slot-
+    Liste. Entfernt man alle Zeilen eines Blocks und speichert, wird der Block
+    gelöscht — kein separater Lösch-Button (außer macOS).
+
+    on_change wird nach erfolgreichem Speichern/Löschen aufgerufen.
+    reservation_store / trigger_reconcile sind optional; ist der Tag
+    heute/zukünftig (oder existiert bereits eine Reservierung), erscheint der
+    Reservierungs-Block. trigger_reconcile() stößt den Kalender-Abgleich an.
     """
     entry = storage.get(date_str)
     day = datetime.date.fromisoformat(date_str)
+    weekday_key = WEEKDAY_KEYS[day.weekday()]
 
     # Feiertags-Warnung beim Anlegen einer Ist-Zeit (nicht beim Edit).
     if entry is None:
@@ -58,13 +64,17 @@ def open_entry_dialog(parent, date_str, storage, settings, on_change,
         day >= datetime.date.today() or existing_reservation is not None
     )
 
+    categories = settings.get("categories") or []
+    default_start = settings.get(f"default_start_{weekday_key}")
+    default_end = settings.get(f"default_end_{weekday_key}")
+    default_pause = settings.get("default_pause")
+
     dialog = tk.Toplevel(parent)
     dialog.title(day.strftime("%d.%m.%Y"))
     dialog.resizable(False, False)
     dialog.grab_set()
-    # focus_set() ist nach grab_set() Pflicht, sonst bleibt der Keyboard-
-    # Fokus auf dem Hauptfenster und Tastatur-Bindungen (z.B. Escape) am
-    # Dialog feuern nie. grab_set steuert nur Mouse-Events.
+    # focus_set() ist nach grab_set() Pflicht, sonst feuern Tastatur-Bindungen
+    # (z.B. Escape) am Dialog nie.
     dialog.focus_set()
     dialog.configure(bg=BG)
     apply_dark_titlebar(dialog)
@@ -74,96 +84,144 @@ def open_entry_dialog(parent, date_str, storage, settings, on_change,
     attach_unfocus_on_click(dialog)
     dialog.bind("<Escape>", lambda _e: dialog.destroy())
 
-    # --- Ist-Zeit ---
-    # Vorauswahl-Priorität beim Anlegen: vorhandener Ist-Eintrag → bestehende
-    # Reservierung → Standardzeit des Wochentags. Eine Reservierung überschreibt
-    # also die Standardzeiten, weil der Tag dann bereits konkret verplant ist.
-    tk.Label(dialog, text="Start:", font=FONT, bg=BG, fg=TEXT).grid(
-        row=0, column=0, padx=10, pady=8, sticky="w")
-    weekday_key = WEEKDAY_KEYS[day.weekday()]
-    if entry:
-        default_start = entry["start"]
-        default_end = entry["end"]
-    elif existing_reservation:
-        default_start = existing_reservation["start"]
-        default_end = existing_reservation["end"]
+    outer = tk.Frame(dialog, bg=BG)
+    outer.pack(padx=12, pady=12)
+
+    # ---------- Ist-Zeit ----------
+    tk.Label(outer, text="Arbeitszeit", font=FONT_BOLD, bg=BG, fg=TEXT).pack(anchor="w")
+    ist_rows_frame = tk.Frame(outer, bg=BG)
+    ist_rows_frame.pack(fill="x")
+    ist_rows = []  # Liste von {frame, start, end, pause, kategorie}
+
+    def add_ist_row(start, end, pause, kategorie):
+        row = tk.Frame(ist_rows_frame, bg=BG)
+        row.pack(fill="x", pady=2)
+        sv = tk.StringVar(value=start)
+        ev = tk.StringVar(value=end)
+        pv = tk.StringVar(value=str(pause))
+        kv = tk.StringVar(value=kategorie)
+        dark_combo(row, sv, TIME_VALUES, width=6).pack(side=tk.LEFT, padx=2)
+        tk.Label(row, text="–", font=FONT, bg=BG, fg=TEXT_MUTED).pack(side=tk.LEFT)
+        dark_combo(row, ev, TIME_VALUES, width=6).pack(side=tk.LEFT, padx=2)
+        dark_combo(row, pv, PAUSE_VALUES, width=4).pack(side=tk.LEFT, padx=2)
+        dark_combo_editable(row, kv, categories, width=14).pack(side=tk.LEFT, padx=2)
+        record = {"frame": row, "start": sv, "end": ev, "pause": pv, "kategorie": kv}
+
+        def remove():
+            row.destroy()
+            ist_rows.remove(record)
+
+        secondary_button(row, "×", remove, padx=8, pady=0).pack(side=tk.LEFT, padx=2)
+        ist_rows.append(record)
+
+    # Vorbelegung: vorhandene Ist-Slots → bestehende Reservierung (erste Slot-
+    # Zeit) → Standardzeit des Wochentags.
+    if entry and entry["slots"]:
+        for s in entry["slots"]:
+            add_ist_row(s["start"], s["end"], s.get("pause", 0), s.get("kategorie", ""))
+    elif existing_reservation and existing_reservation["slots"]:
+        first = existing_reservation["slots"][0]
+        add_ist_row(first["start"], first["end"], default_pause, "")
     else:
-        default_start = settings.get(f"default_start_{weekday_key}")
-        default_end = settings.get(f"default_end_{weekday_key}")
-    start_var = tk.StringVar(value=default_start)
-    dark_combo(dialog, start_var, TIME_VALUES).grid(row=0, column=1, padx=10, pady=8)
+        add_ist_row(default_start, default_end, default_pause, "")
 
-    tk.Label(dialog, text="Ende:", font=FONT, bg=BG, fg=TEXT).grid(
-        row=1, column=0, padx=10, pady=8, sticky="w")
-    end_var = tk.StringVar(value=default_end)
-    dark_combo(dialog, end_var, TIME_VALUES).grid(row=1, column=1, padx=10, pady=8)
+    ist_btns = tk.Frame(outer, bg=BG)
+    ist_btns.pack(fill="x", pady=(2, 8))
+    secondary_button(
+        ist_btns, "+ Slot",
+        lambda: add_ist_row(default_start, default_end, 0, ""),
+    ).pack(side=tk.LEFT, padx=2)
 
-    tk.Label(dialog, text="Pause (Min):", font=FONT, bg=BG, fg=TEXT).grid(
-        row=2, column=0, padx=10, pady=8, sticky="w")
-    default_pause = settings.get("default_pause")
-    if entry and "pause" in entry:
-        current_pause = str(entry["pause"])
-    else:
-        current_pause = str(default_pause) if not entry else "0"
-    pause_var = tk.StringVar(value=current_pause)
-    dark_combo(dialog, pause_var, PAUSE_VALUES).grid(row=2, column=1, padx=10, pady=8)
-
-    def save():
-        ok, msg = validate_entry(start_var.get(), end_var.get(),
-                                 pause_minutes=int(pause_var.get()))
+    def save_ist():
+        slots = [{
+            "start": r["start"].get(),
+            "end": r["end"].get(),
+            "pause": int(r["pause"].get() or 0),
+            "kategorie": r["kategorie"].get().strip(),
+        } for r in ist_rows]
+        if not slots:
+            storage.delete(date_str)
+            dialog.destroy()
+            on_change()
+            return
+        ok, msg = validate_slots(slots, with_pause=True)
         if not ok:
             messagebox.showerror("Fehler", msg, parent=dialog)
             return
-        storage.save(date_str, start_var.get(), end_var.get(),
-                     pause=int(pause_var.get()))
+        storage.save(date_str, slots)
         dialog.destroy()
         on_change()
 
-    def delete():
+    def delete_ist():
         storage.delete(date_str)
         dialog.destroy()
         on_change()
 
-    btn_frame = tk.Frame(dialog, bg=BG)
-    btn_frame.grid(row=3, column=0, columnspan=2, pady=12)
-    primary_button(btn_frame, "Speichern", save).pack(side=tk.LEFT, padx=5)
+    ist_save = tk.Frame(outer, bg=BG)
+    ist_save.pack(fill="x")
+    primary_button(ist_save, "Speichern", save_ist).pack(side=tk.LEFT, padx=2)
     if entry is not None and _SHOW_DELETE_IN_DIALOG:
-        secondary_button(btn_frame, "Löschen", delete).pack(side=tk.LEFT, padx=5)
+        secondary_button(ist_save, "Löschen", delete_ist).pack(side=tk.LEFT, padx=2)
 
-    # --- Reservierung ---
-    # Ist-Zeit und Reservierung sind bewusst getrennte Konzepte mit je eigenem
-    # Speichern-Button. Jeder Block speichert unabhängig und schließt danach den
-    # Dialog — es gibt absichtlich keinen kombinierten Speichern-Pfad.
+    # ---------- Reservierung ----------
     if show_reservation:
         tk.Label(
-            dialog, text="— Reservierung —", font=FONT_BOLD, bg=BG, fg=TEXT_MUTED,
-        ).grid(row=4, column=0, columnspan=2, padx=10, pady=(8, 4))
+            outer, text="— Reservierung —", font=FONT_BOLD, bg=BG, fg=TEXT_MUTED,
+        ).pack(anchor="w", pady=(12, 2))
+        res_rows_frame = tk.Frame(outer, bg=BG)
+        res_rows_frame.pack(fill="x")
+        res_rows = []  # Liste von {frame, start, end, kategorie}
 
-        tk.Label(dialog, text="Start:", font=FONT, bg=BG, fg=TEXT).grid(
-            row=5, column=0, padx=10, pady=8, sticky="w")
-        res_start_var = tk.StringVar(
-            value=existing_reservation["start"] if existing_reservation
-            else settings.get(f"default_start_{weekday_key}")
-        )
-        dark_combo(dialog, res_start_var, TIME_VALUES).grid(
-            row=5, column=1, padx=10, pady=8)
+        def add_res_row(start, end, kategorie):
+            row = tk.Frame(res_rows_frame, bg=BG)
+            row.pack(fill="x", pady=2)
+            sv = tk.StringVar(value=start)
+            ev = tk.StringVar(value=end)
+            kv = tk.StringVar(value=kategorie)
+            dark_combo(row, sv, TIME_VALUES, width=6).pack(side=tk.LEFT, padx=2)
+            tk.Label(row, text="–", font=FONT, bg=BG, fg=TEXT_MUTED).pack(side=tk.LEFT)
+            dark_combo(row, ev, TIME_VALUES, width=6).pack(side=tk.LEFT, padx=2)
+            dark_combo_editable(row, kv, categories, width=14).pack(side=tk.LEFT, padx=2)
+            record = {"frame": row, "start": sv, "end": ev, "kategorie": kv}
 
-        tk.Label(dialog, text="Ende:", font=FONT, bg=BG, fg=TEXT).grid(
-            row=6, column=0, padx=10, pady=8, sticky="w")
-        res_end_var = tk.StringVar(
-            value=existing_reservation["end"] if existing_reservation
-            else settings.get(f"default_end_{weekday_key}")
-        )
-        dark_combo(dialog, res_end_var, TIME_VALUES).grid(
-            row=6, column=1, padx=10, pady=8)
+            def remove():
+                row.destroy()
+                res_rows.remove(record)
+
+            secondary_button(row, "×", remove, padx=8, pady=0).pack(side=tk.LEFT, padx=2)
+            res_rows.append(record)
+
+        if existing_reservation and existing_reservation["slots"]:
+            for s in existing_reservation["slots"]:
+                add_res_row(s["start"], s["end"], s.get("kategorie", ""))
+        else:
+            add_res_row(default_start, default_end, "")
+
+        res_btns = tk.Frame(outer, bg=BG)
+        res_btns.pack(fill="x", pady=(2, 8))
+        secondary_button(
+            res_btns, "+ Slot",
+            lambda: add_res_row(default_start, default_end, ""),
+        ).pack(side=tk.LEFT, padx=2)
 
         def save_reservation():
-            ok, msg = validate_entry(res_start_var.get(), res_end_var.get(),
-                                     pause_minutes=0)
+            slots = [{
+                "start": r["start"].get(),
+                "end": r["end"].get(),
+                "kategorie": r["kategorie"].get().strip(),
+            } for r in res_rows]
+            if not slots:
+                reservation_store.delete(date_str)
+                dialog.destroy()
+                on_change()
+                if trigger_reconcile is not None:
+                    trigger_reconcile()
+                return
+            ok, msg = validate_slots(slots, with_pause=False)
             if not ok:
                 messagebox.showerror("Fehler", msg, parent=dialog)
                 return
-            reservation_store.save(date_str, res_start_var.get(), res_end_var.get())
+            reservation_store.save(date_str, slots)
             dialog.destroy()
             on_change()
             if trigger_reconcile is not None:
@@ -176,12 +234,12 @@ def open_entry_dialog(parent, date_str, storage, settings, on_change,
             if trigger_reconcile is not None:
                 trigger_reconcile()
 
-        res_btn_frame = tk.Frame(dialog, bg=BG)
-        res_btn_frame.grid(row=7, column=0, columnspan=2, pady=12)
-        primary_button(res_btn_frame, "Reservierung speichern",
-                       save_reservation).pack(side=tk.LEFT, padx=5)
+        res_save = tk.Frame(outer, bg=BG)
+        res_save.pack(fill="x")
+        primary_button(res_save, "Reservierung speichern",
+                       save_reservation).pack(side=tk.LEFT, padx=2)
         if existing_reservation is not None and _SHOW_DELETE_IN_DIALOG:
-            secondary_button(res_btn_frame, "Reservierung löschen",
-                             delete_reservation).pack(side=tk.LEFT, padx=5)
+            secondary_button(res_save, "Reservierung löschen",
+                             delete_reservation).pack(side=tk.LEFT, padx=2)
 
     center_dialog_on_parent(dialog, parent)

--- a/src/dialogs/entry_dialog.py
+++ b/src/dialogs/entry_dialog.py
@@ -1,6 +1,7 @@
 import datetime
 import tkinter as tk
 
+from src.category_defaults import resolve_slot_defaults
 from src.holidays_de import get_holidays
 from src.settings import WEEKDAY_KEYS
 from src.theme import (
@@ -56,6 +57,7 @@ def open_entry_dialog(parent, date_str, storage, settings, on_change,
     )
 
     categories = settings.get("categories") or []
+    category_times = settings.get("category_times") or {}
     default_start = settings.get(f"default_start_{weekday_key}")
     default_end = settings.get(f"default_end_{weekday_key}")
     default_pause = settings.get("default_pause")
@@ -91,12 +93,35 @@ def open_entry_dialog(parent, date_str, storage, settings, on_change,
         ev = tk.StringVar(value=end)
         pv = tk.StringVar(value=str(pause))
         kv = tk.StringVar(value=kategorie)
+        # Basis = die Werte, mit denen die Zeile angelegt wurde. Ein Kategorie-
+        # Wechsel überschreibt ein Feld NUR, solange es noch der Basis
+        # entspricht (= nicht manuell geändert), und zieht die Basis nach.
+        base = {"start": start, "end": end, "pause": str(pause)}
         dark_combo(row, sv, TIME_VALUES, width=6).pack(side=tk.LEFT, padx=2)
         tk.Label(row, text="–", font=FONT, bg=BG, fg=TEXT_MUTED).pack(side=tk.LEFT)
         dark_combo(row, ev, TIME_VALUES, width=6).pack(side=tk.LEFT, padx=2)
         dark_combo(row, pv, PAUSE_VALUES, width=4).pack(side=tk.LEFT, padx=2)
         dark_combo_editable(row, kv, categories, width=14).pack(side=tk.LEFT, padx=2)
         record = {"frame": row, "start": sv, "end": ev, "pause": pv, "kategorie": kv}
+
+        def on_cat_change(*_a):
+            t_start, t_end, t_pause = resolve_slot_defaults(
+                category_times, kv.get().strip(),
+                default_start, default_end, default_pause,
+            )
+            t_pause = str(t_pause)
+            if sv.get() == base["start"]:
+                sv.set(t_start)
+                base["start"] = t_start
+            if ev.get() == base["end"]:
+                ev.set(t_end)
+                base["end"] = t_end
+            if pv.get() == base["pause"]:
+                pv.set(t_pause)
+                base["pause"] = t_pause
+
+        # Trace NACH dem initialen kv-Set, damit die Vorbelegung nicht feuert.
+        kv.trace_add("write", on_cat_change)
 
         def remove():
             row.destroy()
@@ -162,11 +187,27 @@ def open_entry_dialog(parent, date_str, storage, settings, on_change,
             sv = tk.StringVar(value=start)
             ev = tk.StringVar(value=end)
             kv = tk.StringVar(value=kategorie)
+            base = {"start": start, "end": end}
             dark_combo(row, sv, TIME_VALUES, width=6).pack(side=tk.LEFT, padx=2)
             tk.Label(row, text="–", font=FONT, bg=BG, fg=TEXT_MUTED).pack(side=tk.LEFT)
             dark_combo(row, ev, TIME_VALUES, width=6).pack(side=tk.LEFT, padx=2)
             dark_combo_editable(row, kv, categories, width=14).pack(side=tk.LEFT, padx=2)
             record = {"frame": row, "start": sv, "end": ev, "kategorie": kv}
+
+            def on_cat_change(*_a):
+                # Reservierungen haben keine Pause → nur Start/Ende anwenden.
+                t_start, t_end, _ = resolve_slot_defaults(
+                    category_times, kv.get().strip(),
+                    default_start, default_end, default_pause,
+                )
+                if sv.get() == base["start"]:
+                    sv.set(t_start)
+                    base["start"] = t_start
+                if ev.get() == base["end"]:
+                    ev.set(t_end)
+                    base["end"] = t_end
+
+            kv.trace_add("write", on_cat_change)
 
             def remove():
                 row.destroy()

--- a/src/dialogs/entry_dialog.py
+++ b/src/dialogs/entry_dialog.py
@@ -86,7 +86,7 @@ def open_entry_dialog(parent, date_str, storage, settings, on_change,
     ist_rows_frame.pack(fill="x")
     ist_rows = []  # Liste von {frame, start, end, pause, kategorie}
 
-    def add_ist_row(start, end, pause, kategorie):
+    def add_ist_row(start, end, pause, kategorie, removable=True):
         row = tk.Frame(ist_rows_frame, bg=BG)
         row.pack(fill="x", pady=2)
         sv = tk.StringVar(value=start)
@@ -133,7 +133,12 @@ def open_entry_dialog(parent, date_str, storage, settings, on_change,
             if not ist_rows:
                 ist_rows_frame.configure(height=1)
 
-        secondary_button(row, "×", remove, padx=8, pady=0).pack(side=tk.LEFT, padx=2)
+        # Bereits gespeicherte Slots tragen kein ×: Löschen läuft ausschließlich
+        # über den Rechtsklick im Kalender (Design-Entscheidung — der Dialog
+        # speichert nur). Das × erscheint nur an neu hinzugefügten, noch nicht
+        # persistierten Zeilen.
+        if removable:
+            secondary_button(row, "×", remove, padx=8, pady=0).pack(side=tk.LEFT, padx=2)
         ist_rows.append(record)
 
     # Vorbelegung: vorhandene Ist-Slots → bestehende Reservierung (erste Slot-
@@ -141,8 +146,11 @@ def open_entry_dialog(parent, date_str, storage, settings, on_change,
     # nur der „+ Slot"-Button erscheint, keine Default-Zeile.
     if entry and entry["slots"]:
         for s in entry["slots"]:
-            add_ist_row(s["start"], s["end"], s.get("pause", 0), s.get("kategorie", ""))
+            add_ist_row(s["start"], s["end"], s.get("pause", 0),
+                        s.get("kategorie", ""), removable=False)
     elif existing_reservation and existing_reservation["slots"]:
+        # Vorschlag aus der Reservierung (noch nicht als Ist-Zeit gespeichert)
+        # → entfernbar.
         first = existing_reservation["slots"][0]
         add_ist_row(first["start"], first["end"], default_pause, "")
 
@@ -186,7 +194,7 @@ def open_entry_dialog(parent, date_str, storage, settings, on_change,
         res_rows_frame.pack(fill="x")
         res_rows = []  # Liste von {frame, start, end, kategorie}
 
-        def add_res_row(start, end, kategorie):
+        def add_res_row(start, end, kategorie, removable=True):
             row = tk.Frame(res_rows_frame, bg=BG)
             row.pack(fill="x", pady=2)
             sv = tk.StringVar(value=start)
@@ -220,14 +228,19 @@ def open_entry_dialog(parent, date_str, storage, settings, on_change,
                 if not res_rows:
                     res_rows_frame.configure(height=1)
 
-            secondary_button(row, "×", remove, padx=8, pady=0).pack(side=tk.LEFT, padx=2)
+            # Gespeicherte Reservierungs-Slots tragen kein × (Löschen per
+            # Rechtsklick im Kalender); nur neue, ungespeicherte Zeilen.
+            if removable:
+                secondary_button(row, "×", remove, padx=8, pady=0).pack(
+                    side=tk.LEFT, padx=2)
             res_rows.append(record)
 
         # Bestehende Reservierung → Zeilen. Sonst leer: nur der „+ Slot"-Button
         # (an der Stelle, wo sonst die Default-Zeile stünde), keine Vorbelegung.
         if existing_reservation and existing_reservation["slots"]:
             for s in existing_reservation["slots"]:
-                add_res_row(s["start"], s["end"], s.get("kategorie", ""))
+                add_res_row(s["start"], s["end"], s.get("kategorie", ""),
+                            removable=False)
 
         res_btns = tk.Frame(outer, bg=BG)
         res_btns.pack(fill="x", pady=(2, 8))

--- a/src/dialogs/entry_dialog.py
+++ b/src/dialogs/entry_dialog.py
@@ -126,6 +126,12 @@ def open_entry_dialog(parent, date_str, storage, settings, on_change,
         def remove():
             row.destroy()
             ist_rows.remove(record)
+            # Ein leeres Tk-Frame behält sonst die Höhe seiner letzten Zeile als
+            # Lücke — beim Entfernen der letzten Zeile explizit kollabieren,
+            # damit der Dialog passend schrumpft (pack_propagate baut die Höhe
+            # beim nächsten "+ Slot" wieder auf).
+            if not ist_rows:
+                ist_rows_frame.configure(height=1)
 
         secondary_button(row, "×", remove, padx=8, pady=0).pack(side=tk.LEFT, padx=2)
         ist_rows.append(record)
@@ -211,6 +217,8 @@ def open_entry_dialog(parent, date_str, storage, settings, on_change,
             def remove():
                 row.destroy()
                 res_rows.remove(record)
+                if not res_rows:
+                    res_rows_frame.configure(height=1)
 
             secondary_button(row, "×", remove, padx=8, pady=0).pack(side=tk.LEFT, padx=2)
             res_rows.append(record)

--- a/src/dialogs/import_dialog.py
+++ b/src/dialogs/import_dialog.py
@@ -423,9 +423,14 @@ class _PerDayDialog:
         return self._result
 
     def _fmt(self, rec):
-        if self.has_pause:
-            return f"{rec['start']}—{rec['end']} (P{rec.get('pause', 0)})"
-        return f"{rec['start']}—{rec['end']}"
+        parts = []
+        for s in rec.get("slots", []):
+            kat = f" {s['kategorie']}" if s.get("kategorie") else ""
+            if self.has_pause:
+                parts.append(f"{s['start']}—{s['end']} (P{s.get('pause', 0)}){kat}")
+            else:
+                parts.append(f"{s['start']}—{s['end']}{kat}")
+        return ", ".join(parts) if parts else "—"
 
     def _build(self):
         tk.Label(

--- a/src/dialogs/send_dialog.py
+++ b/src/dialogs/send_dialog.py
@@ -10,7 +10,7 @@ from src.mail import get_gmail_service, is_offline_error, send_email
 from src.platform_open import open_folder
 from src.report import generate_pdf, generate_report
 from src.theme import (
-    BG, FONT, TEXT,
+    BG, CELL_BG, FONT, TEXT,
     apply_app_icon, apply_combobox_style, apply_dark_titlebar,
     attach_unfocus_on_click, center_dialog_on_parent,
     disable_min_max, dark_combo, primary_button, secondary_button,
@@ -146,6 +146,46 @@ def open_send_dialog(parent, storage, settings, base_path):
     from_day, from_month, from_year = build_date_row(0, "Von:", from_default)
     to_day, to_month, to_year = build_date_row(1, "Bis:", today)
 
+    # --- Kategorie-Auswahl ---
+    # Kategorien aus dem Bestand UND der Settings-Pickliste sammeln ("" = ohne
+    # Kategorie). Alle standardmäßig ausgewählt; sind alle ausgewählt, wird kein
+    # Filter gesetzt. Bewusste Vereinfachung: die Liste wird NICHT auf den
+    # gewählten Zeitraum eingeschränkt (das bräuchte dynamisches Neu-Aufbauen bei
+    # Datumswechsel) — eine im Zeitraum nicht vorkommende Kategorie bleibt
+    # wirkungslos, daher unkritisch.
+    all_entries = storage.get_all()
+    present_categories = sorted(
+        {(s.get("kategorie") or "") for e in all_entries.values() for s in e["slots"]}
+        | {c for c in (settings.get("categories") or [])},
+        key=lambda k: (k == "", k.lower()),
+    )
+    category_vars = {}  # rohe Kategorie -> BooleanVar
+    if present_categories:
+        tk.Label(dialog, text="Kategorien:", font=FONT, bg=BG, fg=TEXT).grid(
+            row=2, column=0, padx=(10, 5), pady=(4, 8), sticky="nw")
+        cat_frame = tk.Frame(dialog, bg=BG)
+        cat_frame.grid(row=2, column=1, columnspan=5, padx=(0, 10), pady=(4, 8), sticky="w")
+        for kat in present_categories:
+            var = tk.BooleanVar(value=True)
+            category_vars[kat] = var
+            label = kat if kat else "(ohne Kategorie)"
+            tk.Checkbutton(
+                cat_frame, text=label, variable=var,
+                font=FONT, bg=BG, fg=TEXT, selectcolor=CELL_BG,
+                activebackground=BG, activeforeground=TEXT,
+                highlightthickness=0, bd=0, anchor="w",
+            ).pack(anchor="w")
+
+    def _selected_categories():
+        """None, wenn keine Kategorien existieren oder alle ausgewählt sind
+        (= kein Filter). Sonst die Menge der ausgewählten rohen Kategorien."""
+        if not category_vars:
+            return None
+        selected = {kat for kat, var in category_vars.items() if var.get()}
+        if len(selected) == len(category_vars):
+            return None
+        return selected
+
     def do_send():
         try:
             date_from = datetime.date(int(from_year.get()), int(from_month.get()), int(from_day.get()))
@@ -162,13 +202,15 @@ def open_send_dialog(parent, storage, settings, base_path):
             )
             return
 
-        entries = storage.get_all()
+        entries = all_entries
+        categories = _selected_categories()
 
         html, total = generate_report(
             date_from, date_to, entries,
             greeting=settings.get("mail_greeting"),
             content=settings.get("mail_content"),
             closing=settings.get("mail_closing"),
+            categories=categories,
         )
 
         if html is None:
@@ -182,7 +224,8 @@ def open_send_dialog(parent, storage, settings, base_path):
         label = f"{date_from.strftime('%d.%m.%Y')} – {date_to.strftime('%d.%m.%Y')}"
 
         try:
-            pdf_bytes = generate_pdf(date_from, date_to, entries, name=settings.get("name"))
+            pdf_bytes = generate_pdf(date_from, date_to, entries, name=settings.get("name"),
+                                     categories=categories)
             service = get_gmail_service(
                 credentials_path, token_path,
                 sync_enabled=settings.get("sync_enabled"),
@@ -241,7 +284,7 @@ def open_send_dialog(parent, storage, settings, base_path):
                 )
 
     btn_frame = tk.Frame(dialog, bg=BG)
-    btn_frame.grid(row=2, column=0, columnspan=6, pady=12)
+    btn_frame.grid(row=3, column=0, columnspan=6, pady=12)
 
     primary_button(btn_frame, "Senden", do_send).pack(side=tk.LEFT, padx=5)
     secondary_button(btn_frame, "Abbrechen", dialog.destroy).pack(side=tk.LEFT, padx=5)

--- a/src/dialogs/send_dialog.py
+++ b/src/dialogs/send_dialog.py
@@ -8,7 +8,7 @@ from tkinter import messagebox
 
 from src.mail import get_gmail_service, is_offline_error, send_email
 from src.platform_open import open_folder
-from src.report import generate_pdf, generate_report
+from src.report import generate_pdf, generate_report, total_hours
 from src.theme import (
     BG, CELL_BG, FONT, TEXT,
     apply_app_icon, apply_combobox_style, apply_dark_titlebar,
@@ -171,6 +171,7 @@ def open_send_dialog(parent, storage, settings, base_path):
             label = kat if kat else "(ohne Kategorie)"
             tk.Checkbutton(
                 cat_frame, text=label, variable=var,
+                command=lambda: _update_total(),
                 font=FONT, bg=BG, fg=TEXT, selectcolor=CELL_BG,
                 activebackground=BG, activeforeground=TEXT,
                 highlightthickness=0, bd=0, anchor="w",
@@ -185,6 +186,30 @@ def open_send_dialog(parent, storage, settings, base_path):
         if len(selected) == len(category_vars):
             return None
         return selected
+
+    # --- Live-Vorschau der Gesamtstunden (Zeitraum × gewählte Kategorien) ---
+    total_label = tk.Label(dialog, text="", font=FONT, bg=BG, fg=TEXT)
+    total_label.grid(row=3, column=0, columnspan=6, padx=10, pady=(0, 8), sticky="w")
+
+    def _current_range():
+        try:
+            df = datetime.date(int(from_year.get()), int(from_month.get()), int(from_day.get()))
+            dt = datetime.date(int(to_year.get()), int(to_month.get()), int(to_day.get()))
+        except ValueError:
+            return None, None
+        return df, dt
+
+    def _update_total(*_):
+        df, dt = _current_range()
+        if df is None or dt is None or df > dt:
+            total_label.config(text="Gesamtstunden: —")
+            return
+        hours = total_hours(df, dt, all_entries, _selected_categories())
+        total_label.config(text=f"Gesamtstunden: {hours}h")
+
+    for _v in (from_day, from_month, from_year, to_day, to_month, to_year):
+        _v.trace_add("write", _update_total)
+    _update_total()
 
     def do_send():
         try:
@@ -284,7 +309,7 @@ def open_send_dialog(parent, storage, settings, base_path):
                 )
 
     btn_frame = tk.Frame(dialog, bg=BG)
-    btn_frame.grid(row=3, column=0, columnspan=6, pady=12)
+    btn_frame.grid(row=4, column=0, columnspan=6, pady=12)
 
     primary_button(btn_frame, "Senden", do_send).pack(side=tk.LEFT, padx=5)
     secondary_button(btn_frame, "Abbrechen", dialog.destroy).pack(side=tk.LEFT, padx=5)

--- a/src/dialogs/settings_dialog.py
+++ b/src/dialogs/settings_dialog.py
@@ -18,6 +18,7 @@ from src.theme import (
     primary_button, secondary_button,
     themed_askyesno, themed_showinfo, themed_showwarning, themed_showerror,
 )
+from src.dialogs.category_dialog import open_category_dialog
 from src.holidays_de import STATES
 from src.settings import WEEKDAY_KEYS, SYNCED_SETTING_KEYS
 from src.time_utils import format_iso_date
@@ -779,6 +780,10 @@ def open_settings_dialog(parent, settings, base_path, on_change, *,
     btn_frame = tk.Frame(dialog, bg=BG)
     btn_frame.grid(row=32, column=0, columnspan=2, pady=12)
 
+    secondary_button(
+        btn_frame, "Kategorien verwalten…",
+        lambda: open_category_dialog(dialog, settings),
+    ).pack(side=tk.LEFT, padx=5)
     primary_button(btn_frame, "Speichern", save_settings).pack(side=tk.LEFT, padx=5)
     secondary_button(btn_frame, "Abbrechen", dialog.destroy).pack(side=tk.LEFT, padx=5)
 

--- a/src/dialogs/share_dialog.py
+++ b/src/dialogs/share_dialog.py
@@ -11,7 +11,7 @@ from src.dialogs.send_dialog import show_missing_credentials_dialog
 from src.mail import get_gmail_service, is_offline_error, send_email
 from src.share import build_share_doc, serialize_share_doc
 from src.theme import (
-    BG, FONT, TEXT,
+    BG, CELL_BG, FONT, TEXT,
     apply_app_icon, apply_dark_titlebar, attach_unfocus_on_click,
     center_dialog_on_parent, disable_min_max,
     dark_entry, primary_button, secondary_button,
@@ -84,6 +84,41 @@ def open_share_dialog(parent, storage, settings, base_path, reservation_store=No
     cb_res.grid(row=row, column=0, columnspan=2, padx=20, pady=(0, 12), sticky="w")
     row += 1
 
+    # --- Kategorie-Auswahl (optional) ---
+    # Kategorien aus Arbeitszeiten + Reservierungen + settings.categories.
+    present_categories = sorted(
+        {(s.get("kategorie") or "")
+         for rec in list(entries.values()) + list(reservations.values())
+         for s in rec["slots"]}
+        | set(settings.get("categories") or []),
+        key=lambda k: (k == "", k.lower()),
+    )
+    category_vars = {}
+    if present_categories:
+        tk.Label(
+            dialog, text="Kategorien:", font=FONT, bg=BG, fg=TEXT,
+        ).grid(row=row, column=0, padx=(20, 6), pady=(0, 4), sticky="nw")
+        cat_frame = tk.Frame(dialog, bg=BG)
+        cat_frame.grid(row=row, column=1, padx=(0, 20), pady=(0, 4), sticky="w")
+        for kat in present_categories:
+            var = tk.BooleanVar(value=True)
+            category_vars[kat] = var
+            tk.Checkbutton(
+                cat_frame, text=(kat if kat else "(ohne Kategorie)"), variable=var,
+                font=FONT, bg=BG, fg=TEXT, selectcolor=CELL_BG,
+                activebackground=BG, activeforeground=TEXT,
+                highlightthickness=0, bd=0, anchor="w",
+            ).pack(anchor="w")
+        row += 1
+
+    def _selected_categories():
+        if not category_vars:
+            return None
+        selected = {kat for kat, var in category_vars.items() if var.get()}
+        if len(selected) == len(category_vars):
+            return None
+        return selected
+
     tk.Label(
         dialog, text="Empfänger:", font=FONT, bg=BG, fg=TEXT,
     ).grid(row=row, column=0, padx=(20, 6), pady=(0, 4), sticky="w")
@@ -125,6 +160,7 @@ def open_share_dialog(parent, storage, settings, base_path, reservation_store=No
                 reservation_store=reservation_store,
                 include_entries=want_entries,
                 include_reservations=want_res,
+                categories=_selected_categories(),
             )
             payload = serialize_share_doc(doc)
             service = get_gmail_service(

--- a/src/gcal.py
+++ b/src/gcal.py
@@ -19,25 +19,29 @@ EVENT_SUMMARY = "Arbeitszeit (reserviert)"
 EVENT_DESCRIPTION = "Von der Zeiterfassung verwaltete Reservierung."
 
 
-def event_payload(date_str, start, end, modified_at):
-    """Baut den Calendar-API-Event-Body aus einer Reservierung.
+def event_payload(date_str, start, end, kategorie, modified_at):
+    """Baut den Calendar-API-Event-Body aus einem Reservierungs-Slot.
 
     date_str ISO ('YYYY-MM-DD'), start/end 'HH:MM'. Die dateTime-Werte tragen
     den lokalen UTC-Offset (`astimezone()`) — kein IANA-Zeitzonenname nötig.
+    Die Kategorie steht im Titel (für die Kalender-Anzeige) UND als private
+    Property (damit parse_event sie verlustfrei zurückliest).
     """
     day = datetime.date.fromisoformat(date_str)
     sh, sm = (int(p) for p in start.split(":"))
     eh, em = (int(p) for p in end.split(":"))
     start_dt = datetime.datetime(day.year, day.month, day.day, sh, sm).astimezone()
     end_dt = datetime.datetime(day.year, day.month, day.day, eh, em).astimezone()
+    summary = f"{EVENT_SUMMARY} — {kategorie}" if kategorie else EVENT_SUMMARY
     return {
-        "summary": EVENT_SUMMARY,
+        "summary": summary,
         "description": EVENT_DESCRIPTION,
         "start": {"dateTime": start_dt.isoformat()},
         "end": {"dateTime": end_dt.isoformat()},
         "extendedProperties": {
             "private": {
                 APP_MARKER_KEY: APP_MARKER_VALUE,
+                "kategorie": kategorie,
                 "modified_at": modified_at,
             },
         },
@@ -66,6 +70,7 @@ def parse_event(event):
         "date": start_dt.date().isoformat(),
         "start": start_dt.strftime("%H:%M"),
         "end": end_dt.strftime("%H:%M"),
+        "kategorie": private.get("kategorie", ""),
         "modified_at": private.get("modified_at", ""),
         "event_id": event.get("id", ""),
     }
@@ -180,16 +185,16 @@ def list_app_events(service, calendar_id):
     return events
 
 
-def create_event(service, calendar_id, date_str, start, end, modified_at):
+def create_event(service, calendar_id, date_str, start, end, kategorie, modified_at):
     """Legt ein Event an und liefert dessen event_id."""
-    body = event_payload(date_str, start, end, modified_at)
+    body = event_payload(date_str, start, end, kategorie, modified_at)
     created = service.events().insert(calendarId=calendar_id, body=body).execute()
     return created["id"]
 
 
-def update_event(service, calendar_id, event_id, date_str, start, end, modified_at):
+def update_event(service, calendar_id, event_id, date_str, start, end, kategorie, modified_at):
     """Überschreibt ein bestehendes Event mit den Reservierungs-Werten."""
-    body = event_payload(date_str, start, end, modified_at)
+    body = event_payload(date_str, start, end, kategorie, modified_at)
     service.events().update(
         calendarId=calendar_id, eventId=event_id, body=body,
     ).execute()

--- a/src/main.py
+++ b/src/main.py
@@ -74,6 +74,11 @@ def _run_pull_in_background(storage, settings, conflicts_store, base, ui_callbac
                     logging.getLogger(__name__).warning(
                         "Quarantine rename failed for %s", fid, exc_info=True)
             remote_doc = _parse_remote_or_quarantine(content, file_id, _quarantine)
+            if sync._remote_is_pre_v3(remote_doc):
+                # Älteres Gerät aktiv: nicht mergen (ein v2-Eintrag hat kein
+                # 'slots' → würde apply_merge verletzen / Daten plätten).
+                ui_callback(ok=False, error=sync.OLD_REMOTE_VERSION_MSG, tb="")
+                return
         local_doc = sync.build_local_doc(storage, settings, conflicts_store)
         merged = sync.merge(local_doc, remote_doc, settings.get("last_pull_at") or "")
         sync.apply_merged_doc(merged, storage, settings, conflicts_store)
@@ -114,6 +119,11 @@ def _run_push_blocking(storage, settings, conflicts_store, base, timeout_seconds
                 if file_id is not None:
                     remote_bytes, _ = drive.download(service, file_id)
                     remote_doc = json.loads(remote_bytes)
+                    if sync._remote_is_pre_v3(remote_doc):
+                        result["ok"] = False
+                        result["error"] = sync.OLD_REMOTE_VERSION_MSG
+                        result["tb"] = ""
+                        return
                 else:
                     remote_doc = {"schema_version": 1, "entries": {}, "settings": {}, "conflicts": []}
                 local_doc = sync.build_local_doc(storage, settings, conflicts_store)

--- a/src/main.py
+++ b/src/main.py
@@ -139,11 +139,11 @@ def _run_push_blocking(storage, settings, conflicts_store, base, timeout_seconds
 
 
 def _run_compaction_blocking(storage, settings, conflicts_store, base, timeout_seconds=20):
-    """User-ausgelöste Kompaktierung: frischer Pull → v1-Guard → Merge →
+    """User-ausgelöste Kompaktierung: frischer Pull → Alt-Client-Guard → Merge →
     Watermark setzen + lokal strippen → Push. Liefert
     {"ok": bool, "reason": str, "error": ..., "tb": ...}.
 
-    reason == "old_version": ein älteres Gerät ist aktiv (Remote ist pre-v2),
+    reason == "old_version": ein älteres Gerät ist aktiv (Remote ist pre-v3),
     Kompaktierung abgebrochen, KEINE Änderung vorgenommen."""
     import json
     from src import drive, sync
@@ -164,8 +164,8 @@ def _run_compaction_blocking(storage, settings, conflicts_store, base, timeout_s
                     remote_doc = json.loads(content)
                 except (json.JSONDecodeError, ValueError):
                     remote_doc = {"schema_version": 1}
-                # v1-Guard auf dem FRISCH gepullten Doc (nie gecacht):
-                if sync._remote_is_pre_v2(remote_doc):
+                # Alt-Client-Guard auf dem FRISCH gepullten Doc (nie gecacht):
+                if sync._remote_is_pre_v3(remote_doc):
                     result.update({"ok": False, "reason": "old_version"})
                     return
             else:

--- a/src/main.py
+++ b/src/main.py
@@ -266,10 +266,19 @@ def main():
     if settings.get("sync_enabled"):
         def _on_sync_done(ok, error, tb=""):
             def apply():
-                if ok:
-                    app.on_sync_pull_success()
-                else:
-                    app.on_sync_pull_error(error, tb)
+                # Der Startup-Sync läuft im Daemon-Thread und marshallt sein
+                # Ergebnis via after(0) zurück. Schließt der Nutzer das Fenster,
+                # bevor dieser Callback feuert, ist der Tk-Interpreter bereits
+                # zerstört — jeder winfo-/config-Aufruf wirft dann
+                # "application has been destroyed". Der Callback ist dann
+                # gegenstandslos und wird verworfen (vgl. tooltip.py).
+                try:
+                    if ok:
+                        app.on_sync_pull_success()
+                    else:
+                        app.on_sync_pull_error(error, tb)
+                except tk.TclError:
+                    pass
             root.after(0, apply)
         threading.Thread(
             target=_run_pull_in_background,

--- a/src/report.py
+++ b/src/report.py
@@ -14,11 +14,10 @@ def _esc_multiline(text):
     return _esc(text).replace("\n", "<br>")
 
 
-COLUMN_LABELS = ["Datum", "Tag", "Start", "Ende", "Stunden"]
+COLUMN_LABELS = ["Datum", "Tag", "Kategorie", "Start", "Ende", "Stunden"]
 
 # Style-Dict pro Render-Ziel. Felder werden direkt als CSS-Strings in die
-# Inline-Styles der Zellen geschrieben — `_week_block` und `_build_table`
-# sind dadurch struktur-, nicht stylegetrieben.
+# Inline-Styles der Zellen geschrieben.
 HTML_STYLE = {
     "table_extra": "border-radius:8px;overflow:hidden;",
     "th_row":      "background:#1e293b;",
@@ -30,6 +29,7 @@ HTML_STYLE = {
     "td_base":     "padding:10px 14px;border-bottom:1px solid rgba(255,255,255,0.08);",
     "c_date":      "color:#cbd5e1;",
     "c_day":       "color:#94a3b8;",
+    "c_kat":       "color:#94a3b8;",
     "c_time":      "color:#cbd5e1;",
     "c_hours":     "color:#00D8A7;font-weight:600;",
     "sum_row":     "background:#263244;",
@@ -51,6 +51,7 @@ PDF_STYLE = {
     "td_base":     "padding:8px 12px;border-bottom:1px solid #d1d5db;",
     "c_date":      "color:#111827;",
     "c_day":       "color:#4b5563;",
+    "c_kat":       "color:#4b5563;",
     "c_time":      "color:#111827;",
     "c_hours":     "color:#111827;font-weight:600;",
     "sum_row":     "background:#cbd5e1;",
@@ -62,9 +63,13 @@ PDF_STYLE = {
 }
 
 
+def _slot_hours(slot):
+    return round(calculate_hours(slot["start"], slot["end"], pause_minutes=slot.get("pause", 0)), 2)
+
+
 def _entry_hours(entry):
-    pause = entry.get("pause", 0)
-    return round(calculate_hours(entry["start"], entry["end"], pause_minutes=pause), 2)
+    """Summe der Stunden über alle Slots eines Tages."""
+    return round(sum(_slot_hours(s) for s in entry.get("slots", [])), 2)
 
 
 def _group_by_week(range_entries):
@@ -92,23 +97,35 @@ def _filter_entries(date_from, date_to, all_entries):
     return range_entries if range_entries else None
 
 
+def _apply_category_filter(entries, categories):
+    """categories=None → unverändert. Sonst werden je Tag nur Slots behalten,
+    deren Kategorie (oder "" für ohne) in `categories` liegt; Tage ohne
+    verbleibende Slots fallen weg. Liefert ein neues Dict."""
+    if categories is None:
+        return entries
+    cats = set(categories)
+    out = {}
+    for date_str, entry in entries.items():
+        kept = [s for s in entry["slots"] if (s.get("kategorie") or "") in cats]
+        if kept:
+            out[date_str] = {"slots": kept}
+    return out
+
+
 def _apply_placeholders(text, label, total):
-    # text ist bereits escaped; label und total sind strukturell sicher
-    # (Datum + Float), werden aber für Konsistenz ebenfalls escaped.
     return text.replace("{zeitraum}", _esc(label)).replace("{gesamt}", _esc(f"{total}h"))
 
 
-# _week_block und _build_table rendern Werte aus dem Storage (entry["start"],
-# entry["end"], weekday, day_fmt, iso_week). Diese sind durch validate_entry
-# bzw. datetime-Formatter strukturell auf [0-9:.-] beschränkt — kein Escape
-# nötig. Wenn diese Quelle sich mal ändert (z.B. freie Eingabe), Escape ergänzen.
+# _week_block / _build_table / _build_category_summary rendern Werte aus dem
+# Storage. start/end/Datum/KW sind strukturell auf [0-9:.-] beschränkt (kein
+# Escape nötig). `kategorie` ist FREIER Nutzertext → wird mit _esc() escaped.
 def _week_block(iso_year, iso_week, week_entries, style):
-    """Render einen Wochen-Block (KW-Header, Tageszeilen, Wochensumme).
-    Returns (rows_html, week_total)."""
+    """Render einen Wochen-Block: KW-Header, je Slot eine Zeile, Tages-Subtotal
+    bei >1 Slot, Wochensumme. Returns (rows_html, week_total)."""
     s = style
     rows = [
         f"<tr style='{s['kw_row']}'>"
-        f"<td colspan='5' style='{s['kw_cell']}'>{get_week_label(iso_year, iso_week)}</td>"
+        f"<td colspan='6' style='{s['kw_cell']}'>{get_week_label(iso_year, iso_week)}</td>"
         f"</tr>"
     ]
 
@@ -117,24 +134,39 @@ def _week_block(iso_year, iso_week, week_entries, style):
         dt = datetime.date.fromisoformat(date_str)
         weekday = DAYS_DE[dt.weekday()]
         day_fmt = dt.strftime("%d.%m.%Y")
-        hours = _entry_hours(entry)
-        week_total += hours
         row_bg = s["row_a"] if idx % 2 == 0 else s["row_b"]
         td = s["td_base"]
-        rows.append(
-            f"<tr style='{row_bg}'>"
-            f"<td style='{td}{s['c_date']}'>{day_fmt}</td>"
-            f"<td style='{td}{s['c_day']}'>{weekday}</td>"
-            f"<td style='{td}{s['c_time']}'>{entry['start']}</td>"
-            f"<td style='{td}{s['c_time']}'>{entry['end']}</td>"
-            f"<td style='{td}{s['c_hours']}'>{hours}h</td>"
-            f"</tr>"
-        )
+        slots = entry["slots"]
+        day_total = 0.0
+        for sidx, slot in enumerate(slots):
+            hours = _slot_hours(slot)
+            day_total += hours
+            week_total += hours
+            date_cell = day_fmt if sidx == 0 else ""
+            day_cell = weekday if sidx == 0 else ""
+            rows.append(
+                f"<tr style='{row_bg}'>"
+                f"<td style='{td}{s['c_date']}'>{date_cell}</td>"
+                f"<td style='{td}{s['c_day']}'>{day_cell}</td>"
+                f"<td style='{td}{s['c_kat']}'>{_esc(slot.get('kategorie') or '')}</td>"
+                f"<td style='{td}{s['c_time']}'>{slot['start']}</td>"
+                f"<td style='{td}{s['c_time']}'>{slot['end']}</td>"
+                f"<td style='{td}{s['c_hours']}'>{hours}h</td>"
+                f"</tr>"
+            )
+        if len(slots) > 1:
+            day_total = round(day_total, 2)
+            rows.append(
+                f"<tr style='{row_bg}'>"
+                f"<td colspan='5' style='{td}{s['c_day']}'>Summe {day_fmt}</td>"
+                f"<td style='{td}{s['c_hours']}'>{day_total}h</td>"
+                f"</tr>"
+            )
 
     week_total = round(week_total, 2)
     rows.append(
         f"<tr style='{s['sum_row']}'>"
-        f"<td colspan='4' style='{s['sum_lbl']}'>Summe KW {iso_week}</td>"
+        f"<td colspan='5' style='{s['sum_lbl']}'>Summe KW {iso_week}</td>"
         f"<td style='{s['sum_hrs']}'>{week_total}h</td>"
         f"</tr>"
     )
@@ -142,8 +174,7 @@ def _week_block(iso_year, iso_week, week_entries, style):
 
 
 def _build_table(groups, style):
-    """Bauen die komplette Stundentabelle (Header, alle Wochen-Blöcke,
-    Gesamt-Footer). Returns (table_html, total)."""
+    """Bauen die komplette Stundentabelle. Returns (table_html, total)."""
     s = style
     week_blocks = []
     total = 0.0
@@ -162,7 +193,7 @@ def _build_table(groups, style):
         f'<tr style="{s["th_row"]}">{th_cells}</tr>'
         f'{"".join(week_blocks)}'
         f'<tr style="{s["total_row"]}">'
-        f'<td colspan="4" style="{s["total_lbl"]}">Gesamt</td>'
+        f'<td colspan="5" style="{s["total_lbl"]}">Gesamt</td>'
         f'<td style="{s["total_hrs"]}">{total}h</td>'
         f'</tr>'
         f'</table>'
@@ -170,18 +201,61 @@ def _build_table(groups, style):
     return table, total
 
 
-def generate_report(date_from, date_to, all_entries, greeting="", content="", closing=""):
-    """Generate an HTML email report with greeting, content, table, and closing.
+def _build_category_summary(range_entries, style):
+    """„Summe je Kategorie"-Tabelle über den (gefilterten) Zeitraum. Leerer
+    String ('' = keine Kategorie) wird als '(ohne Kategorie)' ans Ende
+    sortiert. Liefert '' wenn keine Slots vorhanden."""
+    s = style
+    totals = {}
+    for entry in range_entries.values():
+        for slot in entry["slots"]:
+            kat = slot.get("kategorie") or ""
+            totals[kat] = totals.get(kat, 0.0) + _slot_hours(slot)
+    if not totals:
+        return ""
 
+    td = s["td_base"]
+    rows = []
+    for idx, kat in enumerate(sorted(totals, key=lambda k: (k == "", k.lower()))):
+        label = kat if kat else "(ohne Kategorie)"
+        hours = round(totals[kat], 2)
+        row_bg = s["row_a"] if idx % 2 == 0 else s["row_b"]
+        rows.append(
+            f"<tr style='{row_bg}'>"
+            f"<td style='{td}{s['c_day']}'>{_esc(label)}</td>"
+            f"<td style='{td}{s['c_hours']}'>{hours}h</td>"
+            f"</tr>"
+        )
+
+    return (
+        f'<table style="border-collapse:collapse;width:100%;margin-top:16px;{s["table_extra"]}">'
+        f'<tr style="{s["th_row"]}">'
+        f'<th style="{s["th_cell"]}">Kategorie</th>'
+        f'<th style="{s["th_cell"]}">Stunden</th>'
+        f'</tr>'
+        f'{"".join(rows)}'
+        f'</table>'
+    )
+
+
+def generate_report(date_from, date_to, all_entries, greeting="", content="",
+                    closing="", categories=None):
+    """Generate an HTML email report with greeting, content, table, category
+    summary, and closing.
+
+    categories: None = alle; sonst Menge von Kategorie-Strings ('' = ohne).
     Returns (html, total) tuple, or (None, 0) if no entries.
     """
     range_entries = _filter_entries(date_from, date_to, all_entries)
+    if range_entries:
+        range_entries = _apply_category_filter(range_entries, categories)
     if not range_entries:
         return None, 0
 
     label = f"{date_from.strftime('%d.%m.%Y')} – {date_to.strftime('%d.%m.%Y')}"
     groups = _group_by_week(range_entries)
     table, total = _build_table(groups, HTML_STYLE)
+    category_summary = _build_category_summary(range_entries, HTML_STYLE)
 
     greeting_filled = _apply_placeholders(_esc_multiline(greeting), label, total)
     content_filled = _apply_placeholders(_esc_multiline(content), label, total)
@@ -198,6 +272,7 @@ def generate_report(date_from, date_to, all_entries, greeting="", content="", cl
 {greeting_html}
 {content_html}
 {table}
+{category_summary}
 {closing_html}
 </div>
 </body></html>"""
@@ -205,17 +280,20 @@ def generate_report(date_from, date_to, all_entries, greeting="", content="", cl
     return html_out, total
 
 
-def generate_pdf(date_from, date_to, all_entries, name=""):
+def generate_pdf(date_from, date_to, all_entries, name="", categories=None):
     """Generate a PDF of the time tracking table. Returns PDF bytes, or None if no entries."""
     from xhtml2pdf import pisa
 
     range_entries = _filter_entries(date_from, date_to, all_entries)
+    if range_entries:
+        range_entries = _apply_category_filter(range_entries, categories)
     if not range_entries:
         return None
 
     label = f"{date_from.strftime('%d.%m.%Y')} – {date_to.strftime('%d.%m.%Y')}"
     groups = _group_by_week(range_entries)
     table, _ = _build_table(groups, PDF_STYLE)
+    category_summary = _build_category_summary(range_entries, PDF_STYLE)
 
     name_html = (
         f"<p style='color:#111827;font-size:13px;margin:0 0 2px 0;font-weight:600;'>{_esc(name)}</p>"
@@ -228,6 +306,7 @@ def generate_pdf(date_from, date_to, all_entries, name=""):
 {name_html}
 <p style="color:#4b5563;font-size:12px;margin:0 0 16px 0;">{_esc(label)}</p>
 {table}
+{category_summary}
 </body></html>"""
 
     buffer = io.BytesIO()

--- a/src/report.py
+++ b/src/report.py
@@ -112,6 +112,18 @@ def _apply_category_filter(entries, categories):
     return out
 
 
+def total_hours(date_from, date_to, all_entries, categories=None):
+    """Gesamtstunden im Zeitraum, gefiltert auf die gewählten Kategorien
+    (None = alle). Pure Funktion für die Live-Vorschau im Sende-Dialog —
+    summiert dieselben Slot-Stunden wie der Report. Leerer Bereich → 0.0."""
+    range_entries = _filter_entries(date_from, date_to, all_entries)
+    if range_entries:
+        range_entries = _apply_category_filter(range_entries, categories)
+    if not range_entries:
+        return 0.0
+    return round(sum(_entry_hours(e) for e in range_entries.values()), 2)
+
+
 def _apply_placeholders(text, label, total):
     return text.replace("{zeitraum}", _esc(label)).replace("{gesamt}", _esc(f"{total}h"))
 

--- a/src/reservations.py
+++ b/src/reservations.py
@@ -6,10 +6,10 @@ Google Kalender abgeglichen — NICHT über die Drive-Multi-Device-Sync. Daher
 fehlt hier (anders als bei `Storage`) das `device_id`-Feld.
 
 Schema pro Tag (ISO-Datum als Schlüssel):
-    {start, end, modified_at, deleted, gcal_event_id}
-`gcal_event_id` ist None, bis die Reservierung erstmals in den Kalender
-gepusht wurde. Eine gelöschte Reservierung bleibt als Tombstone (deleted=True)
-erhalten, bis der Reconcile das Event entfernt hat.
+    {slots: [{start, end, kategorie, gcal_event_id}], modified_at, deleted}
+`gcal_event_id` ist None, bis der Slot erstmals in den Kalender gepusht wurde.
+Eine gelöschte Reservierung bleibt als Tombstone (deleted=True, slots=[])
+erhalten, bis der Reconcile die zugehörigen Events entfernt hat.
 """
 
 import datetime
@@ -22,9 +22,19 @@ def _utc_now_iso():
     return datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
-_REQUIRED_RESERVATION_KEYS = frozenset(
-    {"start", "end", "modified_at", "deleted", "gcal_event_id"}
-)
+_REQUIRED_RESERVATION_KEYS = frozenset({"slots", "modified_at", "deleted"})
+
+
+def _normalize_slot(slot):
+    """Vervollständigt einen Reservierungs-Slot auf
+    {start, end, kategorie, gcal_event_id}. Fehlende `kategorie` → "",
+    fehlende `gcal_event_id` → None."""
+    return {
+        "start": slot.get("start"),
+        "end": slot.get("end"),
+        "kategorie": slot.get("kategorie", ""),
+        "gcal_event_id": slot.get("gcal_event_id"),
+    }
 
 
 class ReservationStore:
@@ -44,6 +54,42 @@ class ReservationStore:
             os.replace(self.filepath, f"{self.filepath}.corrupt-{stamp}")
             self._data = {}
             return
+        self._migrate_legacy_reservations()
+
+    def _migrate_legacy_reservations(self):
+        """Wrappt alte Ein-Reservierung-Tage in eine Slot-Liste. Idempotent:
+        Einträge mit `slots` bleiben unangetastet. modified_at/deleted werden
+        nur gesetzt, falls sie fehlen (alte Dateien tragen sie i.d.R. bereits);
+        Fallback ist die File-mtime (best lower bound)."""
+        try:
+            mtime = os.path.getmtime(self.filepath)
+        except OSError:
+            mtime = None
+        fallback_modified_at = (
+            datetime.datetime.fromtimestamp(mtime, datetime.timezone.utc)
+            .strftime("%Y-%m-%dT%H:%M:%SZ")
+            if mtime is not None
+            else _utc_now_iso()
+        )
+        for date, entry in list(self._data.items()):
+            if not isinstance(entry, dict):
+                continue
+            if "slots" in entry:
+                continue
+            if entry.get("deleted"):
+                entry["slots"] = []
+            else:
+                entry["slots"] = [{
+                    "start": entry.get("start"),
+                    "end": entry.get("end"),
+                    "kategorie": "",
+                    "gcal_event_id": entry.get("gcal_event_id"),
+                }]
+            entry.pop("start", None)
+            entry.pop("end", None)
+            entry.pop("gcal_event_id", None)
+            entry.setdefault("modified_at", fallback_modified_at)
+            entry.setdefault("deleted", False)
 
     def _save_to_disk(self):
         tmp = self.filepath + ".tmp"
@@ -58,10 +104,14 @@ class ReservationStore:
 
     @staticmethod
     def _user_shape(entry):
-        return {"start": entry["start"], "end": entry["end"]}
+        """User-Shape: Slots ohne das interne Feld gcal_event_id."""
+        return {"slots": [
+            {"start": s.get("start"), "end": s.get("end"), "kategorie": s.get("kategorie", "")}
+            for s in entry.get("slots", [])
+        ]}
 
     def get_all(self):
-        """{date: {start, end}} ohne Tombstones — für die UI."""
+        """{date: {slots: [...]}} ohne Tombstones — für die UI."""
         return {
             date: self._user_shape(entry)
             for date, entry in self._data.items()
@@ -69,7 +119,8 @@ class ReservationStore:
         }
 
     def get_all_raw(self):
-        """Komplette Objekte inkl. Metadaten und Tombstones — für den Reconcile."""
+        """Komplette Objekte inkl. Metadaten, gcal_event_id und Tombstones —
+        für den Reconcile."""
         return dict(self._data)
 
     def get(self, date_str):
@@ -78,32 +129,27 @@ class ReservationStore:
             return None
         return self._user_shape(entry)
 
-    def save(self, date_str, start, end):
-        """Legt eine Reservierung an oder überschreibt sie. Eine schon
-        vorhandene gcal_event_id bleibt erhalten, damit der Reconcile das
-        bestehende Event aktualisiert statt ein zweites anzulegen."""
-        existing = self._data.get(date_str) or {}
+    def save(self, date_str, slots):
+        """Legt die Reservierungs-Slots eines Tages an oder überschreibt sie.
+        Die übergebenen Slots werden so gespeichert, wie sie sind (inkl.
+        mitgelieferter gcal_event_id). Das Bewahren bestehender event_ids über
+        Edits hinweg übernimmt der Reconcile (AP7), nicht dieser save-Pfad."""
         self._data[date_str] = {
-            "start": start,
-            "end": end,
+            "slots": [_normalize_slot(s) for s in slots],
             "modified_at": _utc_now_iso(),
             "deleted": False,
-            "gcal_event_id": existing.get("gcal_event_id"),
         }
         self._save_to_disk()
 
     def delete(self, date_str):
-        """Tombstone schreiben. gcal_event_id bleibt erhalten, damit der
-        Reconcile weiß, welches Event zu löschen ist."""
-        existing = self._data.get(date_str)
-        if existing is None:
+        """Tombstone schreiben (slots=[]). Der Reconcile entfernt die
+        zugehörigen Kalender-Events über den vollständigen Event-Pull (AP7)."""
+        if date_str not in self._data:
             return
         self._data[date_str] = {
-            "start": None,
-            "end": None,
+            "slots": [],
             "modified_at": _utc_now_iso(),
             "deleted": True,
-            "gcal_event_id": existing.get("gcal_event_id"),
         }
         self._save_to_disk()
 

--- a/src/reservations_sync.py
+++ b/src/reservations_sync.py
@@ -55,6 +55,9 @@ def _merge_one_date(date, local, remotes, watermark, merged, plan):
     if is_tombstone:
         if not remotes:
             return  # Tombstone fällt weg.
+        # Garantiert gesetzt: Tombstone -> local vorhanden -> local_mod; remotes
+        # nicht leer -> remote_mod nicht None.
+        assert local_mod is not None and remote_mod is not None
         if local_mod >= remote_mod:
             for ev in remotes:
                 plan["delete"].append({"event_id": ev["event_id"]})
@@ -79,6 +82,9 @@ def _merge_one_date(date, local, remotes, watermark, merged, plan):
         return
 
     # Fall 5: lokal (echt) + Remote-Events.
+    # Garantiert gesetzt: Fall 2 hat local=None abgefangen -> local_mod; Fall 4
+    # hat leere remotes abgefangen -> remote_mod nicht None.
+    assert local_mod is not None and remote_mod is not None
     if remote_mod > local_mod:
         _adopt_remote(date, remotes, merged)
         return

--- a/src/reservations_sync.py
+++ b/src/reservations_sync.py
@@ -1,10 +1,11 @@
 # src/reservations_sync.py
-"""Reservierungs-Abgleich mit dem Google Kalender.
+"""Reservierungs-Abgleich mit dem Google Kalender (Slot-Modell).
 
-`merge_reservations()` ist eine pure LWW-Merge-Funktion (kein I/O), die
-`reconcile_reservations()` (weiter unten, Task 9) orchestriert pull → merge →
-push. Der Merge spiegelt `sync.py::_merge_one` OHNE den Konflikt-Zweig: bei
-beidseitiger Änderung gewinnt still der jüngere `modified_at`-Stand.
+Jeder Reservierungs-Slot ↔ ein Kalender-Event (Matching über gcal_event_id).
+`merge_reservations()` ist eine pure LWW-Merge-Funktion (kein I/O): pro Datum
+entscheidet `modified_at` (App autoritativ bei Gleichstand), ob die lokalen
+Slots oder die Remote-Events gewinnen. `reconcile_reservations()` orchestriert
+pull → merge → push und schreibt neue event_ids pro Slot zurück.
 """
 
 import datetime
@@ -14,77 +15,116 @@ def _utc_now_iso():
     return datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
-def _from_remote(remote):
-    """Reservierungs-Record aus einem geparsten Kalender-Event."""
+def _slot_from_event(ev):
+    """Reservierungs-Slot aus einem geparsten Kalender-Event."""
     return {
-        "start": remote["start"],
-        "end": remote["end"],
-        "modified_at": remote["modified_at"],
-        "deleted": False,
-        "gcal_event_id": remote["event_id"],
+        "start": ev["start"], "end": ev["end"],
+        "kategorie": ev.get("kategorie", ""), "gcal_event_id": ev["event_id"],
     }
 
 
-def _merge_one_date(date, local, remote, watermark, merged, plan):
-    """Mergt einen einzelnen Tag. Mutiert `merged` und `plan` in-place.
+def _adopt_remote(date, remotes, merged):
+    """Remote gewinnt: die Slots des Tages = die Remote-Events."""
+    merged[date] = {
+        "slots": [_slot_from_event(ev) for ev in remotes],
+        "modified_at": max(ev["modified_at"] for ev in remotes),
+        "deleted": False,
+    }
 
-    `local`  — Reservierungs-Record (echt oder Tombstone) oder None
-    `remote` — geparstes Kalender-Event oder None
-    `watermark` — last_calendar_sync_at
+
+def _merge_one_date(date, local, remotes, watermark, merged, plan):
+    """Mergt einen einzelnen Tag (Slot-Ebene). Mutiert `merged`/`plan`.
+
+    local   — Reservierungs-Record {slots, modified_at, deleted} oder None
+    remotes — Liste geparster Kalender-Events dieses Tages (evtl. leer)
     """
     is_tombstone = local is not None and local.get("deleted")
+    local_mod = local["modified_at"] if local is not None else None
+    remote_mod = max((ev["modified_at"] for ev in remotes), default=None)
 
     # Fall 1: nichts vorhanden.
-    if local is None and remote is None:
+    if local is None and not remotes:
         return
 
-    # Fälle 2 & 3: lokaler Tombstone.
-    if is_tombstone:
-        if remote is None:
-            return  # Tombstone fällt weg, nichts zu tun.
-        if local["modified_at"] >= remote["modified_at"]:
-            plan["delete"].append({"event_id": remote["event_id"]})
-            return  # Löschung gewinnt, Tombstone fällt weg.
-        merged[date] = _from_remote(remote)  # Remote-Update ist jünger.
-        return
-
-    # Fall 6: nur remote → übernehmen.
+    # Fall 2: nur remote → als Slots übernehmen.
     if local is None:
-        merged[date] = _from_remote(remote)
+        _adopt_remote(date, remotes, merged)
         return
 
-    # Fall 5: nur lokal (echt).
-    if remote is None:
-        if local["modified_at"] > watermark:
-            merged[date] = dict(local)  # lokale Neuanlage.
-            plan["create"].append({
-                "date": date, "start": local["start"], "end": local["end"],
-                "modified_at": local["modified_at"],
-            })
+    # Fall 3: lokaler Tombstone.
+    if is_tombstone:
+        if not remotes:
+            return  # Tombstone fällt weg.
+        if local_mod >= remote_mod:
+            for ev in remotes:
+                plan["delete"].append({"event_id": ev["event_id"]})
+            return  # Löschung gewinnt.
+        _adopt_remote(date, remotes, merged)  # Remote-Update jünger.
+        return
+
+    # Fall 4: lokal (echt), keine Remote-Events.
+    if not remotes:
+        if local_mod > watermark:
+            merged[date] = {
+                "slots": [dict(s) for s in local["slots"]],
+                "modified_at": local_mod, "deleted": False,
+            }
+            for i, s in enumerate(local["slots"]):
+                plan["create"].append({
+                    "date": date, "slot_index": i,
+                    "start": s["start"], "end": s["end"],
+                    "kategorie": s.get("kategorie", ""), "modified_at": local_mod,
+                })
         # sonst: war beim letzten Sync da, remote jetzt weg → verwerfen.
         return
 
-    # Fall 4: beide vorhanden (echt) → LWW.
-    if remote["modified_at"] > local["modified_at"]:
-        merged[date] = _from_remote(remote)
+    # Fall 5: lokal (echt) + Remote-Events.
+    if remote_mod > local_mod:
+        _adopt_remote(date, remotes, merged)
         return
-    # Lokal gewinnt (inkl. Gleichstand — App ist autoritativ).
-    record = dict(local)
-    record["gcal_event_id"] = remote["event_id"]
-    merged[date] = record
-    if local["start"] != remote["start"] or local["end"] != remote["end"]:
-        plan["update"].append({
-            "date": date, "event_id": remote["event_id"],
-            "start": local["start"], "end": local["end"],
-            "modified_at": local["modified_at"],
-        })
+
+    # Lokal gewinnt (inkl. Gleichstand — App autoritativ): Slots ↔ Events über
+    # gcal_event_id matchen.
+    remote_by_id = {ev["event_id"]: ev for ev in remotes}
+    matched_ids = set()
+    merged_slots = []
+    for i, s in enumerate(local["slots"]):
+        eid = s.get("gcal_event_id")
+        slot_copy = dict(s)
+        if eid and eid in remote_by_id:
+            matched_ids.add(eid)
+            ev = remote_by_id[eid]
+            if (s["start"] != ev["start"] or s["end"] != ev["end"]
+                    or s.get("kategorie", "") != ev.get("kategorie", "")):
+                plan["update"].append({
+                    "event_id": eid, "date": date,
+                    "start": s["start"], "end": s["end"],
+                    "kategorie": s.get("kategorie", ""), "modified_at": local_mod,
+                })
+        else:
+            # Neuer Slot (noch kein Event oder verwaiste id) → create.
+            slot_copy["gcal_event_id"] = None
+            plan["create"].append({
+                "date": date, "slot_index": i,
+                "start": s["start"], "end": s["end"],
+                "kategorie": s.get("kategorie", ""), "modified_at": local_mod,
+            })
+        merged_slots.append(slot_copy)
+
+    # Remote-Events ohne lokalen Slot → löschen.
+    for ev in remotes:
+        if ev["event_id"] not in matched_ids:
+            plan["delete"].append({"event_id": ev["event_id"]})
+
+    merged[date] = {"slots": merged_slots, "modified_at": local_mod, "deleted": False}
 
 
 def merge_reservations(local_raw, remote_events, watermark):
-    """Pure Merge zwischen lokalen Reservierungen und Kalender-Events.
+    """Pure Merge zwischen lokalen Reservierungs-Records und Kalender-Events.
 
-    local_raw:     {date: {start, end, modified_at, deleted, gcal_event_id}}
-    remote_events: Liste von {date, start, end, modified_at, event_id}
+    local_raw:     {date: {slots: [{start,end,kategorie,gcal_event_id}],
+                           modified_at, deleted}}
+    remote_events: Liste von {date, start, end, kategorie, modified_at, event_id}
     watermark:     last_calendar_sync_at (ISO-String, "" beim Erststart)
 
     Liefert {"merged": {...}, "plan": {"create": [...], "update": [...],
@@ -92,24 +132,14 @@ def merge_reservations(local_raw, remote_events, watermark):
     """
     plan = {"create": [], "update": [], "delete": []}
 
-    # Remote-Events nach Datum gruppieren. Bei mehreren Events pro Tag (seltenes
-    # Race) gewinnt das jüngste, die übrigen landen im delete-Plan — Selbstheilung.
     remote_by_date = {}
     for ev in remote_events:
-        d = ev["date"]
-        if d not in remote_by_date:
-            remote_by_date[d] = ev
-            continue
-        keep, drop = remote_by_date[d], ev
-        if ev["modified_at"] > keep["modified_at"]:
-            keep, drop = ev, keep
-        remote_by_date[d] = keep
-        plan["delete"].append({"event_id": drop["event_id"]})
+        remote_by_date.setdefault(ev["date"], []).append(ev)
 
     merged = {}
     for date in set(local_raw.keys()) | set(remote_by_date.keys()):
         _merge_one_date(
-            date, local_raw.get(date), remote_by_date.get(date),
+            date, local_raw.get(date), remote_by_date.get(date, []),
             watermark, merged, plan,
         )
     return {"merged": merged, "plan": plan}
@@ -117,11 +147,6 @@ def merge_reservations(local_raw, remote_events, watermark):
 
 def reconcile_reservations(service, calendar_id, store, settings):
     """Voller Kalender-Abgleich: pull → merge → push.
-
-    service:     gebauter Google-Calendar-Service (aus gcal.get_calendar_service)
-    calendar_id: ID des Ziel-Kalenders
-    store:       ReservationStore
-    settings:    Settings (liest/schreibt last_calendar_sync_at)
 
     Mutiert store und settings. Wirft bei Netz-/API-Fehlern weiter — der Caller
     entscheidet, ob still geloggt oder als Messagebox gezeigt wird.
@@ -140,21 +165,21 @@ def reconcile_reservations(service, calendar_id, store, settings):
     for item in plan["update"]:
         gcal.update_event(
             service, calendar_id, item["event_id"],
-            item["date"], item["start"], item["end"], item["modified_at"],
+            item["date"], item["start"], item["end"],
+            item["kategorie"], item["modified_at"],
         )
 
     for item in plan["create"]:
         event_id = gcal.create_event(
             service, calendar_id,
-            item["date"], item["start"], item["end"], item["modified_at"],
+            item["date"], item["start"], item["end"],
+            item["kategorie"], item["modified_at"],
         )
-        merged[item["date"]]["gcal_event_id"] = event_id
+        merged[item["date"]]["slots"][item["slot_index"]]["gcal_event_id"] = event_id
 
-    # Rebase: Reservierungen, die seit dem Snapshot lokal gespeichert oder
-    # geändert wurden (z.B. ein parallel laufender Reconcile beim App-Start
-    # oder ein User-Save während des Netzwerk-Teils), dürfen nicht durch den
-    # blinden apply_reconciled-Replace verloren gehen. Sie werden beim nächsten
-    # Reconcile in den Kalender gepusht.
+    # Rebase: Reservierungen, die seit dem Snapshot lokal gespeichert/geändert
+    # wurden (paralleler Reconcile / User-Save während des Netzwerkteils),
+    # dürfen nicht durch den apply_reconciled-Replace verloren gehen.
     for date, entry in store.get_all_raw().items():
         snap = local_snapshot.get(date)
         if snap is None or entry.get("modified_at", "") > snap.get("modified_at", ""):

--- a/src/settings.py
+++ b/src/settings.py
@@ -8,7 +8,7 @@ WEEKDAY_KEYS = ("mon", "tue", "wed", "thu", "fri", "sat", "sun")  # Index = date
 SYNCED_SETTING_KEYS = (
     "recipient", "name", "hourly_rate",
     "mail_subject", "mail_greeting", "mail_content", "mail_closing",
-    "gcal_calendar_id",
+    "gcal_calendar_id", "categories",
 )
 
 DEFAULTS = {
@@ -51,6 +51,7 @@ DEFAULTS = {
     "gcal_enabled": False,
     "gcal_calendar_id": "",
     "last_calendar_sync_at": "",
+    "categories": [],
 }
 
 _COERCE_FAILED = object()

--- a/src/settings.py
+++ b/src/settings.py
@@ -8,7 +8,7 @@ WEEKDAY_KEYS = ("mon", "tue", "wed", "thu", "fri", "sat", "sun")  # Index = date
 SYNCED_SETTING_KEYS = (
     "recipient", "name", "hourly_rate",
     "mail_subject", "mail_greeting", "mail_content", "mail_closing",
-    "gcal_calendar_id", "categories",
+    "gcal_calendar_id", "categories", "category_times",
 )
 
 DEFAULTS = {
@@ -52,6 +52,7 @@ DEFAULTS = {
     "gcal_calendar_id": "",
     "last_calendar_sync_at": "",
     "categories": [],
+    "category_times": {},
 }
 
 _COERCE_FAILED = object()

--- a/src/share.py
+++ b/src/share.py
@@ -1,18 +1,19 @@
 """Arbeitszeiten teilen + importieren — pure functions, kein UI-Import.
 
-Wire-Format v2 (eigenständig, kein Sync-Doc-Re-Use):
+Wire-Format v3 (Slot-Listen):
 {
-  "schema_version": 2,
+  "schema_version": 3,
   "kind": "zeiterfassung-share",
   "exported_at": "<UTC-ISO>",
   "exported_by": "<email or empty>",
-  "entries":      {"YYYY-MM-DD": {"start": "HH:MM", "end": "HH:MM", "pause": int>=0}},
-  "reservations": {"YYYY-MM-DD": {"start": "HH:MM", "end": "HH:MM"}}
+  "entries":      {"YYYY-MM-DD": {"slots": [{"start","end","pause":int>=0,"kategorie":str}]}},
+  "reservations": {"YYYY-MM-DD": {"slots": [{"start","end","kategorie":str}]}}
 }
 
-Beide Felder ("entries", "reservations") sind optional, aber mind. eines muss
-nicht-leer sein. v1-Dateien (nur "entries", Pflichtfeld) werden beim Lesen
-weiterhin akzeptiert (Abwärtskompatibilität).
+Beide Felder sind optional, aber mind. eines muss nicht-leer sein.
+v1-Dateien ({start,end,pause}/Tag, Pflichtfeld) und v2-Dateien (entries +
+reservations, alte Shape) werden beim Lesen weiterhin akzeptiert und in
+1-Slot-Listen (kategorie="") gewrappt (Abwärtskompatibilität).
 """
 
 import datetime
@@ -20,13 +21,18 @@ import json
 import re
 
 
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 3
 KIND = "zeiterfassung-share"
 
 _DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 _TIME_RE = re.compile(r"^\d{2}:\d{2}$")
-_ENTRY_KEYS = frozenset({"start", "end", "pause"})
-_RESERVATION_KEYS = frozenset({"start", "end"})
+
+# Alte (v1/v2) Record-Keys:
+_LEGACY_ENTRY_KEYS = frozenset({"start", "end", "pause"})
+_LEGACY_RESERVATION_KEYS = frozenset({"start", "end"})
+# v3-Slot-Keys:
+_ENTRY_SLOT_KEYS = frozenset({"start", "end", "pause", "kategorie"})
+_RESERVATION_SLOT_KEYS = frozenset({"start", "end", "kategorie"})
 
 
 def _utc_now_iso():
@@ -74,29 +80,82 @@ def _check_keys(date_str, entry, expected_keys, label="Eintrag"):
         raise ShareValidationError(f"{label} {date_str}: {'; '.join(parts)}")
 
 
-def _validate_entries(entries):
+def _validate_pause(date_str, pause):
+    if not isinstance(pause, int) or isinstance(pause, bool) or pause < 0:
+        raise ShareValidationError(f"Eintrag {date_str}: ungültige Pause {pause!r}")
+
+
+def _validate_kategorie(date_str, kategorie):
+    if not isinstance(kategorie, str):
+        raise ShareValidationError(f"Eintrag {date_str}: ungültige Kategorie {kategorie!r}")
+
+
+# --- v1/v2 (alte Shape) ---
+
+def _validate_legacy_entries(entries):
     for date_str, entry in entries.items():
         _validate_date_key(date_str)
-        _check_keys(date_str, entry, _ENTRY_KEYS)
+        _check_keys(date_str, entry, _LEGACY_ENTRY_KEYS)
         _validate_time(date_str, "Startzeit", entry["start"])
         _validate_time(date_str, "Endzeit", entry["end"])
-        pause = entry["pause"]
-        if not isinstance(pause, int) or isinstance(pause, bool) or pause < 0:
-            raise ShareValidationError(f"Eintrag {date_str}: ungültige Pause {pause!r}")
+        _validate_pause(date_str, entry["pause"])
 
 
-def _validate_reservations(reservations):
+def _validate_legacy_reservations(reservations):
     for date_str, entry in reservations.items():
         _validate_date_key(date_str)
-        _check_keys(date_str, entry, _RESERVATION_KEYS, label="Reservierung")
+        _check_keys(date_str, entry, _LEGACY_RESERVATION_KEYS, label="Reservierung")
         _validate_time(date_str, "Startzeit", entry["start"])
         _validate_time(date_str, "Endzeit", entry["end"])
+
+
+def _wrap_legacy_entries(entries):
+    return {
+        d: {"slots": [{"start": e["start"], "end": e["end"],
+                       "pause": e["pause"], "kategorie": ""}]}
+        for d, e in entries.items()
+    }
+
+
+def _wrap_legacy_reservations(reservations):
+    return {
+        d: {"slots": [{"start": r["start"], "end": r["end"], "kategorie": ""}]}
+        for d, r in reservations.items()
+    }
+
+
+# --- v3 (Slot-Shape) ---
+
+def _validate_slot_record(date_str, record, slot_keys, has_pause):
+    if not isinstance(record, dict) or set(record.keys()) != {"slots"}:
+        raise ShareValidationError(f"Eintrag {date_str}: erwartet {{\"slots\": [...]}}.")
+    if not isinstance(record["slots"], list):
+        raise ShareValidationError(f"Eintrag {date_str}: 'slots' ist keine Liste.")
+    for slot in record["slots"]:
+        _check_keys(date_str, slot, slot_keys, label="Slot")
+        _validate_time(date_str, "Startzeit", slot["start"])
+        _validate_time(date_str, "Endzeit", slot["end"])
+        if has_pause:
+            _validate_pause(date_str, slot["pause"])
+        _validate_kategorie(date_str, slot["kategorie"])
+
+
+def _validate_v3_entries(entries):
+    for date_str, record in entries.items():
+        _validate_date_key(date_str)
+        _validate_slot_record(date_str, record, _ENTRY_SLOT_KEYS, has_pause=True)
+
+
+def _validate_v3_reservations(reservations):
+    for date_str, record in reservations.items():
+        _validate_date_key(date_str)
+        _validate_slot_record(date_str, record, _RESERVATION_SLOT_KEYS, has_pause=False)
 
 
 def parse_share_doc(raw_bytes):
     """Parst und validiert Share-File-Inhalt. Wirft ShareValidationError bei
-    jeder Schema-Verletzung — Aufrufer darf den lokalen Bestand nicht antasten,
-    wenn diese Funktion wirft."""
+    jeder Schema-Verletzung. Der zurückgegebene doc hat entries/reservations
+    immer als Slot-Records (v1/v2 werden gewrappt)."""
     try:
         doc = json.loads(raw_bytes)
     except (ValueError, TypeError) as e:
@@ -123,35 +182,65 @@ def parse_share_doc(raw_bytes):
     reservations = doc.get("reservations")
 
     if schema_version == 1:
-        # v1: nur entries, Pflichtfeld (Abwärtskompatibilität für Alt-Dateien).
+        # v1: nur entries, Pflichtfeld, alte Shape → wrappen.
         if not isinstance(entries, dict):
             raise ShareValidationError("Feld 'entries' fehlt oder ist kein Objekt.")
-        _validate_entries(entries)
+        _validate_legacy_entries(entries)
+        doc["entries"] = _wrap_legacy_entries(entries)
         return doc
 
-    # v2: entries und reservations beide optional, mind. eines nicht-leer.
+    if schema_version == 2:
+        # v2: entries + reservations optional, alte Shape → wrappen.
+        if entries is not None:
+            if not isinstance(entries, dict):
+                raise ShareValidationError("Feld 'entries' ist kein Objekt.")
+            _validate_legacy_entries(entries)
+        if reservations is not None:
+            if not isinstance(reservations, dict):
+                raise ShareValidationError("Feld 'reservations' ist kein Objekt.")
+            _validate_legacy_reservations(reservations)
+        if not entries and not reservations:
+            raise ShareValidationError("Datei enthält weder Arbeitszeiten noch Reservierungen.")
+        if entries is not None:
+            doc["entries"] = _wrap_legacy_entries(entries)
+        if reservations is not None:
+            doc["reservations"] = _wrap_legacy_reservations(reservations)
+        return doc
+
+    # v3: Slot-Shape.
     if entries is not None:
         if not isinstance(entries, dict):
             raise ShareValidationError("Feld 'entries' ist kein Objekt.")
-        _validate_entries(entries)
+        _validate_v3_entries(entries)
     if reservations is not None:
         if not isinstance(reservations, dict):
             raise ShareValidationError("Feld 'reservations' ist kein Objekt.")
-        _validate_reservations(reservations)
+        _validate_v3_reservations(reservations)
     if not entries and not reservations:
-        raise ShareValidationError(
-            "Datei enthält weder Arbeitszeiten noch Reservierungen."
-        )
+        raise ShareValidationError("Datei enthält weder Arbeitszeiten noch Reservierungen.")
     return doc
 
 
-def build_share_doc(storage, sender_email, *, reservation_store=None,
-                    include_entries=True, include_reservations=False):
-    """Baut das Share-Doc. Tombstones sind via get_all() bereits gefiltert.
+def _filter_records_by_category(records, categories):
+    """categories=None → unverändert. Sonst je Tag nur Slots behalten, deren
+    Kategorie (oder "") in `categories` liegt; leere Tage fallen weg."""
+    if categories is None:
+        return records
+    cats = set(categories)
+    out = {}
+    for date_str, record in records.items():
+        kept = [s for s in record["slots"] if (s.get("kategorie") or "") in cats]
+        if kept:
+            out[date_str] = {"slots": kept}
+    return out
 
-    include_entries / include_reservations steuern, welche Typen mitgehen.
-    reservations werden nur aufgenommen, wenn ein reservation_store übergeben
-    wurde."""
+
+def build_share_doc(storage, sender_email, *, reservation_store=None,
+                    include_entries=True, include_reservations=False, categories=None):
+    """Baut das v3-Share-Doc aus den Slot-Records von Storage/ReservationStore.
+
+    include_entries / include_reservations steuern die Typen. categories=None →
+    alle; sonst werden Slots auf die Kategorie-Menge gefiltert ('' = ohne)."""
     doc = {
         "schema_version": SCHEMA_VERSION,
         "kind": KIND,
@@ -159,9 +248,10 @@ def build_share_doc(storage, sender_email, *, reservation_store=None,
         "exported_by": sender_email or "",
     }
     if include_entries:
-        doc["entries"] = dict(storage.get_all())
+        doc["entries"] = _filter_records_by_category(dict(storage.get_all()), categories)
     if include_reservations and reservation_store is not None:
-        doc["reservations"] = dict(reservation_store.get_all())
+        doc["reservations"] = _filter_records_by_category(
+            dict(reservation_store.get_all()), categories)
     return doc
 
 
@@ -170,14 +260,19 @@ def serialize_share_doc(doc):
     return json.dumps(doc, indent=2, ensure_ascii=False, sort_keys=True).encode("utf-8")
 
 
+def _slot_signature(slots, keys):
+    """Reihenfolge-normalisierte Signatur einer Slot-Liste über `keys`."""
+    return sorted(tuple(s.get(k) for k in keys) for s in (slots or []))
+
+
 def _entries_equal(a, b):
-    return (a.get("start") == b.get("start")
-            and a.get("end") == b.get("end")
-            and a.get("pause", 0) == b.get("pause", 0))
+    return (_slot_signature(a.get("slots"), ("start", "end", "pause", "kategorie"))
+            == _slot_signature(b.get("slots"), ("start", "end", "pause", "kategorie")))
 
 
 def _reservations_equal(a, b):
-    return a.get("start") == b.get("start") and a.get("end") == b.get("end")
+    return (_slot_signature(a.get("slots"), ("start", "end", "kategorie"))
+            == _slot_signature(b.get("slots"), ("start", "end", "kategorie")))
 
 
 def _diff_records(share_records, local_snapshot, equal_fn, date_from=None, date_to=None):
@@ -236,18 +331,19 @@ def diff_reservations_against_local(share_reservations, reservation_store,
 
 
 def apply_reservation_import(reservation_store, decisions):
-    """Schreibt importierte Reservierungen in den Store. save() setzt
-    modified_at neu und behält eine vorhandene gcal_event_id, sodass der
-    nächste Kalender-Reconcile das Event aktualisiert statt zu duplizieren."""
+    """Schreibt importierte Reservierungen (Slot-Records) in den Store.
+
+    decisions: list of {"date": "YYYY-MM-DD", "entry": {"slots": [...]}}.
+    Der gcal_event_id-Erhalt / Reconcile-Abgleich passiert separat im
+    Kalender-Reconcile (nicht hier)."""
     for d in decisions:
-        entry = d["entry"]
-        reservation_store.save(d["date"], entry["start"], entry["end"])
+        reservation_store.save(d["date"], d["entry"]["slots"])
 
 
 def apply_import(storage, decisions):
-    """Wendet Import-Decisions atomar an (eine save_many-Aufruf).
+    """Wendet Import-Decisions atomar an (ein save_many-Aufruf).
 
-    decisions: list of {"date": "YYYY-MM-DD", "entry": {start, end, pause}}.
+    decisions: list of {"date": "YYYY-MM-DD", "entry": {"slots": [...]}}.
     """
     updates = {d["date"]: d["entry"] for d in decisions}
     storage.save_many(updates)

--- a/src/storage.py
+++ b/src/storage.py
@@ -8,7 +8,21 @@ def _utc_now_iso():
     return datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
-_REQUIRED_ENTRY_KEYS = frozenset({"start", "end", "pause", "modified_at", "device_id", "deleted"})
+_REQUIRED_ENTRY_KEYS = frozenset({"slots", "modified_at", "device_id", "deleted"})
+
+
+def _normalize_slot(slot):
+    """Vervollständigt einen Ist-Zeit-Slot auf {start, end, pause, kategorie}.
+
+    Fehlende `pause` → 0, fehlende `kategorie` → "" (= keine Kategorie,
+    Verhalten wie vor der Migration). Storage validiert die Zeitwerte
+    bewusst nicht (wie bisher) — das ist Sache der UI/Validierung (AP3)."""
+    return {
+        "start": slot.get("start"),
+        "end": slot.get("end"),
+        "pause": slot.get("pause", 0),
+        "kategorie": slot.get("kategorie", ""),
+    }
 
 
 class Storage:
@@ -32,9 +46,11 @@ class Storage:
         self._migrate_legacy_entries()
 
     def _migrate_legacy_entries(self):
-        """Spendet alten Einträgen ohne modified_at/device_id/deleted die
-        Sync-Metadaten. Idempotent: Einträge mit modified_at bleiben unberührt.
-        modified_at wird aus der File-mtime abgeleitet (best lower bound)."""
+        """Rüstet Sync-Metadaten nach UND wrappt alte Ein-Eintrag-Tage in eine
+        Slot-Liste. Idempotent: Einträge mit `slots` bleiben unangetastet,
+        Einträge mit `modified_at` behalten ihre Metadaten.
+        modified_at wird (für ganz alte Einträge ohne Metadaten) aus der
+        File-mtime abgeleitet (best lower bound)."""
         try:
             mtime = os.path.getmtime(self.filepath)
         except OSError:
@@ -48,12 +64,25 @@ class Storage:
         for date, entry in list(self._data.items()):
             if not isinstance(entry, dict):
                 continue
-            if "modified_at" in entry:
-                continue
-            entry.setdefault("pause", 0)
-            entry["modified_at"] = fallback_modified_at
-            entry["device_id"] = self.device_id
-            entry["deleted"] = False
+            # 1. Sync-Metadaten für ganz alte Einträge nachrüsten.
+            if "modified_at" not in entry:
+                entry["modified_at"] = fallback_modified_at
+                entry["device_id"] = self.device_id
+                entry.setdefault("deleted", False)
+            # 2. Slot-Wrapping für Einträge im alten Ein-Eintrag-Schema.
+            if "slots" not in entry:
+                if entry.get("deleted"):
+                    entry["slots"] = []
+                else:
+                    entry["slots"] = [{
+                        "start": entry.get("start"),
+                        "end": entry.get("end"),
+                        "pause": entry.get("pause", 0),
+                        "kategorie": "",
+                    }]
+                entry.pop("start", None)
+                entry.pop("end", None)
+                entry.pop("pause", None)
 
     def _save_to_disk(self):
         tmp = self.filepath + ".tmp"
@@ -68,11 +97,12 @@ class Storage:
 
     @staticmethod
     def _user_shape(entry):
-        """Reduziert ein Roh-Entry auf {start, end, pause} für UI-Callers."""
-        return {"start": entry["start"], "end": entry["end"], "pause": entry.get("pause", 0)}
+        """Reduziert ein Roh-Entry auf {slots: [...]} für UI-Caller.
+        Liefert frische Kopien, damit Caller den internen Stand nicht mutieren."""
+        return {"slots": [dict(s) for s in entry.get("slots", [])]}
 
     def get_all(self):
-        """Liefert {date: {start, end, pause}} ohne Tombstones."""
+        """Liefert {date: {slots: [...]}} ohne Tombstones."""
         return {
             date: self._user_shape(entry)
             for date, entry in self._data.items()
@@ -90,11 +120,9 @@ class Storage:
             return None
         return self._user_shape(entry)
 
-    def save(self, date_str, start, end, pause=0):
+    def save(self, date_str, slots):
         self._data[date_str] = {
-            "start": start,
-            "end": end,
-            "pause": pause,
+            "slots": [_normalize_slot(s) for s in slots],
             "modified_at": _utc_now_iso(),
             "device_id": self.device_id,
             "deleted": False,
@@ -107,9 +135,7 @@ class Storage:
         # Tombstone: behält die Zeile mit deleted=true, damit der Sync ein
         # Delete gegen ein veraltetes Save eines anderen Geräts durchsetzen kann.
         self._data[date_str] = {
-            "start": None,
-            "end": None,
-            "pause": None,
+            "slots": [],
             "modified_at": _utc_now_iso(),
             "device_id": self.device_id,
             "deleted": True,
@@ -118,7 +144,7 @@ class Storage:
 
     def apply_merge(self, merged_entries):
         """Ersetzt den kompletten Storage-Stand durch das Merge-Ergebnis.
-        merged_entries: {date: {start, end, pause, modified_at, device_id, deleted}}.
+        merged_entries: {date: {slots, modified_at, device_id, deleted}}.
         Wirft ValueError, wenn ein Eintrag Pflichtfelder vermissen lässt."""
         for date, entry in merged_entries.items():
             missing = _REQUIRED_ENTRY_KEYS - entry.keys()
@@ -132,7 +158,7 @@ class Storage:
     def save_many(self, updates):
         """Mehrere Einträge in einem einzigen Disk-Write speichern.
 
-        updates: {date_str: {start, end, pause}}. Jeder Eintrag bekommt
+        updates: {date_str: {"slots": [...]}}. Jeder Eintrag bekommt
         frische modified_at/device_id/deleted=False. Existierende Tombstones
         am selben Datum werden überschrieben.
 
@@ -143,9 +169,7 @@ class Storage:
         now = _utc_now_iso()
         for date_str, payload in updates.items():
             self._data[date_str] = {
-                "start": payload["start"],
-                "end": payload["end"],
-                "pause": payload.get("pause", 0),
+                "slots": [_normalize_slot(s) for s in payload.get("slots", [])],
                 "modified_at": now,
                 "device_id": self.device_id,
                 "deleted": False,

--- a/src/storage.py
+++ b/src/storage.py
@@ -83,6 +83,8 @@ class Storage:
                 entry.pop("start", None)
                 entry.pop("end", None)
                 entry.pop("pause", None)
+                entry.setdefault("device_id", self.device_id)
+                entry.setdefault("deleted", False)
 
     def _save_to_disk(self):
         tmp = self.filepath + ".tmp"

--- a/src/sync.py
+++ b/src/sync.py
@@ -17,6 +17,15 @@ import uuid
 SCHEMA_VERSION = 3
 
 
+OLD_REMOTE_VERSION_MSG = (
+    "Ein anderes Gerät nutzt eine ältere App-Version, die das neue Format "
+    "(Mehrfach-Slots/Kategorien) noch nicht versteht.\n\n"
+    "Bitte aktualisiere die App auf dem anderen Gerät, bevor du dort "
+    "synchronisierst. Bis dahin pausiert die Synchronisation, damit keine "
+    "Daten verloren gehen."
+)
+
+
 def _watermark_of(doc):
     return ((doc.get("meta") or {}).get("gc_watermark") or "")
 

--- a/src/sync.py
+++ b/src/sync.py
@@ -14,7 +14,7 @@ import datetime
 import uuid
 
 
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 3
 
 
 def _watermark_of(doc):
@@ -40,10 +40,18 @@ def _utc_now_iso():
     return datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
+def _slots_signature(entry):
+    """Reihenfolge-normalisierte Signatur der Slot-Liste eines Eintrags,
+    für den Gleichheitsvergleich im Merge. Sortiert nach den Slot-Feldern,
+    damit eine reine Umordnung der Slots NICHT als Änderung zählt."""
+    return sorted(
+        (s.get("start"), s.get("end"), s.get("pause", 0), s.get("kategorie", ""))
+        for s in (entry.get("slots") or [])
+    )
+
+
 def _values_equal_entry(a, b):
-    return (a.get("start") == b.get("start")
-            and a.get("end") == b.get("end")
-            and a.get("pause") == b.get("pause")
+    return (_slots_signature(a) == _slots_signature(b)
             and bool(a.get("deleted")) == bool(b.get("deleted")))
 
 
@@ -204,9 +212,7 @@ def merge(local, remote, last_pull_at):
             current = merged["entries"].get(c["key"])
             if current is None or current["modified_at"] < resolved_at:
                 merged["entries"][c["key"]] = {
-                    "start": resolution.get("start"),
-                    "end": resolution.get("end"),
-                    "pause": resolution.get("pause", 0),
+                    "slots": resolution.get("slots", []),
                     "modified_at": resolved_at,
                     "device_id": resolved_by,
                     "deleted": bool(resolution.get("deleted", False)),
@@ -270,19 +276,17 @@ def compact_local(storage, settings, conflicts_store, now):
     ])
 
 
-def _remote_is_pre_v2(remote_doc):
-    """True, wenn das Remote-Doc von einem v1-Gerät stammt (Schema < 2 oder
-    fehlendes/leeres meta ohne gc_watermark-Key) — dann ist gerade ein älteres
-    Gerät aktiv und die Kompaktierung muss abbrechen."""
-    if (remote_doc.get("schema_version") or 1) < 2:
-        return True
-    meta = remote_doc.get("meta")
-    return not (isinstance(meta, dict) and "gc_watermark" in meta)
+def _remote_is_pre_v3(remote_doc):
+    """True, wenn das Remote-Doc von einem Gerät stammt, das das Multi-Slot-
+    Schema (v3) noch nicht versteht (schema_version < 3). Dann ist ein
+    älteres Gerät aktiv: Kompaktierung muss abbrechen, und ein v2-Remote darf
+    nicht in einen v3-Client gemergt werden (er hätte keine `slots`)."""
+    return (remote_doc.get("schema_version") or 1) < 3
 
 
 def resolve_conflict(conflict_id, chosen_value, conflicts_store, storage, settings, device_id):
     """User hat einen Konflikt aufgelöst. chosen_value enthält den gewählten
-    (oder manuell editierten) Wert. Für entries: {start, end, pause} (und
+    (oder manuell editierten) Wert. Für entries: {slots: [...]} (und
     optional deleted). Für settings: {value}.
     Schreibt den Wert in den entsprechenden Store und markiert den Konflikt
     als resolved im ConflictsStore."""
@@ -301,12 +305,7 @@ def resolve_conflict(conflict_id, chosen_value, conflicts_store, storage, settin
         if chosen_value.get("deleted"):
             storage.delete(target["key"])
         else:
-            storage.save(
-                target["key"],
-                chosen_value.get("start"),
-                chosen_value.get("end"),
-                chosen_value.get("pause", 0),
-            )
+            storage.save(target["key"], chosen_value.get("slots", []))
     elif target["kind"] == "setting":
         settings.set_synced(target["key"], chosen_value.get("value"))
 

--- a/src/sync.py
+++ b/src/sync.py
@@ -41,7 +41,7 @@ def _is_settled_conflict(conflict, watermark):
 SYNCED_SETTING_KEYS = (
     "recipient", "name", "hourly_rate",
     "mail_subject", "mail_greeting", "mail_content", "mail_closing",
-    "gcal_calendar_id", "categories",
+    "gcal_calendar_id", "categories", "category_times",
 )
 
 

--- a/src/sync.py
+++ b/src/sync.py
@@ -32,7 +32,7 @@ def _is_settled_conflict(conflict, watermark):
 SYNCED_SETTING_KEYS = (
     "recipient", "name", "hourly_rate",
     "mail_subject", "mail_greeting", "mail_content", "mail_closing",
-    "gcal_calendar_id",
+    "gcal_calendar_id", "categories",
 )
 
 

--- a/src/theme.py
+++ b/src/theme.py
@@ -752,7 +752,7 @@ def themed_askyesno(parent, title: str, message: str) -> bool:
     return result["value"]
 
 
-def themed_ask_delete_choice(parent, title: str, message: str, options):
+def themed_ask_delete_choice(parent, title: str, message: str, options, lock_ms: int = 0):
     """Modaler Lösch-Dialog mit Checkboxen — das Gegenstück zu `themed_askyesno`
     für Tage, an denen mehrere löschbare Objekte liegen (Ist-Zeit UND
     Reservierung).
@@ -774,6 +774,9 @@ def themed_ask_delete_choice(parent, title: str, message: str, options):
     dialog.focus_set()
 
     result = {"value": None}
+    # Optionaler kurzer Lock nach dem Öffnen: verhindert versehentliches
+    # Sofort-Löschen, wenn (wie üblich) alle Optionen vorausgewählt sind.
+    unlock = {"ready": lock_ms <= 0}
 
     tk.Label(
         dialog, text=message, font=FONT, bg=BG, fg=TEXT,
@@ -794,6 +797,8 @@ def themed_ask_delete_choice(parent, title: str, message: str, options):
         checkbuttons.append(cb)
 
     def click_delete():
+        if not unlock["ready"]:
+            return
         selected = {key for key, var in vars_by_key.items() if var.get()}
         # Leere Auswahl ist ein No-Op: Dialog NICHT schließen, sonst landet der
         # Klick auf einem Kalendertag dahinter und öffnet den Speichern-Dialog.
@@ -812,12 +817,20 @@ def themed_ask_delete_choice(parent, title: str, message: str, options):
     secondary_button(btn_frame, "Abbrechen", click_cancel).pack(side=tk.LEFT, padx=6)
 
     def _refresh_delete_btn(*_):
-        # Löschen nur klickbar, wenn mind. eine Option gewählt ist.
+        # Löschen nur klickbar, wenn der Lock abgelaufen ist UND mind. eine
+        # Option gewählt ist.
         set_primary_button_enabled(
-            delete_btn, any(var.get() for var in vars_by_key.values()))
+            delete_btn,
+            unlock["ready"] and any(var.get() for var in vars_by_key.values()))
 
     for cb in checkbuttons:
         cb.config(command=_refresh_delete_btn)
+
+    if lock_ms > 0:
+        def _unlock():
+            unlock["ready"] = True
+            _refresh_delete_btn()
+        dialog.after(lock_ms, _unlock)
     _refresh_delete_btn()
 
     dialog.bind("<Return>", lambda e: click_delete())

--- a/src/theme.py
+++ b/src/theme.py
@@ -167,6 +167,16 @@ def dark_combo(parent, textvariable, values, width=8, **kw):
     )
 
 
+def dark_combo_editable(parent, textvariable, values, width=14, **kw):
+    """Wie dark_combo, aber editierbar (state="normal") — Freitext plus
+    Vorschlagsliste. Für die Kategorie-Auswahl je Slot, deren Werte aus
+    settings['categories'] kommen, aber auch frei eingetippt werden dürfen."""
+    return ttk.Combobox(
+        parent, textvariable=textvariable, values=values,
+        width=width, font=FONT, style="Dark.TCombobox", state="normal", **kw,
+    )
+
+
 def dark_text(parent, width, height, **kw):
     return tk.Text(
         parent, width=width, height=height, font=FONT,

--- a/src/theme.py
+++ b/src/theme.py
@@ -444,6 +444,14 @@ def _stray_click_suppressed(closed_at, now, window=STRAY_CLICK_GUARD_S):
     return 0 <= (now - closed_at) < window
 
 
+def _should_show_delete_button(is_macos, has_entry, has_reservation):
+    """macOS-only Lösch-Button (✕) in der Tageszelle: nur auf macOS und nur,
+    wenn der Tag löschbare Einheiten hat — Ist-Zeit ODER aktive Reservierung.
+    Reine Logik, damit aus den Tests ohne Tk/UI-Deps prüfbar (vgl.
+    _stray_click_suppressed)."""
+    return is_macos and (has_entry or has_reservation)
+
+
 def center_dialog_on_parent(dialog, parent):
     """Position a Toplevel dialog over its parent's screen rect.
 

--- a/src/theme.py
+++ b/src/theme.py
@@ -335,11 +335,28 @@ def attach_unfocus_on_click(dialog):
     Frame-Bg, Frame+Label-Button) ziehen wir den Fokus auf den Dialog.
     """
     def _unfocus(event):
-        if event.widget.winfo_class() in _FOCUSABLE_INPUT_CLASSES:
+        if _click_keeps_focus(event.widget):
             return
         dialog.focus_set()
 
     dialog.bind("<Button-1>", _unfocus, add="+")
+
+
+def _click_keeps_focus(widget):
+    """True, wenn der geklickte Widget den Fokus behalten soll (Eingabefeld).
+
+    Defensiv: Wird ein Widget WÄHREND seines Klick-Events zerstört (z.B. die
+    "×"-Schaltfläche einer Slot-Zeile im Tages-Dialog), liefert Tk für das
+    nachgelagerte Toplevel-`<Button-1>` `event.widget` als Pfad-String statt
+    als Widget-Objekt — `winfo_class()` würde dann mit AttributeError crashen.
+    Ein String- oder bereits zerstörtes Widget → Fokus auf den Dialog ziehen
+    (kein Eingabefeld)."""
+    if isinstance(widget, str):
+        return False
+    try:
+        return widget.winfo_class() in _FOCUSABLE_INPUT_CLASSES
+    except tk.TclError:
+        return False
 
 
 def _parent_workarea(parent):

--- a/src/time_utils.py
+++ b/src/time_utils.py
@@ -98,3 +98,40 @@ def format_iso_datetime(iso, fallback="—"):
     if len(iso) >= 16 and iso[10] in ("T", " "):
         return f"{date_part} {iso[11:16]}"
     return date_part
+
+
+def slots_overlap(slots):
+    """True, wenn sich zwei Slots zeitlich überlappen.
+
+    `slots`: Liste von Dicts mit 'start'/'end' (HH:MM). Slots mit unparsbarer
+    Zeit werden übersprungen (Format-Fehler fängt validate_slots separat ab).
+    Angrenzend (Ende == Start des nächsten) gilt NICHT als Überlappung.
+    """
+    intervals = []
+    for s in slots:
+        start = parse_time(s.get("start"))
+        end = parse_time(s.get("end"))
+        if start is None or end is None:
+            continue
+        intervals.append((start[0] * 60 + start[1], end[0] * 60 + end[1]))
+    intervals.sort()
+    for (_prev_start, prev_end), (next_start, _next_end) in zip(intervals, intervals[1:]):
+        if next_start < prev_end:
+            return True
+    return False
+
+
+def validate_slots(slots, with_pause=True):
+    """Validiert eine Slot-Liste: jeden Slot einzeln (validate_entry) und die
+    zeitliche Überlappungsfreiheit. Liefert (ok, fehlermeldung).
+
+    with_pause=False (Reservierungen): das Pause-Feld wird ignoriert (als 0
+    behandelt). Eine leere Liste ist gültig (ok, "")."""
+    for s in slots:
+        pause = int(s.get("pause", 0)) if with_pause else 0
+        ok, msg = validate_entry(s.get("start"), s.get("end"), pause_minutes=pause)
+        if not ok:
+            return False, msg
+    if slots_overlap(slots):
+        return False, "Zeitslots dürfen sich zeitlich nicht überlappen."
+    return True, ""

--- a/src/ui.py
+++ b/src/ui.py
@@ -34,6 +34,7 @@ from src.dialogs.send_dialog import open_send_dialog
 from src.dialogs.settings_dialog import open_settings_dialog
 from src.theme import (
     BG, CELL_BG, WEEKEND_BG, ACCENT, ACCENT_HOVER, TEXT, TEXT_MUTED,
+    _should_show_delete_button,
     ENTRY_BG, WEEKEND_ENTRY_BG, WEEKEND_FG,
     HOLIDAY_BG, HOLIDAY_BG_HOVER, HOLIDAY_ACCENT,
     RESERVATION_ACCENT, TODAY_ACCENT,
@@ -882,6 +883,30 @@ class App:
         marker.place(relx=1.0, x=-3, y=3, anchor="ne")
         cell._reservation_marker = marker
 
+    def _add_delete_button(self, cell, date_str):
+        """macOS-only: kleines ✕ oben links, das den Lösch-Pfad auslöst.
+
+        <Button-3> ist auf macOS unzuverlässig (Sekundärklick je nach Tk-Version
+        <Button-2>/Control-Klick); dieser Button gibt dort einen verlässlichen
+        Lösch-Auslöser, ohne den Linksklick-Dialog mit Lösch-Buttons zu belasten.
+        Klick ruft denselben _delete_day-Pfad wie der Win/Linux-Rechtsklick
+        (Ja/Nein bzw. Slot-Auswahl). Getaggt als cell._delete_button, damit
+        _cell_hover/_empty_hover seinen Hintergrund beim Hover mitfärben."""
+        bg = cell.cget("bg")
+        btn = tk.Label(
+            cell, text="✕", font=FONT_TINY, bg=bg, fg=TEXT_MUTED, cursor="hand2",
+        )
+        btn.place(relx=0.0, x=3, y=2, anchor="nw")
+        # "break" stoppt jede Propagation, damit der Klick nicht zusätzlich als
+        # Zell-Linksklick (Bearbeiten-Dialog) durchschlägt.
+        btn.bind("<Button-1>",
+                 lambda e, d=date_str: (self._delete_day(d), "break")[1])
+        # fg-Hover (rot als Lösch-Affordance) steuert der Button selbst; den bg
+        # färbt _cell_hover/_empty_hover mit der Zelle.
+        btn.bind("<Enter>", lambda e: btn.config(fg=ACCENT))
+        btn.bind("<Leave>", lambda e: btn.config(fg=TEXT_MUTED))
+        cell._delete_button = btn
+
     def _build_empty_cell(self, parent, date_str, day_text, is_weekend, cell_size):
         bg = WEEKEND_BG if is_weekend else CELL_BG
         hover_bg = WEEKEND_BG_HOVER if is_weekend else CELL_BG_HOVER
@@ -970,6 +995,15 @@ class App:
             tip_parts.append(f"Feiertag: {holidays_map[day_date]}")
         if tip_parts:
             attach_tooltip(cell, "\n".join(tip_parts))
+
+        # macOS-only Lösch-Button (✕) oben links, sobald der Tag löschbare
+        # Einheiten hat (Ist-Zeit ODER aktive Reservierung). reservation wird
+        # nur bei aktivem Kalender-Sync übergeben (vgl. _add_reservation_marker),
+        # daher deckt `reservation is not None` die aktive Reservierung ab.
+        if _should_show_delete_button(
+            platform.system() == "Darwin", bool(entry), reservation is not None
+        ):
+            self._add_delete_button(cell, date_str)
 
         # Heutigen Tag mit blauem Rahmen hervorheben. Vor dem Konflikt-Block,
         # damit ein Konflikt (orange) auf demselben Tag den Rand gewinnt.
@@ -1245,22 +1279,29 @@ class App:
         frame.config(bg=bg)
         day_lbl.config(bg=bg)
         time_lbl.config(bg=bg)
-        # Eck-Marker (nur auf Entry-Zellen mit zusätzlicher Reservierung)
-        # mitfärben, sonst bleibt beim Hover ein andersfarbiges Rechteck stehen.
+        # Eck-Overlays (Reservierungs-Marker, macOS-Lösch-Button) mitfärben,
+        # sonst bleibt beim Hover ein andersfarbiges Rechteck stehen. Nur bg —
+        # die fg des Lösch-Buttons steuert dessen eigener Enter/Leave-Handler.
         marker = getattr(frame, "_reservation_marker", None)
         if marker is not None:
             marker.config(bg=bg)
+        del_btn = getattr(frame, "_delete_button", None)
+        if del_btn is not None:
+            del_btn.config(bg=bg)
 
     @staticmethod
     def _empty_hover(frame, day_lbl, bg):
         frame.config(bg=bg)
         day_lbl.config(bg=bg)
-        # Reservierungs-Eck-Punkt mitfärben — Nur-Reservierungs-Tage sind
-        # Empty-Zellen mit Marker; sonst bliebe beim Hover ein andersfarbiges
-        # Rechteck hinter dem Punkt stehen.
+        # Eck-Overlays mitfärben — Nur-Reservierungs-Tage sind Empty-Zellen mit
+        # Marker (und auf macOS zusätzlich dem Lösch-Button); sonst bliebe beim
+        # Hover ein andersfarbiges Rechteck dahinter stehen. Nur bg.
         marker = getattr(frame, "_reservation_marker", None)
         if marker is not None:
             marker.config(bg=bg)
+        del_btn = getattr(frame, "_delete_button", None)
+        if del_btn is not None:
+            del_btn.config(bg=bg)
 
     def _delete_day(self, date_str):
         """Rechtsklick-Löschen für einen Tag. Löscht NIE ohne Bestätigung.

--- a/src/ui.py
+++ b/src/ui.py
@@ -791,8 +791,16 @@ class App:
         # pixel-fixierte Standardzelle (width=8 in FONT) reinpasst. Wenn der
         # Caller eine breitere Zelle nutzt (z.B. bei ausgeblendeten Wochenenden
         # mit width=11), kann eine größere Schrift übergeben werden.
+        slots = entry.get("slots", [])
+        if slots:
+            first = slots[0]
+            time_text = f"{first['start']}-{first['end']}"
+            if len(slots) > 1:
+                time_text += f"  +{len(slots) - 1}"
+        else:
+            time_text = ""
         time_lbl = tk.Label(
-            cell, text=f"{entry['start']}-{entry['end']}",
+            cell, text=time_text,
             font=time_font, bg=bg, fg=TEXT_MUTED, cursor="hand2",
         )
         time_lbl.pack(pady=(0, pad))
@@ -802,6 +810,13 @@ class App:
             w.bind("<Enter>", lambda e, c=cell, dl=day_lbl, tl=time_lbl, hb=hover_bg: self._cell_hover(c, dl, tl, hb))
             w.bind("<Leave>", lambda e, c=cell, dl=day_lbl, tl=time_lbl, ob=bg: self._cell_hover(c, dl, tl, ob))
         return cell
+
+    @staticmethod
+    def _fmt_slot_line(slot):
+        """Eine Tooltip-Zeile für einen Slot: 'HH:MM-HH:MM  Kategorie'
+        (Kategorie weggelassen, wenn leer)."""
+        kat = f"  {slot['kategorie']}" if slot.get("kategorie") else ""
+        return f"{slot['start']}-{slot['end']}{kat}"
 
     def _add_reservation_marker(self, cell):
         """Runder violetter Eck-Punkt auf einer Ist-Zeitzelle, die zusätzlich
@@ -891,16 +906,26 @@ class App:
             )
 
         # Reservierung ist ein reiner Overlay-Marker (Eck-Punkt) — sie ändert
-        # den Zelltyp nicht. Genau ein attach_tooltip pro Zelle: Mehrfachaufruf
-        # erzeugt überlappende Tooltips (s. attach_tooltip-Docstring).
+        # den Zelltyp nicht. Genau EIN attach_tooltip pro Zelle (Mehrfachaufruf
+        # erzeugt überlappende Tooltips); deshalb alle relevanten Infos
+        # (mehrere Arbeitszeit-Slots, Reservierung, Feiertag) in einen
+        # kombinierten Tooltip. Ein Feiertag-OHNE-Eintrag/-Reservierung zeigt
+        # seinen Namen weiterhin als Zelltext (Holiday-Zelle) bzw. eigenen
+        # Tooltip (name_tooltip) und kommt hier NICHT rein.
+        tip_parts = []
+        if entry and len(entry.get("slots", [])) > 1:
+            tip_parts.append(
+                "Arbeitszeit:\n"
+                + "\n".join(self._fmt_slot_line(s) for s in entry["slots"]))
         if reservation is not None:
             self._add_reservation_marker(cell)
-            tip = f"Reservierung: {reservation['start']}-{reservation['end']}"
-            if is_holiday:
-                tip += f"\nFeiertag: {holidays_map[day_date]}"
-            attach_tooltip(cell, tip)
-        elif entry and is_holiday:
-            attach_tooltip(cell, f"Feiertag: {holidays_map[day_date]}")
+            tip_parts.append(
+                "Reservierung:\n"
+                + "\n".join(self._fmt_slot_line(s) for s in reservation.get("slots", [])))
+        if is_holiday and (reservation is not None or entry):
+            tip_parts.append(f"Feiertag: {holidays_map[day_date]}")
+        if tip_parts:
+            attach_tooltip(cell, "\n".join(tip_parts))
 
         # Heutigen Tag mit blauem Rahmen hervorheben. Vor dem Konflikt-Block,
         # damit ein Konflikt (orange) auf demselben Tag den Rand gewinnt.
@@ -948,9 +973,10 @@ class App:
             self.footer_label.config(text=f"Gesamt: {total_rounded}h")
 
     def _entry_hours(self, entry):
-        return calculate_hours(
-            entry["start"], entry["end"], pause_minutes=entry.get("pause", 0),
-        )
+        return round(sum(
+            calculate_hours(s["start"], s["end"], pause_minutes=s.get("pause", 0))
+            for s in entry.get("slots", [])
+        ), 2)
 
     def _dates_with_unresolved_conflicts(self):
         """Gibt die Menge der ISO-Datums-Strings zurück, für die ungelöste

--- a/src/ui.py
+++ b/src/ui.py
@@ -534,7 +534,7 @@ class App:
             footer_frame, "Teilen…", self._share, padx=12,
         ).pack(side=tk.RIGHT, padx=(0, 4))
         secondary_button(
-            footer_frame, "Monat senden", self._send, padx=12,
+            footer_frame, "Arbeitszeiten senden", self._send, padx=12,
         ).pack(side=tk.RIGHT)
 
     def _prev(self):
@@ -682,7 +682,7 @@ class App:
                 on_show=lambda: self.root.after(0, self._restore_from_tray),
                 on_quit=lambda: self.root.after(0, self._quit_with_sync_push),
                 actions=[
-                    ("Monat senden",
+                    ("Arbeitszeiten senden",
                      lambda: self.root.after(0, self._send), None),
                     ("Teilen…",
                      lambda: self.root.after(0, self._share), None),

--- a/src/ui.py
+++ b/src/ui.py
@@ -119,6 +119,25 @@ def _show_sync_error(parent, error, tb="", suffix=""):
         messagebox.showerror(title, message)
 
 
+def _delete_action(slots, selected, prefix):
+    """Entscheidet beim Rechtsklick-Löschen, was mit einem Typ (Arbeitszeit
+    bzw. Reservierung) passiert.
+
+    `selected` ist die Menge angehakter Keys; pro Typ entweder '<prefix>:all'
+    (ganzer Typ) oder '<prefix>:<index>' (einzelne Slots). Liefert (action,
+    keep): 'none' (Typ nicht betroffen) / 'delete' (Tag-Typ ganz löschen) /
+    'save' (mit den verbleibenden Slots überschreiben)."""
+    keys = {k for k in selected if k.startswith(prefix + ":")}
+    if not keys:
+        return "none", None
+    if f"{prefix}:all" in keys:
+        return "delete", None
+    keep = [s for i, s in enumerate(slots) if f"{prefix}:{i}" not in keys]
+    if not keep:
+        return "delete", None
+    return "save", keep
+
+
 class App:
     def __init__(self, root, storage, settings, base_path=".", conflicts_store=None,
                  reservation_store=None):
@@ -1225,14 +1244,16 @@ class App:
     def _delete_day(self, date_str):
         """Rechtsklick-Löschen für einen Tag. Löscht NIE ohne Bestätigung.
 
-        Je nachdem, was am Tag liegt:
-        - nur Arbeitszeit   → Ja/Nein-Abfrage
-        - nur Reservierung  → Ja/Nein-Abfrage
-        - beides            → Checkbox-Auswahl, was gelöscht werden soll
+        - Genau eine löschbare Einheit (1 Arbeitszeit-Slot ODER 1 Reservierung)
+          → Ja/Nein-Abfrage.
+        - Mehrere Einheiten (mehrere Slots und/oder Arbeitszeit + Reservierung)
+          → Auswahl-Dialog: pro Slot bzw. pro Typ eine Checkbox, alle
+          vorausgewählt; der „Löschen"-Button ist nach dem Öffnen kurz gesperrt
+          (gegen versehentliches Sofort-Löschen).
 
         Reservierungen werden nur berücksichtigt, wenn sie aktiv sind
-        (_reservations_active); das Löschen einer Reservierung stößt den
-        Kalender-Abgleich an.
+        (_reservations_active); eine Reservierungs-Änderung stößt den Kalender-
+        Abgleich an.
         """
         if _stray_click_suppressed(getattr(self.root, "_dialog_closed_at", 0),
                                    time.monotonic()):
@@ -1242,40 +1263,58 @@ class App:
             self.reservation_store.get(date_str)
             if self._reservations_active() else None
         )
-        if entry is None and reservation is None:
+        entry_slots = entry["slots"] if entry else []
+        res_slots = reservation["slots"] if reservation else []
+        if not entry_slots and not res_slots:
             return
 
         date_de = format_iso_date(date_str)
-        delete_entry = False
-        delete_reservation = False
 
-        if entry is not None and reservation is not None:
-            choice = themed_ask_delete_choice(
-                self.root, "Löschen", f"Was für den {date_de} löschen?",
-                [("entry", "Arbeitszeit"), ("reservation", "Reservierung")],
-            )
-            if not choice:
+        # Löschbare Einheiten: bei genau einem Slot der Typ als Ganzes, bei
+        # mehreren je Slot eine Checkbox.
+        options = []
+        if entry_slots:
+            if len(entry_slots) == 1:
+                options.append(("entry:all", "Arbeitszeit"))
+            else:
+                for i, s in enumerate(entry_slots):
+                    options.append((f"entry:{i}", f"Arbeitszeit  {self._fmt_slot_line(s)}"))
+        if res_slots:
+            if len(res_slots) == 1:
+                options.append(("reservation:all", "Reservierung"))
+            else:
+                for i, s in enumerate(res_slots):
+                    options.append((f"reservation:{i}", f"Reservierung  {self._fmt_slot_line(s)}"))
+
+        if len(options) == 1:
+            kind = "Arbeitszeit" if options[0][0].startswith("entry") else "Reservierung"
+            if not themed_askyesno(self.root, f"{kind} löschen",
+                                   f"{kind} für {date_de} löschen?"):
                 return
-            delete_entry = "entry" in choice
-            delete_reservation = "reservation" in choice
-        elif entry is not None:
-            if not themed_askyesno(self.root, "Arbeitszeit löschen",
-                                   f"Arbeitszeit für {date_de} löschen?"):
-                return
-            delete_entry = True
+            selected = {options[0][0]}
         else:
-            if not themed_askyesno(self.root, "Reservierung löschen",
-                                   f"Reservierung für {date_de} löschen?"):
+            selected = themed_ask_delete_choice(
+                self.root, "Löschen", f"Was für den {date_de} löschen?",
+                options, lock_ms=600,
+            )
+            if not selected:
                 return
-            delete_reservation = True
 
-        if delete_entry:
+        entry_action, entry_keep = _delete_action(entry_slots, selected, "entry")
+        if entry_action == "delete":
             self.storage.delete(date_str)
-        if delete_reservation:
+        elif entry_action == "save":
+            self.storage.save(date_str, entry_keep)
+
+        res_action, res_keep = _delete_action(res_slots, selected, "reservation")
+        res_touched = res_action != "none"
+        if res_action == "delete":
             self.reservation_store.delete(date_str)
+        elif res_action == "save":
+            self.reservation_store.save(date_str, res_keep)
 
         self._refresh()
-        if delete_reservation:
+        if res_touched:
             self._trigger_calendar_reconcile()
 
     def _open_dialog(self, date_str):

--- a/src/ui.py
+++ b/src/ui.py
@@ -73,6 +73,10 @@ def _friendly_sync_message(error, tb=""):
     bekommen eine verständliche Meldung OHNE Traceback. Nur bei wirklich
     unerwarteten Fehlern bleibt der Traceback erhalten (CLAUDE.md: Fehler im
     Sendepfad sichtbar machen)."""
+    from src.sync import OLD_REMOTE_VERSION_MSG
+    if str(error) == OLD_REMOTE_VERSION_MSG:
+        return ("Anderes Gerät veraltet", OLD_REMOTE_VERSION_MSG, True)
+
     kind = _classify_sync_error(error)
 
     if kind == "auth":

--- a/src/ui.py
+++ b/src/ui.py
@@ -242,7 +242,7 @@ class App:
                 )
             except TokenAuthError as e:
                 msg = str(e)
-                self.root.after(0, lambda: themed_showinfo(
+                self._marshal_to_ui(lambda: themed_showinfo(
                     self.root,
                     "Gmail-Anmeldung abgelaufen",
                     "Der Gmail-Token konnte nicht automatisch erneuert werden:\n\n"
@@ -254,7 +254,7 @@ class App:
             except Exception as e:
                 logging.getLogger(__name__).exception("Token-Refresh fehlgeschlagen")
                 err = f"{type(e).__name__}: {e}\n\n{traceback.format_exc()}"
-                self.root.after(0, lambda: themed_showinfo(
+                self._marshal_to_ui(lambda: themed_showinfo(
                     self.root, "Token-Refresh fehlgeschlagen", err
                 ))
 
@@ -284,7 +284,7 @@ class App:
                 logging.getLogger(__name__).exception("sender_email-Fetch fehlgeschlagen")
                 return
             if email and email != self.settings.get("sender_email"):
-                self.root.after(0, lambda: self.settings.set("sender_email", email))
+                self._marshal_to_ui(lambda: self.settings.set("sender_email", email))
 
         threading.Thread(target=worker, daemon=True).start()
 
@@ -313,8 +313,8 @@ class App:
                 # Trace landet im Logfile, falls jemand den Fehler diagnostizieren will.
                 logging.getLogger(__name__).exception("Update-Check fehlgeschlagen")
                 return
-            self.root.after(
-                0, lambda: self._handle_update_check_result(release, newer)
+            self._marshal_to_ui(
+                lambda: self._handle_update_check_result(release, newer)
             )
 
         threading.Thread(target=worker, daemon=True).start()
@@ -341,7 +341,7 @@ class App:
             result = run_calendar_reconcile(
                 self.reservation_store, self.settings, self.base_path)
             if result.get("ok"):
-                self.root.after(0, self._refresh)
+                self._marshal_to_ui(self._refresh)
 
         threading.Thread(target=worker, daemon=True).start()
 
@@ -358,7 +358,7 @@ class App:
             from src.main import run_calendar_reconcile
             result = run_calendar_reconcile(
                 self.reservation_store, self.settings, self.base_path)
-            self.root.after(0, lambda: self._on_reconcile_done(result))
+            self._marshal_to_ui(lambda: self._on_reconcile_done(result))
 
         threading.Thread(target=worker, daemon=True).start()
 
@@ -711,6 +711,27 @@ class App:
         self.root.deiconify()
         self.root.lift()
         self.root.focus_force()
+
+    def _marshal_to_ui(self, fn):
+        """Marshallt `fn` aus einem Daemon-Worker auf den Tk-Thread via
+        after(0) und verwirft den Aufruf still, falls das Fenster
+        zwischenzeitlich geschlossen wurde.
+
+        Hintergrund-Threads (Sync-Pull, Reconcile, Update-Check, Token-
+        Refresh) planen ihr Ergebnis per after(0). Schließt der Nutzer das
+        Fenster, bevor der Callback feuert, läuft er gegen den zerstörten
+        Tk-Interpreter -> "application has been destroyed" (TclError). Sowohl
+        das Einplanen als auch das spätere Ausführen werden daher gegen
+        TclError abgesichert (vgl. tooltip.py)."""
+        def guarded():
+            try:
+                fn()
+            except tk.TclError:
+                pass
+        try:
+            self.root.after(0, guarded)
+        except tk.TclError:
+            pass
 
     def _refresh(self):
         if self.view_mode == "month":
@@ -1393,7 +1414,7 @@ class App:
                 self.storage, self.settings, self.conflicts_store,
                 self.base_path, timeout_seconds=15,
             )
-            self.root.after(0, lambda: self._on_manual_sync_done(result))
+            self._marshal_to_ui(lambda: self._on_manual_sync_done(result))
         threading.Thread(target=_do, daemon=True).start()
 
     def _on_manual_sync_done(self, result):
@@ -1421,7 +1442,7 @@ class App:
                 self.storage, self.settings, self.conflicts_store,
                 self.base_path, timeout_seconds=15,
             )
-            self.root.after(0, lambda: self._on_tray_sync_done(result))
+            self._marshal_to_ui(lambda: self._on_tray_sync_done(result))
         threading.Thread(target=_do, daemon=True).start()
 
     def _on_tray_sync_done(self, result):

--- a/tests/test_category_defaults.py
+++ b/tests/test_category_defaults.py
@@ -1,0 +1,118 @@
+"""Pure Logik für die Per-Kategorie-Standardzeiten (Start/Ende/Pause).
+
+resolve_slot_defaults wendet einen Per-Feld-Fallback auf die globalen
+Standardwerte an; rename/remove halten das category_times-Dict konsistent
+zur Kategorie-Liste."""
+
+from src.category_defaults import (
+    remove_category_times,
+    rename_category_times,
+    resolve_slot_defaults,
+)
+
+G = ("08:00", "16:00", 30)  # globale Standardwerte (start, end, pause)
+
+
+# --- resolve_slot_defaults ---
+
+
+def test_unknown_category_falls_back_to_global():
+    assert resolve_slot_defaults({}, "Office", *G) == ("08:00", "16:00", 30)
+
+
+def test_empty_category_string_falls_back_to_global():
+    times = {"Office": {"start": "09:00", "end": "17:00", "pause": 0}}
+    assert resolve_slot_defaults(times, "", *G) == ("08:00", "16:00", 30)
+
+
+def test_full_category_overrides_all_fields():
+    times = {"Office": {"start": "09:00", "end": "17:00", "pause": 45}}
+    assert resolve_slot_defaults(times, "Office", *G) == ("09:00", "17:00", 45)
+
+
+def test_per_field_fallback_missing_keys():
+    """Fehlende Keys im Eintrag → globaler Fallback pro Feld."""
+    times = {"Office": {"start": "09:00"}}
+    assert resolve_slot_defaults(times, "Office", *G) == ("09:00", "16:00", 30)
+
+
+def test_per_field_fallback_empty_strings():
+    """Leere Strings zählen wie 'nicht gesetzt' → globaler Fallback."""
+    times = {"Office": {"start": "", "end": "", "pause": ""}}
+    assert resolve_slot_defaults(times, "Office", *G) == ("08:00", "16:00", 30)
+
+
+def test_pause_zero_is_kept_not_treated_as_unset():
+    times = {"Office": {"pause": 0}}
+    assert resolve_slot_defaults(times, "Office", *G) == ("08:00", "16:00", 0)
+
+
+def test_pause_string_is_coerced_to_int():
+    times = {"Office": {"pause": "45"}}
+    assert resolve_slot_defaults(times, "Office", *G) == ("08:00", "16:00", 45)
+
+
+def test_pause_garbage_falls_back_to_global():
+    times = {"Office": {"pause": "abc"}}
+    assert resolve_slot_defaults(times, "Office", *G) == ("08:00", "16:00", 30)
+
+
+def test_non_dict_entry_falls_back_to_global():
+    times = {"Office": "kaputt"}
+    assert resolve_slot_defaults(times, "Office", *G) == ("08:00", "16:00", 30)
+
+
+# --- rename_category_times ---
+
+
+def test_rename_moves_entry():
+    times = {"Office": {"start": "09:00", "end": "17:00", "pause": 0}}
+    out = rename_category_times(times, "Office", "Büro")
+    assert out == {"Büro": {"start": "09:00", "end": "17:00", "pause": 0}}
+
+
+def test_rename_returns_new_dict_original_untouched():
+    times = {"Office": {"start": "09:00"}}
+    out = rename_category_times(times, "Office", "Büro")
+    assert times == {"Office": {"start": "09:00"}}
+    assert out is not times
+
+
+def test_rename_noop_when_old_has_no_times():
+    times = {"Office": {"start": "09:00"}}
+    assert rename_category_times(times, "Homeoffice", "HO") == times
+
+
+def test_rename_noop_when_new_empty():
+    times = {"Office": {"start": "09:00"}}
+    assert rename_category_times(times, "Office", "  ") == times
+
+
+def test_rename_does_not_clobber_existing_new_entry():
+    times = {"Office": {"start": "09:00"}, "Büro": {"start": "10:00"}}
+    assert rename_category_times(times, "Office", "Büro") == times
+
+
+def test_rename_same_name_is_noop():
+    times = {"Office": {"start": "09:00"}}
+    assert rename_category_times(times, "Office", "Office") == times
+
+
+# --- remove_category_times ---
+
+
+def test_remove_drops_entry():
+    times = {"Office": {"start": "09:00"}, "Büro": {"start": "10:00"}}
+    assert remove_category_times(times, "Office") == {"Büro": {"start": "10:00"}}
+
+
+def test_remove_returns_new_dict_original_untouched():
+    times = {"Office": {"start": "09:00"}}
+    out = remove_category_times(times, "Office")
+    assert times == {"Office": {"start": "09:00"}}
+    assert out is not times
+
+
+def test_remove_unknown_is_noop():
+    times = {"Office": {"start": "09:00"}}
+    assert remove_category_times(times, "Homeoffice") == times

--- a/tests/test_category_defaults.py
+++ b/tests/test_category_defaults.py
@@ -4,11 +4,7 @@ resolve_slot_defaults wendet einen Per-Feld-Fallback auf die globalen
 Standardwerte an; rename/remove halten das category_times-Dict konsistent
 zur Kategorie-Liste."""
 
-from src.category_defaults import (
-    remove_category_times,
-    rename_category_times,
-    resolve_slot_defaults,
-)
+from src.category_defaults import resolve_slot_defaults
 
 G = ("08:00", "16:00", 30)  # globale Standardwerte (start, end, pause)
 
@@ -60,59 +56,3 @@ def test_pause_garbage_falls_back_to_global():
 def test_non_dict_entry_falls_back_to_global():
     times = {"Office": "kaputt"}
     assert resolve_slot_defaults(times, "Office", *G) == ("08:00", "16:00", 30)
-
-
-# --- rename_category_times ---
-
-
-def test_rename_moves_entry():
-    times = {"Office": {"start": "09:00", "end": "17:00", "pause": 0}}
-    out = rename_category_times(times, "Office", "Büro")
-    assert out == {"Büro": {"start": "09:00", "end": "17:00", "pause": 0}}
-
-
-def test_rename_returns_new_dict_original_untouched():
-    times = {"Office": {"start": "09:00"}}
-    out = rename_category_times(times, "Office", "Büro")
-    assert times == {"Office": {"start": "09:00"}}
-    assert out is not times
-
-
-def test_rename_noop_when_old_has_no_times():
-    times = {"Office": {"start": "09:00"}}
-    assert rename_category_times(times, "Homeoffice", "HO") == times
-
-
-def test_rename_noop_when_new_empty():
-    times = {"Office": {"start": "09:00"}}
-    assert rename_category_times(times, "Office", "  ") == times
-
-
-def test_rename_does_not_clobber_existing_new_entry():
-    times = {"Office": {"start": "09:00"}, "Büro": {"start": "10:00"}}
-    assert rename_category_times(times, "Office", "Büro") == times
-
-
-def test_rename_same_name_is_noop():
-    times = {"Office": {"start": "09:00"}}
-    assert rename_category_times(times, "Office", "Office") == times
-
-
-# --- remove_category_times ---
-
-
-def test_remove_drops_entry():
-    times = {"Office": {"start": "09:00"}, "Büro": {"start": "10:00"}}
-    assert remove_category_times(times, "Office") == {"Büro": {"start": "10:00"}}
-
-
-def test_remove_returns_new_dict_original_untouched():
-    times = {"Office": {"start": "09:00"}}
-    out = remove_category_times(times, "Office")
-    assert times == {"Office": {"start": "09:00"}}
-    assert out is not times
-
-
-def test_remove_unknown_is_noop():
-    times = {"Office": {"start": "09:00"}}
-    assert remove_category_times(times, "Homeoffice") == times

--- a/tests/test_category_dialog.py
+++ b/tests/test_category_dialog.py
@@ -1,0 +1,56 @@
+from src.dialogs.category_dialog import add_category, remove_category, rename_category
+
+
+def test_add_category():
+    assert add_category([], "Büro") == ["Büro"]
+
+
+def test_add_strips_whitespace():
+    assert add_category([], "  Büro  ") == ["Büro"]
+
+
+def test_add_empty_is_ignored():
+    assert add_category(["A"], "   ") == ["A"]
+
+
+def test_add_duplicate_is_ignored():
+    assert add_category(["Büro"], "Büro") == ["Büro"]
+
+
+def test_add_returns_new_list():
+    orig = ["A"]
+    result = add_category(orig, "B")
+    assert orig == ["A"]            # Original unverändert
+    assert result == ["A", "B"]
+
+
+def test_remove_category():
+    assert remove_category(["A", "B"], "A") == ["B"]
+
+
+def test_remove_absent_is_noop():
+    assert remove_category(["A"], "X") == ["A"]
+
+
+def test_rename_category():
+    assert rename_category(["A", "B"], "A", "C") == ["C", "B"]
+
+
+def test_rename_strips_whitespace():
+    assert rename_category(["A"], "A", "  C  ") == ["C"]
+
+
+def test_rename_empty_new_is_ignored():
+    assert rename_category(["A"], "A", "   ") == ["A"]
+
+
+def test_rename_absent_old_is_noop():
+    assert rename_category(["A"], "X", "C") == ["A"]
+
+
+def test_rename_to_existing_other_is_ignored():
+    assert rename_category(["A", "B"], "A", "B") == ["A", "B"]
+
+
+def test_rename_to_same_name_keeps_list():
+    assert rename_category(["A", "B"], "A", "A") == ["A", "B"]

--- a/tests/test_category_dialog.py
+++ b/tests/test_category_dialog.py
@@ -1,56 +1,76 @@
-from src.dialogs.category_dialog import add_category, remove_category, rename_category
+"""collect_categories baut aus den Inline-Zeilen (Name + Start/Ende/Pause) die
+beiden persistierten Strukturen: die categories-Liste und das category_times-
+Dict. STANDARD/leere Felder entfallen → Per-Feld-Fallback auf global."""
+
+from src.dialogs.category_dialog import STANDARD, collect_categories
 
 
-def test_add_category():
-    assert add_category([], "Büro") == ["Büro"]
+def _row(name, start=STANDARD, end=STANDARD, pause=STANDARD):
+    return {"name": name, "start": start, "end": end, "pause": pause}
 
 
-def test_add_strips_whitespace():
-    assert add_category([], "  Büro  ") == ["Büro"]
+def test_empty_rows_yield_empty_structures():
+    assert collect_categories([]) == ([], {})
 
 
-def test_add_empty_is_ignored():
-    assert add_category(["A"], "   ") == ["A"]
+def test_name_only_row_has_no_times():
+    cats, times = collect_categories([_row("Office")])
+    assert cats == ["Office"]
+    assert times == {}
 
 
-def test_add_duplicate_is_ignored():
-    assert add_category(["Büro"], "Büro") == ["Büro"]
+def test_full_row_persists_all_fields():
+    cats, times = collect_categories([_row("Office", "09:00", "17:00", "30")])
+    assert cats == ["Office"]
+    assert times == {"Office": {"start": "09:00", "end": "17:00", "pause": 30}}
 
 
-def test_add_returns_new_list():
-    orig = ["A"]
-    result = add_category(orig, "B")
-    assert orig == ["A"]            # Original unverändert
-    assert result == ["A", "B"]
+def test_partial_row_only_persists_set_fields():
+    cats, times = collect_categories([_row("Office", start="09:00")])
+    assert cats == ["Office"]
+    assert times == {"Office": {"start": "09:00"}}
 
 
-def test_remove_category():
-    assert remove_category(["A", "B"], "A") == ["B"]
+def test_pause_zero_is_kept():
+    _, times = collect_categories([_row("Office", pause="0")])
+    assert times == {"Office": {"pause": 0}}
 
 
-def test_remove_absent_is_noop():
-    assert remove_category(["A"], "X") == ["A"]
+def test_name_is_trimmed():
+    cats, _ = collect_categories([_row("  Office  ")])
+    assert cats == ["Office"]
 
 
-def test_rename_category():
-    assert rename_category(["A", "B"], "A", "C") == ["C", "B"]
+def test_empty_name_row_is_skipped():
+    cats, times = collect_categories([_row("   ", "09:00", "17:00", "30")])
+    assert cats == []
+    assert times == {}
 
 
-def test_rename_strips_whitespace():
-    assert rename_category(["A"], "A", "  C  ") == ["C"]
+def test_duplicate_name_keeps_first_occurrence():
+    rows = [
+        _row("Office", "09:00", "17:00", "30"),
+        _row("Office", "10:00", "18:00", "45"),
+    ]
+    cats, times = collect_categories(rows)
+    assert cats == ["Office"]
+    assert times == {"Office": {"start": "09:00", "end": "17:00", "pause": 30}}
 
 
-def test_rename_empty_new_is_ignored():
-    assert rename_category(["A"], "A", "   ") == ["A"]
+def test_order_is_preserved():
+    cats, _ = collect_categories([_row("B"), _row("A"), _row("C")])
+    assert cats == ["B", "A", "C"]
 
 
-def test_rename_absent_old_is_noop():
-    assert rename_category(["A"], "X", "C") == ["A"]
-
-
-def test_rename_to_existing_other_is_ignored():
-    assert rename_category(["A", "B"], "A", "B") == ["A", "B"]
-
-
-def test_rename_to_same_name_keeps_list():
-    assert rename_category(["A", "B"], "A", "A") == ["A", "B"]
+def test_multiple_categories_mixed_times():
+    rows = [
+        _row("Office", "09:00", "17:00", "30"),
+        _row("Homeoffice"),
+        _row("Kunde", start="08:00"),
+    ]
+    cats, times = collect_categories(rows)
+    assert cats == ["Office", "Homeoffice", "Kunde"]
+    assert times == {
+        "Office": {"start": "09:00", "end": "17:00", "pause": 30},
+        "Kunde": {"start": "08:00"},
+    }

--- a/tests/test_conflicts_dialog.py
+++ b/tests/test_conflicts_dialog.py
@@ -1,0 +1,39 @@
+from src.dialogs.conflicts_dialog import _entry_chosen, _fmt_entry_candidate
+
+
+def _cand(slots=None, deleted=False, modified_at="2026-05-20T10:00:00Z", device_id="devABCDEF"):
+    c = {"modified_at": modified_at, "device_id": device_id, "deleted": deleted}
+    if slots is not None:
+        c["slots"] = slots
+    return c
+
+
+def test_entry_chosen_carries_slots():
+    cand = _cand(slots=[{"start": "08:00", "end": "16:00", "pause": 30, "kategorie": "Büro"}])
+    assert _entry_chosen(cand) == {
+        "slots": [{"start": "08:00", "end": "16:00", "pause": 30, "kategorie": "Büro"}],
+        "deleted": False,
+    }
+
+
+def test_entry_chosen_multi_slot_not_lost():
+    slots = [{"start": "08:00", "end": "12:00", "pause": 0, "kategorie": "A"},
+             {"start": "13:00", "end": "17:00", "pause": 30, "kategorie": "B"}]
+    assert _entry_chosen(_cand(slots=slots))["slots"] == slots
+
+
+def test_entry_chosen_deleted_candidate():
+    assert _entry_chosen(_cand(slots=[], deleted=True)) == {"slots": [], "deleted": True}
+
+
+def test_fmt_entry_candidate_lists_slots():
+    cand = _cand(slots=[{"start": "08:00", "end": "12:00", "pause": 0, "kategorie": "Büro"},
+                        {"start": "13:00", "end": "17:00", "pause": 30, "kategorie": ""}])
+    text = _fmt_entry_candidate(cand)
+    assert "08:00—12:00" in text
+    assert "Büro" in text
+    assert "13:00—17:00" in text
+
+
+def test_fmt_entry_candidate_deleted():
+    assert "GELÖSCHT" in _fmt_entry_candidate(_cand(slots=[], deleted=True))

--- a/tests/test_delete_button.py
+++ b/tests/test_delete_button.py
@@ -1,0 +1,29 @@
+"""Sichtbarkeit des macOS-Lösch-Buttons in der Tageszelle.
+
+Reine Entscheidungslogik `_should_show_delete_button`. Die Tk-Verdrahtung
+(_add_delete_button, Aufruf in _build_day_cell, Hover-Repaint) ist UI-Schicht
+und wird wie üblich manuell auf macOS verifiziert.
+"""
+from src.theme import _should_show_delete_button
+
+
+def test_not_macos_never_shows():
+    assert _should_show_delete_button(False, True, True) is False
+    assert _should_show_delete_button(False, True, False) is False
+    assert _should_show_delete_button(False, False, True) is False
+
+
+def test_macos_without_deletable_units_hidden():
+    assert _should_show_delete_button(True, False, False) is False
+
+
+def test_macos_with_entry_shows():
+    assert _should_show_delete_button(True, True, False) is True
+
+
+def test_macos_with_reservation_only_shows():
+    assert _should_show_delete_button(True, False, True) is True
+
+
+def test_macos_with_both_shows():
+    assert _should_show_delete_button(True, True, True) is True

--- a/tests/test_gcal.py
+++ b/tests/test_gcal.py
@@ -2,28 +2,48 @@ from src import gcal
 
 
 def test_event_payload_has_summary_and_marker():
-    body = gcal.event_payload("2026-06-01", "09:00", "17:00", "2026-05-20T10:00:00Z")
+    body = gcal.event_payload("2026-06-01", "09:00", "17:00", "", "2026-05-20T10:00:00Z")
     assert body["summary"] == gcal.EVENT_SUMMARY
     private = body["extendedProperties"]["private"]
     assert private[gcal.APP_MARKER_KEY] == gcal.APP_MARKER_VALUE
+    assert private["kategorie"] == ""
     assert private["modified_at"] == "2026-05-20T10:00:00Z"
 
 
+def test_event_payload_summary_includes_kategorie():
+    body = gcal.event_payload("2026-06-01", "09:00", "17:00", "Büro", "2026-05-20T10:00:00Z")
+    assert body["summary"] == f"{gcal.EVENT_SUMMARY} — Büro"
+    assert body["extendedProperties"]["private"]["kategorie"] == "Büro"
+
+
 def test_event_payload_datetime_encodes_date_and_time():
-    body = gcal.event_payload("2026-06-01", "09:30", "17:45", "2026-05-20T10:00:00Z")
-    # dateTime trägt das Datum und die HH:MM-Zeit (plus lokalem Offset).
+    body = gcal.event_payload("2026-06-01", "09:30", "17:45", "", "2026-05-20T10:00:00Z")
     assert body["start"]["dateTime"].startswith("2026-06-01T09:30:00")
     assert body["end"]["dateTime"].startswith("2026-06-01T17:45:00")
 
 
-def test_parse_event_roundtrips_payload():
-    body = gcal.event_payload("2026-06-01", "09:00", "17:00", "2026-05-20T10:00:00Z")
+def test_parse_event_roundtrips_payload_with_kategorie():
+    body = gcal.event_payload("2026-06-01", "09:00", "17:00", "Büro", "2026-05-20T10:00:00Z")
     body["id"] = "ev-42"
     parsed = gcal.parse_event(body)
     assert parsed == {
         "date": "2026-06-01", "start": "09:00", "end": "17:00",
-        "modified_at": "2026-05-20T10:00:00Z", "event_id": "ev-42",
+        "kategorie": "Büro", "modified_at": "2026-05-20T10:00:00Z", "event_id": "ev-42",
     }
+
+
+def test_parse_event_missing_kategorie_defaults_empty():
+    # Event ohne kategorie-Property (z.B. von einer älteren App-Version)
+    body = {
+        "id": "ev-1",
+        "start": {"dateTime": "2026-06-01T09:00:00+02:00"},
+        "end": {"dateTime": "2026-06-01T17:00:00+02:00"},
+        "extendedProperties": {"private": {
+            gcal.APP_MARKER_KEY: gcal.APP_MARKER_VALUE,
+            "modified_at": "2026-05-20T10:00:00Z",
+        }},
+    }
+    assert gcal.parse_event(body)["kategorie"] == ""
 
 
 def test_parse_event_ignores_non_app_events():
@@ -88,7 +108,7 @@ class _FakeService:
 
 
 def test_list_app_events_filters_and_parses():
-    body = gcal.event_payload("2026-06-01", "09:00", "17:00", "2026-05-20T10:00:00Z")
+    body = gcal.event_payload("2026-06-01", "09:00", "17:00", "", "2026-05-20T10:00:00Z")
     body["id"] = "ev-1"
     foreign = {"id": "ev-2", "start": {"dateTime": "2026-06-02T09:00:00+02:00"},
                "end": {"dateTime": "2026-06-02T17:00:00+02:00"}}
@@ -108,9 +128,20 @@ def test_create_event_returns_event_id():
     recorder = []
     service = _FakeService(recorder)
     event_id = gcal.create_event(
-        service, "cal-1", "2026-06-01", "09:00", "17:00", "2026-05-20T10:00:00Z")
+        service, "cal-1", "2026-06-01", "09:00", "17:00", "Büro", "2026-05-20T10:00:00Z")
     assert event_id == "created-id"
     assert recorder[0][0] == "insert"
+    assert recorder[0][1]["body"]["extendedProperties"]["private"]["kategorie"] == "Büro"
+
+
+def test_update_event_sends_kategorie():
+    recorder = []
+    service = _FakeService(recorder)
+    gcal.update_event(
+        service, "cal-1", "ev-1", "2026-06-01", "09:00", "17:00", "HO", "2026-05-20T10:00:00Z")
+    assert recorder[0][0] == "update"
+    assert recorder[0][1]["eventId"] == "ev-1"
+    assert recorder[0][1]["body"]["extendedProperties"]["private"]["kategorie"] == "HO"
 
 
 def test_delete_event_swallows_already_gone():
@@ -129,5 +160,4 @@ def test_delete_event_swallows_already_gone():
                     return _Boom()
             return _E()
 
-    # Darf NICHT werfen.
     gcal.delete_event(_GoneService(), "cal-1", "ev-x")

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,15 +1,26 @@
 import datetime
+from unittest.mock import patch, MagicMock
+
 from src.report import generate_report
+
+
+def _e(start, end, pause=0, kategorie=""):
+    """Eintrag mit genau einem Slot."""
+    return {"slots": [{"start": start, "end": end, "pause": pause, "kategorie": kategorie}]}
+
+
+def _slot(start, end, pause=0, kategorie=""):
+    return {"start": start, "end": end, "pause": pause, "kategorie": kategorie}
+
 
 def test_empty_entries():
     html, total = generate_report(datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), {})
     assert html is None
     assert total == 0
 
+
 def test_single_entry():
-    entries = {
-        "2026-03-23": {"start": "08:00", "end": "16:30", "pause": 30}
-    }
+    entries = {"2026-03-23": _e("08:00", "16:30", 30)}
     html, total = generate_report(datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries)
     assert "23.03.2026" in html
     assert "Mo" in html
@@ -17,106 +28,160 @@ def test_single_entry():
     assert "16:30" in html
     assert "8.0h" in html
     assert "<table" in html
-    # Dark mode styling
     assert "#0f172a" in html
     assert "#00D8A7" in html
 
+
+def test_kategorie_column_present():
+    entries = {"2026-03-23": _e("08:00", "16:00", 0, "Büro")}
+    html, _ = generate_report(datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries)
+    assert "Kategorie" in html   # Spaltenkopf
+    assert "Büro" in html        # Wert
+
+
 def test_multiple_entries_sorted():
-    entries = {
-        "2026-03-25": {"start": "09:00", "end": "17:00", "pause": 30},
-        "2026-03-23": {"start": "08:00", "end": "16:30", "pause": 30},
-    }
+    entries = {"2026-03-25": _e("09:00", "17:00", 30), "2026-03-23": _e("08:00", "16:30", 30)}
     html, total = generate_report(datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries)
-    pos_23 = html.index("23.03.2026")
-    pos_25 = html.index("25.03.2026")
-    assert pos_23 < pos_25
+    assert html.index("23.03.2026") < html.index("25.03.2026")
+
 
 def test_total_hours():
-    entries = {
-        "2026-03-23": {"start": "08:00", "end": "16:30", "pause": 30},
-        "2026-03-24": {"start": "09:00", "end": "17:00", "pause": 60},
-    }
+    entries = {"2026-03-23": _e("08:00", "16:30", 30), "2026-03-24": _e("09:00", "17:00", 60)}
     html, total = generate_report(datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries)
     assert "15.0h" in html
     assert total == 15.0
 
-def test_filters_outside_range():
+
+def test_multi_slot_day_rows_and_subtotal():
+    """Ein Tag mit zwei Slots: beide Slots als Zeilen + Tages-Subtotal."""
+    entries = {"2026-03-23": {"slots": [
+        _slot("08:00", "12:00", 0, "Büro"),
+        _slot("13:00", "17:00", 0, "Homeoffice"),
+    ]}}
+    html, total = generate_report(datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries)
+    assert "08:00" in html and "12:00" in html
+    assert "13:00" in html and "17:00" in html
+    assert "Büro" in html and "Homeoffice" in html
+    assert "Summe 23.03.2026" in html   # Tages-Subtotal bei >1 Slot
+    assert total == 8.0
+
+
+def test_single_slot_day_has_no_subtotal():
+    entries = {"2026-03-23": _e("08:00", "16:00")}
+    html, _ = generate_report(datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries)
+    assert "Summe 23.03.2026" not in html
+
+
+def test_category_summary_block():
     entries = {
-        "2026-03-23": {"start": "08:00", "end": "16:30", "pause": 0},
-        "2026-04-01": {"start": "09:00", "end": "17:00", "pause": 0},
+        "2026-03-23": {"slots": [_slot("08:00", "12:00", 0, "Büro"),
+                                  _slot("13:00", "17:00", 0, "Homeoffice")]},
+        "2026-03-24": _e("08:00", "12:00", 0, "Büro"),
     }
+    html, _ = generate_report(datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries)
+    # Büro: 4h (Di) + 4h (Mo) = 8h; Homeoffice: 4h
+    assert "Büro" in html
+    assert "Homeoffice" in html
+    assert "8.0h" in html
+    assert "4.0h" in html
+
+
+def test_category_summary_uncategorized_label():
+    entries = {"2026-03-23": _e("08:00", "16:00")}  # kategorie ""
+    html, _ = generate_report(datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries)
+    assert "(ohne Kategorie)" in html
+
+
+def test_category_filter_includes_only_selected():
+    entries = {"2026-03-23": {"slots": [_slot("08:00", "12:00", 0, "Büro"),
+                                         _slot("13:00", "17:00", 0, "Homeoffice")]}}
+    html, total = generate_report(
+        datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries, categories={"Büro"})
+    assert "Büro" in html
+    assert "Homeoffice" not in html
+    assert total == 4.0
+
+
+def test_category_filter_uncategorized_via_empty_string():
+    entries = {"2026-03-23": {"slots": [_slot("08:00", "12:00", 0, ""),
+                                         _slot("13:00", "17:00", 0, "Büro")]}}
+    html, total = generate_report(
+        datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries, categories={""})
+    assert total == 4.0
+    assert "Büro" not in html
+
+
+def test_category_filter_empty_result_returns_none():
+    entries = {"2026-03-23": _e("08:00", "16:00", 0, "Büro")}
+    html, total = generate_report(
+        datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries, categories={"Nichtvorhanden"})
+    assert html is None
+    assert total == 0
+
+
+def test_filters_outside_range():
+    entries = {"2026-03-23": _e("08:00", "16:30"), "2026-04-01": _e("09:00", "17:00")}
     html, total = generate_report(datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries)
     assert "23.03.2026" in html
     assert "01.04.2026" not in html
 
+
 def test_legacy_entry_no_pause():
-    entries = {
-        "2026-03-23": {"start": "08:00", "end": "16:30"}
-    }
+    # Slot ohne pause-Key (Default 0)
+    entries = {"2026-03-23": {"slots": [{"start": "08:00", "end": "16:30", "kategorie": ""}]}}
     html, total = generate_report(datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries)
     assert "8.5h" in html
 
+
 def test_cross_month_range():
     entries = {
-        "2026-02-20": {"start": "08:00", "end": "16:00", "pause": 0},
-        "2026-03-05": {"start": "09:00", "end": "17:00", "pause": 0},
-        "2026-03-20": {"start": "08:00", "end": "16:00", "pause": 0},
+        "2026-02-20": _e("08:00", "16:00"), "2026-03-05": _e("09:00", "17:00"),
+        "2026-03-20": _e("08:00", "16:00"),
     }
     html, total = generate_report(datetime.date(2026, 2, 15), datetime.date(2026, 3, 14), entries)
     assert "20.02.2026" in html
     assert "05.03.2026" in html
     assert "20.03.2026" not in html
 
+
 def test_inclusive_boundaries():
     entries = {
-        "2026-03-01": {"start": "08:00", "end": "16:00", "pause": 0},
-        "2026-03-15": {"start": "08:00", "end": "16:00", "pause": 0},
-        "2026-03-16": {"start": "08:00", "end": "16:00", "pause": 0},
+        "2026-03-01": _e("08:00", "16:00"), "2026-03-15": _e("08:00", "16:00"),
+        "2026-03-16": _e("08:00", "16:00"),
     }
     html, total = generate_report(datetime.date(2026, 3, 1), datetime.date(2026, 3, 15), entries)
     assert "01.03.2026" in html
     assert "15.03.2026" in html
     assert "16.03.2026" not in html
 
+
 def test_alternating_row_colors():
-    entries = {
-        "2026-03-23": {"start": "08:00", "end": "16:00", "pause": 0},
-        "2026-03-24": {"start": "08:00", "end": "16:00", "pause": 0},
-    }
+    entries = {"2026-03-23": _e("08:00", "16:00"), "2026-03-24": _e("08:00", "16:00")}
     html, total = generate_report(datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries)
     assert "#1e293b" in html
     assert "#243347" in html
 
+
 def test_greeting_content_closing_in_html():
-    entries = {
-        "2026-03-23": {"start": "08:00", "end": "16:00", "pause": 0}
-    }
+    entries = {"2026-03-23": _e("08:00", "16:00")}
     html, total = generate_report(
         datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries,
-        greeting="Hallo Welt,",
-        content="hier die Zeiten für {zeitraum}.",
-        closing="Grüße\nMax"
-    )
+        greeting="Hallo Welt,", content="hier die Zeiten für {zeitraum}.", closing="Grüße\nMax")
     assert "Hallo Welt," in html
     assert "hier die Zeiten für 01.03.2026 – 31.03.2026." in html
     assert "Grüße" in html
     assert "Max" in html
 
+
 def test_placeholders_replaced():
-    entries = {
-        "2026-03-23": {"start": "08:00", "end": "16:00", "pause": 0}
-    }
+    entries = {"2026-03-23": _e("08:00", "16:00")}
     html, total = generate_report(
-        datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries,
-        content="Gesamt: {gesamt}"
-    )
+        datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries, content="Gesamt: {gesamt}")
     assert "Gesamt: 8.0h" in html
 
 
 def test_week_header_and_sum_present():
-    entries = {
-        "2026-03-23": {"start": "08:00", "end": "16:00", "pause": 0},
-    }
+    entries = {"2026-03-23": _e("08:00", "16:00")}
     html, total = generate_report(datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries)
     assert "KW 13" in html
     assert "Summe KW 13" in html
@@ -125,98 +190,84 @@ def test_week_header_and_sum_present():
 
 def test_multiple_weeks_each_have_header_and_sum():
     entries = {
-        "2026-03-23": {"start": "08:00", "end": "16:00", "pause": 0},
-        "2026-03-24": {"start": "09:00", "end": "17:00", "pause": 0},
-        "2026-03-30": {"start": "08:00", "end": "17:00", "pause": 60},
+        "2026-03-23": _e("08:00", "16:00"), "2026-03-24": _e("09:00", "17:00"),
+        "2026-03-30": _e("08:00", "17:00", 60),
     }
     html, total = generate_report(datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries)
     assert "KW 13" in html
     assert "KW 14" in html
     assert "Summe KW 13" in html
     assert "Summe KW 14" in html
-    pos_kw13 = html.index("KW 13")
-    pos_kw14 = html.index("KW 14")
-    assert pos_kw13 < pos_kw14
+    assert html.index("KW 13") < html.index("KW 14")
 
 
 def test_week_sum_equals_sum_of_days():
-    entries = {
-        "2026-03-23": {"start": "08:00", "end": "16:00", "pause": 0},
-        "2026-03-24": {"start": "09:00", "end": "17:00", "pause": 0},
-    }
+    entries = {"2026-03-23": _e("08:00", "16:00"), "2026-03-24": _e("09:00", "17:00")}
     html, total = generate_report(datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries)
     assert "16.0h" in html
     assert total == 16.0
 
 
 def test_iso_week_across_year_boundary():
-    entries = {
-        "2025-12-29": {"start": "08:00", "end": "16:00", "pause": 0},
-    }
+    entries = {"2025-12-29": _e("08:00", "16:00")}
     html, total = generate_report(datetime.date(2025, 12, 1), datetime.date(2026, 1, 31), entries)
     assert "KW 1" in html
 
 
-from unittest.mock import patch, MagicMock
-
-
 # --- HTML-Escaping ---
 
+
 def test_greeting_with_ampersand_is_escaped():
-    entries = {"2026-03-23": {"start": "08:00", "end": "16:00", "pause": 0}}
+    entries = {"2026-03-23": _e("08:00", "16:00")}
     html, _ = generate_report(
-        datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries,
-        greeting="Mayer & Söhne,",
-    )
+        datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries, greeting="Mayer & Söhne,")
     assert "Mayer &amp; Söhne," in html
     assert "Mayer & Söhne" not in html
 
 
 def test_greeting_with_html_tag_is_escaped():
-    entries = {"2026-03-23": {"start": "08:00", "end": "16:00", "pause": 0}}
+    entries = {"2026-03-23": _e("08:00", "16:00")}
     html, _ = generate_report(
         datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries,
-        greeting="<script>alert(1)</script>",
-    )
+        greeting="<script>alert(1)</script>")
     assert "&lt;script&gt;alert(1)&lt;/script&gt;" in html
     assert "<script>alert(1)</script>" not in html
 
 
+def test_kategorie_is_escaped():
+    """Kategorie ist freier Nutzertext und muss escaped werden."""
+    entries = {"2026-03-23": _e("08:00", "16:00", 0, "Mayer & <b>Co</b>")}
+    html, _ = generate_report(datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries)
+    assert "Mayer &amp; &lt;b&gt;Co&lt;/b&gt;" in html
+    assert "<b>Co</b>" not in html
+
+
 def test_content_newline_becomes_br():
-    entries = {"2026-03-23": {"start": "08:00", "end": "16:00", "pause": 0}}
+    entries = {"2026-03-23": _e("08:00", "16:00")}
     html, _ = generate_report(
-        datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries,
-        content="Zeile1\nZeile2",
-    )
+        datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries, content="Zeile1\nZeile2")
     assert "Zeile1<br>Zeile2" in html
 
 
 def test_closing_with_lt_and_newline_escaped_with_br():
-    entries = {"2026-03-23": {"start": "08:00", "end": "16:00", "pause": 0}}
+    entries = {"2026-03-23": _e("08:00", "16:00")}
     html, _ = generate_report(
-        datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries,
-        closing="A < B\nFreundlich",
-    )
-    # `<` muss escaped sein, `<br>` darf NICHT escaped sein
+        datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries, closing="A < B\nFreundlich")
     assert "A &lt; B<br>Freundlich" in html
     assert "&lt;br&gt;" not in html
 
 
 def test_placeholder_zeitraum_replaced_after_escape():
-    entries = {"2026-03-23": {"start": "08:00", "end": "16:00", "pause": 0}}
+    entries = {"2026-03-23": _e("08:00", "16:00")}
     html, _ = generate_report(
-        datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries,
-        content="Zeitraum: {zeitraum}",
-    )
+        datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries, content="Zeitraum: {zeitraum}")
     assert "Zeitraum: 01.03.2026 – 31.03.2026" in html
 
 
 def test_pdf_name_is_escaped():
-    """generate_pdf escaped name vor der HTML-Generierung. xhtml2pdf wird
-    gemockt, damit der Test ohne installierte Lib läuft (CI-kompatibel)."""
+    """generate_pdf escaped name; xhtml2pdf wird gemockt (CI ohne Lib)."""
     from src import report as report_mod
-    entries = {"2026-03-23": {"start": "08:00", "end": "16:00", "pause": 0}}
-
+    entries = {"2026-03-23": _e("08:00", "16:00")}
     captured_html = {}
 
     class FakePisa:
@@ -230,9 +281,31 @@ def test_pdf_name_is_escaped():
 
     with patch.dict("sys.modules", {"xhtml2pdf": fake_xhtml2pdf}):
         report_mod.generate_pdf(
-            datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries,
-            name="Müller & Co",
-        )
+            datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries, name="Müller & Co")
 
     assert "Müller &amp; Co" in captured_html["html"]
     assert "Müller & Co" not in captured_html["html"]
+
+
+def test_pdf_category_filter_applied():
+    """generate_pdf respektiert den categories-Filter."""
+    from src import report as report_mod
+    entries = {"2026-03-23": {"slots": [{"start": "08:00", "end": "12:00", "pause": 0, "kategorie": "Büro"},
+                                         {"start": "13:00", "end": "17:00", "pause": 0, "kategorie": "HO"}]}}
+    captured_html = {}
+
+    class FakePisa:
+        @staticmethod
+        def CreatePDF(html_str, dest):
+            captured_html["html"] = html_str
+            return MagicMock(err=0)
+
+    fake_xhtml2pdf = MagicMock()
+    fake_xhtml2pdf.pisa = FakePisa
+
+    with patch.dict("sys.modules", {"xhtml2pdf": fake_xhtml2pdf}):
+        report_mod.generate_pdf(
+            datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries, categories={"Büro"})
+
+    assert "Büro" in captured_html["html"]
+    assert "HO" not in captured_html["html"]

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -309,3 +309,40 @@ def test_pdf_category_filter_applied():
 
     assert "Büro" in captured_html["html"]
     assert "HO" not in captured_html["html"]
+
+
+from src.report import total_hours
+
+
+def test_total_hours_basic():
+    entries = {"2026-03-23": _e("08:00", "16:00", 0)}
+    assert total_hours(datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries) == 8.0
+
+
+def test_total_hours_sums_slots_and_days():
+    entries = {
+        "2026-03-23": {"slots": [_slot("08:00", "12:00", 0, "Büro"), _slot("13:00", "17:00", 30, "HO")]},
+        "2026-03-24": _e("09:00", "17:00", 60),
+    }
+    # 4 + 3.5 + 7 = 14.5
+    assert total_hours(datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries) == 14.5
+
+
+def test_total_hours_category_filter():
+    entries = {"2026-03-23": {"slots": [_slot("08:00", "12:00", 0, "Büro"), _slot("13:00", "17:00", 0, "HO")]}}
+    assert total_hours(datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries, categories={"Büro"}) == 4.0
+
+
+def test_total_hours_none_categories_is_all():
+    entries = {"2026-03-23": {"slots": [_slot("08:00", "12:00", 0, "A"), _slot("13:00", "17:00", 0, "B")]}}
+    assert total_hours(datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries) == 8.0
+
+
+def test_total_hours_empty_range_is_zero():
+    entries = {"2026-03-23": _e("08:00", "16:00", 0)}
+    assert total_hours(datetime.date(2026, 1, 1), datetime.date(2026, 1, 31), entries) == 0.0
+
+
+def test_total_hours_filtered_to_nothing_is_zero():
+    entries = {"2026-03-23": _e("08:00", "16:00", 0, "Büro")}
+    assert total_hours(datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries, categories={"X"}) == 0.0

--- a/tests/test_reservations.py
+++ b/tests/test_reservations.py
@@ -9,44 +9,66 @@ def store(tmp_path):
     return ReservationStore(str(tmp_path / "res.json"))
 
 
+def _slot(start, end, kategorie="", gcal_event_id=None):
+    """Roh-Slot (inkl. gcal_event_id), wie er in get_all_raw erscheint."""
+    return {"start": start, "end": end, "kategorie": kategorie, "gcal_event_id": gcal_event_id}
+
+
+def _ushape(*slots):
+    """Erwartete User-Shape: slots ohne gcal_event_id."""
+    return {"slots": [{"start": s["start"], "end": s["end"], "kategorie": s["kategorie"]}
+                      for s in slots]}
+
+
 def test_load_empty(store):
     assert store.get_all() == {}
 
 
 def test_save_and_get(store):
-    store.save("2026-06-01", "09:00", "17:00")
-    assert store.get("2026-06-01") == {"start": "09:00", "end": "17:00"}
-    assert store.get_all() == {"2026-06-01": {"start": "09:00", "end": "17:00"}}
+    store.save("2026-06-01", [_slot("09:00", "17:00")])
+    assert store.get("2026-06-01") == _ushape(_slot("09:00", "17:00"))
+    assert store.get_all() == {"2026-06-01": _ushape(_slot("09:00", "17:00"))}
+
+
+def test_save_multiple_slots_with_categories(store):
+    slots = [_slot("09:00", "12:00", "Kundentermin"), _slot("13:00", "17:00", "Büro")]
+    store.save("2026-06-01", slots)
+    assert store.get("2026-06-01") == _ushape(*slots)
 
 
 def test_save_stamps_metadata(store):
-    store.save("2026-06-01", "09:00", "17:00")
+    store.save("2026-06-01", [_slot("09:00", "17:00")])
     raw = store.get_all_raw()["2026-06-01"]
     assert raw["deleted"] is False
-    assert raw["gcal_event_id"] is None
     assert raw["modified_at"].endswith("Z") and "T" in raw["modified_at"]
 
 
-def test_save_preserves_existing_event_id(store):
-    store.save("2026-06-01", "09:00", "17:00")
-    store.apply_reconciled({"2026-06-01": {
-        "start": "09:00", "end": "17:00", "modified_at": "2026-05-20T10:00:00Z",
-        "deleted": False, "gcal_event_id": "ev-1",
-    }})
-    store.save("2026-06-01", "08:00", "16:00")
-    assert store.get_all_raw()["2026-06-01"]["gcal_event_id"] == "ev-1"
+def test_save_stores_provided_event_id(store):
+    """save speichert eine mitgelieferte gcal_event_id am Slot. Der Erhalt
+    bestehender event_ids über Edits ist Sache des Reconcile (AP7)."""
+    store.save("2026-06-01", [_slot("09:00", "17:00", "", "ev-1")])
+    assert store.get_all_raw()["2026-06-01"]["slots"][0]["gcal_event_id"] == "ev-1"
 
 
-def test_delete_writes_tombstone_and_keeps_event_id(store):
-    store.apply_reconciled({"2026-06-01": {
-        "start": "09:00", "end": "17:00", "modified_at": "2026-05-20T10:00:00Z",
-        "deleted": False, "gcal_event_id": "ev-1",
-    }})
+def test_slot_defaults_kategorie_and_event_id(store):
+    store.save("2026-06-01", [{"start": "09:00", "end": "17:00"}])
+    slot = store.get_all_raw()["2026-06-01"]["slots"][0]
+    assert slot["gcal_event_id"] is None
+    assert slot["kategorie"] == ""
+
+
+def test_user_shape_excludes_event_id(store):
+    store.save("2026-06-01", [_slot("09:00", "17:00", "Büro", "ev-1")])
+    assert store.get("2026-06-01") == {"slots": [{"start": "09:00", "end": "17:00", "kategorie": "Büro"}]}
+
+
+def test_delete_writes_empty_slots_tombstone(store):
+    store.save("2026-06-01", [_slot("09:00", "17:00", "", "ev-1")])
     store.delete("2026-06-01")
     assert store.get("2026-06-01") is None
     tomb = store.get_all_raw()["2026-06-01"]
     assert tomb["deleted"] is True
-    assert tomb["gcal_event_id"] == "ev-1"
+    assert tomb["slots"] == []
 
 
 def test_delete_nonexistent_is_noop(store):
@@ -55,7 +77,7 @@ def test_delete_nonexistent_is_noop(store):
 
 
 def test_get_excludes_tombstones(store):
-    store.save("2026-06-01", "09:00", "17:00")
+    store.save("2026-06-01", [_slot("09:00", "17:00")])
     store.delete("2026-06-01")
     assert "2026-06-01" not in store.get_all()
     assert "2026-06-01" in store.get_all_raw()
@@ -63,18 +85,25 @@ def test_get_excludes_tombstones(store):
 
 def test_persistence(tmp_path):
     path = str(tmp_path / "res.json")
-    ReservationStore(path).save("2026-06-01", "09:00", "17:00")
-    assert ReservationStore(path).get("2026-06-01") == {"start": "09:00", "end": "17:00"}
+    ReservationStore(path).save("2026-06-01", [_slot("09:00", "17:00")])
+    assert ReservationStore(path).get("2026-06-01") == _ushape(_slot("09:00", "17:00"))
 
 
 def test_apply_reconciled_replaces_data(store):
-    store.save("2026-06-01", "09:00", "17:00")
+    store.save("2026-06-01", [_slot("09:00", "17:00")])
     store.apply_reconciled({"2026-07-01": {
-        "start": "10:00", "end": "18:00", "modified_at": "2026-05-20T10:00:00Z",
-        "deleted": False, "gcal_event_id": "ev-9",
+        "slots": [_slot("10:00", "18:00", "", "ev-9")],
+        "modified_at": "2026-05-20T10:00:00Z", "deleted": False,
     }})
     assert "2026-06-01" not in store.get_all_raw()
-    assert store.get("2026-07-01") == {"start": "10:00", "end": "18:00"}
+    assert store.get("2026-07-01") == _ushape(_slot("10:00", "18:00"))
+
+
+def test_apply_reconciled_rejects_missing_keys(store):
+    with pytest.raises(ValueError, match="missing keys"):
+        store.apply_reconciled({"2026-06-01": {"slots": [_slot("09:00", "17:00")]}})
+    # _data unverändert (kein Halb-Schreiben)
+    assert store.get_all_raw() == {}
 
 
 def test_corrupt_json_is_quarantined_and_starts_empty(tmp_path):
@@ -88,17 +117,10 @@ def test_corrupt_json_is_quarantined_and_starts_empty(tmp_path):
 def test_save_failure_keeps_original_intact(tmp_path):
     path = tmp_path / "res.json"
     store = ReservationStore(str(path))
-    store.save("2026-06-01", "09:00", "17:00")
+    store.save("2026-06-01", [_slot("09:00", "17:00")])
     original = path.read_bytes()
     with mock.patch("os.replace", side_effect=OSError("disk full")):
         with pytest.raises(OSError):
-            store.save("2026-06-02", "09:00", "17:00")
+            store.save("2026-06-02", [_slot("09:00", "17:00")])
     assert path.read_bytes() == original
     assert [p for p in tmp_path.iterdir() if p.suffix == ".tmp"] == []
-
-
-def test_apply_reconciled_rejects_missing_keys(store):
-    with pytest.raises(ValueError, match="missing keys"):
-        store.apply_reconciled({"2026-06-01": {"start": "09:00", "end": "17:00"}})
-    # _data unverändert (kein Halb-Schreiben)
-    assert store.get_all_raw() == {}

--- a/tests/test_reservations_migration.py
+++ b/tests/test_reservations_migration.py
@@ -1,0 +1,75 @@
+import json
+
+from src.reservations import ReservationStore
+
+
+def _write_legacy(tmp_path, payload):
+    path = tmp_path / "legacy_res.json"
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(payload, f)
+    return str(path)
+
+
+def test_legacy_reservation_wrapped_into_single_slot(tmp_path):
+    path = _write_legacy(tmp_path, {
+        "2026-06-01": {
+            "start": "09:00", "end": "17:00",
+            "modified_at": "2026-05-20T10:00:00Z",
+            "deleted": False, "gcal_event_id": "ev-1",
+        },
+    })
+    store = ReservationStore(path)
+    raw = store.get_all_raw()["2026-06-01"]
+    assert raw["slots"] == [
+        {"start": "09:00", "end": "17:00", "kategorie": "", "gcal_event_id": "ev-1"}
+    ]
+    assert raw["modified_at"] == "2026-05-20T10:00:00Z"
+    assert raw["deleted"] is False
+    # alte Top-Level-Felder entfernt
+    assert "start" not in raw and "end" not in raw and "gcal_event_id" not in raw
+
+
+def test_legacy_reservation_tombstone_becomes_empty_slots(tmp_path):
+    path = _write_legacy(tmp_path, {
+        "2026-06-01": {
+            "start": None, "end": None,
+            "modified_at": "2026-05-20T10:00:00Z",
+            "deleted": True, "gcal_event_id": "ev-1",
+        },
+    })
+    store = ReservationStore(path)
+    raw = store.get_all_raw()["2026-06-01"]
+    assert raw["slots"] == []
+    assert raw["deleted"] is True
+
+
+def test_user_facing_get_all_after_migration(tmp_path):
+    path = _write_legacy(tmp_path, {
+        "2026-06-01": {
+            "start": "09:00", "end": "17:00",
+            "modified_at": "2026-05-20T10:00:00Z",
+            "deleted": False, "gcal_event_id": None,
+        },
+    })
+    store = ReservationStore(path)
+    assert store.get_all() == {
+        "2026-06-01": {"slots": [{"start": "09:00", "end": "17:00", "kategorie": ""}]}
+    }
+
+
+def test_reservation_migration_idempotent_after_persist(tmp_path):
+    path = _write_legacy(tmp_path, {
+        "2026-06-01": {
+            "start": "09:00", "end": "17:00",
+            "modified_at": "2026-05-20T10:00:00Z",
+            "deleted": False, "gcal_event_id": "ev-1",
+        },
+    })
+    s1 = ReservationStore(path)
+    s1._save_to_disk()  # migrierte Form persistieren
+    s2 = ReservationStore(path)
+    raw = s2.get_all_raw()["2026-06-01"]
+    assert raw["slots"] == [
+        {"start": "09:00", "end": "17:00", "kategorie": "", "gcal_event_id": "ev-1"}
+    ]
+    assert "slots" not in raw["slots"][0]

--- a/tests/test_reservations_sync.py
+++ b/tests/test_reservations_sync.py
@@ -1,25 +1,31 @@
 from src.reservations_sync import merge_reservations
 
 
-def _local(start="09:00", end="17:00", modified_at="2026-05-20T10:00:00Z",
-           deleted=False, event_id=None):
-    return {"start": start, "end": end, "modified_at": modified_at,
-            "deleted": deleted, "gcal_event_id": event_id}
+def _lslot(start="09:00", end="17:00", kategorie="", event_id=None):
+    return {"start": start, "end": end, "kategorie": kategorie, "gcal_event_id": event_id}
 
 
-def _remote(date="2026-06-01", start="09:00", end="17:00",
+def _local(slots=None, modified_at="2026-05-20T10:00:00Z", deleted=False):
+    return {
+        "slots": slots if slots is not None else [_lslot()],
+        "modified_at": modified_at, "deleted": deleted,
+    }
+
+
+def _remote(date="2026-06-01", start="09:00", end="17:00", kategorie="",
             modified_at="2026-05-20T10:00:00Z", event_id="ev1"):
-    return {"date": date, "start": start, "end": end,
+    return {"date": date, "start": start, "end": end, "kategorie": kategorie,
             "modified_at": modified_at, "event_id": event_id}
 
 
-def test_local_only_new_creates_event():
+def test_local_only_new_creates_event_per_slot():
     res = merge_reservations(
-        {"2026-06-01": _local(modified_at="2026-05-20T10:00:00Z")},
+        {"2026-06-01": _local(slots=[_lslot(kategorie="Büro")],
+                              modified_at="2026-05-20T10:00:00Z")},
         [], "2026-05-19T00:00:00Z")
     assert res["plan"]["create"] == [{
-        "date": "2026-06-01", "start": "09:00", "end": "17:00",
-        "modified_at": "2026-05-20T10:00:00Z"}]
+        "date": "2026-06-01", "slot_index": 0, "start": "09:00", "end": "17:00",
+        "kategorie": "Büro", "modified_at": "2026-05-20T10:00:00Z"}]
     assert "2026-06-01" in res["merged"]
 
 
@@ -31,80 +37,6 @@ def test_local_only_stale_is_dropped():
     assert res["plan"]["create"] == []
 
 
-def test_remote_only_is_imported():
-    res = merge_reservations({}, [_remote()], "2026-05-19T00:00:00Z")
-    assert res["merged"]["2026-06-01"]["start"] == "09:00"
-    assert res["merged"]["2026-06-01"]["gcal_event_id"] == "ev1"
-    assert res["plan"] == {"create": [], "update": [], "delete": []}
-
-
-def test_both_newer_local_wins_and_updates():
-    res = merge_reservations(
-        {"2026-06-01": _local(start="08:00", modified_at="2026-05-21T10:00:00Z")},
-        [_remote(start="09:00", modified_at="2026-05-20T10:00:00Z")],
-        "2026-05-19T00:00:00Z")
-    assert res["merged"]["2026-06-01"]["start"] == "08:00"
-    assert res["merged"]["2026-06-01"]["gcal_event_id"] == "ev1"
-    assert res["plan"]["update"] == [{
-        "date": "2026-06-01", "event_id": "ev1", "start": "08:00",
-        "end": "17:00", "modified_at": "2026-05-21T10:00:00Z"}]
-
-
-def test_both_newer_remote_wins():
-    res = merge_reservations(
-        {"2026-06-01": _local(start="08:00", modified_at="2026-05-20T10:00:00Z")},
-        [_remote(start="09:00", modified_at="2026-05-21T10:00:00Z")],
-        "2026-05-19T00:00:00Z")
-    assert res["merged"]["2026-06-01"]["start"] == "09:00"
-    assert res["plan"]["update"] == []
-
-
-def test_both_equal_values_no_update():
-    res = merge_reservations(
-        {"2026-06-01": _local(modified_at="2026-05-21T10:00:00Z")},
-        [_remote(modified_at="2026-05-20T10:00:00Z")],
-        "2026-05-19T00:00:00Z")
-    assert res["plan"]["update"] == []
-    assert res["merged"]["2026-06-01"]["gcal_event_id"] == "ev1"
-
-
-def test_tombstone_newer_deletes_event():
-    res = merge_reservations(
-        {"2026-06-01": _local(deleted=True, modified_at="2026-05-21T10:00:00Z",
-                              event_id="ev1")},
-        [_remote(modified_at="2026-05-20T10:00:00Z")],
-        "2026-05-19T00:00:00Z")
-    assert res["plan"]["delete"] == [{"event_id": "ev1"}]
-    assert "2026-06-01" not in res["merged"]
-
-
-def test_tombstone_older_than_remote_update_is_dropped():
-    res = merge_reservations(
-        {"2026-06-01": _local(deleted=True, modified_at="2026-05-20T10:00:00Z")},
-        [_remote(modified_at="2026-05-21T10:00:00Z")],
-        "2026-05-19T00:00:00Z")
-    assert res["plan"]["delete"] == []
-    assert res["merged"]["2026-06-01"]["start"] == "09:00"
-
-
-def test_tombstone_without_remote_is_noop():
-    res = merge_reservations(
-        {"2026-06-01": _local(deleted=True, modified_at="2026-05-21T10:00:00Z")},
-        [], "2026-05-19T00:00:00Z")
-    assert res["merged"] == {}
-    assert res["plan"] == {"create": [], "update": [], "delete": []}
-
-
-def test_duplicate_remote_events_keeps_newest_deletes_rest():
-    res = merge_reservations(
-        {},
-        [_remote(modified_at="2026-05-20T10:00:00Z", event_id="old"),
-         _remote(modified_at="2026-05-21T10:00:00Z", event_id="new")],
-        "2026-05-19T00:00:00Z")
-    assert res["merged"]["2026-06-01"]["gcal_event_id"] == "new"
-    assert res["plan"]["delete"] == [{"event_id": "old"}]
-
-
 def test_local_only_exactly_at_watermark_is_dropped():
     res = merge_reservations(
         {"2026-06-01": _local(modified_at="2026-05-19T00:00:00Z")},
@@ -113,13 +45,130 @@ def test_local_only_exactly_at_watermark_is_dropped():
     assert res["plan"]["create"] == []
 
 
-def test_reconcile_creates_event_and_persists_event_id(tmp_path, monkeypatch):
+def test_remote_only_is_imported_as_slots():
+    res = merge_reservations({}, [_remote(kategorie="HO")], "2026-05-19T00:00:00Z")
+    slots = res["merged"]["2026-06-01"]["slots"]
+    assert slots == [{"start": "09:00", "end": "17:00", "kategorie": "HO", "gcal_event_id": "ev1"}]
+    assert res["plan"] == {"create": [], "update": [], "delete": []}
+
+
+def test_remote_only_multiple_events_become_multiple_slots():
+    res = merge_reservations(
+        {},
+        [_remote(start="08:00", end="12:00", event_id="a"),
+         _remote(start="13:00", end="17:00", event_id="b")],
+        "2026-05-19T00:00:00Z")
+    ids = sorted(s["gcal_event_id"] for s in res["merged"]["2026-06-01"]["slots"])
+    assert ids == ["a", "b"]
+    assert res["plan"] == {"create": [], "update": [], "delete": []}
+
+
+def test_local_wins_updates_matched_slot():
+    res = merge_reservations(
+        {"2026-06-01": _local(slots=[_lslot(start="08:00", event_id="ev1")],
+                              modified_at="2026-05-21T10:00:00Z")},
+        [_remote(start="09:00", modified_at="2026-05-20T10:00:00Z", event_id="ev1")],
+        "2026-05-19T00:00:00Z")
+    assert res["plan"]["update"] == [{
+        "event_id": "ev1", "date": "2026-06-01", "start": "08:00", "end": "17:00",
+        "kategorie": "", "modified_at": "2026-05-21T10:00:00Z"}]
+    assert res["merged"]["2026-06-01"]["slots"][0]["gcal_event_id"] == "ev1"
+
+
+def test_local_wins_category_change_updates():
+    res = merge_reservations(
+        {"2026-06-01": _local(slots=[_lslot(kategorie="HO", event_id="ev1")],
+                              modified_at="2026-05-21T10:00:00Z")},
+        [_remote(kategorie="Büro", modified_at="2026-05-20T10:00:00Z", event_id="ev1")],
+        "2026-05-19T00:00:00Z")
+    assert len(res["plan"]["update"]) == 1
+    assert res["plan"]["update"][0]["kategorie"] == "HO"
+
+
+def test_local_wins_equal_values_no_update():
+    res = merge_reservations(
+        {"2026-06-01": _local(slots=[_lslot(event_id="ev1")],
+                              modified_at="2026-05-21T10:00:00Z")},
+        [_remote(modified_at="2026-05-20T10:00:00Z", event_id="ev1")],
+        "2026-05-19T00:00:00Z")
+    assert res["plan"]["update"] == []
+    assert res["merged"]["2026-06-01"]["slots"][0]["gcal_event_id"] == "ev1"
+
+
+def test_local_wins_new_slot_creates_extra_event():
+    res = merge_reservations(
+        {"2026-06-01": _local(
+            slots=[_lslot(start="08:00", end="12:00", event_id="ev1"),
+                   _lslot(start="13:00", end="17:00", event_id=None)],
+            modified_at="2026-05-21T10:00:00Z")},
+        [_remote(start="08:00", end="12:00", modified_at="2026-05-20T10:00:00Z", event_id="ev1")],
+        "2026-05-19T00:00:00Z")
+    assert res["plan"]["update"] == []
+    assert res["plan"]["create"] == [{
+        "date": "2026-06-01", "slot_index": 1, "start": "13:00", "end": "17:00",
+        "kategorie": "", "modified_at": "2026-05-21T10:00:00Z"}]
+    assert res["plan"]["delete"] == []
+
+
+def test_local_wins_removed_slot_deletes_orphan_event():
+    res = merge_reservations(
+        {"2026-06-01": _local(slots=[_lslot(start="08:00", end="12:00", event_id="ev1")],
+                              modified_at="2026-05-21T10:00:00Z")},
+        [_remote(start="08:00", end="12:00", modified_at="2026-05-20T10:00:00Z", event_id="ev1"),
+         _remote(start="13:00", end="17:00", modified_at="2026-05-20T10:00:00Z", event_id="ev2")],
+        "2026-05-19T00:00:00Z")
+    assert res["plan"]["delete"] == [{"event_id": "ev2"}]
+    assert [s["gcal_event_id"] for s in res["merged"]["2026-06-01"]["slots"]] == ["ev1"]
+
+
+def test_remote_wins_adopts_remote_slots():
+    res = merge_reservations(
+        {"2026-06-01": _local(slots=[_lslot(start="08:00", event_id="ev1")],
+                              modified_at="2026-05-20T10:00:00Z")},
+        [_remote(start="09:00", modified_at="2026-05-21T10:00:00Z", event_id="ev1")],
+        "2026-05-19T00:00:00Z")
+    assert res["merged"]["2026-06-01"]["slots"][0]["start"] == "09:00"
+    assert res["plan"]["update"] == []
+
+
+def test_tombstone_newer_deletes_all_events():
+    res = merge_reservations(
+        {"2026-06-01": _local(slots=[], deleted=True, modified_at="2026-05-21T10:00:00Z")},
+        [_remote(modified_at="2026-05-20T10:00:00Z", event_id="ev1"),
+         _remote(start="13:00", modified_at="2026-05-20T10:00:00Z", event_id="ev2")],
+        "2026-05-19T00:00:00Z")
+    deleted = sorted(d["event_id"] for d in res["plan"]["delete"])
+    assert deleted == ["ev1", "ev2"]
+    assert "2026-06-01" not in res["merged"]
+
+
+def test_tombstone_older_than_remote_is_dropped():
+    res = merge_reservations(
+        {"2026-06-01": _local(slots=[], deleted=True, modified_at="2026-05-20T10:00:00Z")},
+        [_remote(modified_at="2026-05-21T10:00:00Z", event_id="ev1")],
+        "2026-05-19T00:00:00Z")
+    assert res["plan"]["delete"] == []
+    assert res["merged"]["2026-06-01"]["slots"][0]["start"] == "09:00"
+
+
+def test_tombstone_without_remote_is_noop():
+    res = merge_reservations(
+        {"2026-06-01": _local(slots=[], deleted=True, modified_at="2026-05-21T10:00:00Z")},
+        [], "2026-05-19T00:00:00Z")
+    assert res["merged"] == {}
+    assert res["plan"] == {"create": [], "update": [], "delete": []}
+
+
+# --- reconcile (mit gemockten gcal-I/O) ---
+
+
+def test_reconcile_creates_event_and_persists_event_id_per_slot(tmp_path, monkeypatch):
     from src import gcal, reservations_sync
     from src.reservations import ReservationStore
     from src.settings import Settings
 
     store = ReservationStore(str(tmp_path / "res.json"))
-    store.save("2026-06-01", "09:00", "17:00")
+    store.save("2026-06-01", [{"start": "09:00", "end": "17:00", "kategorie": "Büro"}])
     settings = Settings(str(tmp_path / "set.json"))
 
     monkeypatch.setattr(gcal, "list_app_events", lambda s, c: [])
@@ -127,43 +176,45 @@ def test_reconcile_creates_event_and_persists_event_id(tmp_path, monkeypatch):
     monkeypatch.setattr(gcal, "delete_event", lambda *a: None)
     monkeypatch.setattr(
         gcal, "create_event",
-        lambda s, c, date, start, end, modified_at: "new-event-id")
+        lambda s, c, date, start, end, kategorie, modified_at: "new-event-id")
 
     reservations_sync.reconcile_reservations(object(), "cal-1", store, settings)
 
-    assert store.get_all_raw()["2026-06-01"]["gcal_event_id"] == "new-event-id"
+    raw = store.get_all_raw()["2026-06-01"]
+    assert raw["slots"][0]["gcal_event_id"] == "new-event-id"
     assert settings.get("last_calendar_sync_at") != ""
 
 
-def test_reconcile_deletes_orphaned_event(tmp_path, monkeypatch):
+def test_reconcile_imported_update_plans_update(tmp_path, monkeypatch):
+    """AP5-Forward-Test: ein lokal geändertes (jüngeres) Slot mit bestehender
+    event_id wird beim Reconcile als update geplant (kein Duplikat)."""
     from src import gcal, reservations_sync
     from src.reservations import ReservationStore
     from src.settings import Settings
 
     store = ReservationStore(str(tmp_path / "res.json"))
+    # Slot mit bereits bekannter event_id (wie nach einem früheren Reconcile).
+    store.save("2026-06-01", [{"start": "10:00", "end": "14:00",
+                               "kategorie": "", "gcal_event_id": "evt-1"}])
     settings = Settings(str(tmp_path / "set.json"))
 
-    remote = {"date": "2026-06-01", "start": "09:00", "end": "17:00",
-              "modified_at": "2026-05-20T10:00:00Z", "event_id": "ev-old"}
-    deleted = []
-    monkeypatch.setattr(gcal, "list_app_events", lambda s, c: [remote, dict(remote)])
+    updated = []
+    remote = {"date": "2026-06-01", "start": "08:00", "end": "12:00",
+              "kategorie": "", "modified_at": "2020-01-01T00:00:00Z", "event_id": "evt-1"}
+    monkeypatch.setattr(gcal, "list_app_events", lambda s, c: [remote])
     monkeypatch.setattr(gcal, "create_event", lambda *a: "x")
-    monkeypatch.setattr(gcal, "update_event", lambda *a: None)
+    monkeypatch.setattr(gcal, "delete_event", lambda *a: None)
     monkeypatch.setattr(
-        gcal, "delete_event",
-        lambda s, c, event_id: deleted.append(event_id))
+        gcal, "update_event",
+        lambda s, c, event_id, *a: updated.append(event_id))
 
     reservations_sync.reconcile_reservations(object(), "cal-1", store, settings)
 
-    assert deleted == ["ev-old"]  # eines der Duplikate wird gelöscht
-    assert store.get("2026-06-01") == {"start": "09:00", "end": "17:00"}
-    assert store.get_all_raw()["2026-06-01"]["gcal_event_id"] == "ev-old"
+    assert updated == ["evt-1"]
+    assert store.get_all_raw()["2026-06-01"]["slots"][0]["start"] == "10:00"
 
 
 def test_reconcile_preserves_concurrent_local_save(tmp_path, monkeypatch):
-    """Eine Reservierung, die WÄHREND des Reconcile-Netzwerkteils lokal
-    gespeichert wird, darf nicht durch den apply_reconciled-Replace verloren
-    gehen."""
     from src import gcal, reservations_sync
     from src.reservations import ReservationStore
     from src.settings import Settings
@@ -172,8 +223,7 @@ def test_reconcile_preserves_concurrent_local_save(tmp_path, monkeypatch):
     settings = Settings(str(tmp_path / "set.json"))
 
     def fake_list(s, c):
-        # Simuliert einen lokalen Save mitten im Reconcile.
-        store.save("2026-07-01", "10:00", "18:00")
+        store.save("2026-07-01", [{"start": "10:00", "end": "18:00", "kategorie": ""}])
         return []
 
     monkeypatch.setattr(gcal, "list_app_events", fake_list)
@@ -183,4 +233,4 @@ def test_reconcile_preserves_concurrent_local_save(tmp_path, monkeypatch):
 
     reservations_sync.reconcile_reservations(object(), "cal-1", store, settings)
 
-    assert store.get("2026-07-01") == {"start": "10:00", "end": "18:00"}
+    assert store.get("2026-07-01") == {"slots": [{"start": "10:00", "end": "18:00", "kategorie": ""}]}

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -447,3 +447,31 @@ def test_categories_synced_doc_roundtrip(tmp_path):
     doc = s.get_synced_doc()
     assert doc["categories"]["value"] == ["Büro", "Kundentermin"]
     assert doc["categories"]["device_id"] == "dev-1"
+
+
+# --- category_times (Per-Kategorie-Standardzeiten) ---
+
+
+def test_category_times_default_is_empty_dict(tmp_settings):
+    assert tmp_settings.get("category_times") == {}
+
+
+def test_category_times_is_synced_setting():
+    assert "category_times" in SYNCED_SETTING_KEYS
+
+
+def test_category_times_persists_dict(tmp_path):
+    path = str(tmp_path / "settings.json")
+    value = {"Office": {"start": "09:00", "end": "17:00", "pause": 0}}
+    s1 = Settings(path)
+    s1.set("category_times", value)
+    s2 = Settings(path)
+    assert s2.get("category_times") == value
+
+
+def test_category_times_non_dict_falls_back_to_default(tmp_path, caplog):
+    path = _write_json(tmp_path, json.dumps({"category_times": ["kaputt"]}))
+    with caplog.at_level("WARNING"):
+        s = Settings(path)
+    assert s.get("category_times") == {}
+    assert any("category_times" in rec.message for rec in caplog.records)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -409,3 +409,41 @@ def test_synced_whitelists_in_settings_and_sync_match():
     from src.settings import SYNCED_SETTING_KEYS as a
     from src.sync import SYNCED_SETTING_KEYS as b
     assert set(a) == set(b)
+
+
+# --- categories (Multi-Slot-Feature, AP2) ---
+
+
+def test_categories_default_is_empty_list(tmp_settings):
+    assert tmp_settings.get("categories") == []
+
+
+def test_categories_is_synced_setting():
+    assert "categories" in SYNCED_SETTING_KEYS
+
+
+def test_categories_persists_list(tmp_path):
+    path = str(tmp_path / "settings.json")
+    s1 = Settings(path)
+    s1.set("categories", ["Büro", "Homeoffice"])
+    s2 = Settings(path)
+    assert s2.get("categories") == ["Büro", "Homeoffice"]
+
+
+def test_categories_non_list_falls_back_to_default(tmp_path, caplog):
+    """Ein Nicht-Listen-Wert wird von _coerce abgelehnt → Default []."""
+    path = _write_json(tmp_path, json.dumps({"categories": "Büro"}))
+    with caplog.at_level("WARNING"):
+        s = Settings(path)
+    assert s.get("categories") == []
+    assert any("categories" in rec.message for rec in caplog.records)
+
+
+def test_categories_synced_doc_roundtrip(tmp_path):
+    path = str(tmp_path / "settings.json")
+    s = Settings(path)
+    s.device_id_for_sync = "dev-1"
+    s.set_synced("categories", ["Büro", "Kundentermin"])
+    doc = s.get_synced_doc()
+    assert doc["categories"]["value"] == ["Büro", "Kundentermin"]
+    assert doc["categories"]["device_id"] == "dev-1"

--- a/tests/test_share.py
+++ b/tests/test_share.py
@@ -1,12 +1,57 @@
+import datetime as _dt
 import json
 
 import pytest
 
-from src.share import ShareValidationError, parse_share_doc
+from src.share import (
+    KIND,
+    SCHEMA_VERSION,
+    ShareValidationError,
+    apply_import,
+    apply_reservation_import,
+    build_share_doc,
+    diff_reservations_against_local,
+    diff_share_against_local,
+    parse_share_doc,
+    serialize_share_doc,
+)
 
 
 def _bytes(obj):
     return json.dumps(obj).encode("utf-8")
+
+
+def _eslot(start, end, pause=0, kategorie=""):
+    return {"start": start, "end": end, "pause": pause, "kategorie": kategorie}
+
+
+def _rslot(start, end, kategorie=""):
+    return {"start": start, "end": end, "kategorie": kategorie}
+
+
+def _erec(*slots):
+    return {"slots": list(slots)}
+
+
+def _v1(**fields):
+    base = {"kind": "zeiterfassung-share", "schema_version": 1}
+    base.update(fields)
+    return _bytes(base)
+
+
+def _v2(**fields):
+    base = {"kind": "zeiterfassung-share", "schema_version": 2}
+    base.update(fields)
+    return _bytes(base)
+
+
+def _v3(**fields):
+    base = {"kind": "zeiterfassung-share", "schema_version": 3}
+    base.update(fields)
+    return _bytes(base)
+
+
+# --- generische Header-Validierung ---
 
 
 def test_parse_rejects_broken_json():
@@ -36,379 +81,93 @@ def test_parse_rejects_missing_schema_version():
 
 def test_parse_rejects_future_schema_version():
     with pytest.raises(ShareValidationError, match="neueren Version"):
-        parse_share_doc(_bytes({
-            "kind": "zeiterfassung-share",
-            "schema_version": 3,
-            "entries": {},
-        }))
-
-
-def test_parse_rejects_missing_entries():
-    with pytest.raises(ShareValidationError, match="entries"):
-        parse_share_doc(_bytes({"kind": "zeiterfassung-share", "schema_version": 1}))
-
-
-def test_parse_rejects_bad_date_key():
-    with pytest.raises(ShareValidationError, match="Datum"):
-        parse_share_doc(_bytes({
-            "kind": "zeiterfassung-share",
-            "schema_version": 1,
-            "entries": {"not-a-date": {"start": "08:00", "end": "16:00", "pause": 0}},
-        }))
-
-
-def test_parse_rejects_extra_entry_field():
-    with pytest.raises(ShareValidationError, match="unbekannt"):
-        parse_share_doc(_bytes({
-            "kind": "zeiterfassung-share",
-            "schema_version": 1,
-            "entries": {"2026-05-14": {"start": "08:00", "end": "16:00", "pause": 0, "deleted": True}},
-        }))
-
-
-def test_parse_rejects_missing_entry_field():
-    with pytest.raises(ShareValidationError, match="fehlend"):
-        parse_share_doc(_bytes({
-            "kind": "zeiterfassung-share",
-            "schema_version": 1,
-            "entries": {"2026-05-14": {"start": "08:00", "end": "16:00"}},
-        }))
-
-
-def test_parse_rejects_bad_time_format():
-    with pytest.raises(ShareValidationError, match="Startzeit"):
-        parse_share_doc(_bytes({
-            "kind": "zeiterfassung-share",
-            "schema_version": 1,
-            "entries": {"2026-05-14": {"start": "8:00", "end": "16:00", "pause": 0}},
-        }))
-
-
-def test_parse_rejects_negative_pause():
-    with pytest.raises(ShareValidationError, match="Pause"):
-        parse_share_doc(_bytes({
-            "kind": "zeiterfassung-share",
-            "schema_version": 1,
-            "entries": {"2026-05-14": {"start": "08:00", "end": "16:00", "pause": -5}},
-        }))
-
-
-def test_parse_rejects_bool_as_pause():
-    """bool ist Subklasse von int — verhindern, dass True als pause=1 durchgeht."""
-    with pytest.raises(ShareValidationError, match="Pause"):
-        parse_share_doc(_bytes({
-            "kind": "zeiterfassung-share",
-            "schema_version": 1,
-            "entries": {"2026-05-14": {"start": "08:00", "end": "16:00", "pause": True}},
-        }))
+        parse_share_doc(_bytes({"kind": "zeiterfassung-share", "schema_version": 4, "entries": {}}))
 
 
 def test_parse_rejects_past_schema_version():
-    """schema_version < 1 ist defensiv reserviert — muss ShareValidationError werfen."""
     with pytest.raises(ShareValidationError, match="schema_version"):
-        parse_share_doc(_bytes({
-            "kind": "zeiterfassung-share",
-            "schema_version": 0,
-            "entries": {},
-        }))
+        parse_share_doc(_bytes({"kind": "zeiterfassung-share", "schema_version": 0, "entries": {}}))
 
 
-def test_parse_rejects_bad_end_time():
-    """Ungültiges Format für end-Zeit schlägt mit passendem Fehler fehl."""
-    with pytest.raises(ShareValidationError, match="Endzeit"):
-        parse_share_doc(_bytes({
-            "kind": "zeiterfassung-share",
-            "schema_version": 1,
-            "entries": {"2026-05-14": {"start": "08:00", "end": "16:0", "pause": 0}},
-        }))
+# --- v1: alte Shape, beim Lesen in Slots gewrappt ---
 
 
-def test_parse_rejects_unreal_time():
-    """Regex-valide aber unmögliche Uhrzeiten (25:00, 08:99) müssen abgelehnt werden."""
-    with pytest.raises(ShareValidationError, match="Startzeit"):
-        parse_share_doc(_bytes({
-            "kind": "zeiterfassung-share",
-            "schema_version": 1,
-            "entries": {"2026-05-14": {"start": "25:00", "end": "16:00", "pause": 0}},
-        }))
-
-
-from src.share import build_share_doc, serialize_share_doc, KIND, SCHEMA_VERSION
-
-
-class _FakeStorage:
-    def __init__(self, entries):
-        self._entries = entries
-
-    def get_all(self):
-        return dict(self._entries)
-
-
-def test_build_share_doc_basic():
-    storage = _FakeStorage({
-        "2026-05-14": {"start": "08:00", "end": "16:00", "pause": 30},
-    })
-    doc = build_share_doc(storage, "alice@example.com")
-    assert doc["kind"] == KIND
-    assert doc["schema_version"] == SCHEMA_VERSION
-    assert doc["exported_by"] == "alice@example.com"
-    assert doc["entries"] == {"2026-05-14": {"start": "08:00", "end": "16:00", "pause": 30}}
-    assert "exported_at" in doc and doc["exported_at"].endswith("Z")
-
-
-def test_build_share_doc_empty_sender():
-    storage = _FakeStorage({})
-    doc = build_share_doc(storage, "")
-    assert doc["exported_by"] == ""
-    assert doc["entries"] == {}
-
-
-def test_build_share_doc_none_sender_becomes_empty_string():
-    storage = _FakeStorage({})
-    doc = build_share_doc(storage, None)
-    assert doc["exported_by"] == ""
-
-
-def test_round_trip_build_serialize_parse():
-    storage = _FakeStorage({
-        "2026-05-14": {"start": "08:00", "end": "16:00", "pause": 30},
-        "2026-05-15": {"start": "09:00", "end": "17:30", "pause": 45},
-    })
-    doc = build_share_doc(storage, "alice@example.com")
-    payload = serialize_share_doc(doc)
-    parsed = parse_share_doc(payload)
-    assert parsed["entries"] == doc["entries"]
-    assert parsed["kind"] == KIND
-    assert parsed["schema_version"] == SCHEMA_VERSION
-
-
-def test_serialize_utf8_umlauts():
-    storage = _FakeStorage({"2026-05-14": {"start": "08:00", "end": "16:00", "pause": 0}})
-    doc = build_share_doc(storage, "äöü@example.com")
-    payload = serialize_share_doc(doc)
-    assert b"\\u" not in payload  # ensure_ascii=False — Umlaute literal
-    parsed = parse_share_doc(payload)
-    assert parsed["exported_by"] == "äöü@example.com"
-
-
-from src.share import diff_share_against_local
-
-
-def test_diff_only_additions():
-    storage = _FakeStorage({})
-    share = {"2026-05-14": {"start": "08:00", "end": "16:00", "pause": 30}}
-    diff = diff_share_against_local(share, storage)
-    assert diff["additions"] == [("2026-05-14", {"start": "08:00", "end": "16:00", "pause": 30})]
-    assert diff["conflicts"] == []
-    assert diff["untouched"] == []
-    assert diff["out_of_range"] == 0
-
-
-def test_diff_only_untouched():
-    storage = _FakeStorage({"2026-05-14": {"start": "08:00", "end": "16:00", "pause": 30}})
-    share = {"2026-05-14": {"start": "08:00", "end": "16:00", "pause": 30}}
-    diff = diff_share_against_local(share, storage)
-    assert diff["additions"] == []
-    assert diff["conflicts"] == []
-    assert diff["untouched"] == ["2026-05-14"]
-
-
-def test_diff_only_conflicts():
-    storage = _FakeStorage({"2026-05-14": {"start": "08:00", "end": "16:00", "pause": 30}})
-    share = {"2026-05-14": {"start": "09:00", "end": "17:30", "pause": 30}}
-    diff = diff_share_against_local(share, storage)
-    assert len(diff["conflicts"]) == 1
-    date, local, shared = diff["conflicts"][0]
-    assert date == "2026-05-14"
-    assert local["start"] == "08:00"
-    assert shared["start"] == "09:00"
-
-
-def test_diff_pause_difference_is_conflict():
-    storage = _FakeStorage({"2026-05-14": {"start": "08:00", "end": "16:00", "pause": 30}})
-    share = {"2026-05-14": {"start": "08:00", "end": "16:00", "pause": 45}}
-    diff = diff_share_against_local(share, storage)
-    assert len(diff["conflicts"]) == 1
-    assert diff["untouched"] == []
-
-
-def test_diff_mixed():
-    storage = _FakeStorage({
-        "2026-05-14": {"start": "08:00", "end": "16:00", "pause": 30},  # untouched
-        "2026-05-15": {"start": "08:00", "end": "16:00", "pause": 30},  # conflict
-    })
-    share = {
-        "2026-05-14": {"start": "08:00", "end": "16:00", "pause": 30},
-        "2026-05-15": {"start": "09:00", "end": "17:00", "pause": 30},
-        "2026-05-16": {"start": "10:00", "end": "18:00", "pause": 0},   # addition
-    }
-    diff = diff_share_against_local(share, storage)
-    assert diff["untouched"] == ["2026-05-14"]
-    assert [d for d, _, _ in diff["conflicts"]] == ["2026-05-15"]
-    assert [d for d, _ in diff["additions"]] == ["2026-05-16"]
-
-
-def test_diff_tombstone_treated_as_addition():
-    """Tombstones im Storage tauchen in get_all() nicht auf → share entry zählt als addition."""
-    class _StorageWithTombstone:
-        def get_all(self):
-            return {}  # tombstone gefiltert
-    share = {"2026-05-14": {"start": "08:00", "end": "16:00", "pause": 0}}
-    diff = diff_share_against_local(share, _StorageWithTombstone())
-    assert len(diff["additions"]) == 1
-    assert diff["conflicts"] == []
-
-
-import datetime as _dt
-
-
-def test_diff_range_filter_excludes_left():
-    storage = _FakeStorage({})
-    share = {
-        "2026-05-10": {"start": "08:00", "end": "16:00", "pause": 0},
-        "2026-05-15": {"start": "08:00", "end": "16:00", "pause": 0},
-    }
-    diff = diff_share_against_local(share, storage, date_from=_dt.date(2026, 5, 12))
-    assert [d for d, _ in diff["additions"]] == ["2026-05-15"]
-    assert diff["out_of_range"] == 1
-
-
-def test_diff_range_filter_excludes_right():
-    storage = _FakeStorage({})
-    share = {
-        "2026-05-10": {"start": "08:00", "end": "16:00", "pause": 0},
-        "2026-05-15": {"start": "08:00", "end": "16:00", "pause": 0},
-    }
-    diff = diff_share_against_local(share, storage, date_to=_dt.date(2026, 5, 12))
-    assert [d for d, _ in diff["additions"]] == ["2026-05-10"]
-    assert diff["out_of_range"] == 1
-
-
-def test_diff_range_filter_inclusive_bounds():
-    storage = _FakeStorage({})
-    share = {
-        "2026-05-10": {"start": "08:00", "end": "16:00", "pause": 0},
-        "2026-05-15": {"start": "08:00", "end": "16:00", "pause": 0},
-    }
-    diff = diff_share_against_local(
-        share, storage,
-        date_from=_dt.date(2026, 5, 10),
-        date_to=_dt.date(2026, 5, 15),
-    )
-    assert len(diff["additions"]) == 2
-    assert diff["out_of_range"] == 0
-
-
-def test_diff_range_filter_completely_outside():
-    storage = _FakeStorage({})
-    share = {"2026-05-14": {"start": "08:00", "end": "16:00", "pause": 0}}
-    diff = diff_share_against_local(
-        share, storage,
-        date_from=_dt.date(2030, 1, 1),
-    )
-    assert diff["additions"] == []
-    assert diff["conflicts"] == []
-    assert diff["untouched"] == []
-    assert diff["out_of_range"] == 1
-
-
-def test_diff_range_none_bounds_unconstrained():
-    storage = _FakeStorage({})
-    share = {"2026-05-14": {"start": "08:00", "end": "16:00", "pause": 0}}
-    diff = diff_share_against_local(share, storage, date_from=None, date_to=None)
-    assert len(diff["additions"]) == 1
-    assert diff["out_of_range"] == 0
-
-
-from src.share import apply_import
-
-
-class _RecordingStorage:
-    def __init__(self):
-        self.save_many_calls = []
-
-    def save_many(self, updates):
-        self.save_many_calls.append(dict(updates))
-
-
-def test_apply_import_empty_is_noop():
-    s = _RecordingStorage()
-    apply_import(s, [])
-    # save_many wird mit leerem Dict aufgerufen; Storage selbst dedupliziert das
-    # zu einem No-op. Hier reicht uns: keine Exception.
-    assert s.save_many_calls in ([], [{}])
-
-
-def test_apply_import_single_call_for_all_decisions():
-    s = _RecordingStorage()
-    decisions = [
-        {"date": "2026-05-14", "entry": {"start": "08:00", "end": "16:00", "pause": 30}},
-        {"date": "2026-05-15", "entry": {"start": "09:00", "end": "17:00", "pause": 0}},
-    ]
-    apply_import(s, decisions)
-    assert len(s.save_many_calls) == 1
-    assert s.save_many_calls[0] == {
-        "2026-05-14": {"start": "08:00", "end": "16:00", "pause": 30},
-        "2026-05-15": {"start": "09:00", "end": "17:00", "pause": 0},
-    }
-
-
-def test_apply_import_integration_with_real_storage(tmp_path):
-    from src.storage import Storage
-    s = Storage(str(tmp_path / "z.json"), device_id="dev1")
-    s.save("2026-05-14", "08:00", "16:00", 30)
-    apply_import(s, [
-        {"date": "2026-05-15", "entry": {"start": "09:00", "end": "17:00", "pause": 0}},
-        {"date": "2026-05-14", "entry": {"start": "10:00", "end": "18:00", "pause": 45}},
-    ])
-    entries = s.get_all()
-    assert entries["2026-05-14"] == {"start": "10:00", "end": "18:00", "pause": 45}
-    assert entries["2026-05-15"] == {"start": "09:00", "end": "17:00", "pause": 0}
-
-
-# --- v2: Reservierungen + abwärtskompatibles Lesen ---
-
-def _v2(**fields):
-    base = {"kind": "zeiterfassung-share", "schema_version": 2}
-    base.update(fields)
-    return _bytes(base)
-
-
-def test_parse_v1_entries_only_still_accepted():
-    doc = parse_share_doc(_bytes({
-        "kind": "zeiterfassung-share",
-        "schema_version": 1,
-        "entries": {"2026-05-14": {"start": "08:00", "end": "16:00", "pause": 0}},
-    }))
+def test_parse_v1_entries_only_wrapped_into_slots():
+    doc = parse_share_doc(_v1(entries={"2026-05-14": {"start": "08:00", "end": "16:00", "pause": 0}}))
     assert doc["schema_version"] == 1
-    assert "2026-05-14" in doc["entries"]
+    assert doc["entries"] == {"2026-05-14": _erec(_eslot("08:00", "16:00", 0, ""))}
 
 
-def test_parse_v2_entries_only():
+def test_parse_v1_rejects_missing_entries():
+    with pytest.raises(ShareValidationError, match="entries"):
+        parse_share_doc(_v1())
+
+
+def test_parse_v1_rejects_bad_date_key():
+    with pytest.raises(ShareValidationError, match="Datum"):
+        parse_share_doc(_v1(entries={"not-a-date": {"start": "08:00", "end": "16:00", "pause": 0}}))
+
+
+def test_parse_v1_rejects_extra_entry_field():
+    with pytest.raises(ShareValidationError, match="unbekannt"):
+        parse_share_doc(_v1(entries={"2026-05-14": {"start": "08:00", "end": "16:00", "pause": 0, "deleted": True}}))
+
+
+def test_parse_v1_rejects_missing_entry_field():
+    with pytest.raises(ShareValidationError, match="fehlend"):
+        parse_share_doc(_v1(entries={"2026-05-14": {"start": "08:00", "end": "16:00"}}))
+
+
+def test_parse_v1_rejects_bad_time_format():
+    with pytest.raises(ShareValidationError, match="Startzeit"):
+        parse_share_doc(_v1(entries={"2026-05-14": {"start": "8:00", "end": "16:00", "pause": 0}}))
+
+
+def test_parse_v1_rejects_negative_pause():
+    with pytest.raises(ShareValidationError, match="Pause"):
+        parse_share_doc(_v1(entries={"2026-05-14": {"start": "08:00", "end": "16:00", "pause": -5}}))
+
+
+def test_parse_v1_rejects_bool_as_pause():
+    with pytest.raises(ShareValidationError, match="Pause"):
+        parse_share_doc(_v1(entries={"2026-05-14": {"start": "08:00", "end": "16:00", "pause": True}}))
+
+
+def test_parse_v1_rejects_bad_end_time():
+    with pytest.raises(ShareValidationError, match="Endzeit"):
+        parse_share_doc(_v1(entries={"2026-05-14": {"start": "08:00", "end": "16:0", "pause": 0}}))
+
+
+def test_parse_v1_rejects_unreal_time():
+    with pytest.raises(ShareValidationError, match="Startzeit"):
+        parse_share_doc(_v1(entries={"2026-05-14": {"start": "25:00", "end": "16:00", "pause": 0}}))
+
+
+# --- v2: alte Shape (entries+reservations), beim Lesen gewrappt ---
+
+
+def test_parse_v2_entries_only_wrapped():
     doc = parse_share_doc(_v2(entries={"2026-05-14": {"start": "08:00", "end": "16:00", "pause": 0}}))
-    assert doc["entries"] == {"2026-05-14": {"start": "08:00", "end": "16:00", "pause": 0}}
+    assert doc["entries"] == {"2026-05-14": _erec(_eslot("08:00", "16:00", 0, ""))}
 
 
-def test_parse_v2_reservations_only():
+def test_parse_v2_reservations_only_wrapped():
     doc = parse_share_doc(_v2(reservations={"2026-05-14": {"start": "08:00", "end": "12:00"}}))
-    assert doc["reservations"] == {"2026-05-14": {"start": "08:00", "end": "12:00"}}
+    assert doc["reservations"] == {"2026-05-14": _erec(_rslot("08:00", "12:00", ""))}
 
 
-def test_parse_v2_both():
+def test_parse_v2_both_wrapped():
     doc = parse_share_doc(_v2(
         entries={"2026-05-14": {"start": "08:00", "end": "16:00", "pause": 0}},
         reservations={"2026-05-15": {"start": "09:00", "end": "12:00"}},
     ))
-    assert doc["entries"] == {"2026-05-14": {"start": "08:00", "end": "16:00", "pause": 0}}
-    assert doc["reservations"] == {"2026-05-15": {"start": "09:00", "end": "12:00"}}
+    assert doc["entries"] == {"2026-05-14": _erec(_eslot("08:00", "16:00", 0, ""))}
+    assert doc["reservations"] == {"2026-05-15": _erec(_rslot("09:00", "12:00", ""))}
 
 
 def test_parse_v2_empty_entries_with_reservations_ok():
-    doc = parse_share_doc(_v2(
-        entries={},
-        reservations={"2026-05-14": {"start": "08:00", "end": "12:00"}},
-    ))
-    assert doc["reservations"] == {"2026-05-14": {"start": "08:00", "end": "12:00"}}
+    doc = parse_share_doc(_v2(entries={}, reservations={"2026-05-14": {"start": "08:00", "end": "12:00"}}))
+    assert doc["reservations"] == {"2026-05-14": _erec(_rslot("08:00", "12:00", ""))}
 
 
 def test_parse_v2_rejects_both_missing():
@@ -441,6 +200,89 @@ def test_parse_v2_reservation_rejects_bad_date_key():
         parse_share_doc(_v2(reservations={"not-a-date": {"start": "08:00", "end": "12:00"}}))
 
 
+# --- v3: Slot-Format ---
+
+
+def test_parse_v3_entries_slots():
+    doc = parse_share_doc(_v3(entries={"2026-05-14": _erec(_eslot("08:00", "12:00", 0, "Büro"),
+                                                           _eslot("13:00", "17:00", 30, "HO"))}))
+    assert doc["entries"]["2026-05-14"]["slots"][0] == _eslot("08:00", "12:00", 0, "Büro")
+    assert doc["entries"]["2026-05-14"]["slots"][1] == _eslot("13:00", "17:00", 30, "HO")
+
+
+def test_parse_v3_reservations_slots():
+    doc = parse_share_doc(_v3(reservations={"2026-05-14": _erec(_rslot("09:00", "12:00", "Termin"))}))
+    assert doc["reservations"]["2026-05-14"]["slots"][0] == _rslot("09:00", "12:00", "Termin")
+
+
+def test_parse_v3_both():
+    doc = parse_share_doc(_v3(
+        entries={"2026-05-14": _erec(_eslot("08:00", "16:00", 0, ""))},
+        reservations={"2026-05-15": _erec(_rslot("09:00", "12:00", ""))},
+    ))
+    assert doc["entries"] and doc["reservations"]
+
+
+def test_parse_v3_rejects_both_missing():
+    with pytest.raises(ShareValidationError, match="weder"):
+        parse_share_doc(_v3())
+
+
+def test_parse_v3_rejects_record_without_slots_key():
+    with pytest.raises(ShareValidationError, match="slots"):
+        parse_share_doc(_v3(entries={"2026-05-14": {"start": "08:00", "end": "16:00", "pause": 0}}))
+
+
+def test_parse_v3_rejects_entry_slot_extra_field():
+    with pytest.raises(ShareValidationError, match="unbekannt"):
+        parse_share_doc(_v3(entries={"2026-05-14": {"slots": [
+            {"start": "08:00", "end": "16:00", "pause": 0, "kategorie": "", "x": 1}]}}))
+
+
+def test_parse_v3_rejects_entry_slot_missing_field():
+    with pytest.raises(ShareValidationError, match="fehlend"):
+        parse_share_doc(_v3(entries={"2026-05-14": {"slots": [
+            {"start": "08:00", "end": "16:00", "pause": 0}]}}))
+
+
+def test_parse_v3_rejects_entry_slot_bad_time():
+    with pytest.raises(ShareValidationError, match="Startzeit"):
+        parse_share_doc(_v3(entries={"2026-05-14": {"slots": [_eslot("25:00", "16:00", 0, "")]}}))
+
+
+def test_parse_v3_rejects_entry_slot_negative_pause():
+    with pytest.raises(ShareValidationError, match="Pause"):
+        parse_share_doc(_v3(entries={"2026-05-14": {"slots": [_eslot("08:00", "16:00", -1, "")]}}))
+
+
+def test_parse_v3_rejects_entry_slot_bool_pause():
+    with pytest.raises(ShareValidationError, match="Pause"):
+        parse_share_doc(_v3(entries={"2026-05-14": {"slots": [
+            {"start": "08:00", "end": "16:00", "pause": True, "kategorie": ""}]}}))
+
+
+def test_parse_v3_rejects_reservation_slot_with_pause():
+    with pytest.raises(ShareValidationError, match="unbekannt"):
+        parse_share_doc(_v3(reservations={"2026-05-14": {"slots": [
+            {"start": "08:00", "end": "12:00", "pause": 0, "kategorie": ""}]}}))
+
+
+def test_parse_v3_rejects_bad_date_key():
+    with pytest.raises(ShareValidationError, match="Datum"):
+        parse_share_doc(_v3(entries={"not-a-date": _erec(_eslot("08:00", "16:00", 0, ""))}))
+
+
+# --- build_share_doc ---
+
+
+class _FakeStorage:
+    def __init__(self, entries):
+        self._entries = entries
+
+    def get_all(self):
+        return dict(self._entries)
+
+
 class _FakeResStore:
     def __init__(self, data):
         self._d = data
@@ -449,48 +291,172 @@ class _FakeResStore:
         return dict(self._d)
 
 
+def test_build_share_doc_basic():
+    storage = _FakeStorage({"2026-05-14": _erec(_eslot("08:00", "16:00", 30, "Büro"))})
+    doc = build_share_doc(storage, "alice@example.com")
+    assert doc["kind"] == KIND
+    assert doc["schema_version"] == SCHEMA_VERSION == 3
+    assert doc["exported_by"] == "alice@example.com"
+    assert doc["entries"] == {"2026-05-14": _erec(_eslot("08:00", "16:00", 30, "Büro"))}
+    assert "exported_at" in doc and doc["exported_at"].endswith("Z")
+
+
+def test_build_share_doc_none_sender_becomes_empty_string():
+    doc = build_share_doc(_FakeStorage({}), None)
+    assert doc["exported_by"] == ""
+
+
 def test_build_doc_entries_only_omits_reservations():
-    storage = _FakeStorage({"2026-05-14": {"start": "08:00", "end": "16:00", "pause": 0}})
-    doc = build_share_doc(storage, "a@b.de")
+    doc = build_share_doc(_FakeStorage({"2026-05-14": _erec(_eslot("08:00", "16:00", 0, ""))}), "a@b.de")
     assert "entries" in doc
     assert "reservations" not in doc
-    assert doc["schema_version"] == 2
+    assert doc["schema_version"] == 3
 
 
 def test_build_doc_reservations_only():
-    storage = _FakeStorage({"2026-05-14": {"start": "08:00", "end": "16:00", "pause": 0}})
-    res = _FakeResStore({"2026-05-15": {"start": "09:00", "end": "12:00"}})
-    doc = build_share_doc(
-        storage, "a@b.de", reservation_store=res,
-        include_entries=False, include_reservations=True,
-    )
+    storage = _FakeStorage({"2026-05-14": _erec(_eslot("08:00", "16:00", 0, ""))})
+    res = _FakeResStore({"2026-05-15": _erec(_rslot("09:00", "12:00", ""))})
+    doc = build_share_doc(storage, "a@b.de", reservation_store=res,
+                          include_entries=False, include_reservations=True)
     assert "entries" not in doc
-    assert doc["reservations"] == {"2026-05-15": {"start": "09:00", "end": "12:00"}}
+    assert doc["reservations"] == {"2026-05-15": _erec(_rslot("09:00", "12:00", ""))}
 
 
-def test_build_doc_both():
-    storage = _FakeStorage({"2026-05-14": {"start": "08:00", "end": "16:00", "pause": 0}})
-    res = _FakeResStore({"2026-05-15": {"start": "09:00", "end": "12:00"}})
-    doc = build_share_doc(
-        storage, "a@b.de", reservation_store=res,
-        include_entries=True, include_reservations=True,
-    )
-    assert doc["entries"] and doc["reservations"]
+def test_build_doc_category_filter_entries():
+    storage = _FakeStorage({"2026-05-14": _erec(_eslot("08:00", "12:00", 0, "Büro"),
+                                                _eslot("13:00", "17:00", 0, "HO"))})
+    doc = build_share_doc(storage, "a@b.de", categories={"Büro"})
+    assert doc["entries"] == {"2026-05-14": _erec(_eslot("08:00", "12:00", 0, "Büro"))}
+
+
+def test_build_doc_category_filter_drops_empty_days():
+    storage = _FakeStorage({"2026-05-14": _erec(_eslot("08:00", "12:00", 0, "Büro"))})
+    doc = build_share_doc(storage, "a@b.de", categories={"Nichtvorhanden"})
+    assert doc["entries"] == {}
+
+
+def test_round_trip_build_serialize_parse():
+    storage = _FakeStorage({
+        "2026-05-14": _erec(_eslot("08:00", "16:00", 30, "Büro")),
+        "2026-05-15": _erec(_eslot("09:00", "17:30", 45, "")),
+    })
+    doc = build_share_doc(storage, "alice@example.com")
     parsed = parse_share_doc(serialize_share_doc(doc))
-    assert parsed["entries"] and parsed["reservations"]
+    assert parsed["entries"] == doc["entries"]
+    assert parsed["schema_version"] == SCHEMA_VERSION
 
 
-from src.share import (
-    apply_reservation_import,
-    diff_reservations_against_local,
-)
+def test_serialize_utf8_umlauts():
+    doc = build_share_doc(_FakeStorage({"2026-05-14": _erec(_eslot("08:00", "16:00", 0, "Büro"))}),
+                          "äöü@example.com")
+    payload = serialize_share_doc(doc)
+    assert b"\\u" not in payload
+    assert parse_share_doc(payload)["exported_by"] == "äöü@example.com"
+
+
+# --- diff (Arbeitszeiten) ---
+
+
+def test_diff_only_additions():
+    share = {"2026-05-14": _erec(_eslot("08:00", "16:00", 30, ""))}
+    diff = diff_share_against_local(share, _FakeStorage({}))
+    assert diff["additions"] == [("2026-05-14", _erec(_eslot("08:00", "16:00", 30, "")))]
+    assert diff["conflicts"] == []
+    assert diff["untouched"] == []
+
+
+def test_diff_only_untouched():
+    local = {"2026-05-14": _erec(_eslot("08:00", "16:00", 30, ""))}
+    share = {"2026-05-14": _erec(_eslot("08:00", "16:00", 30, ""))}
+    diff = diff_share_against_local(share, _FakeStorage(local))
+    assert diff["untouched"] == ["2026-05-14"]
+    assert diff["conflicts"] == []
+
+
+def test_diff_slot_reorder_is_untouched():
+    local = {"2026-05-14": _erec(_eslot("08:00", "12:00", 0, "A"), _eslot("13:00", "17:00", 0, "B"))}
+    share = {"2026-05-14": _erec(_eslot("13:00", "17:00", 0, "B"), _eslot("08:00", "12:00", 0, "A"))}
+    diff = diff_share_against_local(share, _FakeStorage(local))
+    assert diff["untouched"] == ["2026-05-14"]
+
+
+def test_diff_category_difference_is_conflict():
+    local = {"2026-05-14": _erec(_eslot("08:00", "16:00", 30, "Büro"))}
+    share = {"2026-05-14": _erec(_eslot("08:00", "16:00", 30, "HO"))}
+    diff = diff_share_against_local(share, _FakeStorage(local))
+    assert len(diff["conflicts"]) == 1
+    assert diff["untouched"] == []
+
+
+def test_diff_pause_difference_is_conflict():
+    local = {"2026-05-14": _erec(_eslot("08:00", "16:00", 30, ""))}
+    share = {"2026-05-14": _erec(_eslot("08:00", "16:00", 45, ""))}
+    diff = diff_share_against_local(share, _FakeStorage(local))
+    assert len(diff["conflicts"]) == 1
+
+
+def test_diff_range_filter_inclusive_bounds():
+    share = {"2026-05-10": _erec(_eslot("08:00", "16:00", 0, "")),
+             "2026-05-15": _erec(_eslot("08:00", "16:00", 0, ""))}
+    diff = diff_share_against_local(share, _FakeStorage({}),
+                                    date_from=_dt.date(2026, 5, 10), date_to=_dt.date(2026, 5, 15))
+    assert len(diff["additions"]) == 2
+    assert diff["out_of_range"] == 0
+
+
+def test_diff_range_filter_excludes_outside():
+    share = {"2026-05-10": _erec(_eslot("08:00", "16:00", 0, "")),
+             "2026-05-15": _erec(_eslot("08:00", "16:00", 0, ""))}
+    diff = diff_share_against_local(share, _FakeStorage({}), date_from=_dt.date(2026, 5, 12))
+    assert [d for d, _ in diff["additions"]] == ["2026-05-15"]
+    assert diff["out_of_range"] == 1
+
+
+# --- apply (Arbeitszeiten) ---
+
+
+class _RecordingStorage:
+    def __init__(self):
+        self.save_many_calls = []
+
+    def save_many(self, updates):
+        self.save_many_calls.append(dict(updates))
+
+
+def test_apply_import_single_call_for_all_decisions():
+    s = _RecordingStorage()
+    apply_import(s, [
+        {"date": "2026-05-14", "entry": _erec(_eslot("08:00", "16:00", 30, "Büro"))},
+        {"date": "2026-05-15", "entry": _erec(_eslot("09:00", "17:00", 0, ""))},
+    ])
+    assert len(s.save_many_calls) == 1
+    assert s.save_many_calls[0] == {
+        "2026-05-14": _erec(_eslot("08:00", "16:00", 30, "Büro")),
+        "2026-05-15": _erec(_eslot("09:00", "17:00", 0, "")),
+    }
+
+
+def test_apply_import_integration_with_real_storage(tmp_path):
+    from src.storage import Storage
+    s = Storage(str(tmp_path / "z.json"), device_id="dev1")
+    s.save("2026-05-14", [_eslot("08:00", "16:00", 30, "")])
+    apply_import(s, [
+        {"date": "2026-05-15", "entry": _erec(_eslot("09:00", "17:00", 0, ""))},
+        {"date": "2026-05-14", "entry": _erec(_eslot("10:00", "18:00", 45, "Büro"))},
+    ])
+    entries = s.get_all()
+    assert entries["2026-05-14"] == _erec(_eslot("10:00", "18:00", 45, "Büro"))
+    assert entries["2026-05-15"] == _erec(_eslot("09:00", "17:00", 0, ""))
+
+
+# --- diff + apply (Reservierungen) ---
 
 
 def test_diff_reservations_additions_and_conflicts():
-    store = _FakeResStore({"2026-05-14": {"start": "08:00", "end": "12:00"}})
+    store = _FakeResStore({"2026-05-14": _erec(_rslot("08:00", "12:00", ""))})
     share = {
-        "2026-05-14": {"start": "09:00", "end": "12:00"},  # conflict
-        "2026-05-16": {"start": "10:00", "end": "14:00"},  # addition
+        "2026-05-14": _erec(_rslot("09:00", "12:00", "")),  # conflict
+        "2026-05-16": _erec(_rslot("10:00", "14:00", "")),  # addition
     }
     diff = diff_reservations_against_local(share, store)
     assert [d for d, _ in diff["additions"]] == ["2026-05-16"]
@@ -498,90 +464,33 @@ def test_diff_reservations_additions_and_conflicts():
 
 
 def test_diff_reservations_untouched():
-    store = _FakeResStore({"2026-05-14": {"start": "08:00", "end": "12:00"}})
-    share = {"2026-05-14": {"start": "08:00", "end": "12:00"}}
+    store = _FakeResStore({"2026-05-14": _erec(_rslot("08:00", "12:00", ""))})
+    share = {"2026-05-14": _erec(_rslot("08:00", "12:00", ""))}
     diff = diff_reservations_against_local(share, store)
     assert diff["untouched"] == ["2026-05-14"]
-    assert diff["conflicts"] == []
-
-
-def test_diff_reservations_range_filter():
-    store = _FakeResStore({})
-    share = {
-        "2026-05-10": {"start": "08:00", "end": "12:00"},
-        "2026-05-20": {"start": "08:00", "end": "12:00"},
-    }
-    diff = diff_reservations_against_local(share, store, date_from=_dt.date(2026, 5, 15))
-    assert [d for d, _ in diff["additions"]] == ["2026-05-20"]
-    assert diff["out_of_range"] == 1
 
 
 class _RecordingResStore:
     def __init__(self):
         self.saved = []
 
-    def save(self, date_str, start, end):
-        self.saved.append((date_str, start, end))
+    def save(self, date_str, slots):
+        self.saved.append((date_str, slots))
 
 
-def test_apply_reservation_import_calls_save_per_decision():
+def test_apply_reservation_import_calls_save_with_slots():
     store = _RecordingResStore()
     apply_reservation_import(store, [
-        {"date": "2026-05-14", "entry": {"start": "08:00", "end": "12:00"}},
-        {"date": "2026-05-15", "entry": {"start": "09:00", "end": "13:00"}},
+        {"date": "2026-05-14", "entry": _erec(_rslot("08:00", "12:00", "Termin"))},
+        {"date": "2026-05-15", "entry": _erec(_rslot("09:00", "13:00", ""))},
     ])
     assert store.saved == [
-        ("2026-05-14", "08:00", "12:00"),
-        ("2026-05-15", "09:00", "13:00"),
+        ("2026-05-14", [_rslot("08:00", "12:00", "Termin")]),
+        ("2026-05-15", [_rslot("09:00", "13:00", "")]),
     ]
-
-
-def test_apply_reservation_import_integration_keeps_event_id(tmp_path):
-    from src.reservations import ReservationStore
-    store = ReservationStore(str(tmp_path / "r.json"))
-    store.save("2026-05-14", "08:00", "12:00")
-    # gcal_event_id simulieren
-    raw = store.get_all_raw()
-    raw["2026-05-14"]["gcal_event_id"] = "evt-1"
-    store.apply_reconciled(raw)
-    apply_reservation_import(store, [
-        {"date": "2026-05-14", "entry": {"start": "10:00", "end": "14:00"}},
-    ])
-    assert store.get("2026-05-14") == {"start": "10:00", "end": "14:00"}
-    assert store.get_all_raw()["2026-05-14"]["gcal_event_id"] == "evt-1"
 
 
 def test_apply_reservation_import_empty_is_noop():
     store = _RecordingResStore()
     apply_reservation_import(store, [])
     assert store.saved == []
-
-
-def test_apply_reservation_import_then_reconcile_plans_update(tmp_path):
-    """End-to-End-Garantie: ein importiertes Reservierungs-Update wird beim
-    nächsten Kalender-Reconcile als update für das bestehende Event geplant
-    (kein Duplikat, gleiche gcal_event_id)."""
-    from src.reservations import ReservationStore
-    from src.reservations_sync import merge_reservations
-
-    store = ReservationStore(str(tmp_path / "r.json"))
-    store.save("2026-05-14", "08:00", "12:00")
-    raw = store.get_all_raw()
-    raw["2026-05-14"]["gcal_event_id"] = "evt-1"
-    store.apply_reconciled(raw)
-
-    # Import ändert die Zeiten (modified_at = jetzt, jünger als der Remote-Stand).
-    apply_reservation_import(store, [
-        {"date": "2026-05-14", "entry": {"start": "10:00", "end": "14:00"}},
-    ])
-
-    remote_events = [{
-        "date": "2026-05-14", "start": "08:00", "end": "12:00",
-        "modified_at": "2020-01-01T00:00:00Z", "event_id": "evt-1",
-    }]
-    result = merge_reservations(
-        store.get_all_raw(), remote_events, watermark="2020-01-01T00:00:00Z")
-    updates = result["plan"]["update"]
-    assert [u["event_id"] for u in updates] == ["evt-1"]
-    assert result["plan"]["create"] == []
-    assert updates[0]["start"] == "10:00" and updates[0]["end"] == "14:00"

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -4,43 +4,67 @@ from unittest import mock
 import pytest
 from src.storage import Storage
 
+
 @pytest.fixture
 def tmp_storage(tmp_path):
     return Storage(str(tmp_path / "test.json"), device_id="test-device")
 
+
+def _slot(start, end, pause=0, kategorie=""):
+    return {"start": start, "end": end, "pause": pause, "kategorie": kategorie}
+
+
 def test_load_empty(tmp_storage):
     assert tmp_storage.get_all() == {}
 
+
 def test_save_and_load(tmp_storage):
-    tmp_storage.save("2026-03-23", "08:00", "16:30")
+    tmp_storage.save("2026-03-23", [_slot("08:00", "16:30")])
     entries = tmp_storage.get_all()
-    assert entries["2026-03-23"] == {"start": "08:00", "end": "16:30", "pause": 0}
+    assert entries["2026-03-23"] == {"slots": [_slot("08:00", "16:30")]}
+
+
+def test_save_multiple_slots(tmp_storage):
+    slots = [_slot("08:00", "12:00", 0, "Büro"), _slot("13:00", "17:00", 30, "Homeoffice")]
+    tmp_storage.save("2026-03-23", slots)
+    assert tmp_storage.get("2026-03-23") == {"slots": slots}
+
+
+def test_slot_defaults_pause_and_kategorie(tmp_storage):
+    tmp_storage.save("2026-03-23", [{"start": "08:00", "end": "16:30"}])
+    assert tmp_storage.get("2026-03-23") == {"slots": [_slot("08:00", "16:30", 0, "")]}
+
 
 def test_delete_entry(tmp_storage):
-    tmp_storage.save("2026-03-23", "08:00", "16:30")
+    tmp_storage.save("2026-03-23", [_slot("08:00", "16:30")])
     tmp_storage.delete("2026-03-23")
     assert "2026-03-23" not in tmp_storage.get_all()
+
+
+def test_delete_writes_tombstone(tmp_storage):
+    tmp_storage.save("2026-03-23", [_slot("08:00", "16:30")])
+    tmp_storage.delete("2026-03-23")
+    raw = tmp_storage.get_all_raw()["2026-03-23"]
+    assert raw["deleted"] is True
+    assert raw["slots"] == []
+
 
 def test_delete_nonexistent(tmp_storage):
     tmp_storage.delete("2026-01-01")  # should not raise
     assert tmp_storage.get_all_raw() == {}
 
+
 def test_persistence(tmp_path):
     path = str(tmp_path / "test.json")
     s1 = Storage(path)
-    s1.save("2026-03-23", "08:00", "16:30")
+    s1.save("2026-03-23", [_slot("08:00", "16:30")])
     s2 = Storage(path)
-    assert s2.get_all()["2026-03-23"] == {"start": "08:00", "end": "16:30", "pause": 0}
+    assert s2.get_all()["2026-03-23"] == {"slots": [_slot("08:00", "16:30")]}
+
 
 def test_save_with_pause(tmp_storage):
-    tmp_storage.save("2026-03-23", "08:00", "16:30", pause=30)
-    entry = tmp_storage.get("2026-03-23")
-    assert entry == {"start": "08:00", "end": "16:30", "pause": 30}
-
-def test_save_default_pause_zero(tmp_storage):
-    tmp_storage.save("2026-03-23", "08:00", "16:30")
-    entry = tmp_storage.get("2026-03-23")
-    assert entry == {"start": "08:00", "end": "16:30", "pause": 0}
+    tmp_storage.save("2026-03-23", [_slot("08:00", "16:30", 30)])
+    assert tmp_storage.get("2026-03-23") == {"slots": [_slot("08:00", "16:30", 30)]}
 
 
 def test_corrupt_json_is_quarantined_and_starts_empty(tmp_path):
@@ -58,12 +82,12 @@ def test_corrupt_json_is_quarantined_and_starts_empty(tmp_path):
 def test_save_failure_keeps_original_file_intact(tmp_path):
     path = tmp_path / "test.json"
     storage = Storage(str(path))
-    storage.save("2026-03-23", "08:00", "16:30")
+    storage.save("2026-03-23", [_slot("08:00", "16:30")])
     original_bytes = path.read_bytes()
 
     with mock.patch("os.replace", side_effect=OSError("disk full")):
         with pytest.raises(OSError):
-            storage.save("2026-03-24", "09:00", "17:00")
+            storage.save("2026-03-24", [_slot("09:00", "17:00")])
 
     assert path.read_bytes() == original_bytes
     leftovers = [p for p in tmp_path.iterdir() if p.suffix == ".tmp"]
@@ -73,8 +97,8 @@ def test_save_failure_keeps_original_file_intact(tmp_path):
 def test_save_does_not_leave_tmp_files(tmp_path):
     path = tmp_path / "test.json"
     storage = Storage(str(path))
-    storage.save("2026-03-23", "08:00", "16:30")
-    storage.save("2026-03-24", "09:00", "17:00")
+    storage.save("2026-03-23", [_slot("08:00", "16:30")])
+    storage.save("2026-03-24", [_slot("09:00", "17:00")])
 
     leftovers = [p.name for p in tmp_path.iterdir() if p.name.endswith(".tmp")]
     assert leftovers == []
@@ -82,29 +106,34 @@ def test_save_does_not_leave_tmp_files(tmp_path):
 
 def test_save_stamps_modified_at_and_device_id(tmp_path):
     storage = Storage(str(tmp_path / "t.json"), device_id="dev-1")
-    storage.save("2026-05-14", "08:00", "16:00", pause=30)
+    storage.save("2026-05-14", [_slot("08:00", "16:00", 30)])
     raw = storage.get_all_raw()
-    assert raw["2026-05-14"]["start"] == "08:00"
+    assert raw["2026-05-14"]["slots"] == [_slot("08:00", "16:00", 30)]
     assert raw["2026-05-14"]["device_id"] == "dev-1"
-    assert "modified_at" in raw["2026-05-14"]
-    # ISO-Format
     assert "T" in raw["2026-05-14"]["modified_at"]
     assert raw["2026-05-14"]["modified_at"].endswith("Z")
 
 
 def test_get_returns_user_shape_without_metadata(tmp_path):
-    """Bestehende UI-Code-Pfade dürfen sich nicht ändern: get() liefert
-    weiter {start, end, pause}, get_all() ebenso."""
     storage = Storage(str(tmp_path / "t.json"), device_id="dev-1")
-    storage.save("2026-05-14", "08:00", "16:00", pause=30)
-    assert storage.get("2026-05-14") == {"start": "08:00", "end": "16:00", "pause": 30}
-    assert storage.get_all()["2026-05-14"] == {"start": "08:00", "end": "16:00", "pause": 30}
+    storage.save("2026-05-14", [_slot("08:00", "16:00", 30)])
+    assert storage.get("2026-05-14") == {"slots": [_slot("08:00", "16:00", 30)]}
+    assert storage.get_all()["2026-05-14"] == {"slots": [_slot("08:00", "16:00", 30)]}
+
+
+def test_user_shape_returns_independent_copies(tmp_path):
+    """get() darf keine Referenz auf interne Slot-Dicts herausgeben."""
+    storage = Storage(str(tmp_path / "t.json"))
+    storage.save("2026-05-14", [_slot("08:00", "16:00")])
+    got = storage.get("2026-05-14")
+    got["slots"][0]["start"] = "00:00"
+    assert storage.get("2026-05-14")["slots"][0]["start"] == "08:00"
 
 
 def test_apply_merge_rejects_entry_missing_required_keys(tmp_path):
     storage = Storage(str(tmp_path / "t.json"), device_id="dev-1")
     with pytest.raises(ValueError, match="missing keys"):
-        storage.apply_merge({"2026-05-14": {"start": "08:00", "end": "16:00"}})
+        storage.apply_merge({"2026-05-14": {"slots": [_slot("08:00", "16:00")]}})
     # _data unverändert geblieben (kein Halb-Schreiben)
     assert storage.get_all_raw() == {}
 
@@ -112,16 +141,15 @@ def test_apply_merge_rejects_entry_missing_required_keys(tmp_path):
 def test_apply_merge_accepts_complete_entries(tmp_path):
     storage = Storage(str(tmp_path / "t.json"), device_id="dev-1")
     storage.apply_merge({"2026-05-14": {
-        "start": "08:00", "end": "16:00", "pause": 30,
+        "slots": [_slot("08:00", "16:00", 30)],
         "modified_at": "2026-05-14T10:00:00Z",
         "device_id": "other-dev",
         "deleted": False,
     }})
-    assert storage.get("2026-05-14") == {"start": "08:00", "end": "16:00", "pause": 30}
+    assert storage.get("2026-05-14") == {"slots": [_slot("08:00", "16:00", 30)]}
 
 
 def test_save_many_empty_is_noop(tmp_path):
-    """Leeres Dict darf keinen File-Write triggern."""
     path = str(tmp_path / "noop.json")
     s = Storage(path, device_id="d1")
     s.save_many({})
@@ -130,16 +158,16 @@ def test_save_many_empty_is_noop(tmp_path):
 
 def test_save_many_writes_all_entries(tmp_storage):
     tmp_storage.save_many({
-        "2026-05-14": {"start": "08:00", "end": "16:00", "pause": 30},
-        "2026-05-15": {"start": "09:00", "end": "17:30", "pause": 45},
+        "2026-05-14": {"slots": [_slot("08:00", "16:00", 30)]},
+        "2026-05-15": {"slots": [_slot("09:00", "17:30", 45)]},
     })
     entries = tmp_storage.get_all()
-    assert entries["2026-05-14"] == {"start": "08:00", "end": "16:00", "pause": 30}
-    assert entries["2026-05-15"] == {"start": "09:00", "end": "17:30", "pause": 45}
+    assert entries["2026-05-14"] == {"slots": [_slot("08:00", "16:00", 30)]}
+    assert entries["2026-05-15"] == {"slots": [_slot("09:00", "17:30", 45)]}
 
 
 def test_save_many_sets_metadata(tmp_storage):
-    tmp_storage.save_many({"2026-05-14": {"start": "08:00", "end": "16:00", "pause": 30}})
+    tmp_storage.save_many({"2026-05-14": {"slots": [_slot("08:00", "16:00", 30)]}})
     raw = tmp_storage.get_all_raw()["2026-05-14"]
     assert raw["device_id"] == "test-device"
     assert raw["deleted"] is False
@@ -147,23 +175,24 @@ def test_save_many_sets_metadata(tmp_storage):
 
 
 def test_save_many_overwrites_tombstone(tmp_storage):
-    tmp_storage.save("2026-05-14", "08:00", "16:00", 30)
+    tmp_storage.save("2026-05-14", [_slot("08:00", "16:00", 30)])
     tmp_storage.delete("2026-05-14")
     assert tmp_storage.get("2026-05-14") is None
-    tmp_storage.save_many({"2026-05-14": {"start": "09:00", "end": "17:00", "pause": 0}})
-    assert tmp_storage.get("2026-05-14") == {"start": "09:00", "end": "17:00", "pause": 0}
+    tmp_storage.save_many({"2026-05-14": {"slots": [_slot("09:00", "17:00")]}})
+    assert tmp_storage.get("2026-05-14") == {"slots": [_slot("09:00", "17:00")]}
 
 
 def test_save_many_calls_disk_write_once(tmp_storage):
     with mock.patch.object(tmp_storage, "_save_to_disk") as m:
         tmp_storage.save_many({
-            "2026-05-14": {"start": "08:00", "end": "16:00", "pause": 30},
-            "2026-05-15": {"start": "09:00", "end": "17:30", "pause": 45},
+            "2026-05-14": {"slots": [_slot("08:00", "16:00", 30)]},
+            "2026-05-15": {"slots": [_slot("09:00", "17:30", 45)]},
         })
     assert m.call_count == 1
 
 
-def test_save_many_pause_default_zero(tmp_storage):
-    """Pause-Feld fehlt → wird auf 0 default-gesetzt (analog zu save())."""
-    tmp_storage.save_many({"2026-05-14": {"start": "08:00", "end": "16:00"}})
-    assert tmp_storage.get_all()["2026-05-14"]["pause"] == 0
+def test_save_many_slot_defaults(tmp_storage):
+    tmp_storage.save_many({"2026-05-14": {"slots": [{"start": "08:00", "end": "16:00"}]}})
+    slot = tmp_storage.get_all()["2026-05-14"]["slots"][0]
+    assert slot["pause"] == 0
+    assert slot["kategorie"] == ""

--- a/tests/test_storage_migration.py
+++ b/tests/test_storage_migration.py
@@ -1,7 +1,6 @@
 import json
 import os
 
-
 from src.storage import Storage
 
 
@@ -12,20 +11,19 @@ def _write_legacy_json(tmp_path, payload):
     return str(path)
 
 
-def test_legacy_entries_get_metadata_on_load(tmp_path):
-    """Eintrag ohne modified_at/device_id/deleted wird beim Laden migriert."""
+def test_legacy_entry_wrapped_into_single_slot(tmp_path):
+    """Alter Ein-Eintrag-Tag ohne Metadaten → 1-Slot-Liste + Sync-Metadaten."""
     path = _write_legacy_json(tmp_path, {
         "2026-03-23": {"start": "08:00", "end": "16:30", "pause": 30},
     })
     storage = Storage(path, device_id="dev-1")
-    raw = storage.get_all_raw()
-    entry = raw["2026-03-23"]
-    assert entry["start"] == "08:00"
-    assert entry["end"] == "16:30"
-    assert entry["pause"] == 30
-    assert entry["device_id"] == "dev-1"
-    assert entry["deleted"] is False
-    assert entry["modified_at"].endswith("Z")
+    raw = storage.get_all_raw()["2026-03-23"]
+    assert raw["slots"] == [{"start": "08:00", "end": "16:30", "pause": 30, "kategorie": ""}]
+    assert raw["device_id"] == "dev-1"
+    assert raw["deleted"] is False
+    assert raw["modified_at"].endswith("Z")
+    # alte Top-Level-Zeitfelder entfernt
+    assert "start" not in raw and "end" not in raw and "pause" not in raw
 
 
 def test_legacy_modified_at_uses_file_mtime(tmp_path):
@@ -33,27 +31,26 @@ def test_legacy_modified_at_uses_file_mtime(tmp_path):
     path = _write_legacy_json(tmp_path, {
         "2026-03-23": {"start": "08:00", "end": "16:30", "pause": 30},
     })
-    # mtime künstlich setzen
     fixed_mtime = 1_700_000_000  # 2023-11-14T22:13:20Z
     os.utime(path, (fixed_mtime, fixed_mtime))
     storage = Storage(path, device_id="dev-1")
-    entry = storage.get_all_raw()["2026-03-23"]
-    assert entry["modified_at"] == "2023-11-14T22:13:20Z"
+    assert storage.get_all_raw()["2026-03-23"]["modified_at"] == "2023-11-14T22:13:20Z"
 
 
-def test_user_facing_get_all_after_migration_unchanged(tmp_path):
-    """UI-Code sieht nach Migration weiter die schmale Shape."""
+def test_user_facing_get_all_after_migration(tmp_path):
+    """UI-Code sieht nach Migration die Slot-Shape."""
     path = _write_legacy_json(tmp_path, {
         "2026-03-23": {"start": "08:00", "end": "16:30", "pause": 30},
     })
     storage = Storage(path, device_id="dev-1")
     assert storage.get_all() == {
-        "2026-03-23": {"start": "08:00", "end": "16:30", "pause": 30}
+        "2026-03-23": {"slots": [{"start": "08:00", "end": "16:30", "pause": 30, "kategorie": ""}]}
     }
 
 
-def test_partially_migrated_entries_not_touched(tmp_path):
-    """Wenn modified_at schon da ist (z.B. Sync hat geschrieben), keine Re-Migration."""
+def test_v2_entry_with_metadata_gets_slot_wrapped_keeping_metadata(tmp_path):
+    """v2-Eintrag (Metadaten da, aber kein slots-Key) wird in Slots gewrappt;
+    modified_at/device_id bleiben erhalten (keine Re-Stampelung)."""
     path = _write_legacy_json(tmp_path, {
         "2026-03-23": {
             "start": "08:00", "end": "16:30", "pause": 30,
@@ -63,6 +60,37 @@ def test_partially_migrated_entries_not_touched(tmp_path):
         },
     })
     storage = Storage(path, device_id="dev-1")
-    entry = storage.get_all_raw()["2026-03-23"]
-    assert entry["modified_at"] == "2026-05-01T10:00:00Z"
-    assert entry["device_id"] == "other-device"
+    raw = storage.get_all_raw()["2026-03-23"]
+    assert raw["slots"] == [{"start": "08:00", "end": "16:30", "pause": 30, "kategorie": ""}]
+    assert raw["modified_at"] == "2026-05-01T10:00:00Z"
+    assert raw["device_id"] == "other-device"
+
+
+def test_legacy_tombstone_becomes_empty_slots(tmp_path):
+    """Alt-Tombstone (deleted=true, start=null) → slots=[]."""
+    path = _write_legacy_json(tmp_path, {
+        "2026-03-23": {
+            "start": None, "end": None, "pause": None,
+            "modified_at": "2026-05-01T10:00:00Z",
+            "device_id": "other-device",
+            "deleted": True,
+        },
+    })
+    storage = Storage(path, device_id="dev-1")
+    raw = storage.get_all_raw()["2026-03-23"]
+    assert raw["slots"] == []
+    assert raw["deleted"] is True
+
+
+def test_migration_idempotent_after_persist(tmp_path):
+    """Zweites Laden einer bereits migrierten Datei wrappt nicht erneut."""
+    path = _write_legacy_json(tmp_path, {
+        "2026-03-23": {"start": "08:00", "end": "16:30", "pause": 30},
+    })
+    s1 = Storage(path, device_id="dev-1")
+    s1._save_to_disk()  # migrierte Form persistieren
+    s2 = Storage(path, device_id="dev-1")
+    raw = s2.get_all_raw()["2026-03-23"]
+    assert raw["slots"] == [{"start": "08:00", "end": "16:30", "pause": 30, "kategorie": ""}]
+    # Slot ist nicht doppelt verschachtelt
+    assert "slots" not in raw["slots"][0]

--- a/tests/test_storage_migration.py
+++ b/tests/test_storage_migration.py
@@ -95,3 +95,83 @@ def test_migration_idempotent_after_persist(tmp_path):
     assert raw["slots"] == [{"start": "08:00", "end": "16:30", "pause": 30, "kategorie": ""}]
     # Slot ist nicht doppelt verschachtelt
     assert "slots" not in raw["slots"][0]
+
+
+# --- v2 -> v3 über die Sync-Grenze: migrierte Altdaten müssen sich verlustfrei
+#     als v3-Doc bauen und in ein frisches v3-Gerät mergen lassen ---
+
+from src.sync import build_local_doc, merge, apply_merged_doc, SCHEMA_VERSION
+from src.settings import Settings
+from src.conflicts_store import ConflictsStore
+
+
+def _stores(tmp_path, name, device_id):
+    storage = Storage(str(tmp_path / f"{name}.json"), device_id=device_id)
+    settings = Settings(str(tmp_path / f"{name}-s.json"))
+    settings.device_id_for_sync = device_id
+    conflicts = ConflictsStore(str(tmp_path / f"{name}-c.json"))
+    return storage, settings, conflicts
+
+
+def test_migrated_v2_entry_round_trips_through_v3_sync(tmp_path):
+    """End-to-End: Gerät mit flachen v2-Daten wird auf v3 aktualisiert; die
+    migrierten Daten erscheinen als valides v3-Doc (schema_version 3 + slots)
+    und mergen verlustfrei in ein frisches v3-Gerät (kein ValueError in
+    apply_merge, keine geplätteten Einträge)."""
+    path = _write_legacy_json(tmp_path, {
+        "2026-03-23": {
+            "start": "08:00", "end": "16:30", "pause": 30,
+            "modified_at": "2026-05-01T10:00:00Z",
+            "device_id": "old-dev", "deleted": False,
+        },
+    })
+    old = Storage(path, device_id="old-dev")
+    old_settings = Settings(str(tmp_path / "old-s.json"))
+    old_settings.device_id_for_sync = "old-dev"
+    old_conflicts = ConflictsStore(str(tmp_path / "old-c.json"))
+
+    # build_local_doc nach Migration -> v3-Doc mit slots
+    doc = build_local_doc(old, old_settings, old_conflicts)
+    assert SCHEMA_VERSION == 3
+    assert doc["schema_version"] == 3
+    assert doc["entries"]["2026-03-23"]["slots"] == [
+        {"start": "08:00", "end": "16:30", "pause": 30, "kategorie": ""}
+    ]
+
+    # frisches v3-Gerät pullt das Doc -> verlustfreier Merge
+    fresh, fresh_settings, fresh_conflicts = _stores(tmp_path, "fresh", "new-dev")
+    merged = merge(build_local_doc(fresh, fresh_settings, fresh_conflicts), doc, "")
+    apply_merged_doc(merged, fresh, fresh_settings, fresh_conflicts)
+
+    assert fresh.get_all() == {
+        "2026-03-23": {"slots": [
+            {"start": "08:00", "end": "16:30", "pause": 30, "kategorie": ""}]}
+    }
+
+
+def test_migrated_v2_tombstone_round_trips_through_v3_sync(tmp_path):
+    """Auch ein migrierter Alt-Tombstone (deleted=true -> slots=[]) muss die
+    Sync-Grenze als Löschung überstehen, nicht als lebender Leereintrag."""
+    path = _write_legacy_json(tmp_path, {
+        "2026-03-23": {
+            "start": None, "end": None, "pause": None,
+            "modified_at": "2026-05-01T10:00:00Z",
+            "device_id": "old-dev", "deleted": True,
+        },
+    })
+    old = Storage(path, device_id="old-dev")
+    old_settings = Settings(str(tmp_path / "old2-s.json"))
+    old_settings.device_id_for_sync = "old-dev"
+    old_conflicts = ConflictsStore(str(tmp_path / "old2-c.json"))
+
+    doc = build_local_doc(old, old_settings, old_conflicts)
+    assert doc["entries"]["2026-03-23"]["slots"] == []
+    assert doc["entries"]["2026-03-23"]["deleted"] is True
+
+    fresh, fresh_settings, fresh_conflicts = _stores(tmp_path, "fresh2", "new-dev")
+    merged = merge(build_local_doc(fresh, fresh_settings, fresh_conflicts), doc, "")
+    apply_merged_doc(merged, fresh, fresh_settings, fresh_conflicts)
+
+    # Tombstone bleibt Löschung: nicht in der User-Sicht, aber als deleted im Raw.
+    assert "2026-03-23" not in fresh.get_all()
+    assert fresh.get_all_raw()["2026-03-23"]["deleted"] is True

--- a/tests/test_storage_migration.py
+++ b/tests/test_storage_migration.py
@@ -64,6 +64,7 @@ def test_v2_entry_with_metadata_gets_slot_wrapped_keeping_metadata(tmp_path):
     assert raw["slots"] == [{"start": "08:00", "end": "16:30", "pause": 30, "kategorie": ""}]
     assert raw["modified_at"] == "2026-05-01T10:00:00Z"
     assert raw["device_id"] == "other-device"
+    assert raw["deleted"] is False
 
 
 def test_legacy_tombstone_becomes_empty_slots(tmp_path):

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -9,10 +9,15 @@ from src.sync import _merge_one, apply_merged_doc, build_local_doc, merge, resol
 
 
 def _e(start, end, pause, modified_at, device_id="d", deleted=False):
+    slots = [] if deleted else [{"start": start, "end": end, "pause": pause, "kategorie": ""}]
     return {
-        "start": start, "end": end, "pause": pause,
+        "slots": slots,
         "modified_at": modified_at, "device_id": device_id, "deleted": deleted,
     }
+
+
+def _slot(start, end, pause=0, kategorie=""):
+    return {"start": start, "end": end, "pause": pause, "kategorie": kategorie}
 
 
 def test_merge_one_local_only_keeps_local():
@@ -35,7 +40,7 @@ def test_merge_one_equal_values_no_conflict():
     merged, conflict = _merge_one(e1, e2, "2026-05-13T00:00:00Z")
     assert conflict is None
     # bei gleichen Values darf irgendeine Seite gewinnen, aber kein Conflict
-    assert merged["start"] == "08:00"
+    assert merged["slots"][0]["start"] == "08:00"
 
 
 def test_merge_one_only_local_changed_no_conflict():
@@ -115,7 +120,7 @@ def test_merge_local_only_entry_preserved():
 def test_merge_remote_only_entry_added():
     remote = _doc(entries={"2026-05-14": _e("09:00", "17:00", 30, "2026-05-14T10:00:00Z")})
     merged = merge(_doc(), remote, "2026-05-13T00:00:00Z")
-    assert merged["entries"]["2026-05-14"]["start"] == "09:00"
+    assert merged["entries"]["2026-05-14"]["slots"][0]["start"] == "09:00"
 
 
 def test_merge_conflict_creates_conflict_object():
@@ -134,7 +139,7 @@ def test_merge_no_conflict_when_only_one_side_changed():
     remote = _doc(entries={"D": _e("09:00", "17:00", 30, "2026-05-14T10:00:00Z")})
     merged = merge(local, remote, "2026-05-10T00:00:00Z")
     assert merged["conflicts"] == []
-    assert merged["entries"]["D"]["start"] == "09:00"
+    assert merged["entries"]["D"]["slots"][0]["start"] == "09:00"
 
 
 # --- Task 2.4: merge() for Settings (Whitelist) ---
@@ -195,7 +200,7 @@ def test_merge_conflicts_union_by_id():
 def test_merge_conflicts_resolved_wins_over_unresolved():
     """Wenn dasselbe Konflikt-ID auf einer Seite resolved ist, gilt resolved."""
     resolved = _conflict("c-1", resolved=True,
-                         resolution={"start": "08:00", "end": "16:00", "pause": 30},
+                         resolution={"slots": [_slot("08:00", "16:00", 30)]},
                          resolved_at="2026-05-14T11:00:00Z",
                          resolved_by="A")
     unresolved = _conflict("c-1", resolved=False)
@@ -207,10 +212,10 @@ def test_merge_conflicts_resolved_wins_over_unresolved():
 
 def test_merge_conflicts_lww_on_resolved_at_when_both_resolved():
     c_a = _conflict("c-1", resolved=True,
-                    resolution={"start": "08:00"}, resolved_at="2026-05-14T11:00:00Z",
+                    resolution={"slots": [_slot("08:00", "16:00", 30)]}, resolved_at="2026-05-14T11:00:00Z",
                     resolved_by="A")
     c_b = _conflict("c-1", resolved=True,
-                    resolution={"start": "09:00"}, resolved_at="2026-05-14T12:00:00Z",
+                    resolution={"slots": [_slot("09:00", "17:00", 30)]}, resolved_at="2026-05-14T12:00:00Z",
                     resolved_by="B")
     merged = merge(_doc(conflicts=[c_a]), _doc(conflicts=[c_b]), "2026-05-13T00:00:00Z")
     assert len(merged["conflicts"]) == 1
@@ -240,7 +245,7 @@ def test_merge_applies_resolved_conflict_to_entry():
     """Resolved Konflikt aktualisiert merged.entries auf die Resolution."""
     resolved = _conflict("c-1", key="D",
                          resolved=True,
-                         resolution={"start": "10:00", "end": "18:00", "pause": 30},
+                         resolution={"slots": [_slot("10:00", "18:00", 30)]},
                          resolved_at="2026-05-14T12:00:00Z",
                          resolved_by="A")
     local = _doc(
@@ -250,8 +255,8 @@ def test_merge_applies_resolved_conflict_to_entry():
     remote = _doc(entries={"D": _e("09:00", "17:00", 30, "2026-05-14T10:00:00Z")})
     merged = merge(local, remote, "2026-05-13T00:00:00Z")
     e = merged["entries"]["D"]
-    assert e["start"] == "10:00"
-    assert e["end"] == "18:00"
+    assert e["slots"][0]["start"] == "10:00"
+    assert e["slots"][0]["end"] == "18:00"
     assert e["modified_at"] == "2026-05-14T12:00:00Z"
     assert e["device_id"] == "A"
     assert e["deleted"] is False
@@ -274,7 +279,7 @@ def test_merge_applies_resolved_setting_conflict():
 
 def test_build_local_doc_includes_storage_settings_conflicts(tmp_path):
     storage = Storage(str(tmp_path / "z.json"), device_id="A")
-    storage.save("2026-05-14", "08:00", "16:00", 30)
+    storage.save("2026-05-14", [_slot("08:00", "16:00", 30)])
     settings = Settings(str(tmp_path / "s.json"))
     settings.device_id_for_sync = "A"
     settings.set_synced("recipient", "a@b.de")
@@ -285,12 +290,12 @@ def test_build_local_doc_includes_storage_settings_conflicts(tmp_path):
     assert "2026-05-14" in doc["entries"]
     assert doc["settings"]["recipient"]["value"] == "a@b.de"
     assert doc["conflicts"][0]["id"] == "c-1"
-    assert doc["schema_version"] == 2
+    assert doc["schema_version"] == 3
 
 
 def test_round_trip_no_loss(tmp_path):
     storage = Storage(str(tmp_path / "z.json"), device_id="A")
-    storage.save("2026-05-14", "08:00", "16:00", 30)
+    storage.save("2026-05-14", [_slot("08:00", "16:00", 30)])
     settings = Settings(str(tmp_path / "s.json"))
     settings.device_id_for_sync = "A"
     settings.set_synced("name", "Max")
@@ -300,7 +305,7 @@ def test_round_trip_no_loss(tmp_path):
     merged = merge(local, _doc(), "2025-01-01T00:00:00Z")
     apply_merged_doc(merged, storage, settings, conflicts)
 
-    assert storage.get("2026-05-14") == {"start": "08:00", "end": "16:00", "pause": 30}
+    assert storage.get("2026-05-14") == {"slots": [_slot("08:00", "16:00", 30)]}
     assert settings.get("name") == "Max"
 
 
@@ -313,9 +318,9 @@ def test_resolve_entry_conflict_updates_storage_and_marks_resolved(tmp_path):
     conflicts.save_all([{
         "id": "c-1", "kind": "entry", "key": "2026-05-14",
         "candidates": [
-            {"start": "08:00", "end": "16:00", "pause": 30,
+            {"slots": [_slot("08:00", "16:00", 30)],
              "modified_at": "2026-05-14T09:00:00Z", "device_id": "A", "deleted": False},
-            {"start": "09:00", "end": "17:00", "pause": 30,
+            {"slots": [_slot("09:00", "17:00", 30)],
              "modified_at": "2026-05-14T10:00:00Z", "device_id": "B", "deleted": False},
         ],
         "detected_at": "2026-05-14T11:00:00Z",
@@ -323,11 +328,11 @@ def test_resolve_entry_conflict_updates_storage_and_marks_resolved(tmp_path):
         "resolved_at": None, "resolved_by": None,
     }])
 
-    chosen = {"start": "09:00", "end": "17:00", "pause": 30}
+    chosen = {"slots": [_slot("09:00", "17:00", 30)]}
     resolve_conflict("c-1", chosen, conflicts, storage, settings, device_id="A")
 
     # storage hat den Wert
-    assert storage.get("2026-05-14") == {"start": "09:00", "end": "17:00", "pause": 30}
+    assert storage.get("2026-05-14") == {"slots": [_slot("09:00", "17:00", 30)]}
     # conflict ist resolved
     c = conflicts.get_all()[0]
     assert c["resolved"] is True
@@ -499,7 +504,7 @@ def test_merge_recovers_after_failed_compaction_push():
 
 def test_merge_drops_settled_resolved_conflict():
     wm = "2026-05-10T00:00:00Z"
-    c = _conflict("c-1", resolved=True, resolution={"start": "08:00"},
+    c = _conflict("c-1", resolved=True, resolution={"slots": [_slot("08:00", "16:00", 30)]},
                   resolved_at="2026-05-05T00:00:00Z", resolved_by="A")
     local = _meta_doc(conflicts=[c], watermark=wm)
     merged = merge(local, _meta_doc(watermark=wm), "2026-04-01T00:00:00Z")
@@ -509,7 +514,7 @@ def test_merge_drops_settled_resolved_conflict():
 def test_merge_keeps_resolved_conflict_without_resolved_at():
     """Defensiv: resolved=True aber resolved_at None/'' → nicht droppen (kein Crash)."""
     wm = "2026-05-10T00:00:00Z"
-    c = _conflict("c-1", resolved=True, resolution={"start": "08:00"},
+    c = _conflict("c-1", resolved=True, resolution={"slots": [_slot("08:00", "16:00", 30)]},
                   resolved_at=None, resolved_by="A")
     local = _meta_doc(conflicts=[c], watermark=wm)
     merged = merge(local, _meta_doc(watermark=wm), "2026-04-01T00:00:00Z")
@@ -556,7 +561,7 @@ def test_merge_first_sync_device_keeps_history():
     )
     remote = _meta_doc(entries={}, watermark=wm)
     merged = merge(local, remote, "")  # Erstsync
-    assert merged["entries"]["D"]["start"] == "08:00"
+    assert merged["entries"]["D"]["slots"][0]["start"] == "08:00"
 
 
 def test_merge_keeps_fresh_offline_edit_for_excluded_device():
@@ -568,7 +573,7 @@ def test_merge_keeps_fresh_offline_edit_for_excluded_device():
     )
     remote = _meta_doc(entries={}, watermark=wm)
     merged = merge(local, remote, "2026-05-06T00:00:00Z")  # excluded
-    assert merged["entries"]["D"]["start"] == "08:00"
+    assert merged["entries"]["D"]["slots"][0]["start"] == "08:00"
 
 
 def test_merge_no_suppression_when_remote_present():
@@ -588,19 +593,19 @@ def test_merge_no_suppression_when_remote_present():
 
 # --- Kompaktierungs-Helfer ---
 
-from src.sync import compact_local, _remote_is_pre_v2
+from src.sync import compact_local, _remote_is_pre_v3
 
 
 def test_compact_local_strips_stores_and_sets_watermark(tmp_path):
     storage = Storage(str(tmp_path / "z.json"), device_id="A")
-    storage.save("LIVE", "08:00", "16:00", 30)
-    storage.save("DEL", "08:00", "16:00", 30)
+    storage.save("LIVE", [_slot("08:00", "16:00", 30)])
+    storage.save("DEL", [_slot("08:00", "16:00", 30)])
     storage.delete("DEL")  # Tombstone
     settings = Settings(str(tmp_path / "s.json"))
     conflicts = ConflictsStore(str(tmp_path / "c.json"))
     conflicts.save_all([
         {"id": "c-1", "kind": "entry", "key": "X", "candidates": [],
-         "detected_at": "...", "resolved": True, "resolution": {"start": "08:00"},
+         "detected_at": "...", "resolved": True, "resolution": {"slots": [_slot("08:00", "16:00", 30)]},
          "resolved_at": "2026-05-05T00:00:00Z", "resolved_by": "A"},
         {"id": "c-2", "kind": "entry", "key": "Y", "candidates": [],
          "detected_at": "...", "resolved": False, "resolution": None,
@@ -620,8 +625,35 @@ def test_compact_local_strips_stores_and_sets_watermark(tmp_path):
     assert remaining == ["c-2"]        # nur unresolved bleibt
 
 
-def test_remote_is_pre_v2():
-    assert _remote_is_pre_v2({"schema_version": 1, "entries": {}}) is True
-    assert _remote_is_pre_v2({"schema_version": 2, "entries": {}}) is True  # kein meta
-    assert _remote_is_pre_v2({"schema_version": 2, "meta": {"gc_watermark": ""}}) is False
-    assert _remote_is_pre_v2({"schema_version": 2, "meta": {}}) is True     # meta ohne key
+def test_remote_is_pre_v3():
+    assert _remote_is_pre_v3({"schema_version": 1, "entries": {}}) is True
+    assert _remote_is_pre_v3({"schema_version": 2, "entries": {}}) is True
+    assert _remote_is_pre_v3({"schema_version": 3, "entries": {}}) is False
+    assert _remote_is_pre_v3({}) is True  # fehlende schema_version → pre-v3
+
+
+def test_merge_slot_reorder_is_not_a_conflict():
+    """Gleiche Slots in unterschiedlicher Reihenfolge zählen als gleich →
+    kein Konflikt, auch wenn beide Seiten seit last_pull geändert haben."""
+    a = {"slots": [_slot("08:00", "12:00", 0, "Büro"), _slot("13:00", "17:00", 0, "HO")],
+         "modified_at": "2026-05-14T10:00:00Z", "device_id": "A", "deleted": False}
+    b = {"slots": [_slot("13:00", "17:00", 0, "HO"), _slot("08:00", "12:00", 0, "Büro")],
+         "modified_at": "2026-05-14T11:00:00Z", "device_id": "B", "deleted": False}
+    local = _doc(entries={"D": a})
+    remote = _doc(entries={"D": b})
+    merged = merge(local, remote, "2026-05-13T00:00:00Z")
+    assert merged["conflicts"] == []
+
+
+def test_merge_different_slots_conflict_candidates_carry_slots():
+    """Unterschiedliche Slot-Listen, beide geändert → Konflikt; die Kandidaten
+    tragen die jeweilige Slot-Liste."""
+    a = {"slots": [_slot("08:00", "16:00", 30, "Büro")],
+         "modified_at": "2026-05-14T09:00:00Z", "device_id": "A", "deleted": False}
+    b = {"slots": [_slot("09:00", "17:00", 30, "HO")],
+         "modified_at": "2026-05-14T10:00:00Z", "device_id": "B", "deleted": False}
+    merged = merge(_doc(entries={"D": a}), _doc(entries={"D": b}), "2026-05-13T00:00:00Z")
+    assert len(merged["conflicts"]) == 1
+    cand_by_dev = {c["device_id"]: c for c in merged["conflicts"][0]["candidates"]}
+    assert cand_by_dev["A"]["slots"] == [_slot("08:00", "16:00", 30, "Büro")]
+    assert cand_by_dev["B"]["slots"] == [_slot("09:00", "17:00", 30, "HO")]

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -1,0 +1,26 @@
+from src.theme import _click_keeps_focus
+
+
+class _FakeWidget:
+    def __init__(self, cls):
+        self._cls = cls
+
+    def winfo_class(self):
+        return self._cls
+
+
+def test_click_keeps_focus_for_input_widget():
+    assert _click_keeps_focus(_FakeWidget("Entry")) is True
+    assert _click_keeps_focus(_FakeWidget("TCombobox")) is True
+
+
+def test_click_releases_focus_for_non_input_widget():
+    assert _click_keeps_focus(_FakeWidget("Label")) is False
+    assert _click_keeps_focus(_FakeWidget("Frame")) is False
+
+
+def test_click_keeps_focus_handles_destroyed_widget_path_string():
+    # Regression: ein während seines Klick-Events zerstörtes Widget (z.B. die
+    # "×"-Schaltfläche einer Slot-Zeile) liefert event.widget als Pfad-String.
+    # Darf NICHT crashen (AttributeError: 'str' has no 'winfo_class').
+    assert _click_keeps_focus(".!toplevel.!frame.!label") is False

--- a/tests/test_time_calc.py
+++ b/tests/test_time_calc.py
@@ -35,3 +35,75 @@ def test_calculate_hours_with_pause():
 def test_calculate_hours_default_no_pause():
     # Existing behavior unchanged when pause_minutes not provided
     assert calculate_hours("08:00", "16:30") == 8.5
+
+
+from src.time_utils import slots_overlap, validate_slots
+
+
+def _s(start, end, pause=0, kategorie=""):
+    return {"start": start, "end": end, "pause": pause, "kategorie": kategorie}
+
+
+def test_slots_overlap_false_for_disjoint():
+    assert slots_overlap([_s("08:00", "12:00"), _s("13:00", "17:00")]) is False
+
+
+def test_slots_overlap_false_for_adjacent():
+    # Ende == Start des nächsten ist erlaubt (angrenzend, nicht überlappend)
+    assert slots_overlap([_s("08:00", "12:00"), _s("12:00", "17:00")]) is False
+
+
+def test_slots_overlap_true_for_overlap():
+    assert slots_overlap([_s("08:00", "13:00"), _s("12:00", "17:00")]) is True
+
+
+def test_slots_overlap_detects_unsorted_input():
+    # Reihenfolge egal: zweite Liste ist nicht nach start sortiert
+    assert slots_overlap([_s("13:00", "17:00"), _s("08:00", "13:30")]) is True
+
+
+def test_slots_overlap_ignores_unparsable_times():
+    # Ein Slot mit kaputter Zeit wird übersprungen (validate_slots fängt ihn ab)
+    assert slots_overlap([_s("abc", "xyz"), _s("08:00", "12:00")]) is False
+
+
+def test_slots_overlap_empty_and_single():
+    assert slots_overlap([]) is False
+    assert slots_overlap([_s("08:00", "16:00")]) is False
+
+
+def test_validate_slots_ok_single():
+    ok, msg = validate_slots([_s("08:00", "16:30", 30)])
+    assert ok is True
+    assert msg == ""
+
+
+def test_validate_slots_ok_multiple_disjoint():
+    ok, _ = validate_slots([_s("08:00", "12:00", 0, "Büro"), _s("13:00", "17:00", 30, "HO")])
+    assert ok is True
+
+
+def test_validate_slots_empty_is_ok():
+    assert validate_slots([]) == (True, "")
+
+
+def test_validate_slots_rejects_overlap():
+    ok, msg = validate_slots([_s("08:00", "13:00"), _s("12:00", "17:00")])
+    assert ok is False
+    assert "überlapp" in msg.lower()
+
+
+def test_validate_slots_rejects_bad_slot():
+    ok, msg = validate_slots([_s("17:00", "08:00")])  # Ende vor Start
+    assert ok is False
+
+
+def test_validate_slots_rejects_pause_too_big():
+    ok, msg = validate_slots([_s("08:00", "09:00", 90)])  # Pause > Arbeitszeit
+    assert ok is False
+
+
+def test_validate_slots_without_pause_ignores_pause():
+    # Reservierungs-Slots: pause wird ignoriert (with_pause=False), kein Pausenfehler
+    ok, msg = validate_slots([_s("08:00", "09:00", 999)], with_pause=False)
+    assert ok is True

--- a/tests/test_ui_delete.py
+++ b/tests/test_ui_delete.py
@@ -1,0 +1,39 @@
+from src.ui import _delete_action
+
+
+def test_delete_action_none_when_type_not_selected():
+    assert _delete_action([{"start": "08:00"}], {"reservation:all"}, "entry") == ("none", None)
+
+
+def test_delete_action_whole_type():
+    assert _delete_action([{"start": "08:00"}], {"entry:all"}, "entry") == ("delete", None)
+
+
+def test_delete_action_partial_keeps_rest():
+    slots = [{"s": 0}, {"s": 1}, {"s": 2}]
+    action, keep = _delete_action(slots, {"entry:1"}, "entry")
+    assert action == "save"
+    assert keep == [{"s": 0}, {"s": 2}]
+
+
+def test_delete_action_all_indices_selected_becomes_delete():
+    slots = [{"s": 0}, {"s": 1}]
+    assert _delete_action(slots, {"entry:0", "entry:1"}, "entry") == ("delete", None)
+
+
+def test_delete_action_prefix_isolation():
+    slots = [{"s": 0}, {"s": 1}]
+    # Nur Reservierungs-Keys gewählt → entry nicht betroffen.
+    assert _delete_action(slots, {"reservation:0"}, "entry") == ("none", None)
+    # Reservierungs-Teillöschung trifft den reservation-Prefix.
+    action, keep = _delete_action(slots, {"reservation:0"}, "reservation")
+    assert action == "save"
+    assert keep == [{"s": 1}]
+
+
+def test_delete_action_mixed_selection():
+    entry_slots = [{"s": 0}, {"s": 1}]
+    res_slots = [{"r": 0}]
+    selected = {"entry:0", "reservation:all"}
+    assert _delete_action(entry_slots, selected, "entry") == ("save", [{"s": 1}])
+    assert _delete_action(res_slots, selected, "reservation") == ("delete", None)


### PR DESCRIPTION
Implementiert #53: Pro Tag mehrere **Timeslots** mit benutzerdefinierten **Kategorien** — für Ist-Zeiten und Reservierungen. Durchgängig **abwärtskompatibel**.

## Was sich ändert

Das bisherige Modell „1 Tag = 1 Eintrag" wird zu „1 Tag = Liste von Slots", jeder Slot mit eigener Kategorie. Umgesetzt in 7 in sich abgeschlossenen Arbeitspaketen:

- **Datenmodell** (`storage`, `reservations`): Slot-Liste pro Tag + idempotente Migration der Altdaten (→ 1 Slot, leere Kategorie).
- **Sync** (`sync` Schema v2→v3): LWW vergleicht die reihenfolge-normalisierte Slot-Liste; syncbare `categories`-Settingliste; Alt-Client-Guard (ein noch nicht aktualisiertes Gerät wird erkannt, statt Daten zu plätten).
- **Tages-Dialog**: dynamische Slot-Zeilen (hinzufügen/entfernen), Kategorie je Zeile (Freitext + Vorschläge), Non-Overlap-Validierung.
- **Report**: eine Zeile je Slot + Kategorie-Spalte, Tages-Subtotals, „Summe je Kategorie"-Block; Kategorie-Filter + Live-Gesamtstunden im Sende-Dialog.
- **Teilen/Import** (`share` v3): Slot-Wire-Format, v1/v2-Dateien bleiben importierbar (werden zu 1-Slot gewrappt), Export-Kategorie-Filter.
- **Kalender-UI**: Zellen zeigen mehrere Slots kompakt + Tooltip; Kategorie-Verwaltung (eigener Modal); Rechtsklick-Löschen pro Slot wählbar (mit kurzem Button-Lock gegen versehentliches Sofort-Löschen). Auf **macOS** zusätzlich ein kleines **✕ oben links in der Tageszelle** als verlässlicher Lösch-Auslöser (löst denselben `_delete_day`-Pfad aus) — es ersetzt die früheren macOS-Dialog-Lösch-Buttons, da `<Button-3>` (Rechtsklick) dort unzuverlässig ist. Win/Linux bleiben beim Rechtsklick.
- **Standardzeiten & Pause pro Kategorie** (`category_times`, neu): Pro Kategorie konfigurierbare Start-/Endzeit und Pause (ein Satz je Kategorie). Der „Kategorien verwalten"-Dialog ist dafür **zeilenbasiert wie der Tages-Dialog** — eine Zeile je Kategorie `[Name] [Start]–[Ende] [Pause] [×]` plus „+ Kategorie"; alle Kategorien samt Zeiten auf einen Blick, „(Standard)" je Feld = globaler Fallback. Im Tages-Dialog ziehen Slots beim **Kategorie-Wechsel** die Zeiten der Kategorie — aber nur für Felder, die noch dem zuletzt gesetzten Default entsprechen; **manuell geänderte Werte bleiben unangetastet** (Baseline je Slot-Zeile). Reservierungs-Slots analog ohne Pause. Der neue Settings-Key `category_times` ist syncbar (LWW, in beiden `SYNCED_SETTING_KEYS`-Whitelists). Die globalen Standardzeiten gelten weiterhin, wenn ein Slot keine Kategorie hat oder die Kategorie das jeweilige Feld nicht gesetzt hat. Eine read-only **„Standard"-Referenzzeile** oben im Kategorien-Dialog zeigt die globalen Standardzeiten; weichen die Wochentage ab, klappt ein **„Pro Tag ▶/▼"**-Toggle die Zeiten je Tag inline aus (wie der Settings-Disclosure, Fenster wächst mit).
- **Tages-Dialog (Verhalten)**: Gibt es weder Ist-Zeit noch Reservierung, wird **keine** Default-Zeile mehr vorbelegt — nur der „+ Slot"-Button. Das per-Zeile-**×** erscheint **nur an neu hinzugefügten, ungespeicherten** Slots; **bereits gespeicherte** Ist-/Reservierungs-Slots tragen kein × und sind im Dialog nur editierbar/überschreibbar — Löschen läuft ausschließlich über den Rechtsklick im Kalender (verstärkt die Linksklick-speichert/Rechtsklick-löscht-Entscheidung). Leere Slot-Blöcke kollabieren beim Entfernen der letzten Zeile sauber (keine zurückbleibende Lücke).
- **Google-Kalender** (`gcal`, `reservations_sync`): ein Event je Reservierungs-Slot (Kategorie im Titel), Reconcile auf Slot↔Event-Mapping.
- **Umbenennung**: Footer-Button und Tray-Eintrag „Monat senden" heißen jetzt **„Arbeitszeiten senden"**.

## Abwärtskompatibilität

- Bestehende Einträge/Reservierungen migrieren beim Laden zu genau einem Slot mit leerer Kategorie — wer keine Kategorien/mehreren Slots nutzt, merkt nichts.
- `category_times` startet leer (`{}`) — ohne Konfiguration verhält sich alles wie bisher mit den globalen Standardzeiten.
- Alte Share-Dateien (v1/v2) bleiben importierbar.
- Beim Sync gegen ein älteres (pre-v3) Gerät pausiert die Synchronisation mit Hinweis, statt Multi-Slot-Daten zu zerstören.

## ⚠️ Release-Reihenfolge

Dieses v3-Schema darf **erst released werden, nachdem** der Forward-Compat-Guard aus **#62** ausgeliefert ist. Sonst schreibt das erste v3-Gerät ein v3-Doc nach Drive und jede noch nicht aktualisierte Installation crasht beim Sync (`apply_merge`, rückwirkend nicht reparierbar). Reihenfolge also: **#62 zuerst, dann #60.** (Der pyright-Cleanup #63 ist unabhängig und ohne Reihenfolge-Beschränkung.)

## Tests

`pytest`: **497 passed, 1 skipped**. Die pure Logik (Storage, Sync, Report, Share, Validierung, Reconcile, Lösch-/Stunden-Helfer, Kategorie-Standardzeiten) ist voll unit-getestet; die Tkinter-Dialoge sind — wie im Projekt üblich — manuell verifiziert (Tages-Dialog, Kalenderzellen, Sende-/Teilen-/Import-Filter, Kategorie-Verwaltung, Konflikt-/Lösch-Dialog). Die Kategorie-Standardzeiten-Interaktion (Kategorie-Wechsel zieht Zeiten, manuelle Felder bleiben, „(Standard)"-Fallback, Write-back) wurde zusätzlich per echtem Tk-Smoke automatisiert durchgespielt. Der macOS-✕-Button ist macOS-exklusiv und auf einem Mac manuell zu verifizieren (Sichtbarkeit nur bei löschbaren Tagen, Hover, Klick löst Auswahl-/Bestätigungsdialog aus, kein paralleler Bearbeiten-Dialog).

## Hinweise

- Versionsbump (`src/version.py`) + `CHANGELOG.md` + `release:*`-Label sind hier bewusst noch nicht gesetzt — gern beim Merge ergänzen (siehe Release-Prozess in CLAUDE.md).
- Unter `docs/superpowers/` liegen Design-Spec und Umsetzungspläne; falls als Projekt-Doku unerwünscht, kann ich sie in einem Aufräum-Commit entfernen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


