### PR TITLE
fix(sync): Forward-Compat — neueres Remote-Schema tolerant abweisen

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -74,6 +74,13 @@ def _run_pull_in_background(storage, settings, conflicts_store, base, ui_callbac
                     logging.getLogger(__name__).warning(
                         "Quarantine rename failed for %s", fid, exc_info=True)
             remote_doc = _parse_remote_or_quarantine(content, file_id, _quarantine)
+        if sync._remote_is_newer(remote_doc):
+            # Ein neueres Gerät hat ein Doc-Format geschrieben, das diese
+            # Version nicht versteht. NICHT mergen (würde in apply_merge
+            # crashen) und NICHT pushen (würde das neuere Doc überschreiben) —
+            # Pull sauber abbrechen, last_pull_at/etag unverändert lassen.
+            ui_callback(ok=False, error=sync.NEWER_REMOTE_VERSION_MSG, tb="")
+            return
         local_doc = sync.build_local_doc(storage, settings, conflicts_store)
         merged = sync.merge(local_doc, remote_doc, settings.get("last_pull_at") or "")
         sync.apply_merged_doc(merged, storage, settings, conflicts_store)
@@ -116,6 +123,14 @@ def _run_push_blocking(storage, settings, conflicts_store, base, timeout_seconds
                     remote_doc = json.loads(remote_bytes)
                 else:
                     remote_doc = {"schema_version": 1, "entries": {}, "settings": {}, "conflicts": []}
+                if sync._remote_is_newer(remote_doc):
+                    # Ein neueres Gerät hat das Remote-Doc fortgeschrieben.
+                    # Nicht mergen/überschreiben — Push abbrechen, damit die
+                    # neueren Daten erhalten bleiben.
+                    result["ok"] = False
+                    result["error"] = sync.NEWER_REMOTE_VERSION_MSG
+                    result["tb"] = ""
+                    return
                 local_doc = sync.build_local_doc(storage, settings, conflicts_store)
                 merged = sync.merge(local_doc, remote_doc, settings.get("last_pull_at") or "")
                 sync.apply_merged_doc(merged, storage, settings, conflicts_store)

--- a/src/sync.py
+++ b/src/sync.py
@@ -17,6 +17,14 @@ import uuid
 SCHEMA_VERSION = 2
 
 
+NEWER_REMOTE_VERSION_MSG = (
+    "Ein anderes Gerät nutzt eine neuere App-Version mit einem Datenformat, "
+    "das diese (ältere) Version noch nicht versteht.\n\n"
+    "Bitte aktualisiere die App auf diesem Gerät. Bis dahin pausiert die "
+    "Synchronisation, damit keine Daten verloren gehen oder überschrieben werden."
+)
+
+
 def _watermark_of(doc):
     return ((doc.get("meta") or {}).get("gc_watermark") or "")
 
@@ -278,6 +286,18 @@ def _remote_is_pre_v2(remote_doc):
         return True
     meta = remote_doc.get("meta")
     return not (isinstance(meta, dict) and "gc_watermark" in meta)
+
+
+def _remote_is_newer(remote_doc):
+    """True, wenn das Remote-Doc von einer NEUEREN App-Version stammt
+    (schema_version > der hier verstandenen SCHEMA_VERSION).
+
+    Forward-Compat-Guard: Ab Schema 3 enthalten Einträge `slots` statt der
+    flachen `start/end/pause`-Keys. Würde diese ältere Version so ein Doc
+    mergen und via `storage.apply_merge` schreiben, bräche der Required-Key-
+    Validator hart ab ("missing keys ['start','end','pause']"). Stattdessen
+    muss der Pull/Push abbrechen, ohne das neuere Remote-Doc zu überschreiben."""
+    return (remote_doc.get("schema_version") or 1) > SCHEMA_VERSION
 
 
 def resolve_conflict(conflict_id, chosen_value, conflicts_store, storage, settings, device_id):

--- a/src/ui.py
+++ b/src/ui.py
@@ -73,6 +73,10 @@ def _friendly_sync_message(error, tb=""):
     bekommen eine verständliche Meldung OHNE Traceback. Nur bei wirklich
     unerwarteten Fehlern bleibt der Traceback erhalten (CLAUDE.md: Fehler im
     Sendepfad sichtbar machen)."""
+    from src.sync import NEWER_REMOTE_VERSION_MSG
+    if str(error) == NEWER_REMOTE_VERSION_MSG:
+        return ("Update erforderlich", NEWER_REMOTE_VERSION_MSG, True)
+
     kind = _classify_sync_error(error)
 
     if kind == "auth":

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -625,3 +625,77 @@ def test_remote_is_pre_v2():
     assert _remote_is_pre_v2({"schema_version": 2, "entries": {}}) is True  # kein meta
     assert _remote_is_pre_v2({"schema_version": 2, "meta": {"gc_watermark": ""}}) is False
     assert _remote_is_pre_v2({"schema_version": 2, "meta": {}}) is True     # meta ohne key
+
+
+# --- Forward-Compat-Guard: neueres Remote-Schema nicht crashen/überschreiben ---
+
+from src.sync import _remote_is_newer, NEWER_REMOTE_VERSION_MSG, SCHEMA_VERSION
+
+
+def test_remote_is_newer():
+    assert _remote_is_newer({"schema_version": SCHEMA_VERSION + 1, "entries": {}}) is True
+    assert _remote_is_newer({"schema_version": 99, "entries": {}}) is True
+    assert _remote_is_newer({"schema_version": SCHEMA_VERSION, "entries": {}}) is False
+    assert _remote_is_newer({"schema_version": 1, "entries": {}}) is False
+    assert _remote_is_newer({"entries": {}}) is False  # fehlend -> 1
+
+
+def _v3_remote_bytes():
+    """Ein Remote-Doc im v3-Slot-Format, wie es eine neuere App schreibt:
+    Einträge haben `slots` statt der flachen start/end/pause-Keys."""
+    return _json.dumps({
+        "schema_version": 3,
+        "entries": {
+            "2026-06-04": {
+                "slots": [{"start": "08:00", "end": "16:00", "pause": 30,
+                           "kategorie": "Arbeit"}],
+                "modified_at": "2026-06-04T10:00:00Z",
+                "device_id": "B", "deleted": False,
+            }
+        },
+        "settings": {}, "conflicts": [],
+        "meta": {"gc_watermark": ""},
+    }, ensure_ascii=False).encode("utf-8")
+
+
+def test_apply_merge_crashes_on_v3_entry_without_guard(tmp_path):
+    """Beleg für den Grund des Guards: ohne ihn würde das v3-Doc in
+    apply_merge hart abbrechen (fehlende start/end/pause)."""
+    storage = Storage(str(tmp_path / "z.json"), device_id="A")
+    v3_entries = {
+        "2026-06-04": {"slots": [{"start": "08:00", "end": "16:00"}],
+                       "modified_at": "2026-06-04T10:00:00Z",
+                       "device_id": "B", "deleted": False}
+    }
+    with pytest.raises(ValueError):
+        storage.apply_merge(v3_entries)
+
+
+def test_run_pull_aborts_on_newer_remote(tmp_path, monkeypatch):
+    """Pull gegen ein v3-Remote: Callback meldet ok=False mit der Update-
+    Meldung, NICHTS wird lokal angewendet (kein Crash), last_pull_at bleibt
+    unverändert."""
+    from src import drive
+    import src.main as main
+
+    storage = Storage(str(tmp_path / "z.json"), device_id="A")
+    settings = Settings(str(tmp_path / "s.json"))
+    settings.device_id_for_sync = "A"
+    conflicts = ConflictsStore(str(tmp_path / "c.json"))
+    before_pull_at = settings.get("last_pull_at")
+
+    monkeypatch.setattr(drive, "get_drive_service", lambda *a, **k: object())
+    monkeypatch.setattr(drive, "find_sync_file", lambda service: "file-1")
+    monkeypatch.setattr(drive, "download", lambda service, fid: (_v3_remote_bytes(), "etag-x"))
+
+    received = {}
+    def ui_callback(ok, error, tb=""):
+        received["ok"] = ok
+        received["error"] = error
+
+    main._run_pull_in_background(storage, settings, conflicts, str(tmp_path), ui_callback)
+
+    assert received["ok"] is False
+    assert str(received["error"]) == NEWER_REMOTE_VERSION_MSG
+    assert storage.get_all_raw() == {}              # nichts angewendet
+    assert settings.get("last_pull_at") == before_pull_at  # unverändert

--- a/tests/test_ui_sync_errors.py
+++ b/tests/test_ui_sync_errors.py
@@ -6,8 +6,9 @@ weg. Ein 403 'insufficient authentication scopes' muss trotzdem als 'auth'
 (Re-Consent nötig) erkannt werden, nicht als 'unknown' (roher Traceback) oder
 'network' ('Keine Internetverbindung').
 """
-from src.ui import _classify_sync_error
+from src.ui import _classify_sync_error, _friendly_sync_message
 from src.drive import DriveAuthError, DriveNetworkError
+from src.sync import NEWER_REMOTE_VERSION_MSG
 
 
 def test_classify_403_scope_string_is_auth():
@@ -32,3 +33,12 @@ def test_classify_network_error_instance_is_network():
 
 def test_classify_plain_error_is_unknown():
     assert _classify_sync_error("ValueError: kaputt") == "unknown"
+
+
+def test_newer_remote_version_is_friendly_known():
+    """Der Forward-Compat-Hinweis muss als bekannter Fall (ohne Traceback,
+    themed Info) gezeigt werden, nicht als roher 'unerwarteter Fehler'."""
+    title, message, known = _friendly_sync_message(NEWER_REMOTE_VERSION_MSG)
+    assert known is True
+    assert message == NEWER_REMOTE_VERSION_MSG
+    assert "Update" in title


### PR DESCRIPTION
## Worum geht's

Forward-Compat-Schutz der Drive-Synchronisation. Das kommende Multi-Timeslot-/Kategorien-Feature (PR #60) hebt das Sync-Doc auf **Schema 3**: Einträge tragen dann `slots` statt der flachen `start/end/pause`-Keys.

Eine **ältere installierte Version** crasht beim Pull eines solchen v3-Docs hart in `storage.apply_merge`:

```
ValueError: apply_merge: entry '2026-06-04' missing keys ['end', 'pause', 'start']
```

und würde beim Push das neuere Doc mit einem v2-Stand **überschreiben** (Datenverlust auf den v3-Geräten).

## Fix

Neuer Guard `sync._remote_is_newer(remote_doc)`: ist `schema_version` größer als die hier verstandene `SCHEMA_VERSION`, brechen **Pull** und **Push-Retry** sauber mit `NEWER_REMOTE_VERSION_MSG` ab — **ohne** zu mergen und **ohne** das neuere Doc zu überschreiben. `last_pull_at`/`drive_etag` bleiben unverändert. Im UI erscheint die Meldung als bekannter Fall („Update erforderlich") ohne Traceback, analog zum bestehenden Token-/Netz-Handling.

Während der Übergangsphase pausieren beide Seiten den Sync (das v3-Gerät lehnt umgekehrt pre-v3-Docs ab) — kein Datenverlust, kein Clobber. Voller Sync wieder, sobald alle Geräte aktualisiert sind.

## Tests

- `test_remote_is_newer` — Guard-Logik
- `test_apply_merge_crashes_on_v3_entry_without_guard` — schreibt den Crash-Grund fest
- `test_run_pull_aborts_on_newer_remote` — Pull bricht ab, nichts wird angewendet, `last_pull_at` unverändert (gemocktes `drive`)
- `test_newer_remote_version_is_friendly_known` — UI zeigt bekannten Fall ohne Traceback

Komplette Suite grün (399 passed, 1 skipped).

## ⚠️ Release-Reihenfolge

Dieser Guard muss in einem Release **ausgeliefert sein, bevor** das v3-Schema aus **PR #60** released wird. Sonst schreibt das erste v3-Gerät ein v3-Doc nach Drive und jede noch-nicht-aktualisierte Installation crasht beim Sync — rückwirkend nicht reparierbar.

_Versionsbump/Changelog bewusst nicht in diesem PR — die Zielversion wird beim Bündeln der Release-Änderungen gesetzt._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
