### PR TITLE
fix(sync): Forward-Compat-Guard (#62) + Kompaktierungs-Lücke

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 1.15.1 — 2026-06-23
+
+### Behoben
+- Multi-Geräte-Sync: Nutzt ein Gerät bereits eine neuere App-Version mit einem
+  neueren Datenformat, pausiert die Synchronisation auf älteren Geräten jetzt
+  mit einem klaren Hinweis („Update erforderlich"), statt mit einem Fehler
+  abzubrechen oder Daten zu überschreiben. Das gilt für den Abgleich ebenso wie
+  für das Kompaktieren der Sync-Daten. Die vollständige Synchronisation läuft
+  wieder, sobald alle Geräte aktualisiert sind.
+
 ## 1.15.0 — 2026-06-19
 
 ### Hinzugefügt

--- a/src/dialogs/settings_dialog.py
+++ b/src/dialogs/settings_dialog.py
@@ -546,6 +546,11 @@ def open_settings_dialog(parent, settings, base_path, on_change, *,
                         "Ein Gerät nutzt noch eine ältere Version — bitte erst "
                         "alle Geräte aktualisieren und synchronisieren.",
                     )
+                elif res.get("reason") == "newer_version":
+                    from src.sync import NEWER_REMOTE_VERSION_MSG
+                    themed_showwarning(
+                        dialog, "Update erforderlich", NEWER_REMOTE_VERSION_MSG,
+                    )
                 elif not res.get("ok"):
                     detail = f"{res.get('error', '?')}\n\n{res.get('tb', '')}"
                     themed_showerror(

--- a/src/main.py
+++ b/src/main.py
@@ -74,6 +74,13 @@ def _run_pull_in_background(storage, settings, conflicts_store, base, ui_callbac
                     logging.getLogger(__name__).warning(
                         "Quarantine rename failed for %s", fid, exc_info=True)
             remote_doc = _parse_remote_or_quarantine(content, file_id, _quarantine)
+        if sync._remote_is_newer(remote_doc):
+            # Ein neueres Gerät hat ein Doc-Format geschrieben, das diese
+            # Version nicht versteht. NICHT mergen (würde in apply_merge
+            # crashen) und NICHT pushen (würde das neuere Doc überschreiben) —
+            # Pull sauber abbrechen, last_pull_at/etag unverändert lassen.
+            ui_callback(ok=False, error=sync.NEWER_REMOTE_VERSION_MSG, tb="")
+            return
         local_doc = sync.build_local_doc(storage, settings, conflicts_store)
         merged = sync.merge(local_doc, remote_doc, settings.get("last_pull_at") or "")
         sync.apply_merged_doc(merged, storage, settings, conflicts_store)
@@ -116,6 +123,14 @@ def _run_push_blocking(storage, settings, conflicts_store, base, timeout_seconds
                     remote_doc = json.loads(remote_bytes)
                 else:
                     remote_doc = {"schema_version": 1, "entries": {}, "settings": {}, "conflicts": []}
+                if sync._remote_is_newer(remote_doc):
+                    # Ein neueres Gerät hat das Remote-Doc fortgeschrieben.
+                    # Nicht mergen/überschreiben — Push abbrechen, damit die
+                    # neueren Daten erhalten bleiben.
+                    result["ok"] = False
+                    result["error"] = sync.NEWER_REMOTE_VERSION_MSG
+                    result["tb"] = ""
+                    return
                 local_doc = sync.build_local_doc(storage, settings, conflicts_store)
                 merged = sync.merge(local_doc, remote_doc, settings.get("last_pull_at") or "")
                 sync.apply_merged_doc(merged, storage, settings, conflicts_store)

--- a/src/main.py
+++ b/src/main.py
@@ -159,7 +159,10 @@ def _run_compaction_blocking(storage, settings, conflicts_store, base, timeout_s
     {"ok": bool, "reason": str, "error": ..., "tb": ...}.
 
     reason == "old_version": ein älteres Gerät ist aktiv (Remote ist pre-v2),
-    Kompaktierung abgebrochen, KEINE Änderung vorgenommen."""
+    Kompaktierung abgebrochen, KEINE Änderung vorgenommen.
+    reason == "newer_version": ein neueres Gerät hat ein Schema geschrieben, das
+    diese Version nicht versteht — Kompaktierung abgebrochen, kein Merge/Upload
+    (sonst Crash in apply_merge bzw. Überschreiben des neueren Docs)."""
     import json
     from src import drive, sync
 
@@ -179,9 +182,15 @@ def _run_compaction_blocking(storage, settings, conflicts_store, base, timeout_s
                     remote_doc = json.loads(content)
                 except (json.JSONDecodeError, ValueError):
                     remote_doc = {"schema_version": 1}
-                # v1-Guard auf dem FRISCH gepullten Doc (nie gecacht):
+                # Guards auf dem FRISCH gepullten Doc (nie gecacht):
                 if sync._remote_is_pre_v2(remote_doc):
                     result.update({"ok": False, "reason": "old_version"})
+                    return
+                # Forward-Compat: neueres Schema nicht mergen/überschreiben
+                # (analog zu Pull/Push) — sonst crasht apply_merge bzw. das
+                # neuere Remote-Doc würde beim Upload geplättet.
+                if sync._remote_is_newer(remote_doc):
+                    result.update({"ok": False, "reason": "newer_version"})
                     return
             else:
                 remote_doc = {"schema_version": 2, "entries": {}, "settings": {},

--- a/src/sync.py
+++ b/src/sync.py
@@ -17,6 +17,14 @@ import uuid
 SCHEMA_VERSION = 2
 
 
+NEWER_REMOTE_VERSION_MSG = (
+    "Ein anderes Gerät nutzt eine neuere App-Version mit einem Datenformat, "
+    "das diese (ältere) Version noch nicht versteht.\n\n"
+    "Bitte aktualisiere die App auf diesem Gerät. Bis dahin pausiert die "
+    "Synchronisation, damit keine Daten verloren gehen oder überschrieben werden."
+)
+
+
 def _watermark_of(doc):
     return ((doc.get("meta") or {}).get("gc_watermark") or "")
 
@@ -278,6 +286,18 @@ def _remote_is_pre_v2(remote_doc):
         return True
     meta = remote_doc.get("meta")
     return not (isinstance(meta, dict) and "gc_watermark" in meta)
+
+
+def _remote_is_newer(remote_doc):
+    """True, wenn das Remote-Doc von einer NEUEREN App-Version stammt
+    (schema_version > der hier verstandenen SCHEMA_VERSION).
+
+    Forward-Compat-Guard: Ab Schema 3 enthalten Einträge `slots` statt der
+    flachen `start/end/pause`-Keys. Würde diese ältere Version so ein Doc
+    mergen und via `storage.apply_merge` schreiben, bräche der Required-Key-
+    Validator hart ab ("missing keys ['start','end','pause']"). Stattdessen
+    muss der Pull/Push abbrechen, ohne das neuere Remote-Doc zu überschreiben."""
+    return (remote_doc.get("schema_version") or 1) > SCHEMA_VERSION
 
 
 def resolve_conflict(conflict_id, chosen_value, conflicts_store, storage, settings, device_id):

--- a/src/ui.py
+++ b/src/ui.py
@@ -73,6 +73,10 @@ def _friendly_sync_message(error, tb=""):
     bekommen eine verständliche Meldung OHNE Traceback. Nur bei wirklich
     unerwarteten Fehlern bleibt der Traceback erhalten (CLAUDE.md: Fehler im
     Sendepfad sichtbar machen)."""
+    from src.sync import NEWER_REMOTE_VERSION_MSG
+    if str(error) == NEWER_REMOTE_VERSION_MSG:
+        return ("Update erforderlich", NEWER_REMOTE_VERSION_MSG, True)
+
     kind = _classify_sync_error(error)
 
     if kind == "auth":

--- a/src/version.py
+++ b/src/version.py
@@ -1,4 +1,4 @@
-VERSION = "1.15.0"
+VERSION = "1.15.1"
 
 # build_info wird beim Build von build.py generiert (gitignored) und von
 # PyInstaller mitgebündelt. Beim Start aus dem Quellcode existiert es nicht —

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -625,3 +625,77 @@ def test_remote_is_pre_v2():
     assert _remote_is_pre_v2({"schema_version": 2, "entries": {}}) is True  # kein meta
     assert _remote_is_pre_v2({"schema_version": 2, "meta": {"gc_watermark": ""}}) is False
     assert _remote_is_pre_v2({"schema_version": 2, "meta": {}}) is True     # meta ohne key
+
+
+# --- Forward-Compat-Guard: neueres Remote-Schema nicht crashen/überschreiben ---
+
+from src.sync import _remote_is_newer, NEWER_REMOTE_VERSION_MSG, SCHEMA_VERSION
+
+
+def test_remote_is_newer():
+    assert _remote_is_newer({"schema_version": SCHEMA_VERSION + 1, "entries": {}}) is True
+    assert _remote_is_newer({"schema_version": 99, "entries": {}}) is True
+    assert _remote_is_newer({"schema_version": SCHEMA_VERSION, "entries": {}}) is False
+    assert _remote_is_newer({"schema_version": 1, "entries": {}}) is False
+    assert _remote_is_newer({"entries": {}}) is False  # fehlend -> 1
+
+
+def _v3_remote_bytes():
+    """Ein Remote-Doc im v3-Slot-Format, wie es eine neuere App schreibt:
+    Einträge haben `slots` statt der flachen start/end/pause-Keys."""
+    return _json.dumps({
+        "schema_version": 3,
+        "entries": {
+            "2026-06-04": {
+                "slots": [{"start": "08:00", "end": "16:00", "pause": 30,
+                           "kategorie": "Arbeit"}],
+                "modified_at": "2026-06-04T10:00:00Z",
+                "device_id": "B", "deleted": False,
+            }
+        },
+        "settings": {}, "conflicts": [],
+        "meta": {"gc_watermark": ""},
+    }, ensure_ascii=False).encode("utf-8")
+
+
+def test_apply_merge_crashes_on_v3_entry_without_guard(tmp_path):
+    """Beleg für den Grund des Guards: ohne ihn würde das v3-Doc in
+    apply_merge hart abbrechen (fehlende start/end/pause)."""
+    storage = Storage(str(tmp_path / "z.json"), device_id="A")
+    v3_entries = {
+        "2026-06-04": {"slots": [{"start": "08:00", "end": "16:00"}],
+                       "modified_at": "2026-06-04T10:00:00Z",
+                       "device_id": "B", "deleted": False}
+    }
+    with pytest.raises(ValueError):
+        storage.apply_merge(v3_entries)
+
+
+def test_run_pull_aborts_on_newer_remote(tmp_path, monkeypatch):
+    """Pull gegen ein v3-Remote: Callback meldet ok=False mit der Update-
+    Meldung, NICHTS wird lokal angewendet (kein Crash), last_pull_at bleibt
+    unverändert."""
+    from src import drive
+    import src.main as main
+
+    storage = Storage(str(tmp_path / "z.json"), device_id="A")
+    settings = Settings(str(tmp_path / "s.json"))
+    settings.device_id_for_sync = "A"
+    conflicts = ConflictsStore(str(tmp_path / "c.json"))
+    before_pull_at = settings.get("last_pull_at")
+
+    monkeypatch.setattr(drive, "get_drive_service", lambda *a, **k: object())
+    monkeypatch.setattr(drive, "find_sync_file", lambda service: "file-1")
+    monkeypatch.setattr(drive, "download", lambda service, fid: (_v3_remote_bytes(), "etag-x"))
+
+    received = {}
+    def ui_callback(ok, error, tb=""):
+        received["ok"] = ok
+        received["error"] = error
+
+    main._run_pull_in_background(storage, settings, conflicts, str(tmp_path), ui_callback)
+
+    assert received["ok"] is False
+    assert str(received["error"]) == NEWER_REMOTE_VERSION_MSG
+    assert storage.get_all_raw() == {}              # nichts angewendet
+    assert settings.get("last_pull_at") == before_pull_at  # unverändert

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -699,3 +699,31 @@ def test_run_pull_aborts_on_newer_remote(tmp_path, monkeypatch):
     assert str(received["error"]) == NEWER_REMOTE_VERSION_MSG
     assert storage.get_all_raw() == {}              # nichts angewendet
     assert settings.get("last_pull_at") == before_pull_at  # unverändert
+
+
+def test_run_compaction_aborts_on_newer_remote(tmp_path, monkeypatch):
+    """Kompaktierung gegen ein v3-Remote: bricht freundlich ab (reason
+    'newer_version'), wendet NICHTS an und lädt NICHTS hoch (kein Clobber des
+    neueren Docs) — analog zum Pull-Guard, nicht ein roher apply_merge-Crash."""
+    from src import drive
+    import src.main as main
+
+    storage = Storage(str(tmp_path / "z.json"), device_id="A")
+    settings = Settings(str(tmp_path / "s.json"))
+    settings.device_id_for_sync = "A"
+    conflicts = ConflictsStore(str(tmp_path / "c.json"))
+
+    monkeypatch.setattr(drive, "get_drive_service", lambda *a, **k: object())
+    monkeypatch.setattr(drive, "find_sync_file", lambda service: "file-1")
+    monkeypatch.setattr(drive, "download", lambda service, fid: (_v3_remote_bytes(), "etag-x"))
+    upload_calls = []
+    monkeypatch.setattr(
+        drive, "upload",
+        lambda *a, **k: (upload_calls.append(a), ("id", "etag"))[1])
+
+    res = main._run_compaction_blocking(storage, settings, conflicts, str(tmp_path))
+
+    assert res.get("ok") is False
+    assert res.get("reason") == "newer_version"     # freundlicher Fall, kein Traceback
+    assert upload_calls == []                        # neueres Remote-Doc NICHT überschrieben
+    assert storage.get_all_raw() == {}              # nichts lokal angewendet

--- a/tests/test_ui_sync_errors.py
+++ b/tests/test_ui_sync_errors.py
@@ -6,8 +6,9 @@ weg. Ein 403 'insufficient authentication scopes' muss trotzdem als 'auth'
 (Re-Consent nötig) erkannt werden, nicht als 'unknown' (roher Traceback) oder
 'network' ('Keine Internetverbindung').
 """
-from src.ui import _classify_sync_error
+from src.ui import _classify_sync_error, _friendly_sync_message
 from src.drive import DriveAuthError, DriveNetworkError
+from src.sync import NEWER_REMOTE_VERSION_MSG
 
 
 def test_classify_403_scope_string_is_auth():
@@ -32,3 +33,12 @@ def test_classify_network_error_instance_is_network():
 
 def test_classify_plain_error_is_unknown():
     assert _classify_sync_error("ValueError: kaputt") == "unknown"
+
+
+def test_newer_remote_version_is_friendly_known():
+    """Der Forward-Compat-Hinweis muss als bekannter Fall (ohne Traceback,
+    themed Info) gezeigt werden, nicht als roher 'unerwarteter Fehler'."""
+    title, message, known = _friendly_sync_message(NEWER_REMOTE_VERSION_MSG)
+    assert known is True
+    assert message == NEWER_REMOTE_VERSION_MSG
+    assert "Update" in title


### PR DESCRIPTION
Maintainer-Branch des Forward-Compat-Guards (ursprünglich Fork-PR #62 von @Xveyn) auf `origin`, **plus** ein in der Review gefundener Fix (Bug 2).

Zielversion: **v1.15.1** — muss **vor** dem Multi-Slot-Feature (#64, Ziel v1.16.0) released werden, sonst crasht/überschreibt eine ältere Installation beim Sync gegen ein v3-Doc.

## Enthält
- Den vollständigen Stand von #62: Guard `_remote_is_newer`, der Pull und Push-Retry sauber abbricht, wenn das Remote-Doc von einer neueren App-Version stammt (Schema > lokal) — ohne Merge, ohne Überschreiben. Detailbeschreibung siehe #62.
- **Fix (Review-Bug 2):** Die Kompaktierung (`_run_compaction_blocking`) prüfte nur `_remote_is_pre_v2`, nicht `_remote_is_newer` — anders als Pull/Push. Ein noch nicht aktualisierter Client, der während des v3-Rollouts „Kompaktieren" drückt, lief ungebremst in `apply_merge` → roher `ValueError`-Traceback statt der freundlichen „Update erforderlich"-Meldung (kein Datenverlust: der Upload ist der letzte Schritt und wird nie erreicht, das neuere Doc bleibt unangetastet). Guard ergänzt, Settings-Dialog zeigt die bekannte `NEWER_REMOTE_VERSION_MSG`. Roter Test `test_run_compaction_aborts_on_newer_remote` reproduziert den Crash-Pfad.

## Status / offen
- Versionsbump (`src/version.py` → 1.15.1), `CHANGELOG.md` und `release:*`-Label bewusst noch nicht gesetzt.

## Tests
`pytest`: 400 passed, 1 skipped.

Ersetzt inhaltlich den Fork-PR #62. Original-Autor: @Xveyn.
