### PR TITLE
fix(import): Erfolgsmeldung vor on_change zeigen (kein TclError mehr)

### DIFF
--- a/src/dialogs/import_dialog.py
+++ b/src/dialogs/import_dialog.py
@@ -386,13 +386,17 @@ class _ImportSummaryDialog:
                 parent=self.top,
             )
             return
-        self.on_change()
+        # themed_showinfo läuft VOR on_change: on_change kann self.parent
+        # zerstören (settings_dialog._after_import ruft dialog.destroy()), und
+        # der Info-Dialog braucht den Parent noch lebendig — sonst TclError:
+        # bad window path name.
         self.top.destroy()
         themed_showinfo(
             self.parent,
             "Importiert",
             f"{total} Datensätze wurden importiert.",
         )
+        self.on_change()
 
 
 class _PerDayDialog:

--- a/src/dialogs/import_dialog.py
+++ b/src/dialogs/import_dialog.py
@@ -22,7 +22,7 @@ from src.theme import (
     BG, CELL_BG, FONT, FONT_SMALL, TEXT, TEXT_MUTED,
     apply_app_icon, apply_combobox_style, apply_dark_titlebar,
     attach_unfocus_on_click, center_dialog_on_parent, disable_min_max,
-    dark_combo, primary_button, secondary_button, themed_showinfo,
+    dark_combo, primary_button, secondary_button, themed_showerror, themed_showinfo,
 )
 
 
@@ -41,17 +41,17 @@ def open_import_dialog(parent, storage, settings, on_change, reservation_store=N
         with open(path, "rb") as f:
             raw = f.read()
     except OSError as e:
-        messagebox.showerror(
-            "Datei nicht lesbar", f"{type(e).__name__}: {e}", parent=parent)
+        themed_showerror(
+            parent, "Datei nicht lesbar", f"{type(e).__name__}: {e}")
         return
 
     try:
         doc = parse_share_doc(raw)
     except ShareValidationError as e:
-        messagebox.showerror(
+        themed_showerror(
+            parent,
             "Datei ungültig",
             f"Die Datei kann nicht importiert werden:\n\n{e.reason}",
-            parent=parent,
         )
         return
 
@@ -61,10 +61,10 @@ def open_import_dialog(parent, storage, settings, on_change, reservation_store=N
         reservations = {}
 
     if not entries and not reservations:
-        messagebox.showinfo(
+        themed_showinfo(
+            parent,
             "Leere Datei",
             "Die Datei enthält keine importierbaren Daten.",
-            parent=parent,
         )
         return
 
@@ -319,10 +319,10 @@ class _ImportSummaryDialog:
     def _on_next(self):
         d_from, d_to = self._get_range()
         if d_from is None:
-            messagebox.showerror(
+            themed_showerror(
+                self.top,
                 "Ungültiger Zeitraum",
                 "Das Von-Datum muss vor dem Bis-Datum liegen.",
-                parent=self.top,
             )
             return
 
@@ -354,10 +354,10 @@ class _ImportSummaryDialog:
                 planned.append((lambda dec: apply_reservation_import(self.reservation_store, dec), decisions))
 
         if not planned:
-            messagebox.showinfo(
+            themed_showinfo(
+                self.top,
                 "Nichts zu importieren",
                 "Im gewählten Zeitraum gibt es nichts zu übernehmen.",
-                parent=self.top,
             )
             return
 

--- a/tests/test_import_apply_order.py
+++ b/tests/test_import_apply_order.py
@@ -1,0 +1,29 @@
+"""Regression: der „Importiert"-Bestätigungsdialog muss erscheinen, solange
+sein Parent (der Settings-Dialog) noch lebt. on_change() zerstört den Parent
+(settings_dialog._after_import ruft dialog.destroy()), also muss themed_showinfo
+VOR on_change() laufen — sonst TclError: bad window path name."""
+
+from unittest.mock import Mock
+
+import src.dialogs.import_dialog as import_dialog
+from src.dialogs.import_dialog import _ImportSummaryDialog
+
+
+def test_apply_shows_info_before_on_change(monkeypatch):
+    calls = []
+
+    monkeypatch.setattr(
+        import_dialog, "themed_showinfo",
+        lambda *a, **k: calls.append("info"),
+    )
+
+    dlg = _ImportSummaryDialog.__new__(_ImportSummaryDialog)
+    dlg.parent = object()
+    dlg.top = Mock()
+    dlg.on_change = lambda: calls.append("on_change")
+
+    dlg._apply([(lambda dec: None, [{"date": "2026-06-02"}])])
+
+    assert calls == ["info", "on_change"], (
+        "themed_showinfo muss vor on_change laufen (on_change zerstört den Parent)"
+    )


### PR DESCRIPTION
## Problem

Beim Import über **Einstellungen → Daten importieren…** stürzt die App nach dem Bestätigen mit `TclError: bad window path name ".!toplevel10"` ab (sichtbar als „Unerwarteter Fehler"-Dialog, Details im Logfile).

## Root Cause

In `_ImportSummaryDialog._apply` (`src/dialogs/import_dialog.py`) lief die Reihenfolge:

```python
self.on_change()                   # = settings_dialog._after_import → dialog.destroy() → zerstört self.parent
self.top.destroy()
themed_showinfo(self.parent, ...)  # self.parent ist jetzt tot → TclError
```

`self.parent` ist der Settings-Dialog. `on_change` (`_after_import`) zerstört ihn via `dialog.destroy()`. Direkt danach versuchte der „Importiert"-Dialog, das bereits zerstörte Fenster als Parent zu verwenden → `bad window path name`.

Wichtig: Der Crash passiert **nach** dem Apply-Loop — die Daten werden korrekt importiert, nur die Erfolgsmeldung schlägt fehl.

## Fix

`themed_showinfo` läuft jetzt **vor** `on_change`, solange der Parent noch lebt:

```python
self.top.destroy()
themed_showinfo(self.parent, "Importiert", ...)
self.on_change()
```

## Tests

- Neuer Regressionstest `tests/test_import_apply_order.py` prüft, dass `themed_showinfo` vor `on_change` aufgerufen wird (vorher RED, jetzt GREEN).
- Volle Suite grün (vorbestehende `test_drive.py`-Fehler nur lokal mangels Google-API-Libs, unabhängig).
- `ruff check` sauber.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
