### PR TITLE
fix(sync): Push-Guard — kein Clobber beim Schema-Rollout (v1.15.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 1.15.2 — 2026-06-23
+
+### Behoben
+- Multi-Geräte-Sync: Beim Hochladen wird der aktuelle Stand aus Google Drive
+  jetzt zuerst gelesen und zusammengeführt, statt ihn blind zu überschreiben.
+  Dadurch kann ein älteres Gerät die Daten eines Geräts mit neuerem Datenformat
+  nicht mehr versehentlich überschreiben, und gleichzeitige Änderungen auf
+  mehreren Geräten gehen beim Speichern nicht mehr verloren.
+
 ## 1.15.1 — 2026-06-23
 
 ### Behoben

--- a/src/main.py
+++ b/src/main.py
@@ -111,33 +111,36 @@ def _run_push_blocking(storage, settings, conflicts_store, base, timeout_seconds
                 gcal_enabled=settings.get("gcal_enabled"),
             )
             file_id = drive.find_sync_file(service)
-            doc = sync.build_local_doc(storage, settings, conflicts_store)
-            content = json.dumps(doc, ensure_ascii=False).encode("utf-8")
-            expected_etag = settings.get("drive_etag")
-            try:
-                new_id, new_etag = drive.upload(service, content, file_id, expected_etag)
-            except drive.DriveConflictError:
-                # Etag-Mismatch: 1× pull-merge-push retry
-                if file_id is not None:
-                    remote_bytes, _ = drive.download(service, file_id)
+            # Push = download -> Guard -> Merge -> upload. drive.upload kennt
+            # kein File-level If-Match (ignoriert expected_etag), daher MUSS hier
+            # das frische Remote-Doc gelesen und gemergt werden — sonst
+            # überschreibt der Push fremde oder neuere Stände blind (Datenverlust
+            # bzw. Clobber eines neueren Schemas während eines Rollouts).
+            if file_id is not None:
+                remote_bytes, _etag = drive.download(service, file_id)
+                try:
                     remote_doc = json.loads(remote_bytes)
-                else:
+                except (json.JSONDecodeError, ValueError):
                     remote_doc = {"schema_version": 1, "entries": {}, "settings": {}, "conflicts": []}
                 if sync._remote_is_newer(remote_doc):
-                    # Ein neueres Gerät hat das Remote-Doc fortgeschrieben.
-                    # Nicht mergen/überschreiben — Push abbrechen, damit die
-                    # neueren Daten erhalten bleiben.
+                    # Neueres Gerät hat das Remote-Doc fortgeschrieben: nicht
+                    # mergen/überschreiben — Push abbrechen, neuere Daten bleiben.
                     result["ok"] = False
                     result["error"] = sync.NEWER_REMOTE_VERSION_MSG
                     result["tb"] = ""
                     return
-                local_doc = sync.build_local_doc(storage, settings, conflicts_store)
-                merged = sync.merge(local_doc, remote_doc, settings.get("last_pull_at") or "")
-                sync.apply_merged_doc(merged, storage, settings, conflicts_store)
-                doc = sync.build_local_doc(storage, settings, conflicts_store)
-                content = json.dumps(doc, ensure_ascii=False).encode("utf-8")
-                new_id, new_etag = drive.upload(service, content, file_id, expected_etag="")
-            settings.set("drive_etag", new_etag)
+            else:
+                remote_doc = {"schema_version": 1, "entries": {}, "settings": {}, "conflicts": []}
+            local_doc = sync.build_local_doc(storage, settings, conflicts_store)
+            merged = sync.merge(local_doc, remote_doc, settings.get("last_pull_at") or "")
+            sync.apply_merged_doc(merged, storage, settings, conflicts_store)
+            doc = sync.build_local_doc(storage, settings, conflicts_store)
+            content = json.dumps(doc, ensure_ascii=False).encode("utf-8")
+            new_id, new_etag = drive.upload(service, content, file_id, expected_etag="")
+            settings.set_many({
+                "last_pull_at": sync._utc_now_iso(),
+                "drive_etag": new_etag,
+            })
             result["ok"] = True
         except Exception as e:
             logging.getLogger(__name__).exception("Sync push failed: %s", e)

--- a/src/version.py
+++ b/src/version.py
@@ -1,4 +1,4 @@
-VERSION = "1.15.1"
+VERSION = "1.15.2"
 
 # build_info wird beim Build von build.py generiert (gitignored) und von
 # PyInstaller mitgebündelt. Beim Start aus dem Quellcode existiert es nicht —

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -727,3 +727,74 @@ def test_run_compaction_aborts_on_newer_remote(tmp_path, monkeypatch):
     assert res.get("reason") == "newer_version"     # freundlicher Fall, kein Traceback
     assert upload_calls == []                        # neueres Remote-Doc NICHT überschrieben
     assert storage.get_all_raw() == {}              # nichts lokal angewendet
+
+
+def test_run_push_aborts_on_newer_remote(tmp_path, monkeypatch):
+    """Push gegen ein v3-Remote (neueres Schema): bricht mit der Update-Meldung
+    ab und lädt NICHTS hoch — überschreibt das neuere Doc also nicht. Lokale
+    Daten bleiben unverändert."""
+    from src import drive
+    import src.main as main
+
+    storage = Storage(str(tmp_path / "z.json"), device_id="A")
+    storage.save("2026-06-09", "09:00", "17:00", 30)
+    before = storage.get_all_raw()
+    settings = Settings(str(tmp_path / "s.json"))
+    settings.device_id_for_sync = "A"
+    conflicts = ConflictsStore(str(tmp_path / "c.json"))
+
+    monkeypatch.setattr(drive, "get_drive_service", lambda *a, **k: object())
+    monkeypatch.setattr(drive, "find_sync_file", lambda service: "file-1")
+    monkeypatch.setattr(drive, "download", lambda service, fid: (_v3_remote_bytes(), "etag-x"))
+    upload_calls = []
+    monkeypatch.setattr(
+        drive, "upload",
+        lambda *a, **k: (upload_calls.append(a), ("id", "etag"))[1])
+
+    res = main._run_push_blocking(storage, settings, conflicts, str(tmp_path))
+
+    assert res.get("ok") is False
+    assert str(res.get("error")) == NEWER_REMOTE_VERSION_MSG
+    assert upload_calls == []                        # kein Clobber des v3-Docs
+    assert storage.get_all_raw() == before           # lokal unverändert
+
+
+def test_run_push_merges_remote_before_upload(tmp_path, monkeypatch):
+    """Push lädt das aktuelle Remote-Doc, merged es mit dem lokalen Stand und
+    lädt die Vereinigung hoch — fremde Einträge werden nicht blind überschrieben
+    und der Remote-Stand wird auch lokal übernommen."""
+    from src import drive
+    import src.main as main
+
+    storage = Storage(str(tmp_path / "z.json"), device_id="A")
+    storage.save("2026-06-09", "09:00", "17:00", 30)   # lokal: Eintrag A
+    settings = Settings(str(tmp_path / "s.json"))
+    settings.device_id_for_sync = "A"
+    conflicts = ConflictsStore(str(tmp_path / "c.json"))
+
+    remote = {
+        "schema_version": 2,
+        "entries": {"2026-06-20": {                    # remote: Eintrag B
+            "start": "08:00", "end": "16:00", "pause": 30,
+            "modified_at": "2026-06-20T10:00:00Z", "device_id": "B", "deleted": False,
+        }},
+        "settings": {}, "conflicts": [], "meta": {"gc_watermark": ""},
+    }
+    remote_bytes = _json.dumps(remote, ensure_ascii=False).encode("utf-8")
+
+    monkeypatch.setattr(drive, "get_drive_service", lambda *a, **k: object())
+    monkeypatch.setattr(drive, "find_sync_file", lambda service: "file-1")
+    monkeypatch.setattr(drive, "download", lambda service, fid: (remote_bytes, "etag-x"))
+    uploaded = {}
+
+    def _fake_upload(service, content, file_id=None, expected_etag=None):
+        uploaded["doc"] = _json.loads(content)
+        return ("file-1", "etag-new")
+
+    monkeypatch.setattr(drive, "upload", _fake_upload)
+
+    res = main._run_push_blocking(storage, settings, conflicts, str(tmp_path))
+
+    assert res.get("ok") is True
+    assert set(uploaded["doc"]["entries"]) == {"2026-06-09", "2026-06-20"}
+    assert "2026-06-20" in storage.get_all_raw()      # Remote-Eintrag lokal übernommen


### PR DESCRIPTION
Patch-Release **v1.15.2** — schließt eine Datenverlust-Lücke im Sync-Push, die für den anstehenden Schema-v3-Rollout (#64, v1.16.0) kritisch ist.

## Problem
`_run_push_blocking` lud das lokale Sync-Doc **bedingungslos** nach Drive hoch. Der Versions-/Merge-Guard lag nur im `except DriveConflictError`-Zweig — der **nie feuert**, weil `drive.upload` `expected_etag` ignoriert (kein File-level If-Match). Folgen:
- Ein noch nicht aktualisiertes Gerät überschreibt beim Schließen/Sync ein bereits hochgezogenes **neueres Schema (v3)** → Clobber/Datenverlust auf dem v3-Gerät. Der in v1.15.1 eingeführte Guard schützte nur den **Pull**, nicht den **Push**.
- Auch unabhängig vom Schema: gleichzeitige Änderungen mehrerer Geräte konnten beim Push verloren gehen (kein Merge vor dem Upload).

## Fix
Push macht jetzt **download → Guard → Merge → upload** (analog zur Kompaktierung):
- Neueres Remote-Schema → Push bricht mit `NEWER_REMOTE_VERSION_MSG` ab (kein Clobber).
- Sonst: Remote wird gelesen und mit dem lokalen Stand gemergt, die Vereinigung hochgeladen (und lokal übernommen).
- Der tote `DriveConflictError`-Zweig ist entfernt.

## Tests
Neu: `test_run_push_aborts_on_newer_remote` (kein Clobber eines v3-Docs) und `test_run_push_merges_remote_before_upload` (Vereinigung statt blindem Überschreiben). `pytest`: 402 passed, 1 skipped.

## Rollout-Reihenfolge
**v1.15.2 muss vor v1.16.0 released und propagiert werden**, damit alle Geräte einen wirksamen Push-Guard haben, bevor v3-Docs entstehen.
