### PR TITLE
refactor(oauth): Token-Boilerplate in src/oauth_utils.py zentralisieren (#47)

### DIFF
--- a/src/drive.py
+++ b/src/drive.py
@@ -7,7 +7,8 @@ Scope: drive.appdata (non-sensitive, per-app-isolated).
 
 import io
 import os
-import stat
+
+from src.oauth_utils import write_token
 
 SYNC_FILENAME = "zeiterfassung-sync.json"
 SYNC_MIMETYPE = "application/json"
@@ -68,15 +69,6 @@ SYNC_SCOPES = [
 ]
 
 
-def _write_token(creds, token_path):
-    with open(token_path, "w") as f:
-        f.write(creds.to_json())
-    try:
-        os.chmod(token_path, stat.S_IRUSR | stat.S_IWUSR)  # 0o600
-    except OSError:
-        pass
-
-
 def get_drive_service(credentials_path, token_path, gcal_enabled=False):
     """OAuth mit kombinierten Scopes (Gmail + Drive appdata, optional Calendar).
     Token wird mit allen Scopes geschrieben — Gmail send und Calendar
@@ -104,7 +96,7 @@ def get_drive_service(credentials_path, token_path, gcal_enabled=False):
             raise DriveAuthError(str(e)) from e
         except TransportError as e:
             raise DriveNetworkError(str(e)) from e
-        _write_token(creds, token_path)
+        write_token(creds, token_path)
 
     if not creds or not creds.valid:
         if not os.path.exists(credentials_path):
@@ -113,7 +105,7 @@ def get_drive_service(credentials_path, token_path, gcal_enabled=False):
             )
         flow = InstalledAppFlow.from_client_secrets_file(credentials_path, scopes)
         creds = flow.run_local_server(port=0)
-        _write_token(creds, token_path)
+        write_token(creds, token_path)
 
     return build("drive", "v3", credentials=creds)
 

--- a/src/gcal.py
+++ b/src/gcal.py
@@ -9,6 +9,7 @@ Die pure Helper `event_payload` / `parse_event` haben keine Google-Abhängigkeit
 import datetime
 
 from src.mail import get_scopes
+from src.oauth_utils import discard_token_for_scope_upgrade, write_token
 
 # Marker in extendedProperties.private — über diesen findet der Pull "seine"
 # Events; manuell angelegte Termine bleiben dadurch unangetastet.
@@ -85,9 +86,7 @@ def get_calendar_service(credentials_path="credentials.json",
     Scopes aus dem gemeinsamen token.json. Spiegelt get_gmail_service inkl.
     Scope-Upgrade-Erkennung. Google-Imports lazy (CI ohne requirements.txt).
     """
-    import json as _json
     import os
-    import stat
 
     from google.oauth2.credentials import Credentials
     from google.auth.transport.requests import Request
@@ -96,29 +95,12 @@ def get_calendar_service(credentials_path="credentials.json",
 
     scopes = get_scopes(sync_enabled, gcal_enabled=True)
 
-    def _write(c):
-        with open(token_path, "w") as f:
-            f.write(c.to_json())
-        try:
-            os.chmod(token_path, stat.S_IRUSR | stat.S_IWUSR)  # 0o600
-        except OSError:
-            pass
-
     creds = None
     if os.path.exists(token_path):
         creds = Credentials.from_authorized_user_file(token_path, scopes)
         # Scope-Upgrade-Erkennung: hat der Token nicht alle Scopes, frischer Flow.
-        try:
-            with open(token_path, "r", encoding="utf-8") as f:
-                granted = set(_json.load(f).get("scopes") or [])
-            if not set(scopes).issubset(granted):
-                creds = None
-                try:
-                    os.remove(token_path)
-                except OSError:
-                    pass
-        except Exception:
-            pass
+        if discard_token_for_scope_upgrade(token_path, scopes):
+            creds = None
 
     if creds and creds.expired and creds.refresh_token:
         # Spiegelt get_gmail_service: ein ungültiger Refresh-Token (RefreshError)
@@ -127,7 +109,7 @@ def get_calendar_service(credentials_path="credentials.json",
         from google.auth.exceptions import RefreshError
         try:
             creds.refresh(Request())
-            _write(creds)
+            write_token(creds, token_path)
         except RefreshError:
             creds = None
 
@@ -138,7 +120,7 @@ def get_calendar_service(credentials_path="credentials.json",
             )
         flow = InstalledAppFlow.from_client_secrets_file(credentials_path, scopes)
         creds = flow.run_local_server(port=0)
-        _write(creds)
+        write_token(creds, token_path)
 
     return build("calendar", "v3", credentials=creds)
 

--- a/src/mail.py
+++ b/src/mail.py
@@ -2,11 +2,12 @@
 import base64
 import os
 import socket
-import stat
 from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
 from email.mime.application import MIMEApplication
 from email.header import Header
+
+from src.oauth_utils import discard_token_for_scope_upgrade, write_token
 
 GMAIL_SEND_SCOPE = "https://www.googleapis.com/auth/gmail.send"
 DRIVE_APPDATA_SCOPE = "https://www.googleapis.com/auth/drive.appdata"
@@ -64,7 +65,7 @@ def fetch_user_email(token_path="token.json", sync_enabled=False, gcal_enabled=F
             from google.auth.transport.requests import Request
             try:
                 creds.refresh(Request())
-                _write_token(creds, token_path)
+                write_token(creds, token_path)
             except Exception:
                 log.warning("fetch_user_email: token refresh failed")
                 return ""
@@ -165,21 +166,6 @@ def is_offline_error(exc):
     return False
 
 
-def _write_token(creds, token_path):
-    """Persistiere Credentials und setze restriktive Permissions (Unix only).
-
-    Auf Windows bleibt das chmod ein No-op — POSIX-Permissions gibt es
-    dort nicht. `try/except OSError` deckt zusätzlich exotische Filesystems
-    (sshfs, FAT32 auf USB-Stick) ab, wo chmod fehlschlagen kann.
-    """
-    with open(token_path, "w") as f:
-        f.write(creds.to_json())
-    try:
-        os.chmod(token_path, stat.S_IRUSR | stat.S_IWUSR)  # 0o600
-    except OSError:
-        pass
-
-
 def _refresh_and_persist(creds, token_path):
     """Refresh credentials and write them back. Translates Google exceptions."""
     from google.auth.exceptions import RefreshError, TransportError
@@ -192,7 +178,7 @@ def _refresh_and_persist(creds, token_path):
     except TransportError as e:
         raise TokenNetworkError(str(e)) from e
 
-    _write_token(creds, token_path)
+    write_token(creds, token_path)
 
 
 def refresh_token_if_needed(token_path="token.json", sync_enabled=False,
@@ -244,22 +230,12 @@ def get_gmail_service(credentials_path="credentials.json", token_path="token.jso
 
     if os.path.exists(token_path):
         creds = Credentials.from_authorized_user_file(token_path, scopes)
-        # Scope-Upgrade-Erkennung: wenn der gespeicherte Token nicht alle
-        # angeforderten Scopes hat (typisch nach Feature-Update), zwingt wir
+        # Scope-Upgrade-Erkennung: deckt der gespeicherte Token nicht alle
+        # angeforderten Scopes ab (typisch nach Feature-Update), erzwingen wir
         # einen frischen OAuth-Flow. Sonst bleibt der Token "valid" und der
         # User wundert sich, warum eine Scope-abhängige Funktion 401/403 wirft.
-        try:
-            import json as _json
-            with open(token_path, "r", encoding="utf-8") as f:
-                granted = set(_json.load(f).get("scopes") or [])
-            if not set(scopes).issubset(granted):
-                creds = None
-                try:
-                    os.remove(token_path)
-                except OSError:
-                    pass
-        except Exception:
-            pass
+        if discard_token_for_scope_upgrade(token_path, scopes):
+            creds = None
 
     if creds and creds.expired and creds.refresh_token:
         try:
@@ -276,7 +252,7 @@ def get_gmail_service(credentials_path="credentials.json", token_path="token.jso
             )
         flow = InstalledAppFlow.from_client_secrets_file(credentials_path, scopes)
         creds = flow.run_local_server(port=0)
-        _write_token(creds, token_path)
+        write_token(creds, token_path)
 
     return build("gmail", "v1", credentials=creds)
 

--- a/src/oauth_utils.py
+++ b/src/oauth_utils.py
@@ -1,0 +1,74 @@
+"""Gemeinsame OAuth-Helfer für die Google-API-Wrapper (mail/drive/gcal).
+
+Zentralisiert den zuvor mehrfach kopierten Boilerplate (Issue #47):
+Token-Persistenz mit restriktiven Permissions und die Scope-Upgrade-Erkennung.
+
+Reine stdlib — **keine** Google-Imports auf Modulebene. Damit bleibt die
+Lazy-Import-Konvention der Wrapper erhalten (CI installiert kein
+`requirements.txt`, siehe CLAUDE.md); `creds` wird nur über `creds.to_json()`
+angefasst, was die aufrufende Seite ohnehin schon hält.
+"""
+
+import json
+import os
+import stat
+import tempfile
+
+
+def write_token(creds, token_path):
+    """Persistiere Credentials atomar und setze restriktive Permissions.
+
+    Geschrieben wird in eine Temp-Datei im selben Verzeichnis, dann via
+    `os.replace` atomar an die Zielstelle bewegt — so kann ein abgebrochener
+    Schreibvorgang nie eine halbe Token-Datei hinterlassen.
+
+    Die Permissions werden auf `0o600` gesetzt. Auf Windows ist das chmod ein
+    No-op (keine POSIX-Permissions); `try/except OSError` deckt zusätzlich
+    exotische Filesystems (sshfs, FAT32) ab, wo chmod fehlschlagen kann.
+    """
+    token_path = os.fspath(token_path)
+    directory = os.path.dirname(os.path.abspath(token_path))
+    fd, tmp_path = tempfile.mkstemp(
+        dir=directory, prefix=".token-", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(creds.to_json())
+        try:
+            os.chmod(tmp_path, stat.S_IRUSR | stat.S_IWUSR)  # 0o600
+        except OSError:
+            pass
+        os.replace(tmp_path, token_path)
+    except BaseException:
+        try:
+            os.remove(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def discard_token_for_scope_upgrade(token_path, scopes):
+    """Erzwinge einen frischen OAuth-Flow, wenn der gespeicherte Token nicht
+    alle angeforderten `scopes` abdeckt (typisch nach einem Feature-Update).
+
+    Deckt der Token die Scopes nicht ab, wird die Token-Datei gelöscht und
+    `True` geliefert — die aufrufende Seite setzt dann `creds = None` und
+    durchläuft den vollen Consent. Andernfalls `False`.
+
+    Bei Lesefehlern (kein/defektes JSON) konservativ `False`: der Token bleibt
+    unangetastet, statt einen womöglich gültigen Token wegzuwerfen. Spiegelt
+    das frühere `except Exception: pass` in den Wrappern.
+    """
+    try:
+        with open(token_path, "r", encoding="utf-8") as f:
+            granted = set(json.load(f).get("scopes") or [])
+    except (OSError, ValueError):
+        return False
+
+    if set(scopes).issubset(granted):
+        return False
+
+    try:
+        os.remove(token_path)
+    except OSError:
+        pass
+    return True

--- a/tests/test_oauth_utils.py
+++ b/tests/test_oauth_utils.py
@@ -1,0 +1,101 @@
+"""Tests für die zentralisierten OAuth-Helfer (Issue #47).
+
+write_token: atomar + 0o600. discard_token_for_scope_upgrade: löscht den Token
+nur, wenn die gespeicherten Scopes die angeforderten nicht abdecken."""
+
+import json
+import os
+import stat
+from unittest.mock import MagicMock
+
+from src.oauth_utils import write_token, discard_token_for_scope_upgrade
+
+
+def test_write_token_writes_creds_json(tmp_path):
+    path = str(tmp_path / "token.json")
+    creds = MagicMock()
+    creds.to_json.return_value = '{"token": "abc"}'
+
+    write_token(creds, path)
+
+    with open(path) as f:
+        assert f.read() == '{"token": "abc"}'
+
+
+def test_write_token_sets_0o600_permissions(tmp_path):
+    path = str(tmp_path / "token.json")
+    creds = MagicMock()
+    creds.to_json.return_value = "{}"
+
+    write_token(creds, path)
+
+    mode = stat.S_IMODE(os.stat(path).st_mode)
+    # Auf POSIX exakt 0o600; auf Windows ignoriert das OS die Permission-Bits,
+    # daher nur dort prüfen.
+    if os.name == "posix":
+        assert mode == 0o600
+
+
+def test_write_token_atomic_no_leftover_tmp_files(tmp_path):
+    path = str(tmp_path / "token.json")
+    creds = MagicMock()
+    creds.to_json.return_value = '{"token": "abc"}'
+
+    write_token(creds, path)
+
+    names = os.listdir(str(tmp_path))
+    assert names == ["token.json"], f"unerwartete Temp-Reste: {names}"
+
+
+def test_write_token_overwrites_existing(tmp_path):
+    path = str(tmp_path / "token.json")
+    with open(path, "w") as f:
+        f.write("old")
+    creds = MagicMock()
+    creds.to_json.return_value = "new"
+
+    write_token(creds, path)
+
+    with open(path) as f:
+        assert f.read() == "new"
+
+
+def _write_token_file(path, scopes):
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump({"token": "t", "scopes": scopes}, f)
+
+
+def test_discard_returns_false_when_all_scopes_covered(tmp_path):
+    path = str(tmp_path / "token.json")
+    _write_token_file(path, ["a", "b", "c"])
+
+    assert discard_token_for_scope_upgrade(path, ["a", "b"]) is False
+    assert os.path.exists(path)
+
+
+def test_discard_removes_token_when_scope_missing(tmp_path):
+    path = str(tmp_path / "token.json")
+    _write_token_file(path, ["a"])
+
+    assert discard_token_for_scope_upgrade(path, ["a", "b"]) is True
+    assert not os.path.exists(path)
+
+
+def test_discard_returns_false_on_unreadable_token(tmp_path):
+    """Defektes/leeres JSON darf den Token nicht löschen — spiegelt das
+    bisherige `except: pass` (Token unangetastet, kein erzwungener Flow)."""
+    path = str(tmp_path / "token.json")
+    with open(path, "w") as f:
+        f.write("not json")
+
+    assert discard_token_for_scope_upgrade(path, ["a"]) is False
+    assert os.path.exists(path)
+
+
+def test_discard_treats_missing_scopes_key_as_no_coverage(tmp_path):
+    path = str(tmp_path / "token.json")
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump({"token": "t"}, f)
+
+    assert discard_token_for_scope_upgrade(path, ["a"]) is True
+    assert not os.path.exists(path)


### PR DESCRIPTION
Closes #47.

## Problem

Der OAuth-Boilerplate war über die drei Google-Wrapper kopiert. Bei einem Security-Fix (Permission-Logik, Scope-Erkennung) mussten alle Kopien gepflegt werden.

- `_write_token()` (Token + `0o600`) — identisch in `mail.py`, `drive.py` und als Closure in `gcal.py`
- Scope-Upgrade-Erkennung — dupliziert in `mail.py::get_gmail_service` und `gcal.py::get_calendar_service`

## Lösung

Neues Modul **`src/oauth_utils.py`** (pure stdlib, **keine** Google-Imports → die Lazy-Import-Konvention der Wrapper bleibt intakt, CLAUDE.md):

- **`write_token(creds, token_path)`** — schreibt jetzt **atomar** (tempfile + `os.replace`) und setzt `0o600`. Bisher war das Schreiben nicht atomar; ein Abbruch konnte eine halbe Token-Datei hinterlassen. (Signatur `(creds, token_path)` beibehalten — entspricht der bisherigen dominanten Reihenfolge, minimale Call-Site-Änderung.)
- **`discard_token_for_scope_upgrade(token_path, scopes) -> bool`** — zentralisiert die Scope-Upgrade-Erkennung: deckt der Token die angeforderten Scopes nicht ab → löschen + `True`. Lesefehler (kein/defektes JSON) → konservativ `False` (Token unangetastet), spiegelt das frühere `except: pass`.

`mail.py`, `drive.py`, `gcal.py` importieren daraus; ihre `_write_token`-Kopien und die duplizierte Scope-Prüfung entfallen. Netto **−50 Zeilen** in den Wrappern.

## Akzeptanzkriterien

- [x] `_write_token`-Logik existiert nur noch an einer Stelle
- [x] Scope-Upgrade-Check zentralisiert
- [x] Token-Permissions bleiben `0o600`
- [x] Bestehende Tests (`test_mail.py`, `test_drive.py`, `test_gcal.py`) grün; lazy Imports intakt

## Tests

- Neues `tests/test_oauth_utils.py`: atomarer Write (keine Temp-Reste), `0o600` (POSIX), Scope-Coverage, defektes JSON löscht nicht.
- Volle Suite lokal: **515 passed, 1 skipped** (inkl. `test_drive.py` mit installierten Google-Libs).
- `ruff check` sauber.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
