### PR TITLE
refactor(ui): Duplikat-Helfer + BackgroundTaskRunner (#49)

### DIFF
--- a/docs/superpowers/plans/2026-06-23-ui-bg-tasks.md
+++ b/docs/superpowers/plans/2026-06-23-ui-bg-tasks.md
@@ -1,0 +1,912 @@
+# ui.py-Entflechtung (Helfer + BackgroundTaskRunner) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Die billigen Duplikate in `src/ui.py` über Helfer zusammenführen und die Background-Tasks in eine eigene Klasse `BackgroundTaskRunner` (`src/background_tasks.py`) auslagern — erfüllt alle vier Akzeptanzkriterien von Issue #49.
+
+**Architecture:** Vier Helfer (`_navigate`, `_hover`, `_cell_layout_metrics`) bleiben Methoden/Statics von `App`. Die proaktiven Worker und die Thread-Mechanik wandern in eine neue, Tk-freie Klasse `BackgroundTaskRunner`; `App` konstruiert sie und übergibt UI-Arbeit als Callbacks. Verhalten bleibt unverändert.
+
+**Tech Stack:** Python 3, Tkinter, pytest. Reine stdlib im neuen Modul (keine Tk-/Google-Imports auf Modulebene; `run_calendar_reconcile` Lazy-Import in der Methode).
+
+## Global Constraints
+
+- Verhalten unverändert (AC 4) — UI manuell verifiziert (Month/Week, Navigation, Hover, Sync, Tray).
+- `src/background_tasks.py`: **keine** Tk-Imports, **keine** Google-Imports auf Modulebene. `from src.main import run_calendar_reconcile` bleibt Lazy-Import **innerhalb** der Methode (Circular-Import-Schutz: `src.main` importiert `App` aus `ui`).
+- Datum intern ISO, UI deutsch (hier nicht berührt, aber nicht brechen).
+- Lint: `python -m ruff check .` muss grün sein.
+- Tests: `python -m pytest` grün (lokal sind Google-Libs installiert).
+- Commit-Messages enden mit `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`.
+- PowerShell 5.1: keine `&&`-Verkettung; `;` oder `if ($?) { }`.
+
+---
+
+### Task 1: `_navigate(direction)` ersetzt `_prev`/`_next`
+
+**Files:**
+- Modify: `src/ui.py` (Methoden `_prev`/`_next` bei ~540-568; Key-Bindings bei ~210-211)
+- Test: `tests/test_ui_navigate.py` (neu)
+
+**Interfaces:**
+- Produces: `App._navigate(self, direction)` — `direction ∈ {-1, +1}`; mutiert `self.year`/`self.month` (month-Modus) bzw. `self.iso_year`/`self.current_week` (week-Modus) und ruft `self._refresh()`.
+
+- [ ] **Step 1: Failing test schreiben**
+
+`tests/test_ui_navigate.py`:
+```python
+"""_navigate ersetzt _prev/_next. Getestet ohne Tk über einen Stub mit den
+relevanten Attributen; _refresh ist ein No-op."""
+
+import datetime
+
+from src.ui import App
+
+
+class _Stub:
+    def __init__(self, **kw):
+        self.__dict__.update(kw)
+        self.refreshed = 0
+
+    def _refresh(self):
+        self.refreshed += 1
+
+
+def _nav(stub, direction):
+    App._navigate(stub, direction)
+
+
+def test_month_forward_within_year():
+    s = _Stub(view_mode="month", year=2026, month=6)
+    _nav(s, +1)
+    assert (s.year, s.month) == (2026, 7)
+    assert s.refreshed == 1
+
+
+def test_month_backward_wraps_to_previous_year():
+    s = _Stub(view_mode="month", year=2026, month=1)
+    _nav(s, -1)
+    assert (s.year, s.month) == (2025, 12)
+
+
+def test_month_forward_wraps_to_next_year():
+    s = _Stub(view_mode="month", year=2026, month=12)
+    _nav(s, +1)
+    assert (s.year, s.month) == (2027, 1)
+
+
+def test_week_forward_advances_seven_days():
+    # KW 26/2026 -> +1 Woche = KW 27
+    s = _Stub(view_mode="week", iso_year=2026, current_week=26)
+    _nav(s, +1)
+    assert (s.iso_year, s.current_week) == (2026, 27)
+
+
+def test_week_backward_crosses_year_boundary():
+    # KW 1/2026 -> -1 Woche landet in 2025
+    s = _Stub(view_mode="week", iso_year=2026, current_week=1)
+    _nav(s, -1)
+    assert s.iso_year == 2025
+    assert s.current_week >= 52
+```
+
+- [ ] **Step 2: Test failt sehen**
+
+Run: `python -m pytest tests/test_ui_navigate.py -q`
+Expected: FAIL — `AttributeError: type object 'App' has no attribute '_navigate'`.
+
+- [ ] **Step 3: `_navigate` implementieren, `_prev`/`_next` entfernen**
+
+In `src/ui.py` die beiden Methoden `_prev` und `_next` (ganzer Block ~540-568) ersetzen durch:
+```python
+    def _navigate(self, direction):
+        """Blättert die Ansicht um `direction` Einheiten (-1 zurück, +1 vor):
+        im Monatsmodus ±1 Monat (mit Jahreswechsel), im Wochenmodus ±7 Tage."""
+        if self.view_mode == "month":
+            m = self.month + direction
+            if m < 1:
+                self.month, self.year = 12, self.year - 1
+            elif m > 12:
+                self.month, self.year = 1, self.year + 1
+            else:
+                self.month = m
+        else:
+            monday = get_week_dates(self.iso_year, self.current_week)[0] \
+                + datetime.timedelta(days=7 * direction)
+            self.iso_year, self.current_week = monday.isocalendar()[:2]
+        self._refresh()
+```
+
+- [ ] **Step 4: Key-Bindings umbiegen**
+
+In `src/ui.py` (~210-211):
+```python
+        self.root.bind("<Left>", lambda e: self._prev())
+        self.root.bind("<Right>", lambda e: self._next())
+```
+ersetzen durch:
+```python
+        self.root.bind("<Left>", lambda e: self._navigate(-1))
+        self.root.bind("<Right>", lambda e: self._navigate(+1))
+```
+
+- [ ] **Step 5: Sicherstellen, dass keine `_prev`/`_next`-Referenzen übrig sind**
+
+Run: `python -m pytest tests/test_ui_navigate.py -q ; python -m ruff check src/ui.py`
+Grep zur Kontrolle: es darf kein `self._prev(` / `self._next(` mehr geben.
+Expected: Tests PASS, Lint grün.
+
+- [ ] **Step 6: Commit**
+
+```
+git add src/ui.py tests/test_ui_navigate.py
+git commit -m "refactor(ui): _prev/_next zu _navigate(direction) zusammenfuehren (#49)"
+```
+
+---
+
+### Task 2: `_hover(frame, bg, *labels)` vereint `_cell_hover`/`_empty_hover`
+
+**Files:**
+- Modify: `src/ui.py` (Statics `_cell_hover` ~1278, `_empty_hover` ~1293; Call-Sites ~855-856, ~936-937, ~1266-1269)
+- Test: `tests/test_ui_hover.py` (neu)
+
+**Interfaces:**
+- Produces: `App._hover(frame, bg, *labels)` (staticmethod) — setzt `bg` auf `frame`, jedes Label in `labels` und die Overlay-Widgets `frame._reservation_marker` / `frame._delete_button` falls vorhanden.
+
+- [ ] **Step 1: Failing test schreiben**
+
+`tests/test_ui_hover.py`:
+```python
+"""_hover faerbt Frame, uebergebene Labels und vorhandene Eck-Overlays."""
+
+from src.ui import App
+
+
+class _FakeWidget:
+    def __init__(self):
+        self.bg = None
+
+    def config(self, bg):
+        self.bg = bg
+
+
+def test_hover_colors_frame_and_labels():
+    frame, day, time = _FakeWidget(), _FakeWidget(), _FakeWidget()
+    App._hover(frame, "#123456", day, time)
+    assert frame.bg == "#123456"
+    assert day.bg == "#123456"
+    assert time.bg == "#123456"
+
+
+def test_hover_colors_overlay_widgets_when_present():
+    frame = _FakeWidget()
+    frame._reservation_marker = _FakeWidget()
+    frame._delete_button = _FakeWidget()
+    App._hover(frame, "#abcdef")
+    assert frame._reservation_marker.bg == "#abcdef"
+    assert frame._delete_button.bg == "#abcdef"
+
+
+def test_hover_without_overlays_does_not_fail():
+    frame, day = _FakeWidget(), _FakeWidget()
+    App._hover(frame, "#000000", day)
+    assert frame.bg == "#000000"
+    assert day.bg == "#000000"
+```
+
+- [ ] **Step 2: Test failt sehen**
+
+Run: `python -m pytest tests/test_ui_hover.py -q`
+Expected: FAIL — `AttributeError: type object 'App' has no attribute '_hover'`.
+
+- [ ] **Step 3: `_hover` implementieren, `_cell_hover`/`_empty_hover` entfernen**
+
+In `src/ui.py` den ganzen Block der beiden Statics (`_cell_hover` ~1278-1291 und `_empty_hover` ~1292-1304, inkl. der `@staticmethod`-Dekoratoren) ersetzen durch:
+```python
+    @staticmethod
+    def _hover(frame, bg, *labels):
+        """Faerbt Zelle + uebergebene Labels beim Hover. Die Eck-Overlays
+        (_reservation_marker, macOS-_delete_button) werden mitgefaerbt, sonst
+        bleibt ein andersfarbiges Rechteck stehen. Nur bg — die fg des
+        Loesch-Buttons steuert dessen eigener Enter/Leave-Handler."""
+        frame.config(bg=bg)
+        for lbl in labels:
+            lbl.config(bg=bg)
+        for attr in ("_reservation_marker", "_delete_button"):
+            w = getattr(frame, attr, None)
+            if w is not None:
+                w.config(bg=bg)
+```
+
+- [ ] **Step 4: Call-Sites umstellen**
+
+Entry-Zelle (`src/ui.py` ~855-856):
+```python
+            w.bind("<Enter>", lambda e, c=cell, dl=day_lbl, tl=time_lbl, hb=hover_bg: self._cell_hover(c, dl, tl, hb))
+            w.bind("<Leave>", lambda e, c=cell, dl=day_lbl, tl=time_lbl, ob=bg: self._cell_hover(c, dl, tl, ob))
+```
+→
+```python
+            w.bind("<Enter>", lambda e, c=cell, dl=day_lbl, tl=time_lbl, hb=hover_bg: self._hover(c, hb, dl, tl))
+            w.bind("<Leave>", lambda e, c=cell, dl=day_lbl, tl=time_lbl, ob=bg: self._hover(c, ob, dl, tl))
+```
+
+Empty-Zelle (`src/ui.py` ~936-937):
+```python
+            w.bind("<Enter>", lambda e, c=cell, dl=day_lbl, hb=hover_bg: self._empty_hover(c, dl, hb))
+            w.bind("<Leave>", lambda e, c=cell, dl=day_lbl, ob=bg: self._empty_hover(c, dl, ob))
+```
+→
+```python
+            w.bind("<Enter>", lambda e, c=cell, dl=day_lbl, hb=hover_bg: self._hover(c, hb, dl))
+            w.bind("<Leave>", lambda e, c=cell, dl=day_lbl, ob=bg: self._hover(c, ob, dl))
+```
+
+Holiday-Zelle (`src/ui.py` ~1266-1269):
+```python
+            w.bind("<Enter>", lambda e, c=cell, dl=day_lbl, nl=name_lbl:
+                self._cell_hover(c, dl, nl, HOLIDAY_BG_HOVER))
+            w.bind("<Leave>", lambda e, c=cell, dl=day_lbl, nl=name_lbl:
+                self._cell_hover(c, dl, nl, HOLIDAY_BG))
+```
+→
+```python
+            w.bind("<Enter>", lambda e, c=cell, dl=day_lbl, nl=name_lbl:
+                self._hover(c, HOLIDAY_BG_HOVER, dl, nl))
+            w.bind("<Leave>", lambda e, c=cell, dl=day_lbl, nl=name_lbl:
+                self._hover(c, HOLIDAY_BG, dl, nl))
+```
+
+- [ ] **Step 5: Tests + Lint, keine `_cell_hover`/`_empty_hover`-Reste**
+
+Run: `python -m pytest tests/test_ui_hover.py -q ; python -m ruff check src/ui.py`
+Grep-Kontrolle: kein `_cell_hover` / `_empty_hover` mehr im Code.
+Expected: PASS, Lint grün.
+
+- [ ] **Step 6: Commit**
+
+```
+git add src/ui.py tests/test_ui_hover.py
+git commit -m "refactor(ui): _cell_hover/_empty_hover zu _hover zusammenfuehren (#49)"
+```
+
+---
+
+### Task 3: `_cell_layout_metrics(frame)` entdoppelt das Probe-Pattern
+
+**Files:**
+- Modify: `src/ui.py` (Konstanten oben; Probe-Block in `_refresh_month` ~1094-1105 und `_refresh_week` ~1178-1184)
+
+**Interfaces:**
+- Produces: `App._cell_layout_metrics(self, frame) -> (cell_size, entry_time_font, holiday_name_font, wide_cells)` — `cell_size` ist `(reqwidth, reqheight)` eines Probe-Labels.
+- Produces: Modulkonstanten `PROBE_WIDTH_WIDE = 12`, `PROBE_WIDTH_NARROW = 8`, `PROBE_HEIGHT = 3`.
+
+*Kein Headless-Unit-Test (braucht Tk-Display); Verifikation über bestehende Render-Pfade + manuelles AC-4-Smoke in Task 7.*
+
+- [ ] **Step 1: Konstanten + Methode anlegen**
+
+In `src/ui.py` nach den Imports (vor `class App` bzw. zu den bestehenden Modul-Konstanten) ergänzen:
+```python
+# Probe-Label-Geometrie zur Zellgroessen-Messung (Month- und Week-Render teilen sie).
+PROBE_WIDTH_WIDE = 12    # ausgeblendetes Wochenende -> breitere Zellen
+PROBE_WIDTH_NARROW = 8   # 7-Spalten-Modus
+PROBE_HEIGHT = 3
+```
+
+Als neue Methode in `App` (z.B. direkt vor `_refresh_month`):
+```python
+    def _cell_layout_metrics(self, frame):
+        """Misst die natuerliche Pixelgroesse einer Standard-Tageszelle (Probe-
+        Label) und liefert die layout-abhaengigen Groessen.
+
+        Bei ausgeblendetem Wochenende (5 statt 7 Spalten) bleibt mehr Horizontal-
+        platz pro Spalte: breitere Zellen und groessere Zeit-/Feiertagsschrift
+        (FONT statt FONT_SMALL), damit z.B. '09:30-17:00' bequem lesbar bleibt.
+        Holiday-Zellen werden spaeter auf `cell_size` fixiert, damit lange
+        Feiertagsnamen die Spalte nicht aufweiten (Header-Reflow/Flackern)."""
+        wide_cells = not self.settings.get("show_weekend")
+        probe_width = PROBE_WIDTH_WIDE if wide_cells else PROBE_WIDTH_NARROW
+        entry_time_font = FONT if wide_cells else FONT_SMALL
+        holiday_name_font = FONT if wide_cells else FONT_SMALL
+        probe = tk.Label(frame, text="", font=FONT, width=probe_width, height=PROBE_HEIGHT)
+        probe.update_idletasks()
+        cell_size = (probe.winfo_reqwidth(), probe.winfo_reqheight())
+        probe.destroy()
+        return cell_size, entry_time_font, holiday_name_font, wide_cells
+```
+
+- [ ] **Step 2: `_refresh_month` umstellen**
+
+In `src/ui.py` den Block ~1094-1105 (von `wide_cells = not self.settings.get("show_weekend")` bis `probe.destroy()`) ersetzen durch:
+```python
+        cell_size, entry_time_font, holiday_name_font, wide_cells = \
+            self._cell_layout_metrics(new_frame)
+```
+Die nachfolgende Nutzung (`holiday_max_len=12 if wide_cells else 9`, `entry_time_font`, `holiday_name_font`, `cell_size`) bleibt unverändert.
+
+- [ ] **Step 3: `_refresh_week` umstellen**
+
+In `src/ui.py` den analogen Block ~1178-1184 ersetzen durch:
+```python
+        cell_size, entry_time_font, holiday_name_font, wide_cells = \
+            self._cell_layout_metrics(new_frame)
+```
+Falls `_refresh_week` `wide_cells` nicht weiterverwendet, ist die Variable ungenutzt → dann in der Entpackung durch `_` ersetzen, damit Lint (F841) nicht meckert. (Vor dem Commit per Lint prüfen.)
+
+- [ ] **Step 4: Lint + voller Testlauf (Render-Pfade dürfen nicht brechen)**
+
+Run: `python -m ruff check src/ui.py ; python -m pytest -q`
+Expected: Lint grün; Tests PASS (gleiche Anzahl wie vorher).
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/ui.py
+git commit -m "refactor(ui): Probe-Label-Messung in _cell_layout_metrics buendeln (#49)"
+```
+
+---
+
+### Task 4: `BackgroundTaskRunner.run()` — neues Modul + Thread-Helfer
+
+**Files:**
+- Create: `src/background_tasks.py`
+- Test: `tests/test_background_tasks.py` (neu)
+
+**Interfaces:**
+- Produces: `BackgroundTaskRunner(marshal, settings, base_path, reservation_store, reservations_active)`
+- Produces: `BackgroundTaskRunner.run(self, fn, on_done=None)` — führt `fn()` im Daemon-Thread aus und liefert dessen Rückgabe via `marshal(lambda: on_done(result))`. `marshal` ist eine Callable `(callback) -> None`.
+
+- [ ] **Step 1: Failing test schreiben**
+
+`tests/test_background_tasks.py`:
+```python
+"""BackgroundTaskRunner: run() fuehrt fn im Thread aus und liefert das
+Ergebnis ueber marshal an on_done. marshal wird im Test synchron gefakt."""
+
+import threading
+
+from src.background_tasks import BackgroundTaskRunner
+
+
+def _runner(**overrides):
+    kw = dict(
+        marshal=lambda cb: cb(),          # synchron ausfuehren
+        settings=overrides.pop("settings", {}),
+        base_path=overrides.pop("base_path", "."),
+        reservation_store=overrides.pop("reservation_store", None),
+        reservations_active=overrides.pop("reservations_active", lambda: False),
+    )
+    kw.update(overrides)
+    return BackgroundTaskRunner(**kw)
+
+
+def test_run_executes_fn_and_delivers_result_to_on_done():
+    done = threading.Event()
+    received = {}
+
+    def on_done(result):
+        received["value"] = result
+        done.set()
+
+    _runner().run(lambda: 42, on_done)
+
+    assert done.wait(timeout=5)
+    assert received["value"] == 42
+
+
+def test_run_without_on_done_still_executes_fn():
+    ran = threading.Event()
+
+    def fn():
+        ran.set()
+        return None
+
+    _runner().run(fn)
+
+    assert ran.wait(timeout=5)
+```
+
+- [ ] **Step 2: Test failt sehen**
+
+Run: `python -m pytest tests/test_background_tasks.py -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'src.background_tasks'`.
+
+- [ ] **Step 3: Modul mit `run()` implementieren**
+
+`src/background_tasks.py`:
+```python
+"""Hintergrund-Tasks der App (Token-Refresh, Sender-Email, Update-Check,
+Kalender-Reconcile) und die gemeinsame Thread-Mechanik.
+
+Tk-frei und ohne Google-Imports auf Modulebene: `run_calendar_reconcile`
+wird lazy in der Methode importiert (Circular-Import-Schutz — src.main zieht
+App aus src.ui). UI-Arbeit (Dialoge, Banner, Refresh) macht die Klasse nicht
+selbst, sondern liefert Ergebnisse ueber `marshal` an Callbacks der App.
+"""
+
+import logging
+import os
+import threading
+import traceback
+
+from src.mail import (
+    fetch_user_email,
+    refresh_token_if_needed,
+    TokenAuthError,
+    TokenNetworkError,
+)
+from src.updater import check_latest_release, is_newer, should_check_today
+from src.version import VERSION
+
+log = logging.getLogger(__name__)
+
+
+class BackgroundTaskRunner:
+    def __init__(self, marshal, settings, base_path, reservation_store,
+                 reservations_active):
+        self._marshal = marshal                          # App._marshal_to_ui
+        self._settings = settings
+        self._base_path = base_path
+        self._reservation_store = reservation_store
+        self._reservations_active = reservations_active  # callable -> bool
+
+    def run(self, fn, on_done=None):
+        """Fuehrt fn() in einem Daemon-Thread aus und liefert dessen Rueckgabe
+        via marshal an on_done auf dem UI-Thread."""
+        def worker():
+            result = fn()
+            if on_done is not None:
+                self._marshal(lambda: on_done(result))
+        threading.Thread(target=worker, daemon=True).start()
+```
+
+- [ ] **Step 4: Tests grün**
+
+Run: `python -m pytest tests/test_background_tasks.py -q`
+Expected: PASS (2 Tests).
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/background_tasks.py tests/test_background_tasks.py
+git commit -m "feat(ui): BackgroundTaskRunner mit run()-Thread-Helfer (#49)"
+```
+
+---
+
+### Task 5: `refresh_token` + `fetch_sender_email` in den Runner
+
+**Files:**
+- Modify: `src/background_tasks.py` (zwei Methoden ergänzen)
+- Modify: `src/ui.py` (`_proactive_token_refresh`/`_proactive_sender_email_fetch` entfernen; `__init__`-Wiring; Runner konstruieren)
+- Test: `tests/test_background_tasks.py` (Guard-Test für `fetch_sender_email`)
+
+**Interfaces:**
+- Consumes: `BackgroundTaskRunner.run` (Task 4).
+- Produces: `BackgroundTaskRunner.refresh_token(self, on_auth_error, on_error)` — `on_auth_error(msg: str)`, `on_error(tb: str)`.
+- Produces: `BackgroundTaskRunner.fetch_sender_email(self)` — setzt bei neuer Adresse `settings["sender_email"]` via marshal; no-op ohne `token.json`.
+- Produces: `App._bg` (Instanz von `BackgroundTaskRunner`), gesetzt in `__init__`.
+
+- [ ] **Step 1: Guard-Test für `fetch_sender_email` schreiben**
+
+In `tests/test_background_tasks.py` ergänzen:
+```python
+def test_fetch_sender_email_noop_without_token(tmp_path):
+    # base_path ohne token.json -> fetch_user_email darf nicht aufgerufen werden
+    import src.background_tasks as bg
+
+    called = {"n": 0}
+    orig = bg.fetch_user_email
+    bg.fetch_user_email = lambda *a, **k: called.__setitem__("n", called["n"] + 1) or ""
+    try:
+        _runner(base_path=str(tmp_path)).fetch_sender_email()
+        import time
+        time.sleep(0.2)
+    finally:
+        bg.fetch_user_email = orig
+    assert called["n"] == 0
+```
+
+- [ ] **Step 2: Test failt sehen**
+
+Run: `python -m pytest tests/test_background_tasks.py::test_fetch_sender_email_noop_without_token -q`
+Expected: FAIL — `AttributeError: 'BackgroundTaskRunner' object has no attribute 'fetch_sender_email'`.
+
+- [ ] **Step 3: Methoden im Runner implementieren**
+
+In `src/background_tasks.py` in der Klasse ergänzen:
+```python
+    def refresh_token(self, on_auth_error, on_error):
+        """Erneuert den Gmail-Token beim Start im Hintergrund. Auth-Fehler ->
+        on_auth_error(msg); unerwartete Fehler -> on_error(traceback);
+        Netzwerkfehler werden still uebergangen (Offline-Start)."""
+        token_path = os.path.join(self._base_path, "token.json")
+
+        def fn():
+            try:
+                refresh_token_if_needed(
+                    token_path,
+                    sync_enabled=self._settings.get("sync_enabled"),
+                    gcal_enabled=self._settings.get("gcal_enabled"),
+                )
+                return None
+            except TokenAuthError as e:
+                return ("auth", str(e))
+            except TokenNetworkError:
+                return None
+            except Exception:
+                log.exception("Token-Refresh fehlgeschlagen")
+                return ("error", traceback.format_exc())
+
+        def on_done(outcome):
+            if outcome is None:
+                return
+            kind, payload = outcome
+            if kind == "auth":
+                on_auth_error(payload)
+            else:
+                on_error(payload)
+
+        self.run(fn, on_done)
+
+    def fetch_sender_email(self):
+        """Holt einmalig pro Start die authentifizierte E-Mail ueber OAuth2-
+        Userinfo und cached sie in settings.sender_email. Still bei fehlendem
+        Token/Netz/Scope (der naechste Send-Dialog triggert den Re-Consent)."""
+        token_path = os.path.join(self._base_path, "token.json")
+        if not os.path.exists(token_path):
+            return
+
+        def fn():
+            try:
+                email = fetch_user_email(
+                    token_path,
+                    sync_enabled=self._settings.get("sync_enabled"),
+                    gcal_enabled=self._settings.get("gcal_enabled"),
+                )
+            except Exception:
+                log.exception("sender_email-Fetch fehlgeschlagen")
+                return None
+            return email
+
+        def on_done(email):
+            if email and email != self._settings.get("sender_email"):
+                self._settings.set("sender_email", email)
+
+        self.run(fn, on_done)
+```
+
+- [ ] **Step 4: Runner in `App.__init__` konstruieren + verdrahten**
+
+In `src/ui.py` oben den Import ergänzen (zu den `from src...`-Imports):
+```python
+from src.background_tasks import BackgroundTaskRunner
+```
+
+In `App.__init__`, vor den bisherigen `self._proactive_*`-Aufrufen (~221-226), den Runner anlegen:
+```python
+        self._bg = BackgroundTaskRunner(
+            self._marshal_to_ui, self.settings, self.base_path,
+            self.reservation_store, self._reservations_active,
+        )
+```
+
+Die beiden Zeilen
+```python
+        self._proactive_token_refresh()
+        self._proactive_sender_email_fetch()
+```
+ersetzen durch:
+```python
+        self._bg.refresh_token(
+            on_auth_error=lambda msg: themed_showinfo(
+                self.root,
+                "Gmail-Anmeldung abgelaufen",
+                "Der Gmail-Token konnte nicht automatisch erneuert werden:\n\n"
+                f"{msg}\n\n"
+                "Beim nächsten Senden wirst du zur erneuten Anmeldung aufgefordert.",
+            ),
+            on_error=lambda tb: themed_showinfo(
+                self.root, "Token-Refresh fehlgeschlagen", tb,
+            ),
+        )
+        self._bg.fetch_sender_email()
+```
+
+- [ ] **Step 5: Alte Methoden entfernen**
+
+In `src/ui.py` die Methoden `_proactive_token_refresh` (~229-262) und `_proactive_sender_email_fetch` (~264-290) vollständig löschen.
+
+- [ ] **Step 6: Tests + Lint**
+
+Run: `python -m pytest tests/test_background_tasks.py -q ; python -m ruff check src/ui.py src/background_tasks.py`
+Grep-Kontrolle: kein `_proactive_token_refresh` / `_proactive_sender_email_fetch` mehr.
+Expected: PASS, Lint grün.
+
+- [ ] **Step 7: Commit**
+
+```
+git add src/ui.py src/background_tasks.py tests/test_background_tasks.py
+git commit -m "refactor(ui): Token-Refresh + Sender-Email in BackgroundTaskRunner (#49)"
+```
+
+---
+
+### Task 6: `check_update` + `reconcile_on_start` + `trigger_reconcile` in den Runner
+
+**Files:**
+- Modify: `src/background_tasks.py` (drei Methoden)
+- Modify: `src/ui.py` (`_proactive_update_check`/`_proactive_calendar_reconcile`/`_trigger_calendar_reconcile` entfernen; `__init__`-Wiring; Caller von `_trigger_calendar_reconcile`)
+- Test: `tests/test_background_tasks.py` (Guard-Tests)
+
+**Interfaces:**
+- Consumes: `BackgroundTaskRunner.run`, `self._reservations_active`, `self._settings`.
+- Produces: `BackgroundTaskRunner.check_update(self, on_result)` — `on_result(release, newer: bool)`; läuft nur wenn `should_check_today(...)`.
+- Produces: `BackgroundTaskRunner.reconcile_on_start(self, on_ok)` — `on_ok()` nur bei Erfolg; guard `reservations_active()`.
+- Produces: `BackgroundTaskRunner.trigger_reconcile(self, on_done)` — `on_done(result: dict)`; guard `reservations_active()`.
+
+- [ ] **Step 1: Guard-Tests schreiben**
+
+In `tests/test_background_tasks.py` ergänzen:
+```python
+def test_check_update_skips_when_not_due(monkeypatch):
+    import src.background_tasks as bg
+    monkeypatch.setattr(bg, "should_check_today", lambda v: False)
+    called = {"n": 0}
+    monkeypatch.setattr(bg, "check_latest_release",
+                        lambda repo: called.__setitem__("n", called["n"] + 1))
+    r = _runner(settings={"last_update_check_at": None})
+    # settings als dict -> .get reicht; should_check_today ist gepatcht
+    r.check_update(on_result=lambda rel, newer: None)
+    import time
+    time.sleep(0.2)
+    assert called["n"] == 0
+
+
+def test_reconcile_on_start_skips_when_reservations_inactive():
+    ran = {"n": 0}
+    r = _runner(reservations_active=lambda: False)
+    r.reconcile_on_start(on_ok=lambda: ran.__setitem__("n", ran["n"] + 1))
+    import time
+    time.sleep(0.2)
+    assert ran["n"] == 0
+```
+
+Hinweis: `_runner`-Settings ist ein dict; `check_update` nutzt nur `should_check_today` (gepatcht) und `check_latest_release` (gepatcht) — `settings.get` wird nicht gebraucht. dict besitzt `.get`.
+
+- [ ] **Step 2: Tests failen sehen**
+
+Run: `python -m pytest tests/test_background_tasks.py -k "check_update or reconcile_on_start" -q`
+Expected: FAIL — Methoden existieren noch nicht.
+
+- [ ] **Step 3: Methoden im Runner implementieren**
+
+In `src/background_tasks.py` in der Klasse ergänzen:
+```python
+    def check_update(self, on_result):
+        """Fragt 1x pro Kalendertag GitHub nach einer neueren Version. `is_newer`
+        wird bereits im Worker ausgewertet, damit on_result(release, newer) im
+        UI-Thread keine ungeschuetzte Logik mehr ausfuehrt. Fehler still."""
+        if not should_check_today(self._settings.get("last_update_check_at")):
+            return
+
+        def fn():
+            try:
+                release = check_latest_release("MargenHeld/Zeiterfassung")
+                if release is None:
+                    return None
+                return (release, is_newer(VERSION, release.version))
+            except Exception:
+                log.exception("Update-Check fehlgeschlagen")
+                return None
+
+        def on_done(result):
+            if result is None:
+                return
+            release, newer = result
+            on_result(release, newer)
+
+        self.run(fn, on_done)
+
+    def reconcile_on_start(self, on_ok):
+        """Gleicht beim Start die Reservierungen mit dem Google Kalender ab.
+        Fehler werden STILL geloggt (Offline-Start nicht stoeren); bei Erfolg
+        on_ok() im UI-Thread."""
+        if not self._reservations_active():
+            return
+
+        def fn():
+            from src.main import run_calendar_reconcile
+            return run_calendar_reconcile(
+                self._reservation_store, self._settings, self._base_path)
+
+        def on_done(result):
+            if result.get("ok"):
+                on_ok()
+
+        self.run(fn, on_done)
+
+    def trigger_reconcile(self, on_done):
+        """Stoesst nach einer Reservierungsaenderung den Abgleich an. Das
+        Ergebnis geht IMMER an on_done(result) (User hat aktiv gespeichert und
+        erwartet Feedback)."""
+        if not self._reservations_active():
+            return
+
+        def fn():
+            from src.main import run_calendar_reconcile
+            return run_calendar_reconcile(
+                self._reservation_store, self._settings, self._base_path)
+
+        self.run(fn, on_done)
+```
+
+- [ ] **Step 4: `App.__init__`-Wiring**
+
+In `src/ui.py` die Zeilen
+```python
+        self._update_banner = None
+        self._proactive_update_check()
+        self._proactive_calendar_reconcile()
+```
+ersetzen durch:
+```python
+        self._update_banner = None
+        self._bg.check_update(on_result=self._handle_update_check_result)
+        self._bg.reconcile_on_start(on_ok=self._refresh)
+```
+
+- [ ] **Step 5: Caller von `_trigger_calendar_reconcile` umbiegen**
+
+Es gibt genau zwei Stellen in `src/ui.py`:
+
+(a) Direkter Aufruf in `_delete_day` (~1380):
+```python
+        if res_touched:
+            self._trigger_calendar_reconcile()
+```
+→
+```python
+        if res_touched:
+            self._bg.trigger_reconcile(self._on_reconcile_done)
+```
+
+(b) Als no-arg Callback an `open_entry_dialog` in `_open_dialog` (~1394):
+```python
+            trigger_reconcile=self._trigger_calendar_reconcile,
+```
+→
+```python
+            trigger_reconcile=lambda: self._bg.trigger_reconcile(self._on_reconcile_done),
+```
+(`open_entry_dialog` ruft `trigger_reconcile()` argumentlos — das Lambda erhält diese Signatur.)
+
+- [ ] **Step 6: Alte Methoden entfernen**
+
+In `src/ui.py` `_proactive_update_check`, `_proactive_calendar_reconcile` und `_trigger_calendar_reconcile` vollständig löschen. `_reservations_active`, `_handle_update_check_result`, `_on_reconcile_done` BLEIBEN.
+
+- [ ] **Step 7: Tests + Lint**
+
+Run: `python -m pytest tests/test_background_tasks.py -q ; python -m ruff check src/ui.py src/background_tasks.py`
+Grep-Kontrolle: kein `_proactive_update_check` / `_proactive_calendar_reconcile` / `_trigger_calendar_reconcile` mehr.
+Expected: PASS, Lint grün.
+
+- [ ] **Step 8: Commit**
+
+```
+git add src/ui.py src/background_tasks.py tests/test_background_tasks.py
+git commit -m "refactor(ui): Update-Check + Kalender-Reconcile in BackgroundTaskRunner (#49)"
+```
+
+---
+
+### Task 7: Sync-Methoden über `run()` + Gesamtverifikation
+
+**Files:**
+- Modify: `src/ui.py` (`_on_sync_clicked` ~1444-1459, `_tray_sync` ~1470-1487)
+
+**Interfaces:**
+- Consumes: `App._bg.run` (Task 4).
+
+- [ ] **Step 1: `_on_sync_clicked` über `run()` führen**
+
+In `src/ui.py` den Worker-Teil von `_on_sync_clicked`:
+```python
+        self.sync_status_label.config(text="Synchronisiere…")
+        import threading
+        from src.main import _run_push_blocking
+        def _do():
+            result = _run_push_blocking(
+                self.storage, self.settings, self.conflicts_store,
+                self.base_path, timeout_seconds=15,
+            )
+            self._marshal_to_ui(lambda: self._on_manual_sync_done(result))
+        threading.Thread(target=_do, daemon=True).start()
+```
+ersetzen durch:
+```python
+        self.sync_status_label.config(text="Synchronisiere…")
+        from src.main import _run_push_blocking
+        self._bg.run(
+            lambda: _run_push_blocking(
+                self.storage, self.settings, self.conflicts_store,
+                self.base_path, timeout_seconds=15,
+            ),
+            self._on_manual_sync_done,
+        )
+```
+
+- [ ] **Step 2: `_tray_sync` über `run()` führen**
+
+In `src/ui.py` den Worker-Teil von `_tray_sync`:
+```python
+        import threading
+        from src.main import _run_push_blocking
+
+        def _do():
+            result = _run_push_blocking(
+                self.storage, self.settings, self.conflicts_store,
+                self.base_path, timeout_seconds=15,
+            )
+            self._marshal_to_ui(lambda: self._on_tray_sync_done(result))
+        threading.Thread(target=_do, daemon=True).start()
+```
+ersetzen durch:
+```python
+        from src.main import _run_push_blocking
+        self._bg.run(
+            lambda: _run_push_blocking(
+                self.storage, self.settings, self.conflicts_store,
+                self.base_path, timeout_seconds=15,
+            ),
+            self._on_tray_sync_done,
+        )
+```
+
+- [ ] **Step 3: `threading`-Import prüfen**
+
+Nach den Tasks nutzt `src/ui.py` ggf. kein `threading` mehr direkt. Grep `threading` in `src/ui.py`: wenn keine Verwendung mehr → `import threading` (Zeile ~10) entfernen. Wenn noch verwendet → lassen. Lint (F401) entscheidet mit.
+
+- [ ] **Step 4: Voller Testlauf + Lint**
+
+Run: `python -m pytest -q ; python -m ruff check .`
+Expected: alle Tests PASS (bestehende + neue `test_ui_navigate`, `test_ui_hover`, `test_background_tasks`); Lint grün.
+
+- [ ] **Step 5: Manuelle AC-4-Verifikation (In-Place-Build)**
+
+Build + Exe ersetzen (Inno fehlt lokal → nur PyInstaller-Artefakt in den Install-Ordner kopieren):
+```
+python build.py
+```
+Dann die gebaute App starten und prüfen:
+- Month↔Week-Toggle (Tab), Vor/Zurück mit `<Left>`/`<Right>`.
+- Hover über Entry-, Holiday-, Empty- und Nur-Reservierungs-Zelle (Eck-Overlay färbt mit).
+- Manueller Sync (Status-Label „Synchronisiere…“ → Ergebnis), Tray-Sync (Toast).
+- App-Start ohne Internet: kein Fehlerdialog (stiller Offline-Pfad).
+
+Falls Build/Start hier nicht möglich: mindestens `python -m src.main` aus dem Repo starten und dieselben Punkte prüfen.
+
+- [ ] **Step 6: Commit**
+
+```
+git add src/ui.py
+git commit -m "refactor(ui): Sync-Methoden ueber BackgroundTaskRunner.run() (#49)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- AC 1 (Thread-Muster über einen Helper): Task 4 (`run()`) + Tasks 5/6 (proaktive) + Task 7 (Sync). ✓
+- AC 2 (Hover + Probe dedupliziert): Task 2 (`_hover`) + Task 3 (`_cell_layout_metrics`). ✓ (Navigation als Bonus-Dedup in Task 1.)
+- AC 3 (≥1 Verantwortlichkeit ausgelagert): Tasks 4–6 (`BackgroundTaskRunner`). ✓
+- AC 4 (Verhalten unverändert, manuell): Task 7 Step 5. ✓
+
+**Type-Konsistenz:** `run(fn, on_done)`, `refresh_token(on_auth_error, on_error)`, `fetch_sender_email()`, `check_update(on_result)`, `reconcile_on_start(on_ok)`, `trigger_reconcile(on_done)`, `_navigate(direction)`, `_hover(frame, bg, *labels)`, `_cell_layout_metrics(frame) -> (cell_size, entry_time_font, holiday_name_font, wide_cells)` — über alle Tasks konsistent verwendet.
+
+**Platzhalter:** keine.
+
+**Offene Risiken:**
+- `_trigger_calendar_reconcile`-Caller (Task 6 Step 5): exakte Stelle per Grep verifizieren, bevor entfernt wird.
+- `threading`/`wide_cells`-Import-/Variablen-Reste: durch Lint (F401/F841) in Tasks 3 & 7 abgesichert.

--- a/docs/superpowers/specs/2026-06-23-ui-bg-tasks-design.md
+++ b/docs/superpowers/specs/2026-06-23-ui-bg-tasks-design.md
@@ -1,0 +1,206 @@
+# Design: ui.py entflechten — Duplikat-Helfer + BackgroundTaskRunner
+
+**Issue:** #49 (Refactor: ui.py God-Object entflechten + interne Thread-/Hover-Duplikation)
+**Scope dieses PRs:** Erster Schritt — alle vier billigen Duplikat-Helfer **plus** eine
+Verantwortlichkeit (Background-Tasks) in eine eigene Klasse auslagern. Erfüllt alle vier
+Akzeptanzkriterien von #49; weitere Extraktionen (GridRenderer, SyncOrchestrator) bleiben
+Folge-PRs.
+
+**Leitprinzip:** Verhalten bleibt unverändert (AC 4). Kein Big-Bang — nur Dedup + eine
+saubere Extraktion mit klarer Schnittstelle.
+
+## Ausgangslage
+
+`src/ui.py` ist ~1541 Zeilen; die `App`-Klasse vermengt Rendering, Sync, Background-Tasks,
+Dialog-Routing und Tray. Konkret dedupliziert werden in diesem PR:
+
+- **Worker-Thread-Muster** 7× nahezu identisch: `_proactive_token_refresh`,
+  `_proactive_sender_email_fetch`, `_proactive_update_check`,
+  `_proactive_calendar_reconcile`, `_trigger_calendar_reconcile`, `_on_sync_clicked`,
+  `_tray_sync`. Alle bauen `threading.Thread(target=worker, daemon=True).start()` und
+  marshallen ihr Ergebnis per `self._marshal_to_ui(lambda: on_done(result))`.
+- **Hover** `_cell_hover(frame, day_lbl, time_lbl, bg)` / `_empty_hover(frame, day_lbl, bg)`
+  — identischer Overlay-Färb-Kern (Frame + Labels + `_reservation_marker` + `_delete_button`),
+  Unterschied nur das zusätzliche `time_lbl`.
+- **Probe-Label** in `_refresh_month` und `_refresh_week` doppelt: `probe_width`,
+  `entry_time_font`, `holiday_name_font`, Mess-Probe.
+- **Navigation** `_prev` / `_next` strukturgleich (nur ±1 Monat bzw. ±7 Tage).
+
+## Teil A — Vier Duplikat-Helfer (in `App`)
+
+### A1. `_navigate(direction)` ersetzt `_prev`/`_next`
+
+`direction ∈ {-1, +1}`.
+
+```python
+def _navigate(self, direction):
+    if self.view_mode == "month":
+        m = self.month + direction
+        if m < 1:    self.month, self.year = 12, self.year - 1
+        elif m > 12: self.month, self.year = 1, self.year + 1
+        else:        self.month = m
+    else:
+        monday = get_week_dates(self.iso_year, self.current_week)[0] \
+                 + datetime.timedelta(days=7 * direction)
+        self.iso_year, self.current_week = monday.isocalendar()[:2]
+    self._refresh()
+```
+
+Die zwei Key-Bindings (`<Left>`/`<Right>`) rufen `_navigate(-1)`/`_navigate(+1)`.
+`_prev`/`_next` entfallen (keine externen Caller — nur die zwei Lambdas).
+
+### A2. `_hover(frame, bg, *labels)` vereint `_cell_hover`/`_empty_hover`
+
+```python
+@staticmethod
+def _hover(frame, bg, *labels):
+    frame.config(bg=bg)
+    for lbl in labels:
+        lbl.config(bg=bg)
+    # Eck-Overlays mitfärben, sonst bleibt beim Hover ein andersfarbiges
+    # Rechteck stehen. Nur bg — die fg des Lösch-Buttons steuert dessen
+    # eigener Enter/Leave-Handler.
+    for attr in ("_reservation_marker", "_delete_button"):
+        w = getattr(frame, attr, None)
+        if w is not None:
+            w.config(bg=bg)
+```
+
+Aufrufer:
+- Entry-Zelle (`_build_entry_cell`): `_hover(c, bg, day_lbl, time_lbl)`
+- Holiday-Zelle (`_build_holiday_cell`): `_hover(c, bg, day_lbl, name_lbl)`
+- Empty-Zelle (`_build_empty_cell`): `_hover(c, bg, day_lbl)`
+
+### A3. `_cell_layout_metrics(frame)` zieht das doppelte Probe-Pattern zusammen
+
+Neue Modul-Konstanten: `PROBE_WIDTH_WIDE = 12`, `PROBE_WIDTH_NARROW = 8`, `PROBE_HEIGHT = 3`.
+
+```python
+def _cell_layout_metrics(self, frame):
+    """Misst die natürliche Pixelgröße einer Standard-Tageszelle (Probe-Label)
+    und liefert die layout-abhängigen Größen. Bei ausgeblendetem Wochenende
+    (5 statt 7 Spalten) breitere Zellen + größere Zeit-/Feiertagsschrift."""
+    wide_cells = not self.settings.get("show_weekend")
+    probe_width = PROBE_WIDTH_WIDE if wide_cells else PROBE_WIDTH_NARROW
+    entry_time_font = FONT if wide_cells else FONT_SMALL
+    holiday_name_font = FONT if wide_cells else FONT_SMALL
+    probe = tk.Label(frame, text="", font=FONT, width=probe_width, height=PROBE_HEIGHT)
+    probe.update_idletasks()
+    cell_size = (probe.winfo_reqwidth(), probe.winfo_reqheight())
+    probe.destroy()
+    return cell_size, entry_time_font, holiday_name_font, wide_cells
+```
+
+`_refresh_month`/`_refresh_week` rufen den Helfer statt der inline-Blöcke. Die
+ausführlichen Erklär-Kommentare (Feiertagszellen-Fixierung, Reihenhöhe) bleiben an den
+Aufrufstellen bzw. wandern in den Helfer. Die `holiday_max_len`-Logik bleibt lokal
+(Month: `12 if wide_cells else 9`; Week: unverändert), da sie sich je Ansicht unterscheidet.
+
+## Teil B — `BackgroundTaskRunner` (neues Modul `src/background_tasks.py`)
+
+Eigene Verantwortlichkeit: **Background-Ausführung + die proaktiven Startup-Tasks**.
+Pure Mechanik, keine Tk-Imports, keine Google-Imports auf Modulebene. `run_calendar_reconcile`
+aus `src.main` bleibt Lazy-Import **innerhalb** der Methode (verhindert Circular-Import, da
+`src.main` `App` aus `ui` zieht — wie schon im Bestandscode).
+
+### Schnittstelle
+
+```python
+class BackgroundTaskRunner:
+    def __init__(self, marshal, settings, base_path, reservation_store,
+                 reservations_active):
+        self._marshal = marshal                          # App._marshal_to_ui
+        self._settings = settings
+        self._base_path = base_path
+        self._reservation_store = reservation_store
+        self._reservations_active = reservations_active  # App._reservations_active (callable)
+
+    def run(self, fn, on_done=None):
+        """fn() im Daemon-Thread ausführen; dessen Rückgabe via marshal an
+        on_done auf dem UI-Thread liefern. Der eine Thread-Helfer (AC 1)."""
+        def worker():
+            result = fn()
+            if on_done is not None:
+                self._marshal(lambda: on_done(result))
+        threading.Thread(target=worker, daemon=True).start()
+```
+
+`run()` ist **der** Thread-Helfer — auch die in `App` verbleibenden Sync-Methoden
+(`_on_sync_clicked`, `_tray_sync`) nutzen ihn statt eigener `threading.Thread`-Kopien.
+Damit existiert das Muster nur noch an einer Stelle.
+
+### Die fünf proaktiven Tasks
+
+Die Klasse entscheidet (Guards) und macht das Background-I/O; UI-Arbeit (Dialoge, Banner,
+Refresh) bleibt in `App` und kommt als Callback rein.
+
+| Methode | Guard | Background-I/O | UI-Callback (App) |
+|---|---|---|---|
+| `refresh_token(on_auth_error, on_error)` | — | `refresh_token_if_needed` | Dialog bei auth/unerwartet |
+| `fetch_sender_email()` | `token.json` existiert | `fetch_user_email` | setzt `settings` selbst (via marshal) |
+| `check_update(on_result)` | `should_check_today` | `check_latest_release` + `is_newer` | `_handle_update_check_result` |
+| `reconcile_on_start(on_ok)` | `reservations_active()` | `run_calendar_reconcile` | `_refresh` (nur bei ok) |
+| `trigger_reconcile(on_done)` | `reservations_active()` | `run_calendar_reconcile` | `_on_reconcile_done(result)` |
+
+`refresh_token`: Die Fehler-**Klassifizierung** wandert in den Worker (`fn` liefert
+`None` | `("auth", msg)` | `("error", tb)`), das **Anzeigen** in den App-Callback. Das ist
+sauberer als der Bestand (dort marshallte der Worker selbst Dialoge). `TokenNetworkError`
+bleibt still (Offline-Start nicht stören).
+
+### Wiring in `App`
+
+```python
+# __init__:
+self._bg = BackgroundTaskRunner(
+    self._marshal_to_ui, self.settings, self.base_path,
+    self.reservation_store, self._reservations_active,
+)
+...
+self._bg.refresh_token(
+    on_auth_error=lambda msg: themed_showinfo(self.root, "Gmail-Anmeldung abgelaufen", ...),
+    on_error=lambda tb: themed_showinfo(self.root, "Token-Refresh fehlgeschlagen", tb),
+)
+self._bg.fetch_sender_email()
+self._bg.check_update(on_result=self._handle_update_check_result)
+self._bg.reconcile_on_start(on_ok=self._refresh)
+```
+
+`_trigger_calendar_reconcile` (nach Reservierungs-Speichern) →
+`self._bg.trigger_reconcile(self._on_reconcile_done)`.
+
+Die alten `_proactive_*`-Methoden und `_trigger_calendar_reconcile` entfallen aus `App`;
+`_reservations_active`, `_handle_update_check_result`, `_on_reconcile_done`,
+`_marshal_to_ui` bleiben in `App` (UI-/State-nah).
+
+## Tests
+
+Neues `tests/test_background_tasks.py` (das Modul ist ohne Tk/Display testbar):
+
+- `run(fn, on_done)` führt `fn` aus und liefert dessen Ergebnis an `on_done` — mit
+  synchronem Fake-`marshal` (ruft den Callback sofort) und `threading.Event` zum Abwarten
+  des Worker-Threads.
+- `run(fn)` ohne `on_done` ruft nichts zurück, führt `fn` aber aus.
+- Guards: `check_update` ruft `check_latest_release` **nicht**, wenn `should_check_today`
+  False ist; `reconcile_on_start`/`trigger_reconcile` laufen nicht, wenn
+  `reservations_active()` False liefert. (Monkeypatch der I/O-Funktionen.)
+- `fetch_sender_email` bricht ohne `token.json` früh ab.
+
+Bestehende Suite bleibt grün: `tests/test_ui_delete.py` u.a. importieren `src.ui`; die
+genutzten Modul-Funktionen (`_delete_action`, `_classify_sync_error`,
+`_friendly_sync_message`, `_show_sync_error`) bleiben unangetastet.
+
+## Verifikation (AC 4 — Verhalten unverändert)
+
+Manuell per In-Place-Build (`build.py` → Exe nach `%LOCALAPPDATA%\Programs\Zeiterfassung\`),
+geprüft werden:
+
+- Month/Week-Wechsel (Tab) und Vor/Zurück-Navigation (`<Left>`/`<Right>`, Tray)
+- Hover über Entry-, Holiday-, Empty- und Nur-Reservierungs-Zellen (Overlay färbt mit)
+- Manueller Sync (Status-Label) und Tray-Sync (Toast)
+- Update-Banner-Pfad bzw. stiller Offline-Start
+
+## Nicht-Ziele (Folge-PRs)
+
+- `GridRenderer` (Rendering-Extraktion) — größter Volumen-Gewinn, höchste Kopplung.
+- `SyncOrchestrator` (Sync + Status + Pull-Callbacks).
+- Weitere Aufteilung des Dialog-Routings / Tray-Managements.

--- a/src/background_tasks.py
+++ b/src/background_tasks.py
@@ -13,6 +13,8 @@ import threading
 import traceback
 
 from src.mail import fetch_user_email, refresh_token_if_needed, TokenAuthError, TokenNetworkError
+from src.updater import check_latest_release, is_newer, should_check_today
+from src.version import VERSION
 
 log = logging.getLogger(__name__)
 
@@ -91,5 +93,62 @@ class BackgroundTaskRunner:
         def on_done(email):
             if email and email != self._settings.get("sender_email"):
                 self._settings.set("sender_email", email)
+
+        self.run(fn, on_done)
+
+    def check_update(self, on_result):
+        """Fragt 1x pro Kalendertag GitHub nach einer neueren Version. `is_newer`
+        wird bereits im Worker ausgewertet, damit on_result(release, newer) im
+        UI-Thread keine ungeschuetzte Logik mehr ausfuehrt. Fehler still."""
+        if not should_check_today(self._settings.get("last_update_check_at")):
+            return
+
+        def fn():
+            try:
+                release = check_latest_release("MargenHeld/Zeiterfassung")
+                if release is None:
+                    return None
+                return (release, is_newer(VERSION, release.version))
+            except Exception:
+                log.exception("Update-Check fehlgeschlagen")
+                return None
+
+        def on_done(result):
+            if result is None:
+                return
+            release, newer = result
+            on_result(release, newer)
+
+        self.run(fn, on_done)
+
+    def reconcile_on_start(self, on_ok):
+        """Gleicht beim Start die Reservierungen mit dem Google Kalender ab.
+        Fehler werden STILL geloggt (Offline-Start nicht stoeren); bei Erfolg
+        on_ok() im UI-Thread."""
+        if not self._reservations_active():
+            return
+
+        def fn():
+            from src.main import run_calendar_reconcile  # lazy: Circular-Import-Schutz
+            return run_calendar_reconcile(
+                self._reservation_store, self._settings, self._base_path)
+
+        def on_done(result):
+            if result.get("ok"):
+                on_ok()
+
+        self.run(fn, on_done)
+
+    def trigger_reconcile(self, on_done):
+        """Stoesst nach einer Reservierungsaenderung den Abgleich an. Das
+        Ergebnis geht IMMER an on_done(result) (User hat aktiv gespeichert und
+        erwartet Feedback)."""
+        if not self._reservations_active():
+            return
+
+        def fn():
+            from src.main import run_calendar_reconcile  # lazy: Circular-Import-Schutz
+            return run_calendar_reconcile(
+                self._reservation_store, self._settings, self._base_path)
 
         self.run(fn, on_done)

--- a/src/background_tasks.py
+++ b/src/background_tasks.py
@@ -1,0 +1,32 @@
+"""Hintergrund-Tasks der App (Token-Refresh, Sender-Email, Update-Check,
+Kalender-Reconcile) und die gemeinsame Thread-Mechanik.
+
+Tk-frei und ohne Google-Imports auf Modulebene: `run_calendar_reconcile`
+wird lazy in der Methode importiert (Circular-Import-Schutz — src.main zieht
+App aus src.ui). UI-Arbeit (Dialoge, Banner, Refresh) macht die Klasse nicht
+selbst, sondern liefert Ergebnisse ueber `marshal` an Callbacks der App.
+"""
+
+import logging
+import threading
+
+log = logging.getLogger(__name__)
+
+
+class BackgroundTaskRunner:
+    def __init__(self, marshal, settings, base_path, reservation_store,
+                 reservations_active):
+        self._marshal = marshal                          # App._marshal_to_ui
+        self._settings = settings
+        self._base_path = base_path
+        self._reservation_store = reservation_store
+        self._reservations_active = reservations_active  # callable -> bool
+
+    def run(self, fn, on_done=None):
+        """Fuehrt fn() in einem Daemon-Thread aus und liefert dessen Rueckgabe
+        via marshal an on_done auf dem UI-Thread."""
+        def worker():
+            result = fn()
+            if on_done is not None:
+                self._marshal(lambda: on_done(result))
+        threading.Thread(target=worker, daemon=True).start()

--- a/src/background_tasks.py
+++ b/src/background_tasks.py
@@ -8,7 +8,11 @@ selbst, sondern liefert Ergebnisse ueber `marshal` an Callbacks der App.
 """
 
 import logging
+import os
 import threading
+import traceback
+
+from src.mail import fetch_user_email, refresh_token_if_needed, TokenAuthError, TokenNetworkError
 
 log = logging.getLogger(__name__)
 
@@ -30,3 +34,62 @@ class BackgroundTaskRunner:
             if on_done is not None:
                 self._marshal(lambda: on_done(result))
         threading.Thread(target=worker, daemon=True).start()
+
+    def refresh_token(self, on_auth_error, on_error):
+        """Erneuert den Gmail-Token beim Start im Hintergrund. Auth-Fehler ->
+        on_auth_error(msg); unerwartete Fehler -> on_error(traceback);
+        Netzwerkfehler werden still uebergangen (Offline-Start)."""
+        token_path = os.path.join(self._base_path, "token.json")
+
+        def fn():
+            try:
+                refresh_token_if_needed(
+                    token_path,
+                    sync_enabled=self._settings.get("sync_enabled"),
+                    gcal_enabled=self._settings.get("gcal_enabled"),
+                )
+                return None
+            except TokenAuthError as e:
+                return ("auth", str(e))
+            except TokenNetworkError:
+                return None
+            except Exception:
+                log.exception("Token-Refresh fehlgeschlagen")
+                return ("error", traceback.format_exc())
+
+        def on_done(outcome):
+            if outcome is None:
+                return
+            kind, payload = outcome
+            if kind == "auth":
+                on_auth_error(payload)
+            else:
+                on_error(payload)
+
+        self.run(fn, on_done)
+
+    def fetch_sender_email(self):
+        """Holt einmalig pro Start die authentifizierte E-Mail ueber OAuth2-
+        Userinfo und cached sie in settings.sender_email. Still bei fehlendem
+        Token/Netz/Scope (der naechste Send-Dialog triggert den Re-Consent)."""
+        token_path = os.path.join(self._base_path, "token.json")
+        if not os.path.exists(token_path):
+            return
+
+        def fn():
+            try:
+                email = fetch_user_email(
+                    token_path,
+                    sync_enabled=self._settings.get("sync_enabled"),
+                    gcal_enabled=self._settings.get("gcal_enabled"),
+                )
+            except Exception:
+                log.exception("sender_email-Fetch fehlgeschlagen")
+                return None
+            return email
+
+        def on_done(email):
+            if email and email != self._settings.get("sender_email"):
+                self._settings.set("sender_email", email)
+
+        self.run(fn, on_done)

--- a/src/background_tasks.py
+++ b/src/background_tasks.py
@@ -34,7 +34,10 @@ class BackgroundTaskRunner:
         def worker():
             result = fn()
             if on_done is not None:
-                self._marshal(lambda: on_done(result))
+                # Lokale Bindung: Pyright traegt das None-Narrowing sonst nicht
+                # in die Closure (reportOptionalCall-FP).
+                done = on_done
+                self._marshal(lambda: done(result))
         threading.Thread(target=worker, daemon=True).start()
 
     def refresh_token(self, on_auth_error, on_error):

--- a/src/ui.py
+++ b/src/ui.py
@@ -20,10 +20,7 @@ from src.tooltip import attach_tooltip
 from src.drive import DriveAuthError, DriveNetworkError
 from src.version import VERSION, version_label
 from src.updater import (
-    check_latest_release,
-    is_newer,
     pick_asset_url,
-    should_check_today,
     today_iso,
     Release,
 )
@@ -243,40 +240,9 @@ class App:
         )
         self._bg.fetch_sender_email()
         self._update_banner = None
-        self._proactive_update_check()
-        self._proactive_calendar_reconcile()
+        self._bg.check_update(on_result=self._handle_update_check_result)
+        self._bg.reconcile_on_start(on_ok=self._refresh)
         self.root.protocol("WM_DELETE_WINDOW", self._on_close)
-
-    def _proactive_update_check(self):
-        """Fragt einmal pro Kalendertag GitHub nach einer neueren Version.
-
-        Der HTTP-Call läuft in einem Daemon-Thread; alle State-Mutationen
-        (Settings-Write, Banner-Aufbau) werden via `root.after(0, ...)` auf
-        den UI-Thread marshallt, damit `Settings.set` nicht parallel zu
-        Schreibvorgängen aus dem Settings-Dialog läuft.
-
-        Fehler werden still verschluckt — Update-Hinweis ist nice-to-have.
-        """
-        if not should_check_today(self.settings.get("last_update_check_at")):
-            return
-
-        def worker():
-            try:
-                release = check_latest_release("MargenHeld/Zeiterfassung")
-                if release is None:
-                    return
-                newer = is_newer(VERSION, release.version)
-            except Exception:
-                # Pure Logik, robust gegen exotische Tags. Bei jedem Fehler:
-                # nichts persistieren, nichts anzeigen — morgen nochmal probieren.
-                # Trace landet im Logfile, falls jemand den Fehler diagnostizieren will.
-                logging.getLogger(__name__).exception("Update-Check fehlgeschlagen")
-                return
-            self._marshal_to_ui(
-                lambda: self._handle_update_check_result(release, newer)
-            )
-
-        threading.Thread(target=worker, daemon=True).start()
 
     def _reservations_active(self):
         """True, wenn Reservierungen angezeigt/bearbeitet werden dürfen: ein
@@ -285,41 +251,6 @@ class App:
         gerendert noch im Tages-Dialog angeboten."""
         return (self.reservation_store is not None
                 and bool(self.settings.get("gcal_enabled")))
-
-    def _proactive_calendar_reconcile(self):
-        """Gleicht beim App-Start die Reservierungen mit dem Google Kalender ab.
-
-        Läuft im Hintergrund. Fehler werden STILL geloggt (ein Offline-Start
-        darf nicht nerven — analog Token-Refresh/Update-Check).
-        """
-        if not self._reservations_active():
-            return
-
-        def worker():
-            from src.main import run_calendar_reconcile
-            result = run_calendar_reconcile(
-                self.reservation_store, self.settings, self.base_path)
-            if result.get("ok"):
-                self._marshal_to_ui(self._refresh)
-
-        threading.Thread(target=worker, daemon=True).start()
-
-    def _trigger_calendar_reconcile(self):
-        """Stößt nach einer Reservierungsänderung den Kalender-Abgleich an.
-
-        Fehler werden hier ALS MESSAGEBOX gezeigt — der User hat aktiv
-        gespeichert und erwartet Feedback (CLAUDE.md: Sendepfad-Fehler sichtbar).
-        """
-        if not self._reservations_active():
-            return
-
-        def worker():
-            from src.main import run_calendar_reconcile
-            result = run_calendar_reconcile(
-                self.reservation_store, self.settings, self.base_path)
-            self._marshal_to_ui(lambda: self._on_reconcile_done(result))
-
-        threading.Thread(target=worker, daemon=True).start()
 
     def _on_reconcile_done(self, result):
         if not result.get("ok"):
@@ -1296,7 +1227,7 @@ class App:
 
         self._refresh()
         if res_touched:
-            self._trigger_calendar_reconcile()
+            self._bg.trigger_reconcile(self._on_reconcile_done)
 
     def _open_dialog(self, date_str):
         if _stray_click_suppressed(getattr(self.root, "_dialog_closed_at", 0),
@@ -1310,7 +1241,7 @@ class App:
             on_change=self._refresh,
             reservation_store=(
                 self.reservation_store if self._reservations_active() else None),
-            trigger_reconcile=self._trigger_calendar_reconcile,
+            trigger_reconcile=lambda: self._bg.trigger_reconcile(self._on_reconcile_done),
         )
 
     def _send(self):
@@ -1367,7 +1298,6 @@ class App:
                           "Synchronisation ist deaktiviert. In den Einstellungen aktivierbar.")
             return
         self.sync_status_label.config(text="Synchronisiere…")
-        import threading
         from src.main import _run_push_blocking
         def _do():
             result = _run_push_blocking(
@@ -1394,7 +1324,6 @@ class App:
         deaktiviert wurde."""
         if not self.settings.get("sync_enabled"):
             return
-        import threading
         from src.main import _run_push_blocking
 
         def _do():

--- a/src/ui.py
+++ b/src/ui.py
@@ -7,7 +7,6 @@ import datetime
 import logging
 import os
 import platform
-import threading
 import time
 import traceback
 import webbrowser
@@ -1299,13 +1298,13 @@ class App:
             return
         self.sync_status_label.config(text="Synchronisiere…")
         from src.main import _run_push_blocking
-        def _do():
-            result = _run_push_blocking(
+        self._bg.run(
+            lambda: _run_push_blocking(
                 self.storage, self.settings, self.conflicts_store,
                 self.base_path, timeout_seconds=15,
-            )
-            self._marshal_to_ui(lambda: self._on_manual_sync_done(result))
-        threading.Thread(target=_do, daemon=True).start()
+            ),
+            self._on_manual_sync_done,
+        )
 
     def _on_manual_sync_done(self, result):
         if not result.get("ok"):
@@ -1325,14 +1324,13 @@ class App:
         if not self.settings.get("sync_enabled"):
             return
         from src.main import _run_push_blocking
-
-        def _do():
-            result = _run_push_blocking(
+        self._bg.run(
+            lambda: _run_push_blocking(
                 self.storage, self.settings, self.conflicts_store,
                 self.base_path, timeout_seconds=15,
-            )
-            self._marshal_to_ui(lambda: self._on_tray_sync_done(result))
-        threading.Thread(target=_do, daemon=True).start()
+            ),
+            self._on_tray_sync_done,
+        )
 
     def _on_tray_sync_done(self, result):
         # Still aktualisieren, damit der nächste Fenster-Aufruf den Stand zeigt.

--- a/src/ui.py
+++ b/src/ui.py
@@ -839,8 +839,8 @@ class App:
         for w in (cell, day_lbl, time_lbl):
             w.bind("<Button-1>", lambda e, d=date_str: self._open_dialog(d))
             w.bind("<Button-3>", lambda e, d=date_str: self._delete_day(d))
-            w.bind("<Enter>", lambda e, c=cell, dl=day_lbl, tl=time_lbl, hb=hover_bg: self._cell_hover(c, dl, tl, hb))
-            w.bind("<Leave>", lambda e, c=cell, dl=day_lbl, tl=time_lbl, ob=bg: self._cell_hover(c, dl, tl, ob))
+            w.bind("<Enter>", lambda e, c=cell, dl=day_lbl, tl=time_lbl, hb=hover_bg: self._hover(c, hb, dl, tl))
+            w.bind("<Leave>", lambda e, c=cell, dl=day_lbl, tl=time_lbl, ob=bg: self._hover(c, ob, dl, tl))
         return cell
 
     @staticmethod
@@ -856,7 +856,7 @@ class App:
         rendert je nach Font als kaum sichtbarer Fleck; das Oval gibt einen
         sauber gerundeten, größenkontrollierten Punkt. place() überlagert die
         gepackten Kind-Widgets. Der Marker wird als cell._reservation_marker
-        getaggt, damit _cell_hover seinen Hintergrund beim Hover mitfärbt."""
+        getaggt, damit _hover seinen Hintergrund beim Hover mitfärbt."""
         box, dot = 12, 7
         marker = tk.Canvas(
             cell, width=box, height=box, bg=cell.cget("bg"),
@@ -878,7 +878,7 @@ class App:
         Lösch-Auslöser, ohne den Linksklick-Dialog mit Lösch-Buttons zu belasten.
         Klick ruft denselben _delete_day-Pfad wie der Win/Linux-Rechtsklick
         (Ja/Nein bzw. Slot-Auswahl). Getaggt als cell._delete_button, damit
-        _cell_hover/_empty_hover seinen Hintergrund beim Hover mitfärben."""
+        _hover seinen Hintergrund beim Hover mitfärbt."""
         bg = cell.cget("bg")
         btn = tk.Label(
             cell, text="✕", font=FONT_TINY, bg=bg, fg=TEXT_MUTED, cursor="hand2",
@@ -889,7 +889,7 @@ class App:
         btn.bind("<Button-1>",
                  lambda e, d=date_str: (self._delete_day(d), "break")[1])
         # fg-Hover (rot als Lösch-Affordance) steuert der Button selbst; den bg
-        # färbt _cell_hover/_empty_hover mit der Zelle.
+        # färbt _hover mit der Zelle.
         btn.bind("<Enter>", lambda e: btn.config(fg=ACCENT))
         btn.bind("<Leave>", lambda e: btn.config(fg=TEXT_MUTED))
         cell._delete_button = btn
@@ -920,8 +920,8 @@ class App:
         for w in (cell, day_lbl):
             w.bind("<Button-1>", lambda e, d=date_str: self._open_dialog(d))
             w.bind("<Button-3>", lambda e, d=date_str: self._delete_day(d))
-            w.bind("<Enter>", lambda e, c=cell, dl=day_lbl, hb=hover_bg: self._empty_hover(c, dl, hb))
-            w.bind("<Leave>", lambda e, c=cell, dl=day_lbl, ob=bg: self._empty_hover(c, dl, ob))
+            w.bind("<Enter>", lambda e, c=cell, dl=day_lbl, hb=hover_bg: self._hover(c, hb, dl))
+            w.bind("<Leave>", lambda e, c=cell, dl=day_lbl, ob=bg: self._hover(c, ob, dl))
         return cell
 
     def _build_day_cell(self, parent, date_str, day_text, day_date, is_weekend,
@@ -1251,9 +1251,9 @@ class App:
             if on_right_click is not None:
                 w.bind("<Button-3>", lambda e: on_right_click())
             w.bind("<Enter>", lambda e, c=cell, dl=day_lbl, nl=name_lbl:
-                self._cell_hover(c, dl, nl, HOLIDAY_BG_HOVER))
+                self._hover(c, HOLIDAY_BG_HOVER, dl, nl))
             w.bind("<Leave>", lambda e, c=cell, dl=day_lbl, nl=name_lbl:
-                self._cell_hover(c, dl, nl, HOLIDAY_BG))
+                self._hover(c, HOLIDAY_BG, dl, nl))
         if name_tooltip and truncated != name:
             # Geteilter Tooltip über alle drei Widgets — _Tooltip trackt sie
             # gemeinsam, sodass Pointer-Wechsel zwischen Frame und Child-
@@ -1262,33 +1262,18 @@ class App:
         return cell
 
     @staticmethod
-    def _cell_hover(frame, day_lbl, time_lbl, bg):
+    def _hover(frame, bg, *labels):
+        """Faerbt Zelle + uebergebene Labels beim Hover. Die Eck-Overlays
+        (_reservation_marker, macOS-_delete_button) werden mitgefaerbt, sonst
+        bleibt ein andersfarbiges Rechteck stehen. Nur bg — die fg des
+        Loesch-Buttons steuert dessen eigener Enter/Leave-Handler."""
         frame.config(bg=bg)
-        day_lbl.config(bg=bg)
-        time_lbl.config(bg=bg)
-        # Eck-Overlays (Reservierungs-Marker, macOS-Lösch-Button) mitfärben,
-        # sonst bleibt beim Hover ein andersfarbiges Rechteck stehen. Nur bg —
-        # die fg des Lösch-Buttons steuert dessen eigener Enter/Leave-Handler.
-        marker = getattr(frame, "_reservation_marker", None)
-        if marker is not None:
-            marker.config(bg=bg)
-        del_btn = getattr(frame, "_delete_button", None)
-        if del_btn is not None:
-            del_btn.config(bg=bg)
-
-    @staticmethod
-    def _empty_hover(frame, day_lbl, bg):
-        frame.config(bg=bg)
-        day_lbl.config(bg=bg)
-        # Eck-Overlays mitfärben — Nur-Reservierungs-Tage sind Empty-Zellen mit
-        # Marker (und auf macOS zusätzlich dem Lösch-Button); sonst bliebe beim
-        # Hover ein andersfarbiges Rechteck dahinter stehen. Nur bg.
-        marker = getattr(frame, "_reservation_marker", None)
-        if marker is not None:
-            marker.config(bg=bg)
-        del_btn = getattr(frame, "_delete_button", None)
-        if del_btn is not None:
-            del_btn.config(bg=bg)
+        for lbl in labels:
+            lbl.config(bg=bg)
+        for attr in ("_reservation_marker", "_delete_button"):
+            w = getattr(frame, attr, None)
+            if w is not None:
+                w.config(bg=bg)
 
     def _delete_day(self, date_str):
         """Rechtsklick-Löschen für einen Tag. Löscht NIE ohne Bestätigung.

--- a/src/ui.py
+++ b/src/ui.py
@@ -207,8 +207,8 @@ class App:
         self._apply_always_on_top()
         self._tray = None
         self._apply_tray_setting()
-        self.root.bind("<Left>", lambda e: self._prev())
-        self.root.bind("<Right>", lambda e: self._next())
+        self.root.bind("<Left>", lambda e: self._navigate(-1))
+        self.root.bind("<Right>", lambda e: self._navigate(+1))
         # Tab schaltet zwischen Monat- und Wochenansicht. "break" verhindert
         # die Default-Focus-Traversal, die sonst zwischen den Toggle-Buttons
         # springen würde und das Toggle visuell zerschießt.
@@ -537,34 +537,21 @@ class App:
             footer_frame, "Arbeitszeiten senden", self._send, padx=12,
         ).pack(side=tk.RIGHT)
 
-    def _prev(self):
+    def _navigate(self, direction):
+        """Blättert die Ansicht um `direction` Einheiten (-1 zurück, +1 vor):
+        im Monatsmodus ±1 Monat (mit Jahreswechsel), im Wochenmodus ±7 Tage."""
         if self.view_mode == "month":
-            if self.month == 1:
-                self.month = 12
-                self.year -= 1
+            m = self.month + direction
+            if m < 1:
+                self.month, self.year = 12, self.year - 1
+            elif m > 12:
+                self.month, self.year = 1, self.year + 1
             else:
-                self.month -= 1
+                self.month = m
         else:
-            dates = get_week_dates(self.iso_year, self.current_week)
-            prev_monday = dates[0] - datetime.timedelta(days=7)
-            iso = prev_monday.isocalendar()
-            self.iso_year = iso[0]
-            self.current_week = iso[1]
-        self._refresh()
-
-    def _next(self):
-        if self.view_mode == "month":
-            if self.month == 12:
-                self.month = 1
-                self.year += 1
-            else:
-                self.month += 1
-        else:
-            dates = get_week_dates(self.iso_year, self.current_week)
-            next_monday = dates[0] + datetime.timedelta(days=7)
-            iso = next_monday.isocalendar()
-            self.iso_year = iso[0]
-            self.current_week = iso[1]
+            monday = get_week_dates(self.iso_year, self.current_week)[0] \
+                + datetime.timedelta(days=7 * direction)
+            self.iso_year, self.current_week = monday.isocalendar()[:2]
         self._refresh()
 
     def _on_tab_toggle_view(self, _event=None):

--- a/src/ui.py
+++ b/src/ui.py
@@ -458,7 +458,7 @@ class App:
         # die Reihenh\u00f6he folgt sonst dem gr\u00f6\u00dften Kind.
         tk.Label(frame, text="", font=FONT_HEADER, bg=BG, width=0).pack(side=tk.LEFT)
 
-        icon_button(frame, "\u2039", self._prev).pack(side=tk.LEFT)
+        icon_button(frame, "\u2039", lambda: self._navigate(-1)).pack(side=tk.LEFT)
 
         toggle_frame = tk.Frame(frame, bg=BG)
         toggle_frame.pack(side=tk.LEFT, padx=10)
@@ -487,7 +487,7 @@ class App:
             fg=TEXT_MUTED, hover_fg=TEXT,
         ).pack(side=tk.RIGHT)
 
-        self._next_button = icon_button(frame, "\u203a", self._next)
+        self._next_button = icon_button(frame, "\u203a", lambda: self._navigate(+1))
         self._next_button.pack(side=tk.RIGHT, padx=(0, 5))
 
         # --- Sync-Button und Status (Multi-Device-Sync) ---

--- a/src/ui.py
+++ b/src/ui.py
@@ -139,6 +139,12 @@ def _delete_action(slots, selected, prefix):
     return "save", keep
 
 
+# Probe-Label-Geometrie zur Zellgroessen-Messung (Month- und Week-Render teilen sie).
+PROBE_WIDTH_WIDE = 12    # ausgeblendetes Wochenende -> breitere Zellen
+PROBE_WIDTH_NARROW = 8   # 7-Spalten-Modus
+PROBE_HEIGHT = 3
+
+
 class App:
     def __init__(self, root, storage, settings, base_path=".", conflicts_store=None,
                  reservation_store=None):
@@ -1053,6 +1059,25 @@ class App:
             if c.get("kind") == "entry" and not c.get("resolved")
         }
 
+    def _cell_layout_metrics(self, frame):
+        """Misst die natuerliche Pixelgroesse einer Standard-Tageszelle (Probe-
+        Label) und liefert die layout-abhaengigen Groessen.
+
+        Bei ausgeblendetem Wochenende (5 statt 7 Spalten) bleibt mehr Horizontal-
+        platz pro Spalte: breitere Zellen und groessere Zeit-/Feiertagsschrift
+        (FONT statt FONT_SMALL), damit z.B. '09:30-17:00' bequem lesbar bleibt.
+        Holiday-Zellen werden spaeter auf `cell_size` fixiert, damit lange
+        Feiertagsnamen die Spalte nicht aufweiten (Header-Reflow/Flackern)."""
+        wide_cells = not self.settings.get("show_weekend")
+        probe_width = PROBE_WIDTH_WIDE if wide_cells else PROBE_WIDTH_NARROW
+        entry_time_font = FONT if wide_cells else FONT_SMALL
+        holiday_name_font = FONT if wide_cells else FONT_SMALL
+        probe = tk.Label(frame, text="", font=FONT, width=probe_width, height=PROBE_HEIGHT)
+        probe.update_idletasks()
+        cell_size = (probe.winfo_reqwidth(), probe.winfo_reqheight())
+        probe.destroy()
+        return cell_size, entry_time_font, holiday_name_font, wide_cells
+
     def _refresh_month(self):
         # In den versteckten Backbuffer bauen, dann via lift() in den Vordergrund
         # holen — verhindert sichtbare leere Fläche zwischen Refreshes.
@@ -1068,28 +1093,8 @@ class App:
         state = self.settings.get("state")
         holidays_map = get_holidays(state, self.year) if state else {}
 
-        # Probe-Label, um die natürliche Pixel-Größe einer Standard-Tageszelle
-        # zu ermitteln. Wird genutzt für:
-        #  (a) Feiertagszellen pixel-fixieren — sonst weiten lange Feiertags-
-        #      namen die Spalte auf, das Grid wächst und der Header-Reflow
-        #      lässt den Monatsnamen flackern.
-        #  (b) konstante Reihenhöhe (minsize unten), damit gepaddete Wochen
-        #      ohne Content nicht zusammenklappen.
-        # Bei ausgeblendeten Wochenenden (5 Spalten statt 7) bleibt mehr
-        # Horizontalplatz pro Spalte — Zellen werden breiter, damit die
-        # Zeit-Zeile in FONT_SMALL statt FONT_TINY lesbar dargestellt wird.
-        wide_cells = not self.settings.get("show_weekend")
-        probe_width = 12 if wide_cells else 8
-        # FONT_SMALL (8pt) statt FONT_TINY (7pt) im 7-Spalten-Modus — Spalten
-        # werden durch sticky="nsew" + columnconfigure(weight=1) über die
-        # Probe-Breite hinaus gestreckt, sodass "09:30-17:00" auch in 8pt
-        # bequem reinpasst und besser lesbar bleibt.
-        entry_time_font = FONT if wide_cells else FONT_SMALL
-        holiday_name_font = FONT if wide_cells else FONT_SMALL
-        probe = tk.Label(new_frame, text="", font=FONT, width=probe_width, height=3)
-        probe.update_idletasks()
-        cell_size = (probe.winfo_reqwidth(), probe.winfo_reqheight())
-        probe.destroy()
+        cell_size, entry_time_font, holiday_name_font, wide_cells = \
+            self._cell_layout_metrics(new_frame)
 
         # Auf 6 Wochen padden, damit die Fensterhöhe zwischen Monaten konstant
         # bleibt und `geometry("")` in `_refresh` keinen sichtbaren Resize auslöst.
@@ -1158,18 +1163,8 @@ class App:
             for y in {dates[0].year, dates[-1].year}:
                 holidays_map.update(get_holidays(state, y))
 
-        # Probe-Label, um die natürliche Pixel-Größe einer Standard-Wochenzelle
-        # zu ermitteln. Holiday-Zellen werden auf diese Größe fixiert, damit
-        # längere Feiertagsnamen die Spalte nicht aufweiten.
-        # Bei ausgeblendeten Wochenenden: breitere Zellen + größere Time-Schrift.
-        wide_cells = not self.settings.get("show_weekend")
-        probe_width = 12 if wide_cells else 8
-        entry_time_font = FONT if wide_cells else FONT_SMALL
-        holiday_name_font = FONT if wide_cells else FONT_SMALL
-        probe = tk.Label(new_frame, text="", font=FONT, width=probe_width, height=3)
-        probe.update_idletasks()
-        cell_size = (probe.winfo_reqwidth(), probe.winfo_reqheight())
-        probe.destroy()
+        cell_size, entry_time_font, holiday_name_font, wide_cells = \
+            self._cell_layout_metrics(new_frame)
 
         n = self._visible_day_count()
         # Einmal pro Render berechnen, nicht pro Zelle.

--- a/src/ui.py
+++ b/src/ui.py
@@ -17,7 +17,6 @@ from src.time_utils import (
 )
 from src.holidays_de import get_holidays
 from src.tooltip import attach_tooltip
-from src.mail import fetch_user_email, refresh_token_if_needed, TokenAuthError, TokenNetworkError
 from src.drive import DriveAuthError, DriveNetworkError
 from src.version import VERSION, version_label
 from src.updater import (
@@ -29,6 +28,7 @@ from src.updater import (
     Release,
 )
 
+from src.background_tasks import BackgroundTaskRunner
 from src.dialogs.entry_dialog import open_entry_dialog
 from src.dialogs.send_dialog import open_send_dialog
 from src.dialogs.settings_dialog import open_settings_dialog
@@ -225,75 +225,27 @@ class App:
         # gestartet) — keine sichtbaren Zwischenzustände.
         self._fixed_width = self._measure_max_width()
         self._refresh()
-        self._proactive_token_refresh()
-        self._proactive_sender_email_fetch()
+        self._bg = BackgroundTaskRunner(
+            self._marshal_to_ui, self.settings, self.base_path,
+            self.reservation_store, self._reservations_active,
+        )
+        self._bg.refresh_token(
+            on_auth_error=lambda msg: themed_showinfo(
+                self.root,
+                "Gmail-Anmeldung abgelaufen",
+                "Der Gmail-Token konnte nicht automatisch erneuert werden:\n\n"
+                f"{msg}\n\n"
+                "Beim nächsten Senden wirst du zur erneuten Anmeldung aufgefordert.",
+            ),
+            on_error=lambda tb: themed_showinfo(
+                self.root, "Token-Refresh fehlgeschlagen", tb,
+            ),
+        )
+        self._bg.fetch_sender_email()
         self._update_banner = None
         self._proactive_update_check()
         self._proactive_calendar_reconcile()
         self.root.protocol("WM_DELETE_WINDOW", self._on_close)
-
-    def _proactive_token_refresh(self):
-        """Erneuert den Gmail-Token beim App-Start im Hintergrund.
-
-        Auth-Fehler werden als Messagebox gezeigt, Netzwerkfehler still
-        übergangen, damit ein Offline-Start nicht stört.
-        """
-        token_path = os.path.join(self.base_path, "token.json")
-
-        def worker():
-            try:
-                refresh_token_if_needed(
-                    token_path,
-                    sync_enabled=self.settings.get("sync_enabled"),
-                    gcal_enabled=self.settings.get("gcal_enabled"),
-                )
-            except TokenAuthError as e:
-                msg = str(e)
-                self._marshal_to_ui(lambda: themed_showinfo(
-                    self.root,
-                    "Gmail-Anmeldung abgelaufen",
-                    "Der Gmail-Token konnte nicht automatisch erneuert werden:\n\n"
-                    f"{msg}\n\n"
-                    "Beim nächsten Senden wirst du zur erneuten Anmeldung aufgefordert."
-                ))
-            except TokenNetworkError:
-                pass
-            except Exception as e:
-                logging.getLogger(__name__).exception("Token-Refresh fehlgeschlagen")
-                err = f"{type(e).__name__}: {e}\n\n{traceback.format_exc()}"
-                self._marshal_to_ui(lambda: themed_showinfo(
-                    self.root, "Token-Refresh fehlgeschlagen", err
-                ))
-
-        threading.Thread(target=worker, daemon=True).start()
-
-    def _proactive_sender_email_fetch(self):
-        """Holt einmalig pro App-Start die authentifizierte E-Mail-Adresse über
-        das OAuth2-Userinfo-Endpoint und cached sie in `settings.sender_email`.
-
-        Schlägt still fehl, wenn kein Token, kein Netz oder der userinfo.email-
-        Scope dem Token noch nicht gewährt wurde — der nächste Send-Dialog
-        triggert dann den OAuth-Re-Consent, und beim nächsten App-Start klappt
-        es. So bekommt der User nichts mit, wenn alles funktioniert.
-        """
-        token_path = os.path.join(self.base_path, "token.json")
-        if not os.path.exists(token_path):
-            return
-
-        def worker():
-            try:
-                email = fetch_user_email(
-                    token_path,
-                    sync_enabled=self.settings.get("sync_enabled"),
-                    gcal_enabled=self.settings.get("gcal_enabled"),
-                )
-            except Exception:
-                logging.getLogger(__name__).exception("sender_email-Fetch fehlgeschlagen")
-                return
-            if email and email != self.settings.get("sender_email"):
-                self._marshal_to_ui(lambda: self.settings.set("sender_email", email))
-
-        threading.Thread(target=worker, daemon=True).start()
 
     def _proactive_update_check(self):
         """Fragt einmal pro Kalendertag GitHub nach einer neueren Version.
@@ -628,7 +580,7 @@ class App:
             # anstoßen. Damit erscheint die Absender-Adresse automatisch nach
             # Sync-Aktivierung (frischer Token mit userinfo.email-Scope), ohne
             # dass der User den "Aktualisieren"-Button drücken muss.
-            self._proactive_sender_email_fetch()
+            self._bg.fetch_sender_email()
         open_settings_dialog(
             self.root, self.settings, self.base_path,
             on_change=_on_change,

--- a/tests/test_background_tasks.py
+++ b/tests/test_background_tasks.py
@@ -44,6 +44,29 @@ def test_run_without_on_done_still_executes_fn():
     assert ran.wait(timeout=5)
 
 
+def test_check_update_skips_when_not_due(monkeypatch):
+    import src.background_tasks as bg
+    monkeypatch.setattr(bg, "should_check_today", lambda v: False)
+    called = {"n": 0}
+    monkeypatch.setattr(bg, "check_latest_release",
+                        lambda repo: called.__setitem__("n", called["n"] + 1))
+    r = _runner(settings={"last_update_check_at": None})
+    # settings als dict -> .get reicht; should_check_today ist gepatcht
+    r.check_update(on_result=lambda rel, newer: None)
+    import time
+    time.sleep(0.2)
+    assert called["n"] == 0
+
+
+def test_reconcile_on_start_skips_when_reservations_inactive():
+    ran = {"n": 0}
+    r = _runner(reservations_active=lambda: False)
+    r.reconcile_on_start(on_ok=lambda: ran.__setitem__("n", ran["n"] + 1))
+    import time
+    time.sleep(0.2)
+    assert ran["n"] == 0
+
+
 def test_fetch_sender_email_noop_without_token(tmp_path):
     # base_path ohne token.json -> fetch_user_email darf nicht aufgerufen werden
     import src.background_tasks as bg

--- a/tests/test_background_tasks.py
+++ b/tests/test_background_tasks.py
@@ -42,3 +42,19 @@ def test_run_without_on_done_still_executes_fn():
     _runner().run(fn)
 
     assert ran.wait(timeout=5)
+
+
+def test_fetch_sender_email_noop_without_token(tmp_path):
+    # base_path ohne token.json -> fetch_user_email darf nicht aufgerufen werden
+    import src.background_tasks as bg
+
+    called = {"n": 0}
+    orig = bg.fetch_user_email
+    bg.fetch_user_email = lambda *a, **k: called.__setitem__("n", called["n"] + 1) or ""
+    try:
+        _runner(base_path=str(tmp_path)).fetch_sender_email()
+        import time
+        time.sleep(0.2)
+    finally:
+        bg.fetch_user_email = orig
+    assert called["n"] == 0

--- a/tests/test_background_tasks.py
+++ b/tests/test_background_tasks.py
@@ -1,0 +1,44 @@
+"""BackgroundTaskRunner: run() fuehrt fn im Thread aus und liefert das
+Ergebnis ueber marshal an on_done. marshal wird im Test synchron gefakt."""
+
+import threading
+
+from src.background_tasks import BackgroundTaskRunner
+
+
+def _runner(**overrides):
+    kw = dict(
+        marshal=lambda cb: cb(),          # synchron ausfuehren
+        settings=overrides.pop("settings", {}),
+        base_path=overrides.pop("base_path", "."),
+        reservation_store=overrides.pop("reservation_store", None),
+        reservations_active=overrides.pop("reservations_active", lambda: False),
+    )
+    kw.update(overrides)
+    return BackgroundTaskRunner(**kw)
+
+
+def test_run_executes_fn_and_delivers_result_to_on_done():
+    done = threading.Event()
+    received = {}
+
+    def on_done(result):
+        received["value"] = result
+        done.set()
+
+    _runner().run(lambda: 42, on_done)
+
+    assert done.wait(timeout=5)
+    assert received["value"] == 42
+
+
+def test_run_without_on_done_still_executes_fn():
+    ran = threading.Event()
+
+    def fn():
+        ran.set()
+        return None
+
+    _runner().run(fn)
+
+    assert ran.wait(timeout=5)

--- a/tests/test_ui_hover.py
+++ b/tests/test_ui_hover.py
@@ -1,0 +1,35 @@
+"""_hover faerbt Frame, uebergebene Labels und vorhandene Eck-Overlays."""
+
+from src.ui import App
+
+
+class _FakeWidget:
+    def __init__(self):
+        self.bg = None
+
+    def config(self, bg):
+        self.bg = bg
+
+
+def test_hover_colors_frame_and_labels():
+    frame, day, time = _FakeWidget(), _FakeWidget(), _FakeWidget()
+    App._hover(frame, "#123456", day, time)
+    assert frame.bg == "#123456"
+    assert day.bg == "#123456"
+    assert time.bg == "#123456"
+
+
+def test_hover_colors_overlay_widgets_when_present():
+    frame = _FakeWidget()
+    frame._reservation_marker = _FakeWidget()
+    frame._delete_button = _FakeWidget()
+    App._hover(frame, "#abcdef")
+    assert frame._reservation_marker.bg == "#abcdef"
+    assert frame._delete_button.bg == "#abcdef"
+
+
+def test_hover_without_overlays_does_not_fail():
+    frame, day = _FakeWidget(), _FakeWidget()
+    App._hover(frame, "#000000", day)
+    assert frame.bg == "#000000"
+    assert day.bg == "#000000"

--- a/tests/test_ui_navigate.py
+++ b/tests/test_ui_navigate.py
@@ -1,8 +1,6 @@
 """_navigate ersetzt _prev/_next. Getestet ohne Tk über einen Stub mit den
 relevanten Attributen; _refresh ist ein No-op."""
 
-import datetime
-
 from src.ui import App
 
 

--- a/tests/test_ui_navigate.py
+++ b/tests/test_ui_navigate.py
@@ -1,0 +1,53 @@
+"""_navigate ersetzt _prev/_next. Getestet ohne Tk über einen Stub mit den
+relevanten Attributen; _refresh ist ein No-op."""
+
+import datetime
+
+from src.ui import App
+
+
+class _Stub:
+    def __init__(self, **kw):
+        self.__dict__.update(kw)
+        self.refreshed = 0
+
+    def _refresh(self):
+        self.refreshed += 1
+
+
+def _nav(stub, direction):
+    App._navigate(stub, direction)
+
+
+def test_month_forward_within_year():
+    s = _Stub(view_mode="month", year=2026, month=6)
+    _nav(s, +1)
+    assert (s.year, s.month) == (2026, 7)
+    assert s.refreshed == 1
+
+
+def test_month_backward_wraps_to_previous_year():
+    s = _Stub(view_mode="month", year=2026, month=1)
+    _nav(s, -1)
+    assert (s.year, s.month) == (2025, 12)
+
+
+def test_month_forward_wraps_to_next_year():
+    s = _Stub(view_mode="month", year=2026, month=12)
+    _nav(s, +1)
+    assert (s.year, s.month) == (2027, 1)
+
+
+def test_week_forward_advances_seven_days():
+    # KW 26/2026 -> +1 Woche = KW 27
+    s = _Stub(view_mode="week", iso_year=2026, current_week=26)
+    _nav(s, +1)
+    assert (s.iso_year, s.current_week) == (2026, 27)
+
+
+def test_week_backward_crosses_year_boundary():
+    # KW 1/2026 -> -1 Woche landet in 2025
+    s = _Stub(view_mode="week", iso_year=2026, current_week=1)
+    _nav(s, -1)
+    assert s.iso_year == 2025
+    assert s.current_week >= 52


### PR DESCRIPTION
Closes #49 (erster Schritt — siehe „Scope" unten).

## Problem

`src/ui.py` (~1540 Zeilen) ist ein God-Object mit spürbarer interner Duplikation: das Worker-Thread-Muster (`threading.Thread` + `marshal`) lag 7× kopiert vor, `_cell_hover`/`_empty_hover` teilten ihren Kern, das Probe-Label zur Zellmessung war in `_refresh_month`/`_refresh_week` doppelt, und `_prev`/`_next` waren strukturgleich.

## Lösung (kein Big-Bang)

**Vier Duplikat-Helfer** zusammengeführt:
- `_prev`/`_next` → `_navigate(direction)` (inkl. der Header-Pfeil-Buttons ‹/› und der `<Left>`/`<Right>`-Bindings)
- `_cell_hover`/`_empty_hover` → `_hover(frame, bg, *labels)`
- doppeltes Probe-Label → `_cell_layout_metrics(frame)` + Konstanten `PROBE_WIDTH_WIDE`/`PROBE_WIDTH_NARROW`/`PROBE_HEIGHT`

**Eine Verantwortlichkeit ausgelagert** — neues Modul `src/background_tasks.py` mit `BackgroundTaskRunner`:
- `run(fn, on_done)` ist **der** eine Thread-Helfer; alle 7 bisherigen Kopien (inkl. der Sync-Methoden) laufen jetzt darüber.
- Die fünf proaktiven Tasks (`refresh_token`, `fetch_sender_email`, `check_update`, `reconcile_on_start`, `trigger_reconcile`) leben in der Klasse; `App` übergibt die UI-Arbeit (Dialoge/Banner/Refresh) als Callbacks.
- Tk-frei, keine Google-Imports auf Modulebene; `run_calendar_reconcile` bleibt Lazy-Import in der Methode (Circular-Import-Schutz). `import threading` ist aus `ui.py` verschwunden.

Verhalten bleibt unverändert (reiner Refactor). Netto verschiebt/entdoppelt sich Logik; `ui.py` wird schlanker.

## Akzeptanzkriterien (#49)

- [x] Worker-Thread-Muster über einen Helper, keine Kopien mehr
- [x] Hover- und Probe-Duplikation entfernt
- [x] Mindestens eine Verantwortlichkeit (Background-Tasks) in eigene Klasse/Modul ausgelagert
- [x] Verhalten unverändert (manuell verifiziert: App-Start + Background-Tasks ohne Fehler; Month/Week, Navigation, Sync, Hover code-seitig geprüft)

## Tests

- Neu: `tests/test_ui_navigate.py`, `tests/test_ui_hover.py`, `tests/test_background_tasks.py` (Stub-/Fake-basiert, ohne Tk-Display — Navigations-Math, Hover-Färbung, `run()`-Threading + Task-Guards).
- Volle Suite: **520 passed, 1 skipped**. `ruff check .` sauber.

## Scope / Folge-PRs

Bewusst **schrittweise** gehalten (Issue: „kein Big-Bang"). Weitere Extraktionen (`GridRenderer` für das Rendering, `SyncOrchestrator` für Sync/Status) bleiben Folge-PRs.

## Doku

Enthält Design-Spec + Implementierungsplan unter `docs/superpowers/` als Begleit-Dokumentation des Refactorings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
