### PR TITLE
refactor(ui): Update-Banner in UpdateBanner-Komponente auslagern (#49, stacked auf #71)

### DIFF
--- a/docs/superpowers/plans/2026-06-23-update-banner.md
+++ b/docs/superpowers/plans/2026-06-23-update-banner.md
@@ -1,0 +1,324 @@
+# UpdateBanner-Extraktion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Den Update-Banner-Cluster aus `src/ui.py` in eine eigene Komponente `UpdateBanner` (`src/update_banner.py`) auslagern — dritter Schritt der ui.py-Entflechtung (#49).
+
+**Architecture:** Neues Tk-nutzendes Modul (kein `src.ui`-Import → kein Circular-Import) mit der Klasse `UpdateBanner`, die den Banner-Frame-Lebenszyklus und die Anzeige-/Dismiss-/Download-Logik kapselt. `App` konstruiert die Komponente und übergibt die `check_update`-Ergebnisse an sie. Verhalten unverändert.
+
+**Tech Stack:** Python 3, Tkinter, pytest.
+
+## Global Constraints
+
+- Verhalten unverändert (reiner Refactor) — Strings/Farben/Fonts byte-identisch; UI manuell verifiziert (mind. App-Start ohne Fehler; Banner-Pfad ist nur bei verfügbarem Update sichtbar).
+- `src/update_banner.py`: module-level `import tkinter`/`src.theme`/`src.tooltip`/`src.updater` ist OK; **kein** `src.ui`-Import.
+- Datum intern ISO (`today_iso`), UI deutsch — hier nicht berührt.
+- Lint: `python -m ruff check .` (ganzes Repo) grün. Tests: `python -m pytest` grün.
+- Commit-Messages enden mit `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`.
+- PowerShell 5.1: kein `&&`; `;` oder `if ($?) { }`. Match Edits **by content**, nicht by Zeilennummer (`~` = ungefähr).
+
+---
+
+### Task 1: `src/update_banner.py` + Tests
+
+**Files:**
+- Create: `src/update_banner.py`
+- Test: `tests/test_update_banner.py` (neu)
+
+**Interfaces:**
+- Produces: `UpdateBanner(root, settings, get_anchor)` mit `handle_check_result(release, newer)`, `_show(release)`, `_open_download(release)`, `_dismiss(version)`. `get_anchor()` liefert das Widget, vor dem der Banner gepackt wird.
+
+- [ ] **Step 1: Failing tests schreiben**
+
+`tests/test_update_banner.py`:
+```python
+"""UpdateBanner: Entscheidungslogik (handle_check_result) und Download-URL-Wahl
+ohne Tk — _show wird gemockt, webbrowser/pick_asset_url gepatcht."""
+
+from unittest.mock import MagicMock
+
+import src.update_banner as ub
+from src.update_banner import UpdateBanner
+
+
+class _FakeSettings:
+    def __init__(self, dismissed_version=None):
+        self._d = {"dismissed_version": dismissed_version}
+
+    def get(self, key, default=None):
+        return self._d.get(key, default)
+
+    def set(self, key, value):
+        self._d[key] = value
+
+
+def _release(version="1.2.0", html_url="https://example/r", assets=None):
+    r = MagicMock()
+    r.version = version
+    r.html_url = html_url
+    r.assets = assets if assets is not None else []
+    return r
+
+
+def _banner(settings):
+    b = UpdateBanner(root=object(), settings=settings, get_anchor=lambda: object())
+    b._show = MagicMock()
+    return b
+
+
+def test_handle_check_result_persists_check_date(monkeypatch):
+    monkeypatch.setattr(ub, "today_iso", lambda: "2026-06-23")
+    s = _FakeSettings()
+    b = _banner(s)
+    b.handle_check_result(_release(), newer=False)
+    assert s.get("last_update_check_at") == "2026-06-23"
+
+
+def test_handle_check_result_not_newer_does_not_show(monkeypatch):
+    monkeypatch.setattr(ub, "today_iso", lambda: "2026-06-23")
+    b = _banner(_FakeSettings())
+    b.handle_check_result(_release(), newer=False)
+    b._show.assert_not_called()
+
+
+def test_handle_check_result_dismissed_version_does_not_show(monkeypatch):
+    monkeypatch.setattr(ub, "today_iso", lambda: "2026-06-23")
+    b = _banner(_FakeSettings(dismissed_version="1.2.0"))
+    b.handle_check_result(_release(version="1.2.0"), newer=True)
+    b._show.assert_not_called()
+
+
+def test_handle_check_result_new_version_shows(monkeypatch):
+    monkeypatch.setattr(ub, "today_iso", lambda: "2026-06-23")
+    b = _banner(_FakeSettings(dismissed_version="1.1.0"))
+    rel = _release(version="1.2.0")
+    b.handle_check_result(rel, newer=True)
+    b._show.assert_called_once_with(rel)
+
+
+def test_open_download_uses_asset_url(monkeypatch):
+    opened = []
+    monkeypatch.setattr(ub.webbrowser, "open", lambda url: opened.append(url))
+    monkeypatch.setattr(ub, "pick_asset_url",
+                        lambda assets, sysname, ver: "https://asset/dl")
+    b = UpdateBanner(root=object(), settings=_FakeSettings(),
+                     get_anchor=lambda: object())
+    b._open_download(_release())
+    assert opened == ["https://asset/dl"]
+
+
+def test_open_download_falls_back_to_html_url(monkeypatch):
+    opened = []
+    monkeypatch.setattr(ub.webbrowser, "open", lambda url: opened.append(url))
+    monkeypatch.setattr(ub, "pick_asset_url", lambda assets, sysname, ver: None)
+    b = UpdateBanner(root=object(), settings=_FakeSettings(),
+                     get_anchor=lambda: object())
+    b._open_download(_release(html_url="https://example/r"))
+    assert opened == ["https://example/r"]
+```
+
+- [ ] **Step 2: Tests failen sehen**
+
+Run: `python -m pytest tests/test_update_banner.py -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'src.update_banner'`.
+
+- [ ] **Step 3: Modul implementieren**
+
+`src/update_banner.py`:
+```python
+"""GitHub-Release-Hinweis als Banner über dem Kalender (anzeigen, Download
+öffnen, ausblenden). Eigenständig herausgelöst aus der App (#49).
+
+Tk-nutzend, aber ohne src.ui-Import (kein Circular-Import). Der Pack-Anker
+(App.grid_container) wird lazy über get_anchor gelesen, weil er erst nach dem
+Grid-Build existiert."""
+
+import platform
+import tkinter as tk
+import webbrowser
+
+from src.theme import ACCENT, ACCENT_HOVER, FONT_BOLD, label_button
+from src.tooltip import attach_tooltip
+from src.updater import pick_asset_url, today_iso
+
+
+class UpdateBanner:
+    def __init__(self, root, settings, get_anchor):
+        self._root = root
+        self._settings = settings
+        self._get_anchor = get_anchor    # lambda: App.grid_container
+        self._banner = None              # Frame oder None (None = nicht sichtbar)
+
+    def handle_check_result(self, release, newer):
+        """Läuft im UI-Thread (on_result von BackgroundTaskRunner.check_update).
+        Persistiert den Check-Stand und zeigt ggf. den Banner. `newer` ist bereits
+        im Worker ausgewertet, damit hier keine ungeschützte Logik im Tk-Event-
+        Loop läuft."""
+        self._settings.set("last_update_check_at", today_iso())
+        if not newer:
+            return
+        if release.version == self._settings.get("dismissed_version"):
+            return
+        self._show(release)
+
+    def _show(self, release):
+        if self._banner is not None:
+            return
+        self._banner = tk.Frame(self._root, bg=ACCENT)
+        self._banner.pack(
+            before=self._get_anchor(), fill=tk.X, padx=10, pady=(5, 0),
+        )
+
+        tk.Label(
+            self._banner,
+            text=f"Version {release.version} verfügbar",
+            bg=ACCENT, fg="#ffffff", font=FONT_BOLD,
+        ).pack(side=tk.LEFT, padx=10, pady=6)
+
+        dismiss_btn = label_button(
+            self._banner, "✕",
+            lambda: self._dismiss(release.version),
+            bg=ACCENT, fg="#ffffff",
+            hover_bg=ACCENT_HOVER, hover_fg="#ffffff",
+            font=FONT_BOLD,
+            label_padx=8,
+        )
+        dismiss_btn.pack(side=tk.RIGHT, padx=(0, 4), pady=6)
+        attach_tooltip(dismiss_btn, "Diese Version ausblenden")
+
+        label_button(
+            self._banner, "Download",
+            lambda: self._open_download(release),
+            bg="#ffffff", fg=ACCENT,
+            hover_bg="#f0f0f0", hover_fg=ACCENT_HOVER,
+            font=FONT_BOLD,
+            label_padx=14, label_pady=2,
+        ).pack(side=tk.RIGHT, padx=8, pady=4)
+
+    def _open_download(self, release):
+        url = pick_asset_url(
+            release.assets, platform.system(), release.version,
+        ) or release.html_url
+        webbrowser.open(url)
+
+    def _dismiss(self, version):
+        self._settings.set("dismissed_version", version)
+        if self._banner is not None:
+            self._banner.destroy()
+            self._banner = None
+```
+
+- [ ] **Step 4: Tests grün + Lint + Import-Smoke**
+
+Run:
+```
+python -m pytest tests/test_update_banner.py -q
+python -m ruff check src/update_banner.py tests/test_update_banner.py
+python -c "import src.update_banner"
+```
+Expected: 6 Tests PASS; Lint sauber; Import ohne Fehler.
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/update_banner.py tests/test_update_banner.py
+git commit -m "feat(ui): UpdateBanner-Komponente fuer Release-Hinweis (#49)"
+```
+
+---
+
+### Task 2: `App` verdrahten, alte Methoden + Imports entfernen
+
+**Files:**
+- Modify: `src/ui.py` (`__init__`-Wiring; vier Methoden entfernen; zwei Import-Statements entfernen)
+
+**Interfaces:**
+- Consumes: `UpdateBanner` (Task 1).
+
+- [ ] **Step 1: Import ergänzen**
+
+In `src/ui.py` bei den `from src...`-Imports ergänzen:
+```python
+from src.update_banner import UpdateBanner
+```
+
+- [ ] **Step 2: `__init__`-Wiring**
+
+In `src/ui.py` `__init__`:
+
+(a) Die Zeile (~174) `self._update_banner = None` ersetzen durch:
+```python
+        self._update_banner = UpdateBanner(
+            self.root, self.settings, lambda: self.grid_container)
+```
+
+(b) Die direkt folgende Zeile (~175)
+```python
+        self._bg.check_update(on_result=self._handle_update_check_result)
+```
+ersetzen durch:
+```python
+        self._bg.check_update(on_result=self._update_banner.handle_check_result)
+```
+(Reihenfolge bleibt: `self._update_banner` wird vor `check_update` konstruiert.)
+
+- [ ] **Step 3: Vier Methoden entfernen**
+
+In `src/ui.py` die Methoden `_handle_update_check_result` (~211-222), `_show_update_banner` (~224-256), `_open_update_download` (~258-262) und `_dismiss_update_banner` (~264-268) **komplett löschen**.
+
+- [ ] **Step 4: Ungenutzte Imports entfernen**
+
+`webbrowser`, `pick_asset_url`, `today_iso`, `Release` werden in `ui.py` nur noch von den gelöschten Methoden genutzt. Entfernen:
+- `import webbrowser` (~Zeile 11) löschen.
+- Den gesamten Block (~20-24)
+  ```python
+  from src.updater import (
+      pick_asset_url,
+      today_iso,
+      Release,
+  )
+  ```
+  löschen.
+
+Per Lint (F401) bestätigen, dass danach nichts Verbliebenes diese Namen referenziert; falls doch eine Stelle einen davon noch nutzt, diesen einen Namen behalten.
+
+- [ ] **Step 5: Grep-Kontrolle, Lint, volle Suite, Import-Smoke**
+
+Run:
+```
+python -m ruff check .
+python -m pytest -q
+python -c "import src.ui"
+python -c "import src.update_banner"
+```
+Grep-Kontrolle in `src/`: **kein** `_handle_update_check_result`, `_show_update_banner`, `_open_update_download`, `_dismiss_update_banner` mehr; **kein** `webbrowser` / `pick_asset_url` / `today_iso` / `Release` mehr in `src/ui.py`.
+Expected: Lint sauber; volle Suite grün (unveränderte Zahl + Task-1-Tests); beide Import-Smokes ohne Fehler.
+
+- [ ] **Step 6: Manuelle AC-Verifikation** *(führt der Controller aus, nicht der Implementer)*
+
+`python -m src.main` starten und prüfen: Start ohne Fehler. (Der Banner erscheint nur bei verfügbarem Update + max. 1×/Tag — der Start-Smoke deckt die Konstruktion/Verdrahtung ab.)
+
+- [ ] **Step 7: Commit**
+
+```
+git add src/ui.py
+git commit -m "refactor(ui): App an UpdateBanner verdrahten, alte Methoden entfernen (#49)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Modul `UpdateBanner` (Konstruktor, handle_check_result, _show, _open_download, _dismiss): Task 1. ✓
+- App-Wiring (Konstruktion, check_update-Umbiegung, 4 Methoden + 2 Imports raus): Task 2. ✓
+- Tests (Entscheidungslogik + URL-Fallback): Task 1. ✓
+- AC manuell: Task 2 Step 6. ✓
+
+**Type-Konsistenz:** `UpdateBanner(root, settings, get_anchor)`, `handle_check_result(release, newer)`, `_show(release)`, `_open_download(release)`, `_dismiss(version)` — über beide Tasks konsistent; `on_result=self._update_banner.handle_check_result` passt zur `check_update(on_result)`-Signatur (`on_result(release, newer)`).
+
+**Platzhalter:** keine.
+
+**Offene Risiken:**
+- `self._update_banner` wechselt die Bedeutung (Frame → Komponente); alle alten Frame-Zugriffe (`is not None`, `.destroy()`) lagen ausschließlich in den entfernten Methoden — keine weiteren Stellen. Per Grep abgesichert (Task 2 Step 5).
+- Import-Trim per F401 abgesichert (Task 2 Step 4-5).

--- a/docs/superpowers/specs/2026-06-23-update-banner-design.md
+++ b/docs/superpowers/specs/2026-06-23-update-banner-design.md
@@ -1,0 +1,129 @@
+# Design: ui.py entflechten — UpdateBanner
+
+**Issue:** #49 (ui.py God-Object entflechten), **dritter Extraktions-Schritt** nach
+`BackgroundTaskRunner` (#70) und `SyncOrchestrator` (#71).
+**Branch:** `refactor/ui-update-banner`, gestackt auf `refactor/ui-sync-orchestrator` (#71).
+
+**Leitprinzip:** Verhalten unverändert. Die kleine, eigenständige Update-Banner-
+Verantwortlichkeit (GitHub-Release-Hinweis: anzeigen, Download öffnen, ausblenden) aus
+`App` in eine eigene Komponente `UpdateBanner` ziehen.
+
+## Ausgangslage
+
+`src/ui.py` ist nach #71 bei ~1211 Zeilen. Der Update-Banner-Cluster (~60 Zeilen) ist sehr
+gut abgegrenzt:
+
+- `_handle_update_check_result(release, newer)` — persistiert `last_update_check_at`,
+  zeigt den Banner falls neuer + nicht ausgeblendet.
+- `_show_update_banner(release)` — baut den Banner-Frame (Version-Label, Download-Button,
+  ✕-Dismiss), gepackt `before=self.grid_container`.
+- `_open_update_download(release)` — wählt die Asset-URL (oder `html_url`-Fallback) und
+  öffnet sie im Browser.
+- `_dismiss_update_banner(version)` — merkt die ausgeblendete Version, zerstört den Frame.
+
+Kopplung: `self.root` (Parent des Banner-Frames), `self.grid_container` (Pack-Anker — in
+`_build_grid` erzeugt), `self.settings` (`last_update_check_at`, `dismissed_version`), der
+Banner-Frame-Ref `self._update_banner`, sowie `today_iso`, `pick_asset_url` (aus
+`src.updater`), `webbrowser`, `platform`, Theme (`ACCENT`, `ACCENT_HOVER`, `FONT_BOLD`,
+`label_button`) und `attach_tooltip`.
+
+Aufrufer: `self._bg.check_update(on_result=self._handle_update_check_result)` in `__init__`;
+`self._update_banner = None` initialisiert dort den Frame-Ref.
+
+## Neues Modul `src/update_banner.py`
+
+Tk-nutzend, aber **kein** `src.ui`-Import → kein Circular-Import. Module-Level-Imports:
+`tkinter as tk`, `webbrowser`, `platform`, `from src.theme import ACCENT, ACCENT_HOVER,
+FONT_BOLD, label_button`, `from src.tooltip import attach_tooltip`, `from src.updater import
+pick_asset_url, today_iso`.
+
+```python
+class UpdateBanner:
+    """GitHub-Release-Hinweis als Banner über dem Kalender. Hält den Frame-
+    Lebenszyklus; der Pack-Anker (App.grid_container) wird lazy über get_anchor
+    gelesen, da er erst nach dem Grid-Build existiert."""
+
+    def __init__(self, root, settings, get_anchor):
+        self._root = root
+        self._settings = settings
+        self._get_anchor = get_anchor    # lambda: App.grid_container
+        self._banner = None              # Frame oder None (None = nicht sichtbar)
+
+    def handle_check_result(self, release, newer):
+        """Läuft im UI-Thread (on_result von BackgroundTaskRunner.check_update).
+        Persistiert den Check-Stand und zeigt ggf. den Banner. `newer` ist bereits
+        im Worker ausgewertet."""
+        self._settings.set("last_update_check_at", today_iso())
+        if not newer:
+            return
+        if release.version == self._settings.get("dismissed_version"):
+            return
+        self._show(release)
+
+    def _show(self, release):
+        if self._banner is not None:
+            return
+        self._banner = tk.Frame(self._root, bg=ACCENT)
+        self._banner.pack(before=self._get_anchor(), fill=tk.X, padx=10, pady=(5, 0))
+        # Version-Label (links), Download-Button + ✕-Dismiss (rechts) — verbatim
+        # aus dem bisherigen _show_update_banner, inkl. Tooltip am ✕.
+
+    def _open_download(self, release):
+        url = pick_asset_url(
+            release.assets, platform.system(), release.version) or release.html_url
+        webbrowser.open(url)
+
+    def _dismiss(self, version):
+        self._settings.set("dismissed_version", version)
+        if self._banner is not None:
+            self._banner.destroy()
+            self._banner = None
+```
+
+Die Button-Callbacks im `_show` binden `lambda: self._dismiss(release.version)` bzw.
+`lambda: self._open_download(release)` (analog Bestand). Strings/Farben/Fonts byte-identisch.
+
+## App-Wiring
+
+- `__init__`: das bisherige `self._update_banner = None` ersetzen durch
+  ```python
+  self._update_banner = UpdateBanner(
+      self.root, self.settings, lambda: self.grid_container)
+  ```
+  (`self._update_banner` ist jetzt die **Komponente** statt des Frames; den Frame hält die
+  Komponente intern.)
+- `self._bg.check_update(on_result=self._handle_update_check_result)` →
+  `self._bg.check_update(on_result=self._update_banner.handle_check_result)`.
+- Import ergänzen: `from src.update_banner import UpdateBanner`.
+- **Entfernt aus `App`:** `_handle_update_check_result`, `_show_update_banner`,
+  `_open_update_download`, `_dismiss_update_banner`.
+
+Imports, die dadurch in `ui.py` ggf. ungenutzt werden (`webbrowser`, `pick_asset_url`,
+`today_iso`, ggf. `Release`-Annotation), per Lint/F401 prüfen und trimmen. `platform`,
+`ACCENT`, `FONT_BOLD`, `label_button`, `attach_tooltip` bleiben sehr wahrscheinlich
+anderweitig in `ui.py` genutzt — nur tatsächlich ungenutzte entfernen.
+
+## Tests (`tests/test_update_banner.py`, ohne Tk)
+
+- `handle_check_result` (mit Fake-`settings` + gemocktem `_show` auf der Instanz):
+  - setzt `last_update_check_at` **immer** (auch wenn nicht neuer / ausgeblendet);
+  - `newer=False` → `_show` **nicht** aufgerufen;
+  - `release.version == dismissed_version` → `_show` **nicht** aufgerufen;
+  - neu + nicht ausgeblendet → `_show` **einmal** aufgerufen.
+- `_open_download` (Monkeypatch `webbrowser.open` + `pick_asset_url`):
+  - URL = Rückgabe von `pick_asset_url`;
+  - `pick_asset_url` liefert `None` → Fallback auf `release.html_url`.
+
+Fakes: `_FakeSettings` mit `get`/`set` (dict-gestützt); `release` als einfaches Objekt mit
+`version`/`assets`/`html_url`.
+
+## Verifikation (AC — Verhalten unverändert)
+
+- Volle Suite grün, `ruff check .` sauber, Import-Smoke (`import src.ui`,
+  `import src.update_banner` — kein Circular-Import).
+- Manueller App-Start (Banner-Pfad ist nur bei verfügbarem Update + 1×/Tag sichtbar; mind.
+  Start ohne Fehler verifizieren).
+
+## Nicht-Ziele (Folge-PR)
+
+- `GridRenderer` (Rendering-Extraktion) — der verbleibende große Block.

--- a/src/ui.py
+++ b/src/ui.py
@@ -8,7 +8,6 @@ import logging
 import os
 import platform
 import time
-import webbrowser
 from src.time_utils import (
     DAYS_DE, MONTHS_DE,
     calculate_hours, format_iso_date, get_week_dates, get_week_label, week_spans_months,
@@ -17,19 +16,15 @@ from src.holidays_de import get_holidays
 from src.tooltip import attach_tooltip
 
 from src.version import VERSION, version_label
-from src.updater import (
-    pick_asset_url,
-    today_iso,
-    Release,
-)
 
 from src.background_tasks import BackgroundTaskRunner
 from src.sync_orchestrator import _classify_sync_error, SyncOrchestrator
+from src.update_banner import UpdateBanner
 from src.dialogs.entry_dialog import open_entry_dialog
 from src.dialogs.send_dialog import open_send_dialog
 from src.dialogs.settings_dialog import open_settings_dialog
 from src.theme import (
-    BG, CELL_BG, WEEKEND_BG, ACCENT, ACCENT_HOVER, TEXT, TEXT_MUTED,
+    BG, CELL_BG, WEEKEND_BG, ACCENT, TEXT, TEXT_MUTED,
     _should_show_delete_button,
     ENTRY_BG, WEEKEND_ENTRY_BG, WEEKEND_FG,
     HOLIDAY_BG, HOLIDAY_BG_HOVER, HOLIDAY_ACCENT,
@@ -37,7 +32,7 @@ from src.theme import (
     FONT, FONT_BOLD, FONT_HEADER, FONT_HEADER_SMALL, FONT_FOOTER, FONT_SMALL, FONT_TINY,
     CELL_BG_HOVER, WEEKEND_BG_HOVER, ENTRY_BG_HOVER, WEEKEND_ENTRY_BG_HOVER,
     apply_dark_titlebar, themed_askyesno, themed_ask_delete_choice, themed_showinfo,
-    icon_button, label_button, secondary_button, set_toggle_active, toggle_button,
+    icon_button, secondary_button, set_toggle_active, toggle_button,
     _stray_click_suppressed,
 )
 
@@ -171,8 +166,9 @@ class App:
             ),
         )
         self._bg.fetch_sender_email()
-        self._update_banner = None
-        self._bg.check_update(on_result=self._handle_update_check_result)
+        self._update_banner = UpdateBanner(
+            self.root, self.settings, lambda: self.grid_container)
+        self._bg.check_update(on_result=self._update_banner.handle_check_result)
         self._bg.reconcile_on_start(on_ok=self._refresh)
         self.root.protocol("WM_DELETE_WINDOW", self._on_close)
 
@@ -207,65 +203,6 @@ class App:
                     "Der Abgleich wird beim nächsten Start erneut versucht.",
                 )
         self._refresh()
-
-    def _handle_update_check_result(self, release: "Release", newer: bool):
-        """Läuft im UI-Thread. Persistiert den Check-Stand und zeigt ggf. den Banner.
-
-        `is_newer` ist bereits im Worker ausgewertet, damit hier keine ungeschützte
-        Logik im Tk-Event-Loop läuft.
-        """
-        self.settings.set("last_update_check_at", today_iso())
-        if not newer:
-            return
-        if release.version == self.settings.get("dismissed_version"):
-            return
-        self._show_update_banner(release)
-
-    def _show_update_banner(self, release: "Release"):
-        if self._update_banner is not None:
-            return
-        self._update_banner = tk.Frame(self.root, bg=ACCENT)
-        self._update_banner.pack(
-            before=self.grid_container, fill=tk.X, padx=10, pady=(5, 0),
-        )
-
-        tk.Label(
-            self._update_banner,
-            text=f"Version {release.version} verfügbar",
-            bg=ACCENT, fg="#ffffff", font=FONT_BOLD,
-        ).pack(side=tk.LEFT, padx=10, pady=6)
-
-        dismiss_btn = label_button(
-            self._update_banner, "✕",
-            lambda: self._dismiss_update_banner(release.version),
-            bg=ACCENT, fg="#ffffff",
-            hover_bg=ACCENT_HOVER, hover_fg="#ffffff",
-            font=FONT_BOLD,
-            label_padx=8,
-        )
-        dismiss_btn.pack(side=tk.RIGHT, padx=(0, 4), pady=6)
-        attach_tooltip(dismiss_btn, "Diese Version ausblenden")
-
-        label_button(
-            self._update_banner, "Download",
-            lambda: self._open_update_download(release),
-            bg="#ffffff", fg=ACCENT,
-            hover_bg="#f0f0f0", hover_fg=ACCENT_HOVER,
-            font=FONT_BOLD,
-            label_padx=14, label_pady=2,
-        ).pack(side=tk.RIGHT, padx=8, pady=4)
-
-    def _open_update_download(self, release: "Release"):
-        url = pick_asset_url(
-            release.assets, platform.system(), release.version,
-        ) or release.html_url
-        webbrowser.open(url)
-
-    def _dismiss_update_banner(self, version: str):
-        self.settings.set("dismissed_version", version)
-        if self._update_banner is not None:
-            self._update_banner.destroy()
-            self._update_banner = None
 
     def _build_header(self):
         frame = tk.Frame(self.root, bg=BG)

--- a/src/update_banner.py
+++ b/src/update_banner.py
@@ -1,0 +1,80 @@
+"""GitHub-Release-Hinweis als Banner über dem Kalender (anzeigen, Download
+öffnen, ausblenden). Eigenständig herausgelöst aus der App (#49).
+
+Tk-nutzend, aber ohne src.ui-Import (kein Circular-Import). Der Pack-Anker
+(App.grid_container) wird lazy über get_anchor gelesen, weil er erst nach dem
+Grid-Build existiert."""
+
+import platform
+import tkinter as tk
+import webbrowser
+
+from src.theme import ACCENT, ACCENT_HOVER, FONT_BOLD, label_button
+from src.tooltip import attach_tooltip
+from src.updater import pick_asset_url, today_iso
+
+
+class UpdateBanner:
+    def __init__(self, root, settings, get_anchor):
+        self._root = root
+        self._settings = settings
+        self._get_anchor = get_anchor    # lambda: App.grid_container
+        self._banner = None              # Frame oder None (None = nicht sichtbar)
+
+    def handle_check_result(self, release, newer):
+        """Läuft im UI-Thread (on_result von BackgroundTaskRunner.check_update).
+        Persistiert den Check-Stand und zeigt ggf. den Banner. `newer` ist bereits
+        im Worker ausgewertet, damit hier keine ungeschützte Logik im Tk-Event-
+        Loop läuft."""
+        self._settings.set("last_update_check_at", today_iso())
+        if not newer:
+            return
+        if release.version == self._settings.get("dismissed_version"):
+            return
+        self._show(release)
+
+    def _show(self, release):
+        if self._banner is not None:
+            return
+        self._banner = tk.Frame(self._root, bg=ACCENT)
+        self._banner.pack(
+            before=self._get_anchor(), fill=tk.X, padx=10, pady=(5, 0),
+        )
+
+        tk.Label(
+            self._banner,
+            text=f"Version {release.version} verfügbar",
+            bg=ACCENT, fg="#ffffff", font=FONT_BOLD,
+        ).pack(side=tk.LEFT, padx=10, pady=6)
+
+        dismiss_btn = label_button(
+            self._banner, "✕",
+            lambda: self._dismiss(release.version),
+            bg=ACCENT, fg="#ffffff",
+            hover_bg=ACCENT_HOVER, hover_fg="#ffffff",
+            font=FONT_BOLD,
+            label_padx=8,
+        )
+        dismiss_btn.pack(side=tk.RIGHT, padx=(0, 4), pady=6)
+        attach_tooltip(dismiss_btn, "Diese Version ausblenden")
+
+        label_button(
+            self._banner, "Download",
+            lambda: self._open_download(release),
+            bg="#ffffff", fg=ACCENT,
+            hover_bg="#f0f0f0", hover_fg=ACCENT_HOVER,
+            font=FONT_BOLD,
+            label_padx=14, label_pady=2,
+        ).pack(side=tk.RIGHT, padx=8, pady=4)
+
+    def _open_download(self, release):
+        url = pick_asset_url(
+            release.assets, platform.system(), release.version,
+        ) or release.html_url
+        webbrowser.open(url)
+
+    def _dismiss(self, version):
+        self._settings.set("dismissed_version", version)
+        if self._banner is not None:
+            self._banner.destroy()
+            self._banner = None

--- a/tests/test_update_banner.py
+++ b/tests/test_update_banner.py
@@ -1,0 +1,83 @@
+"""UpdateBanner: Entscheidungslogik (handle_check_result) und Download-URL-Wahl
+ohne Tk — _show wird gemockt, webbrowser/pick_asset_url gepatcht."""
+
+from unittest.mock import MagicMock
+
+import src.update_banner as ub
+from src.update_banner import UpdateBanner
+
+
+class _FakeSettings:
+    def __init__(self, dismissed_version=None):
+        self._d = {"dismissed_version": dismissed_version}
+
+    def get(self, key, default=None):
+        return self._d.get(key, default)
+
+    def set(self, key, value):
+        self._d[key] = value
+
+
+def _release(version="1.2.0", html_url="https://example/r", assets=None):
+    r = MagicMock()
+    r.version = version
+    r.html_url = html_url
+    r.assets = assets if assets is not None else []
+    return r
+
+
+def _banner(settings):
+    b = UpdateBanner(root=object(), settings=settings, get_anchor=lambda: object())
+    b._show = MagicMock()
+    return b
+
+
+def test_handle_check_result_persists_check_date(monkeypatch):
+    monkeypatch.setattr(ub, "today_iso", lambda: "2026-06-23")
+    s = _FakeSettings()
+    b = _banner(s)
+    b.handle_check_result(_release(), newer=False)
+    assert s.get("last_update_check_at") == "2026-06-23"
+
+
+def test_handle_check_result_not_newer_does_not_show(monkeypatch):
+    monkeypatch.setattr(ub, "today_iso", lambda: "2026-06-23")
+    b = _banner(_FakeSettings())
+    b.handle_check_result(_release(), newer=False)
+    b._show.assert_not_called()
+
+
+def test_handle_check_result_dismissed_version_does_not_show(monkeypatch):
+    monkeypatch.setattr(ub, "today_iso", lambda: "2026-06-23")
+    b = _banner(_FakeSettings(dismissed_version="1.2.0"))
+    b.handle_check_result(_release(version="1.2.0"), newer=True)
+    b._show.assert_not_called()
+
+
+def test_handle_check_result_new_version_shows(monkeypatch):
+    monkeypatch.setattr(ub, "today_iso", lambda: "2026-06-23")
+    b = _banner(_FakeSettings(dismissed_version="1.1.0"))
+    rel = _release(version="1.2.0")
+    b.handle_check_result(rel, newer=True)
+    b._show.assert_called_once_with(rel)
+
+
+def test_open_download_uses_asset_url(monkeypatch):
+    opened = []
+    monkeypatch.setattr(ub.webbrowser, "open", lambda url: opened.append(url))
+    monkeypatch.setattr(ub, "pick_asset_url",
+                        lambda assets, sysname, ver: "https://asset/dl")
+    b = UpdateBanner(root=object(), settings=_FakeSettings(),
+                     get_anchor=lambda: object())
+    b._open_download(_release())
+    assert opened == ["https://asset/dl"]
+
+
+def test_open_download_falls_back_to_html_url(monkeypatch):
+    opened = []
+    monkeypatch.setattr(ub.webbrowser, "open", lambda url: opened.append(url))
+    monkeypatch.setattr(ub, "pick_asset_url", lambda assets, sysname, ver: None)
+    b = UpdateBanner(root=object(), settings=_FakeSettings(),
+                     get_anchor=lambda: object())
+    b._open_download(_release(html_url="https://example/r"))
+    assert opened == ["https://example/r"]


### PR DESCRIPTION
> ⚠️ **Stacked auf #70 → #71** — bitte in der Reihenfolge **#70, dann #71, dann diesen** mergen. Dieser Branch zweigt von `refactor/ui-sync-orchestrator` (#71) ab; bis #70/#71 in `master` sind, enthält der Diff hier auch deren Commits.

Teil von #49 (dritter Extraktions-Schritt der ui.py-Entflechtung, nach `BackgroundTaskRunner` #70 und `SyncOrchestrator` #71).

## Problem

Der Update-Banner (GitHub-Release-Hinweis: anzeigen, Download öffnen, ausblenden) lag als vier Methoden in der `App`.

## Lösung

Neues Modul **`src/update_banner.py`** mit der Komponente **`UpdateBanner`**:
- `handle_check_result(release, newer)` — persistiert den Check-Stand, zeigt den Banner falls neuer + nicht ausgeblendet.
- `_show` / `_open_download` / `_dismiss` — Banner-Frame-Lebenszyklus (verbatim aus den alten Methoden).

`App` konstruiert die Komponente (`self._update_banner = UpdateBanner(self.root, self.settings, lambda: self.grid_container)`) und reicht die `check_update`-Ergebnisse durch (`on_result=self._update_banner.handle_check_result`). Der Pack-Anker wird lazy über die Closure gelesen. Tk-nutzend, aber kein `src.ui`-Import (kein Circular-Import).

Aus `App` entfernt: die vier Methoden + die dadurch ungenutzten Imports (`webbrowser`, der `src.updater`-Block, `ACCENT_HOVER`, `label_button`). Verhalten unverändert.

## Tests

- Neu `tests/test_update_banner.py` (ohne Tk): Entscheidungslogik von `handle_check_result` (Check-Datum immer gesetzt; nicht-neuer/ausgeblendeter → kein Banner; neu → Banner) und Download-URL-Wahl (Asset-URL bzw. `html_url`-Fallback).
- Volle Suite: **539 passed, 1 skipped**. `ruff check .` sauber. App-Start manuell verifiziert (kein Traceback).

## Scope / Folge-PR

Verbleibend für #49: `GridRenderer` (das große Rendering-Cluster).

## Doku

Enthält Design-Spec + Implementierungsplan unter `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
