### PR TITLE
fix: zwei echte pyright-Typfehler (theme + tray)

### DIFF
--- a/src/theme.py
+++ b/src/theme.py
@@ -746,7 +746,7 @@ def themed_ask_delete_choice(parent, title: str, message: str, options):
     apply_app_icon(dialog)
     dialog.focus_set()
 
-    result = {"value": None}
+    result: dict[str, set[str] | None] = {"value": None}
 
     tk.Label(
         dialog, text=message, font=FONT, bg=BG, fg=TEXT,

--- a/src/tray.py
+++ b/src/tray.py
@@ -90,7 +90,9 @@ class TrayIcon:
         for label, callback, visible in self._actions:
             items.append(pystray.MenuItem(
                 label, self._wrap_action(callback),
-                visible=self._wrap_visible(visible),
+                # pystray akzeptiert für `visible` auch ein Callable (dynamische
+                # Sichtbarkeit), sein Typ-Stub deklariert aber nur bool.
+                visible=self._wrap_visible(visible),  # pyright: ignore[reportArgumentType]
             ))
         if self._actions:
             items.append(pystray.Menu.SEPARATOR)


### PR DESCRIPTION
## Worum geht's

Zwei echte Typfehler beheben, die `pyright`/Pylance auf `master` meldet — kleines, **verhaltensneutrales** Type-Cleanup.

## Fixes

- **`theme.py` (`themed_ask_delete_choice`)**: `result = {"value": None}` wurde als `dict[str, None]` inferiert, sodass die spätere Set-Zuweisung `result["value"] = selected` als `reportArgumentType` fehlschlug. Dict explizit als `dict[str, set[str] | None]` annotiert (lokale Variablen-Annotation → zur Laufzeit nicht ausgewertet, kein Cost).
- **`tray.py`**: pystray akzeptiert für `visible` auch ein Callable (dynamische Sichtbarkeit), sein Typ-Stub deklariert aber nur `bool`. Gezieltes `# pyright: ignore[reportArgumentType]` mit erklärendem Kommentar (Stub-Limitation, kein Code-Bug).

Beide sind `reportArgumentType` und damit config-unabhängig (auch im Default-Modus Error).

## Tests

`pytest`: **395 passed, 1 skipped**. Keine Verhaltensänderung (Annotation + ein Ignore-Kommentar).

## Reihenfolge / Abhängigkeiten

Reines Type-Cleanup ohne Laufzeit-/Schema-Wirkung → **keine Release-Reihenfolge-Beschränkung**, unabhängig von #60 und #62 mergebar.

Hinweis: Die vollständige pyright/Pylance-Konfiguration (`[tool.pyright]`-Block, der das Tkinter-/Stub-Rauschen auf das relevante Signal reduziert) liegt in **PR #60**. Diese beiden Fixes sind davon unabhängig echte Korrektheits-Fixes und stehen für sich. Eine verbleibende, in #60 bewusst als Warnung tolerierte Stelle (`tray.py` `icon._message`, privates pystray-Attribut) wird hier absichtlich nicht angefasst.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
