### PR TITLE
refactor(ui): Rendering in GridRenderer auslagern — #49 Abschluss (stacked auf #72)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,8 +144,12 @@ Lokal: `pytest` aus dem Repo-Root. Alle Tests müssen vor dem PR-Merge grün sei
 
 ## Struktur
 
+> Detaillierte Architektur-Referenz (Schichten, App-Komponenten, Verträge,
+> Threading-Modell): **`src/CLAUDE.md`** — bei Verantwortlichkeits-Änderungen
+> mitpflegen.
+
 - `src/main.py` — Einstiegspunkt; baut `Tk`-Root, instanziert `Storage`/`Settings`/`App`, behandelt `--minimized`
-- `src/ui.py` — Tkinter-GUI (Kalender, Header, Banner-Updater)
+- `src/ui.py` — Tkinter-GUI; `App` ist schlanker Koordinator über `GridRenderer`/`BackgroundTaskRunner`/`SyncOrchestrator`/`UpdateBanner` (siehe `src/CLAUDE.md`)
 - `src/dialogs/` — Modal-Dialoge (`entry_dialog`, `send_dialog`, `settings_dialog`)
 - `src/storage.py` — JSON-Persistenz der Zeiteinträge (Schlüssel: ISO-Datum)
 - `src/settings.py` — Benutzereinstellungen mit Defaults

--- a/README.md
+++ b/README.md
@@ -25,10 +25,15 @@ Desktop-App zur Erfassung von Arbeitszeiten mit Kalenderansicht, PDF-Report und 
 Zeiterfassung/
 ├── src/
 │   ├── main.py            # Einstiegspunkt
-│   ├── ui.py              # Tkinter-GUI (Kalender, Header, Banner-Updater)
-│   ├── dialogs/           # Modal-Dialoge (entry, send, settings, share, import, conflicts)
+│   ├── ui.py              # Tkinter-GUI; App koordiniert die Komponenten (Chrome, Navigation, Dialog-Routing)
+│   ├── grid_renderer.py   # Kalender-/Grid-Rendering (Monats-/Wochenansicht, Zelltypen, Double-Buffer)
+│   ├── background_tasks.py # Hintergrund-Worker + Thread-Mechanik (Token-Refresh, Update-Check, Reconcile)
+│   ├── sync_orchestrator.py # Drive-Sync-Steuerung (manuell/Tray/Pull/Quit, Fehler-Aufbereitung)
+│   ├── update_banner.py   # GitHub-Release-Hinweis-Banner
+│   ├── dialogs/           # Modal-Dialoge (entry, send, settings, share, import, conflicts, category)
 │   ├── storage.py         # JSON-Persistenz der Zeiteinträge
 │   ├── settings.py        # Einstellungen mit Standardwerten
+│   ├── category_defaults.py # Default-Kategorien für Zeit-Slots
 │   ├── report.py          # HTML- & PDF-Reportgenerierung
 │   ├── mail.py            # Gmail OAuth2-Authentifizierung & Versand
 │   ├── drive.py           # Google Drive API-Wrapper (Multi-Device-Sync)
@@ -59,6 +64,8 @@ Zeiterfassung/
 ├── settings.json          # Benutzereinstellungen (wird automatisch erstellt)
 └── zeiterfassung.json     # Gespeicherte Zeiteinträge (wird automatisch erstellt)
 ```
+
+> Detaillierte Architektur — die `App`-Komponenten (`GridRenderer`, `BackgroundTaskRunner`, `SyncOrchestrator`, `UpdateBanner`), ihre Verträge und das Threading-Modell: [`src/CLAUDE.md`](src/CLAUDE.md).
 
 ## Installation
 

--- a/docs/superpowers/plans/2026-06-23-grid-renderer.md
+++ b/docs/superpowers/plans/2026-06-23-grid-renderer.md
@@ -399,6 +399,14 @@ In `src/ui.py` folgende Methoden **komplett löschen** (sie leben jetzt im Rende
 
 **Behalten:** `_refresh` (Shim), `_open_dialog`, `_delete_day`, `_navigate`, `_set_view`, `_update_toggle_style`, `_on_tab_toggle_view`, `_build_header`, `_build_footer`.
 
+**WICHTIG — `_fmt_slot_line`-Aufrufer in `_delete_day`:** `_delete_day` bleibt in `App`, ruft aber `self._fmt_slot_line(s)` an zwei Stellen (~1061, ~1067). Da `_fmt_slot_line` in den Renderer wandert, diese beiden Aufrufe auf den Static der Klasse umstellen (`ui.py` importiert `GridRenderer` aus Step 1):
+```python
+options.append((f"entry:{i}", f"Arbeitszeit  {GridRenderer._fmt_slot_line(s)}"))
+...
+options.append((f"reservation:{i}", f"Reservierung  {GridRenderer._fmt_slot_line(s)}"))
+```
+(`_fmt_slot_line` bleibt `@staticmethod` auf `GridRenderer`.) Per Grep verifizieren, dass `self._fmt_slot_line` danach nirgends mehr in `ui.py` vorkommt.
+
 - [ ] **Step 5: Ungenutzte Imports trimmen**
 
 Per `python -m ruff check src/ui.py` die jetzt ungenutzten Imports finden und entfernen — erwartbar betroffen: aus `src.theme` viele Zell-Farben/-Fonts (z.B. `CELL_BG`, `WEEKEND_BG`, `ENTRY_BG`, `WEEKEND_ENTRY_BG`, `WEEKEND_FG`, `HOLIDAY_*`, `RESERVATION_ACCENT`, `TODAY_ACCENT`, `*_HOVER`, `FONT_TINY`, `_should_show_delete_button`), aus `src.time_utils` ggf. `DAYS_DE`/`get_week_dates`?/`week_spans_months`/`calculate_hours`, `get_holidays`, ggf. `attach_tooltip`, `calendar`. **Nur tatsächlich ungenutzte entfernen** — Namen, die `_navigate`/`_set_view`/`_open_dialog`/`_delete_day`/`_build_header`/`_build_footer` noch nutzen, bleiben (z.B. `get_week_dates` in `_navigate`, `FONT_HEADER`? nein bleibt im Renderer, `ACCENT`/`BG`/`FONT_FOOTER` in `_build_footer`/`_build_header`, `format_iso_date`/`themed_*` in `_delete_day`). Lint entscheidet.

--- a/docs/superpowers/plans/2026-06-23-grid-renderer.md
+++ b/docs/superpowers/plans/2026-06-23-grid-renderer.md
@@ -1,0 +1,448 @@
+# GridRenderer-Extraktion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Das Kalender-/Grid-Rendering aus `src/ui.py` in eine eigene Komponente `GridRenderer` (`src/grid_renderer.py`) auslagern — letzter Schritt der ui.py-Entflechtung (#49).
+
+**Architecture:** Neues Tk-Rendering-Modul (kein `src.ui`-Import). `GridRenderer` besitzt den kompletten Rendering-State (Double-Buffer, Geometrie); bekommt Stores per Konstruktor, Datum/View per `refresh(...)`, Interaktion (`_open_dialog`/`_delete_day`) als Callbacks. `App._refresh` wird ein dünner Shim. Verhalten unverändert.
+
+**Tech Stack:** Python 3, Tkinter, pytest.
+
+## Global Constraints
+
+- Verhalten unverändert (reiner Move-Refactor) — alle Strings/Farben/Fonts/Geometrie byte-identisch.
+- `src/grid_renderer.py`: **kein** `src.ui`-Import. Datum/View ist **nicht** Renderer-Eigentum — kommt per `refresh(...)`/`measure_max_width(...)`-Parametern (App bleibt die Quelle).
+- `measure_max_width` behält die bewusste `settings._data["show_weekend"]`-Direktmutation (Pre-Mainloop-Probing, kein Disk-Save).
+- Lint: `python -m ruff check .` (ganzes Repo) grün. Tests: `python -m pytest` grün.
+- Commit-Messages enden mit `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`.
+- PowerShell 5.1: kein `&&`; `;` oder `if ($?) { }`. Match Edits **by content**, nicht by Zeilennummer (`~` = ungefähr).
+
+### Substitutions-Tabelle (für ALLE verbatim verschobenen Methoden)
+
+Beim Verschieben jeder Methode aus `App` in `GridRenderer` exakt diese Ersetzungen anwenden — sonst nichts ändern:
+
+| In `App` (alt) | In `GridRenderer` (neu) |
+|---|---|
+| `self.storage` | `self._storage` |
+| `self.settings` | `self._settings` |
+| `self.reservation_store` | `self._reservation_store` |
+| `self.conflicts_store` | `self._conflicts_store` |
+| `self.root` | `self._root` |
+| `self.view_mode` | `self._view_mode` |
+| `self.year` / `self.month` | `self._year` / `self._month` |
+| `self.iso_year` / `self.current_week` | `self._iso_year` / `self._current_week` |
+| `self.grid_frames` | `self._grid_frames` |
+| `self.grid_frame` | `self._grid_frame` |
+| `self.grid_container` | `self.grid_container` *(unverändert — public)* |
+| `self.header_label` | `self._header_label` |
+| `self.footer_label` | `self._footer_label` |
+| `self._open_dialog` | `self._on_cell_click` |
+| `self._delete_day` | `self._on_cell_right_click` |
+
+Unverändert bleiben (bereits `_`-prefixed, werden Renderer-Attribute/-Methoden): `self._active_grid_idx`, `self._fixed_width`, `self._suppress_geometry`, `self._last_refresh_view`, `self._last_refresh_columns`, `self._reservations_active` *(jetzt das injizierte Callable, gleiche Aufruf-Syntax)*, und alle `self._build_*` / `self._hover` / `self._truncate` / `self._fmt_slot_line` / `self._entry_hours` / `self._visible_day_count` / `self._dates_with_unresolved_conflicts` / `self._cell_layout_metrics` / `self._get_inactive_grid` / `self._activate_grid` / `self._update_footer` / `self._refresh_month` / `self._refresh_week` / `self._build_grid_header` (alle ziehen mit).
+
+---
+
+### Task 1: `src/grid_renderer.py` + Tests
+
+**Files:**
+- Create: `src/grid_renderer.py`
+- Test: `tests/test_grid_renderer.py` (neu)
+- Modify: `tests/test_ui_hover.py` (Import-Migration)
+
+**Interfaces:**
+- Produces: `GridRenderer(root, storage, settings, reservation_store, conflicts_store, on_cell_click, on_cell_right_click, reservations_active)` mit `build_grid(parent)`, `attach_labels(header_label, footer_label)`, `refresh(view_mode, year, month, iso_year, current_week)`, `measure_max_width(view_mode, year, month, iso_year, current_week)`, der public-Attribut `grid_container`, und allen verschobenen Rendering-Methoden. `on_cell_click(date_str)` / `on_cell_right_click(date_str)` / `reservations_active()` sind Callables.
+
+**Hinweis:** `ui.py` wird in DIESER Task NICHT verändert (außer dem Test-Import). Die Rendering-Methoden existieren danach transient in beiden Dateien — `ui.py` nutzt weiter seine eigenen (Task 2 entfernt sie). Der Baum bleibt grün.
+
+- [ ] **Step 1: Failing tests schreiben**
+
+`tests/test_grid_renderer.py`:
+```python
+"""GridRenderer: reine Helfer ohne Tk (statics + Methoden, die nur settings/
+conflicts_store lesen)."""
+
+from unittest.mock import MagicMock
+
+from src.time_utils import calculate_hours
+from src.grid_renderer import GridRenderer
+
+
+def _renderer(show_weekend=True, conflicts=None):
+    settings = MagicMock(get=lambda k, d=None: {"show_weekend": show_weekend}.get(k, d))
+    cstore = MagicMock(get_all=lambda: conflicts) if conflicts is not None else None
+    return GridRenderer(
+        root=object(), storage=object(), settings=settings,
+        reservation_store=None, conflicts_store=cstore,
+        on_cell_click=lambda d: None, on_cell_right_click=lambda d: None,
+        reservations_active=lambda: False,
+    )
+
+
+def test_fmt_slot_line_with_category():
+    assert GridRenderer._fmt_slot_line(
+        {"start": "08:00", "end": "12:00", "kategorie": "Büro"}) == "08:00-12:00  Büro"
+
+
+def test_fmt_slot_line_without_category():
+    assert GridRenderer._fmt_slot_line(
+        {"start": "08:00", "end": "12:00"}) == "08:00-12:00"
+
+
+def test_truncate_clips_long_text():
+    assert GridRenderer._truncate("Donnerstag", 5) == "Donn…"
+
+
+def test_truncate_keeps_short_text():
+    assert GridRenderer._truncate("Mo", 5) == "Mo"
+
+
+def test_entry_hours_sums_slots():
+    entry = {"slots": [
+        {"start": "08:00", "end": "12:00", "pause": 0},
+        {"start": "13:00", "end": "17:00", "pause": 0},
+    ]}
+    expected = round(
+        calculate_hours("08:00", "12:00", pause_minutes=0)
+        + calculate_hours("13:00", "17:00", pause_minutes=0), 2)
+    assert _renderer()._entry_hours(entry) == expected == 8.0
+
+
+def test_entry_hours_subtracts_pause():
+    entry = {"slots": [{"start": "08:00", "end": "12:00", "pause": 30}]}
+    assert _renderer()._entry_hours(entry) == 3.5
+
+
+def test_visible_day_count_with_weekend():
+    assert _renderer(show_weekend=True)._visible_day_count() == 7
+
+
+def test_visible_day_count_without_weekend():
+    assert _renderer(show_weekend=False)._visible_day_count() == 5
+
+
+def test_dates_with_unresolved_conflicts_filters_entry_kind():
+    conflicts = [
+        {"key": "2026-06-01", "kind": "entry", "resolved": False},
+        {"key": "2026-06-02", "kind": "entry", "resolved": True},
+        {"key": "2026-06-03", "kind": "reservation", "resolved": False},
+    ]
+    assert _renderer(conflicts=conflicts)._dates_with_unresolved_conflicts() == {"2026-06-01"}
+
+
+def test_dates_with_unresolved_conflicts_none_store():
+    assert _renderer()._dates_with_unresolved_conflicts() == set()
+```
+
+- [ ] **Step 2: Test failen sehen**
+
+Run: `python -m pytest tests/test_grid_renderer.py -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'src.grid_renderer'`.
+
+- [ ] **Step 3: Modul-Gerüst (Header, Imports, Konstanten, Konstruktor, öffentliche Methoden)**
+
+`src/grid_renderer.py` — Anfang:
+```python
+"""Kalender-/Grid-Rendering der App (Monats-/Wochenansicht, Zelltypen,
+Double-Buffer). Eigenständig herausgelöst aus dem App-God-Object (#49).
+
+Tk-nutzend, aber kein src.ui-Import. Datum/View ist NICHT Renderer-Eigentum:
+es kommt per refresh(...)/measure_max_width(...)-Parametern; App bleibt die
+Quelle (von _navigate/_set_view mutiert)."""
+
+import calendar
+import datetime
+import platform
+import tkinter as tk
+
+from src.time_utils import (
+    DAYS_DE, MONTHS_DE,
+    calculate_hours, get_week_dates, get_week_label, week_spans_months,
+)
+from src.holidays_de import get_holidays
+from src.tooltip import attach_tooltip
+from src.theme import (
+    BG, CELL_BG, WEEKEND_BG, ACCENT, TEXT, TEXT_MUTED,
+    ENTRY_BG, WEEKEND_ENTRY_BG, WEEKEND_FG,
+    HOLIDAY_BG, HOLIDAY_BG_HOVER, HOLIDAY_ACCENT,
+    RESERVATION_ACCENT, TODAY_ACCENT,
+    CELL_BG_HOVER, WEEKEND_BG_HOVER, ENTRY_BG_HOVER, WEEKEND_ENTRY_BG_HOVER,
+    FONT, FONT_BOLD, FONT_TINY, FONT_SMALL, FONT_HEADER, FONT_HEADER_SMALL,
+    _should_show_delete_button,
+)
+
+# Probe-Label-Geometrie zur Zellgrößen-Messung (aus ui.py übernommen).
+PROBE_WIDTH_WIDE = 12
+PROBE_WIDTH_NARROW = 8
+PROBE_HEIGHT = 3
+
+
+class GridRenderer:
+    def __init__(self, root, storage, settings, reservation_store, conflicts_store,
+                 on_cell_click, on_cell_right_click, reservations_active):
+        self._root = root
+        self._storage = storage
+        self._settings = settings
+        self._reservation_store = reservation_store
+        self._conflicts_store = conflicts_store
+        self._on_cell_click = on_cell_click            # (date_str) -> None
+        self._on_cell_right_click = on_cell_right_click  # (date_str) -> None
+        self._reservations_active = reservations_active  # () -> bool
+        # Rendering-State:
+        self.grid_container = None
+        self._grid_frames = None
+        self._active_grid_idx = 0
+        self._grid_frame = None
+        self._header_label = None
+        self._footer_label = None
+        self._fixed_width = None
+        self._suppress_geometry = False
+        self._last_refresh_view = None
+        self._last_refresh_columns = None
+        # Transienter Datum/View-Stand (von refresh gesetzt):
+        self._view_mode = None
+        self._year = None
+        self._month = None
+        self._iso_year = None
+        self._current_week = None
+
+    def build_grid(self, parent):
+        # Double-Buffer: zwei dauerhafte Frames im selben Grid-Slot. Refresh
+        # baut in den inaktiven (versteckt unter dem aktiven), dann lift()
+        # tauscht atomar.
+        self.grid_container = tk.Frame(parent, bg=BG)
+        self.grid_container.pack(fill=tk.BOTH, expand=True, padx=10, pady=5)
+        self.grid_container.rowconfigure(0, weight=1)
+        self.grid_container.columnconfigure(0, weight=1)
+        self._grid_frames = []
+        for _ in range(2):
+            f = tk.Frame(self.grid_container, bg=BG)
+            f.grid(row=0, column=0, sticky="nsew")
+            for col in range(7):
+                f.columnconfigure(col, weight=1)
+            self._grid_frames.append(f)
+        self._grid_frames[0].lift()
+        self._active_grid_idx = 0
+        self._grid_frame = self._grid_frames[0]
+
+    def attach_labels(self, header_label, footer_label):
+        self._header_label = header_label
+        self._footer_label = footer_label
+
+    def refresh(self, view_mode, year, month, iso_year, current_week):
+        self._view_mode = view_mode
+        self._year = year
+        self._month = month
+        self._iso_year = iso_year
+        self._current_week = current_week
+        if self._view_mode == "month":
+            # FONT_HEADER (16pt) + width=16 — längste Variante "September 2026".
+            self._header_label.config(
+                text=f"{MONTHS_DE[self._month]} {self._year}",
+                font=FONT_HEADER, width=16,
+            )
+            self._refresh_month()
+        else:
+            # FONT_HEADER_SMALL (12pt) + width=32 — KW-Variante mit Jahreswechsel.
+            self._header_label.config(
+                text=get_week_label(self._iso_year, self._current_week),
+                font=FONT_HEADER_SMALL, width=32,
+            )
+            self._refresh_week()
+        current_cols = self._visible_day_count()
+        view_changed = self._last_refresh_view != self._view_mode
+        cols_changed = self._last_refresh_columns != current_cols
+        if view_changed or cols_changed:
+            self._last_refresh_view = self._view_mode
+            self._last_refresh_columns = current_cols
+            # Inactive-Frame komplett ersetzen umgeht Tks reqheight-Cache.
+            inactive_idx = 1 - self._active_grid_idx
+            self._grid_frames[inactive_idx].destroy()
+            new_inactive = tk.Frame(self.grid_container, bg=BG)
+            new_inactive.grid(row=0, column=0, sticky="nsew")
+            for col in range(7):
+                new_inactive.columnconfigure(col, weight=1 if col < current_cols else 0)
+            self._grid_frames[inactive_idx] = new_inactive
+            self._grid_frames[self._active_grid_idx].lift()
+            self._root.update_idletasks()
+            if not self._suppress_geometry:
+                width = max(self._fixed_width or 0, self._root.winfo_reqwidth())
+                self._root.geometry(f"{width}x{self._root.winfo_reqheight()}")
+
+    def measure_max_width(self, view_mode, year, month, iso_year, current_week):
+        """Pre-warm: rendert alle 4 (view × show_weekend)-Kombinationen einmal
+        in den versteckten Backbuffer und merkt die maximale reqwidth intern
+        (self._fixed_width). show_weekend wird über _data temporär mutiert
+        (kein Disk-Save) und wiederhergestellt; _suppress_geometry verhindert
+        den Resize während der Messung. Läuft vor mainloop()."""
+        saved_weekend = self._settings.get("show_weekend")
+        max_w = 0
+        self._suppress_geometry = True
+        try:
+            for view in ("month", "week"):
+                for weekend in (True, False):
+                    self._settings._data["show_weekend"] = weekend
+                    self._last_refresh_view = None
+                    self._last_refresh_columns = None
+                    self.refresh(view, year, month, iso_year, current_week)
+                    self._root.update_idletasks()
+                    w = self._root.winfo_reqwidth()
+                    if w > max_w:
+                        max_w = w
+        finally:
+            self._suppress_geometry = False
+            self._settings._data["show_weekend"] = saved_weekend
+            self._last_refresh_view = None
+            self._last_refresh_columns = None
+        self._fixed_width = max_w
+        return max_w
+```
+
+- [ ] **Step 4: Übrige Rendering-Methoden verbatim verschieben**
+
+Aus `src/ui.py` die folgenden Methoden **kopieren** (nicht löschen — das macht Task 2) und in `GridRenderer` einfügen, dabei die **Substitutions-Tabelle** (oben) anwenden:
+
+`_refresh_month`, `_refresh_week`, `_visible_day_count`, `_get_inactive_grid`, `_activate_grid`, `_update_footer`, `_entry_hours`, `_dates_with_unresolved_conflicts`, `_cell_layout_metrics`, `_build_grid_header`, `_build_entry_cell`, `_fmt_slot_line` (static), `_add_reservation_marker`, `_add_delete_button`, `_build_empty_cell`, `_build_day_cell`, `_build_holiday_cell`, `_hover` (static), `_truncate` (static).
+
+Wichtig:
+- `_refresh_month` liest jetzt `self._year`/`self._month`; `_refresh_week` liest `self._iso_year`/`self._current_week` (transient von `refresh` gesetzt) — die Tabelle deckt das ab.
+- Keine `_build_grid`/`_refresh`/`_measure_max_width`-Kopie (sind oben schon als `build_grid`/`refresh`/`measure_max_width` umgesetzt).
+- Importiere in `grid_renderer.py` nur die Theme-/time_utils-Namen, die die verschobenen Methoden tatsächlich nutzen — der Import-Block oben ist die Erwartung; falls eine Methode einen weiteren Namen braucht, ergänzen; ungenutzte entfernen (ruff F401 muss grün sein).
+
+- [ ] **Step 5: `tests/test_ui_hover.py` migrieren**
+
+In `tests/test_ui_hover.py` den Import
+```python
+from src.ui import App
+```
+ändern zu
+```python
+from src.grid_renderer import GridRenderer
+```
+und im Testkörper `App._hover` durch `GridRenderer._hover` ersetzen (gleiche Aufrufe — `_hover` ist eine staticmethod mit identischer Signatur). Sonst nichts ändern.
+
+- [ ] **Step 6: Tests grün + Lint + Import-Smoke**
+
+Run:
+```
+python -m pytest tests/test_grid_renderer.py tests/test_ui_hover.py -q
+python -m ruff check src/grid_renderer.py tests/test_grid_renderer.py tests/test_ui_hover.py
+python -c "import src.grid_renderer"
+python -m pytest -q
+```
+Expected: Helfer- + Hover-Tests grün; Lint sauber (kein F401 in grid_renderer.py); `import src.grid_renderer` ohne Fehler; volle Suite grün (unveränderte Zahl + neue Tests; `ui.py` unverändert lauffähig).
+
+- [ ] **Step 7: Commit**
+
+```
+git add src/grid_renderer.py tests/test_grid_renderer.py tests/test_ui_hover.py
+git commit -m "feat(ui): GridRenderer-Komponente (Rendering aus App herausgeloest) (#49)"
+```
+
+---
+
+### Task 2: `App` verdrahten, Rendering-Methoden + Imports entfernen
+
+**Files:**
+- Modify: `src/ui.py` (`__init__`-Wiring; `_refresh`-Shim; ~19 Rendering-Methoden + `self._fixed_width` + Probe-Konstanten entfernen; Imports trimmen)
+
+**Interfaces:**
+- Consumes: `GridRenderer` (Task 1).
+
+- [ ] **Step 1: Import ergänzen**
+
+In `src/ui.py` bei den `from src...`-Imports ergänzen:
+```python
+from src.grid_renderer import GridRenderer
+```
+
+- [ ] **Step 2: `__init__`-Wiring**
+
+In `src/ui.py` `__init__`:
+
+(a) Direkt nach der `SyncOrchestrator`-Konstruktion (und vor `self._build_header()`) den Renderer konstruieren:
+```python
+        self._renderer = GridRenderer(
+            self.root, self.storage, self.settings, self.reservation_store,
+            self.conflicts_store, self._open_dialog, self._delete_day,
+            self._reservations_active,
+        )
+```
+
+(b) `self._build_grid()` ersetzen durch `self._renderer.build_grid(self.root)`.
+
+(c) Nach `self._build_footer()` (und vor `self._sync.attach_widgets(...)`) ergänzen:
+```python
+        self._renderer.attach_labels(self.header_label, self.footer_label)
+```
+
+(d) `self._fixed_width = self._measure_max_width()` ersetzen durch:
+```python
+        self._renderer.measure_max_width(
+            self.view_mode, self.year, self.month, self.iso_year, self.current_week)
+```
+
+(e) Der UpdateBanner-Anker (`lambda: self.grid_container`) → `lambda: self._renderer.grid_container`.
+
+- [ ] **Step 3: `_refresh`-Shim**
+
+In `src/ui.py` die alte `_refresh`-Methode (der ganze Body, ~481-543) ersetzen durch:
+```python
+    def _refresh(self):
+        self._renderer.refresh(
+            self.view_mode, self.year, self.month, self.iso_year, self.current_week)
+```
+
+- [ ] **Step 4: Rendering-Methoden + `_build_grid` + `_measure_max_width` entfernen**
+
+In `src/ui.py` folgende Methoden **komplett löschen** (sie leben jetzt im Renderer): `_build_grid`, `_measure_max_width`, `_refresh_month`, `_refresh_week`, `_visible_day_count`, `_build_grid_header`, `_build_entry_cell`, `_fmt_slot_line`, `_add_reservation_marker`, `_add_delete_button`, `_build_empty_cell`, `_build_day_cell`, `_build_holiday_cell`, `_get_inactive_grid`, `_activate_grid`, `_update_footer`, `_entry_hours`, `_dates_with_unresolved_conflicts`, `_cell_layout_metrics`, `_hover`, `_truncate`. Außerdem die Modul-Konstanten `PROBE_WIDTH_WIDE`/`PROBE_WIDTH_NARROW`/`PROBE_HEIGHT` (am Dateianfang) entfernen.
+
+**Behalten:** `_refresh` (Shim), `_open_dialog`, `_delete_day`, `_navigate`, `_set_view`, `_update_toggle_style`, `_on_tab_toggle_view`, `_build_header`, `_build_footer`.
+
+- [ ] **Step 5: Ungenutzte Imports trimmen**
+
+Per `python -m ruff check src/ui.py` die jetzt ungenutzten Imports finden und entfernen — erwartbar betroffen: aus `src.theme` viele Zell-Farben/-Fonts (z.B. `CELL_BG`, `WEEKEND_BG`, `ENTRY_BG`, `WEEKEND_ENTRY_BG`, `WEEKEND_FG`, `HOLIDAY_*`, `RESERVATION_ACCENT`, `TODAY_ACCENT`, `*_HOVER`, `FONT_TINY`, `_should_show_delete_button`), aus `src.time_utils` ggf. `DAYS_DE`/`get_week_dates`?/`week_spans_months`/`calculate_hours`, `get_holidays`, ggf. `attach_tooltip`, `calendar`. **Nur tatsächlich ungenutzte entfernen** — Namen, die `_navigate`/`_set_view`/`_open_dialog`/`_delete_day`/`_build_header`/`_build_footer` noch nutzen, bleiben (z.B. `get_week_dates` in `_navigate`, `FONT_HEADER`? nein bleibt im Renderer, `ACCENT`/`BG`/`FONT_FOOTER` in `_build_footer`/`_build_header`, `format_iso_date`/`themed_*` in `_delete_day`). Lint entscheidet.
+
+- [ ] **Step 6: Grep-Kontrolle, Lint, volle Suite, Import-Smoke**
+
+Run:
+```
+python -m ruff check .
+python -m pytest -q
+python -c "import src.ui"
+python -c "import src.grid_renderer"
+python -c "import src.main"
+```
+Grep-Kontrolle in `src/ui.py`: **keine** der in Step 4 gelöschten Methodennamen mehr als `def` vorhanden; `self.grid_container`/`self.grid_frames`/`self._fixed_width`/`self.header_label`-Schreibzugriffe nur noch dort, wo sie hingehören (header_label/footer_label-Erzeugung in `_build_header`/`_build_footer` bleibt). Es darf **kein** `self._build_grid`/`self._measure_max_width`/`self._refresh_month`/`self._refresh_week`-Aufruf mehr geben.
+Expected: Lint sauber; volle Suite grün (unveränderte Zahl); alle Import-Smokes ohne Fehler (kein Circular-Import).
+
+- [ ] **Step 7: Manuelle AC-Verifikation mit Screenshot** *(führt der Controller aus, nicht der Implementer)*
+
+`python -m src.main` starten; Screenshot in **Monats-** und **Wochenansicht**; visuell prüfen: Grid + Wochentags-Header, Entry-/Holiday-/Empty-Zellen, Reservierungs-Marker, Heute-/Konflikt-Rahmen, Footer-Summe, Update-Banner-Position, Weekend-Toggle (5↔7 Spalten), Navigation, Tab-Umschaltung.
+
+- [ ] **Step 8: Commit**
+
+```
+git add src/ui.py
+git commit -m "refactor(ui): App an GridRenderer verdrahten, Rendering-Methoden entfernen (#49)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Modul `GridRenderer` (Konstruktor, build_grid, attach_labels, refresh, measure_max_width, alle Rendering-Methoden, Konstanten): Task 1. ✓
+- App-Wiring (Renderer-Konstruktion, _refresh-Shim, build_grid/measure/anchor, Methoden + Imports raus): Task 2. ✓
+- Tests (reine Helfer) + Hover-Migration: Task 1. ✓
+- AC manuell + Screenshot: Task 2 Step 7. ✓
+
+**Type-Konsistenz:** `GridRenderer(root, storage, settings, reservation_store, conflicts_store, on_cell_click, on_cell_right_click, reservations_active)`; `build_grid(parent)`; `attach_labels(header_label, footer_label)`; `refresh(view_mode, year, month, iso_year, current_week)`; `measure_max_width(view_mode, year, month, iso_year, current_week)`; `App._refresh()` ruft `refresh` mit genau diesen 5 Werten — konsistent. `on_cell_click`/`on_cell_right_click` = `App._open_dialog`/`_delete_day` (beide `(date_str) -> None`); `reservations_active` = `App._reservations_active` (`() -> bool`).
+
+**Platzhalter:** keine.
+
+**Offene Risiken:**
+- Transiente Duplikation nach Task 1 (Rendering-Logik in ui.py UND grid_renderer.py) — gewollt, in Task 2 aufgelöst; jeder Commit für sich grün.
+- Import-Trim (ui.py + grid_renderer.py) strikt per ruff F401 — keine Namen raten.
+- `_refresh`-Shim erhält ALLE bestehenden `self._refresh`-Aufrufer + die als Callback übergebenen `on_refresh=self._refresh`/`on_ok=self._refresh` (SyncOrchestrator/BackgroundTaskRunner) — Signatur `_refresh(self)` bleibt unverändert.
+- Höchstes Risiko visuell: Screenshot-Abnahme in Task 2 Step 7 ist Pflicht.

--- a/docs/superpowers/specs/2026-06-23-grid-renderer-design.md
+++ b/docs/superpowers/specs/2026-06-23-grid-renderer-design.md
@@ -1,0 +1,197 @@
+# Design: ui.py entflechten — GridRenderer (Abschluss)
+
+**Issue:** #49 (ui.py God-Object entflechten), **vierter und letzter** Extraktions-Schritt
+nach `BackgroundTaskRunner` (#70), `SyncOrchestrator` (#71), `UpdateBanner` (#72).
+**Branch:** `refactor/ui-grid-renderer`, gestackt auf `refactor/ui-update-banner` (#72).
+
+**Leitprinzip:** Verhalten unverändert. Das Kalender-/Grid-Rendering — der eigentliche
+God-Object-Kern (~600 Zeilen) — aus `App` in eine eigene Komponente `GridRenderer`
+(`src/grid_renderer.py`) ziehen. Damit ist die ui.py-Entflechtungs-Reihe von #49 durch.
+
+Dies ist die riskanteste Extraktion: visuell sensibel, Double-Buffer + Fenster-Geometrie,
+nicht headless-testbar. Daher kleine, gestaffelte Tasks + Screenshot-Abnahme.
+
+## Ausgangslage
+
+`src/ui.py` ist nach #72 bei ~1136 Zeilen. Das Rendering-Cluster ist intern kohäsiv, hängt
+aber über drei Kanäle an `App`:
+1. **App-State (Stores):** `storage`, `settings`, `reservation_store`, `conflicts_store`.
+2. **Datum/View-State:** `view_mode`, `year`, `month`, `iso_year`, `current_week` — von
+   `_navigate`/`_set_view` mutiert; **bleibt App-Eigentum**, wird per `refresh(...)` übergeben.
+3. **Interaktion:** die Zell-Builder binden `_open_dialog` (Linksklick) und `_delete_day`
+   (Rechtsklick) sowie `_reservations_active` — werden als Callbacks injiziert.
+
+Reiner Rendering-State (Double-Buffer-Frames, Geometrie-Tracking, `_fixed_width`) wandert
+**vollständig** in den Renderer. `header_label`/`footer_label` werden weiter in `App`
+erzeugt (Header/Footer-Chrome), aber vom Renderer beschrieben (per `attach_labels`).
+
+### Methoden-Klassifikation (aus der Coupling-Karte)
+
+- **Pure Rendering → Renderer:** `_refresh`, `_refresh_month`, `_refresh_week`, `_build_grid`,
+  `_build_grid_header`, `_build_entry_cell`, `_build_empty_cell`, `_build_day_cell`,
+  `_build_holiday_cell`, `_get_inactive_grid`, `_activate_grid`, `_update_footer`,
+  `_cell_layout_metrics`, `_add_reservation_marker`, `_add_delete_button`, `_measure_max_width`,
+  `_visible_day_count`, `_dates_with_unresolved_conflicts`, `_entry_hours`, `_hover`,
+  `_truncate`, `_fmt_slot_line`.
+- **Interaktion/Persistenz → bleibt App:** `_open_dialog`, `_delete_day` (Klick-Handler, die
+  die Zellen binden — injiziert).
+- **Navigation/Chrome → bleibt App:** `_navigate`, `_set_view`, `_update_toggle_style`,
+  `_on_tab_toggle_view`, `_build_header`, `_build_footer`.
+
+## Teil A — Neues Modul `src/grid_renderer.py`
+
+Tk-Rendering-Komponente, **kein** `src.ui`-Import. Modul-Konstanten `PROBE_WIDTH_WIDE = 12`,
+`PROBE_WIDTH_NARROW = 8`, `PROBE_HEIGHT = 3` ziehen aus `ui.py` mit.
+
+### Konstruktor & öffentliche Schnittstelle
+
+```python
+class GridRenderer:
+    def __init__(self, root, storage, settings, reservation_store, conflicts_store,
+                 on_cell_click, on_cell_right_click, reservations_active):
+        self._root = root
+        self._storage = storage
+        self._settings = settings
+        self._reservation_store = reservation_store
+        self._conflicts_store = conflicts_store
+        self._on_cell_click = on_cell_click            # App._open_dialog (date_str) -> None
+        self._on_cell_right_click = on_cell_right_click  # App._delete_day (date_str) -> None
+        self._reservations_active = reservations_active  # () -> bool
+        # Rendering-State (von build_grid/attach_labels/measure gesetzt):
+        self.grid_container = None
+        self._grid_frames = None
+        self._active_grid_idx = 0
+        self._grid_frame = None
+        self._header_label = None
+        self._footer_label = None
+        self._fixed_width = None
+        self._suppress_geometry = False
+        self._last_refresh_view = None
+        self._last_refresh_columns = None
+
+    def build_grid(self, parent):
+        """Erzeugt grid_container + die zwei gestapelten Double-Buffer-Frames in parent."""
+
+    def attach_labels(self, header_label, footer_label):
+        """Die in App erzeugten Header-/Footer-Labels, die refresh/_update_footer beschreiben."""
+
+    def refresh(self, view_mode, year, month, iso_year, current_week):
+        """Der eine Render-Eintritt: setzt header_label (Text/Font/Width je View), rendert in
+        den Backbuffer, aktiviert ihn, aktualisiert den Footer, regelt die Fenster-Geometrie."""
+
+    def measure_max_width(self, view_mode, year, month, iso_year, current_week):
+        """Probt die 4 Kombinationen (View × show_weekend) im versteckten Backbuffer und merkt
+        die maximale reqwidth intern (self._fixed_width). show_weekend wird nach dem Proben
+        wiederhergestellt. Vor dem ersten echten refresh aufgerufen."""
+```
+
+### Verhaltens-Details (1:1 zum Bestand)
+
+- **Double-Buffer:** `build_grid` legt `grid_container` (mit `rowconfigure(0, weight=1)`,
+  `columnconfigure(0, weight=1)`) und zwei `tk.Frame`s an (beide `grid(row=0,col=0,
+  sticky="nsew")`), liftet Frame 0, `_active_grid_idx=0`. `_get_inactive_grid` zerstört die
+  Kinder des Backbuffers + reset row/col-config; `_activate_grid` liftet + flippt den Index.
+  Der View-/Spalten-Wechsel-Sonderfall (Backbuffer komplett neu erzeugen, um Tks
+  reqheight-Cache zu leeren) bleibt erhalten.
+- **header_label:** `refresh` setzt Text (Monatsname bzw. KW-Label), Font (`FONT_HEADER` 16
+  / `FONT_HEADER_SMALL` 12) und Width (16/32) je View — verbatim.
+- **Zell-Builder:** binden `self._on_cell_click`/`self._on_cell_right_click` statt der alten
+  direkten `App`-Methoden; `_build_day_cell` reicht sie analog als Lambdas an
+  `_build_holiday_cell` weiter. `_add_delete_button` bindet `self._on_cell_right_click`.
+- **Reservierungen:** `_refresh_month`/`_refresh_week` holen `reservation_store.get_all()` nur
+  wenn `self._reservations_active()` True liefert (sonst `{}`).
+- **measure_max_width:** mutiert `settings._data["show_weekend"]` temporär (wie der Bestand,
+  bewusst nicht via `.set()`), rendert die 4 Kombinationen mit dem übergebenen Datum, merkt
+  `_fixed_width`, stellt `show_weekend` wieder her. Strings/Geometrie unverändert.
+- Statische Helfer `_hover(frame, bg, *labels)`, `_truncate(text, max_len)`,
+  `_fmt_slot_line(slot)` bleiben `@staticmethod`. `_entry_hours(entry)`,
+  `_visible_day_count()`, `_dates_with_unresolved_conflicts()` werden Renderer-Methoden
+  (lesen `settings`/`conflicts_store`).
+
+## Teil B — Verdrahtung in `App`
+
+### `__init__` (Renderer vor `_build_header`; Labels nach Build; measure/refresh delegiert)
+
+```python
+self._renderer = GridRenderer(
+    self.root, self.storage, self.settings, self.reservation_store,
+    self.conflicts_store, self._open_dialog, self._delete_day,
+    self._reservations_active,
+)
+self._build_header()                       # erzeugt header_label (+ sync/nav chrome)
+self._renderer.build_grid(self.root)       # ersetzt das bisherige self._build_grid()
+self._build_footer()                       # erzeugt footer_label
+self._renderer.attach_labels(self.header_label, self.footer_label)
+self._sync.attach_widgets(self.sync_button, self.sync_status_label, self._next_button)
+self._sync.update_status_label()
+self._apply_always_on_top()
+self._apply_tray_setting()
+... bindings ...
+self._renderer.measure_max_width(
+    self.view_mode, self.year, self.month, self.iso_year, self.current_week)
+self._refresh()
+self._update_banner = UpdateBanner(
+    self.root, self.settings, lambda: self._renderer.grid_container)
+self._bg.check_update(on_result=self._update_banner.handle_check_result)
+self._bg.reconcile_on_start(on_ok=self._refresh)
+```
+
+### `_refresh` bleibt als dünner Shim in `App`
+
+Er ist der eine Render-Eintritt für **alle** bestehenden Aufrufer (Navigation, `_set_view`,
+`_delete_day`, `_open_dialog`-`on_change`, sowie die Callbacks `on_refresh=self._refresh` in
+SyncOrchestrator und `on_ok=self._refresh` in BackgroundTaskRunner):
+```python
+def _refresh(self):
+    self._renderer.refresh(
+        self.view_mode, self.year, self.month, self.iso_year, self.current_week)
+```
+
+### Weitere Call-Site-Änderungen
+- `self._build_grid()` → `self._renderer.build_grid(self.root)`; `App._build_grid` entfällt.
+- `self._fixed_width = self._measure_max_width()` → `self._renderer.measure_max_width(...)`
+  (App speichert `_fixed_width` nicht mehr — Renderer-intern).
+- UpdateBanner-Anker `lambda: self.grid_container` → `lambda: self._renderer.grid_container`.
+
+### Entfernt aus `App`
+Alle „Pure Rendering"-Methoden (siehe Klassifikation) + `self._fixed_width` + die
+Probe-Konstanten. **Bleibt:** `_refresh` (Shim), `_open_dialog`, `_delete_day`, `_navigate`,
+`_set_view`, `_update_toggle_style`, `_on_tab_toggle_view`, `_build_header`, `_build_footer`.
+
+Theme-/`time_utils`-/`holidays_de`-/`tooltip`-Imports in `ui.py`, die nur noch das Rendering
+nutzte, per Lint (F401) trimmen; in `grid_renderer.py` neu importieren.
+
+## Tests
+
+- **Migration:** `tests/test_ui_hover.py` → `from src.grid_renderer import GridRenderer`
+  (testet `GridRenderer._hover`). Per Grep prüfen, ob weitere Tests auf verschobene Methoden
+  zeigen, und migrieren.
+- **Neu `tests/test_grid_renderer.py`** (ohne Tk, reine Helfer):
+  - `_entry_hours`: Summe über mehrere Slots (`calculate_hours`).
+  - `_visible_day_count`: 7 bei `show_weekend=True`, 5 bei `False` (Fake-settings).
+  - `_dates_with_unresolved_conflicts`: `conflicts_store.get_all()` liefert eine Liste von
+    Dicts `{"key": <iso>, "kind": <str>, "resolved": <bool>}`; die Methode gibt die Menge der
+    `key`s zurück, für die `kind == "entry"` **und** `not resolved`. Test: Mix aus
+    entry/reservation-kind, resolved/unresolved → nur unresolved entry-keys; `conflicts_store
+    = None` → leere Menge.
+  - `_truncate`: Clipping + `…`-Suffix; kurzer Text unverändert.
+  - `_fmt_slot_line`: `"HH:MM-HH:MM  Kategorie"`-Format.
+
+  Fakes: `_FakeSettings.get(key, default)`; `_FakeConflicts.get_all()` liefert die obige
+  Dict-Liste.
+
+## Verifikation (AC — Verhalten unverändert, höchstes Risiko)
+
+- Volle Suite grün, `ruff check .` sauber, Import-Smoke (`import src.ui`,
+  `import src.grid_renderer`, `import src.main` — kein Circular-Import).
+- **Manueller Smoke mit Screenshot** (Rendering ist nicht headless-testbar):
+  App starten, Screenshot in **Monats-** und **Wochenansicht**; visuell prüfen:
+  Grid + Wochentags-Header rendern; Entry-/Holiday-/Empty-Zellen; Reservierungs-Marker;
+  Heute-Rahmen (blau) / Konflikt-Rahmen (orange); Footer-Summe; Update-Banner-Position;
+  Weekend-Toggle (5↔7 Spalten); Vor/Zurück-Navigation; Tab-Umschaltung.
+
+## Abschluss
+
+Mit diesem PR ist die ui.py-Entflechtung von #49 durch: `App` ist ein schlanker Koordinator
+über `BackgroundTaskRunner`, `SyncOrchestrator`, `UpdateBanner` und `GridRenderer`, plus die
+Interaktions-/Navigations-/Chrome-Schicht.

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -1,0 +1,124 @@
+# src/ — Architektur & Aufbau
+
+Detail-Referenz zum inneren Aufbau von `src/`. Ergänzt die Modul-Liste und die
+Konventionen aus der Projekt-`CLAUDE.md` im Repo-Root (Datumsformat, Klick-Modell,
+UTF-8-Mail-Pipeline, Lazy-Google-Imports für CI) — die gelten hier weiter und werden
+**nicht** wiederholt.
+
+> **Diese Datei pflegen.** Wer eine Verantwortlichkeit verschiebt, eine Komponente
+> hinzufügt/entfernt oder einen der unten beschriebenen Verträge ändert, aktualisiert
+> diese Datei im selben PR. Sie ist die Karte des Aufbaus; veraltet ist sie schlimmer
+> als gar nicht vorhanden.
+
+## Schichten-Überblick
+
+```
+main.py  ── Einstiegspunkt: Tk-Root + Storage/Settings/App, --minimized, Sync-Pull-Thread
+   │
+   ▼
+ui.py::App  ── schlanker KOORDINATOR (kein God-Object mehr)
+   ├─ besitzt: Datum/View-State (year/month/view_mode/iso_year/current_week),
+   │           Header-/Footer-/Tray-Chrome, Dialog-Routing, Navigation
+   ├─ delegiert an vier Komponenten ▼
+   │
+   ├─ GridRenderer        (grid_renderer.py)   — Kalender-/Grid-Rendering
+   ├─ BackgroundTaskRunner(background_tasks.py) — Hintergrund-Worker + Thread-Mechanik
+   ├─ SyncOrchestrator    (sync_orchestrator.py)— Drive-Sync (manuell/Tray/Pull/Quit)
+   └─ UpdateBanner        (update_banner.py)    — GitHub-Release-Hinweis
+```
+
+`App` hält den fachlichen Zustand und die Widget-Chrome (Header/Footer/Tray), die
+Komponenten kapseln je eine Verantwortlichkeit. Datenfluss läuft App → Komponente
+(per Methodenaufruf / Konstruktor), Rückfluss per **injizierten Callbacks** (App reicht
+z.B. `_open_dialog`/`_refresh` rein) — die Komponenten importieren `src.ui` **nicht**
+(kein Zyklus).
+
+## Die vier App-Komponenten und ihre Verträge
+
+### GridRenderer (`grid_renderer.py`)
+Rendering der Monats-/Wochenansicht inkl. Double-Buffer und Fenster-Geometrie.
+- **Datum/View gehört App**, nicht dem Renderer: `refresh(view_mode, year, month, iso_year,
+  current_week)` bekommt den aktuellen Stand pro Render übergeben (kein Dual-State).
+  `App._refresh()` ist nur ein dünner Shim, der diese 5 Werte weiterreicht — er ist der
+  **eine** Render-Eintritt für alle Aufrufer (Navigation, Dialog-`on_change`, Sync-/
+  Reconcile-Callbacks `on_refresh`/`on_ok`).
+- **Interaktion injiziert:** `on_cell_click` (= `App._open_dialog`), `on_cell_right_click`
+  (= `App._delete_day`), `reservations_active` (= `App._reservations_active`). Die Zellen
+  binden diese Callbacks, nicht App-Methoden direkt.
+- **Widgets:** der Renderer besitzt `grid_container` + die zwei Double-Buffer-Frames
+  (`build_grid(parent)`); `header_label`/`footer_label` werden in `App._build_header`/
+  `_build_footer` erzeugt und per `attach_labels(...)` nachgereicht (der Renderer beschreibt
+  sie). `measure_max_width(...)` pinnt vor `mainloop()` die Fensterbreite (4-Kombi-Probing).
+- `_fmt_slot_line` ist `@staticmethod`; `App._delete_day` ruft es als
+  `GridRenderer._fmt_slot_line(...)` (bleibt in App, nutzt aber den Renderer-Static).
+
+### BackgroundTaskRunner (`background_tasks.py`)
+Thread-Mechanik **und** die proaktiven Startup-Tasks.
+- `run(fn, on_done=None)` ist **der** Thread-Helfer: führt `fn()` im Daemon-Thread aus,
+  liefert das Ergebnis via `marshal` (= `App._marshal_to_ui`) an `on_done` auf dem
+  **UI-Thread**. Auch `SyncOrchestrator` nutzt `run()` — es gibt nur dieses eine Muster.
+- Eigene Tasks: `refresh_token`, `fetch_sender_email`, `check_update`, `reconcile_on_start`,
+  `trigger_reconcile`. UI-Arbeit (Dialoge/Banner/Refresh) bleibt in App und kommt als Callback.
+- Tk-frei, keine Google-Imports auf Modulebene; `run_calendar_reconcile` wird **lazy in der
+  Methode** aus `src.main` importiert (Circular-Import-Schutz: `main → ui → background_tasks`).
+
+### SyncOrchestrator (`sync_orchestrator.py`)
+Drive-Sync: manueller Sync, Tray-Sync, Pull-Callbacks, Status-Label, Quit-Push, Fehler-
+Aufbereitung (`_classify_sync_error`/`_friendly_sync_message`/`_show_sync_error` — auch von
+Tests genutzt). Reine Formatier-Helfer `_status_text`/`_tray_toast` sind ohne Tk testbar.
+- Header-Widgets per `attach_widgets(...)`; Tray **lazy** über `get_tray=lambda: App._tray`
+  (einzige Quelle bleibt `App._tray`); `_run_push_blocking` lazy aus `src.main`.
+- `App.on_sync_pull_success`/`on_sync_pull_error` bleiben als dünne Delegatoren (Public-API
+  für `main.py`). `tray.stop()`/`root.destroy()` bleiben in `App._quit_with_sync_push`.
+
+### UpdateBanner (`update_banner.py`)
+Banner über dem Kalender (anzeigen/Download/ausblenden). `handle_check_result(release, newer)`
+ist das `on_result` von `BackgroundTaskRunner.check_update`. Pack-Anker **lazy** über
+`get_anchor=lambda: App._renderer.grid_container` (Grid existiert erst nach dem Build).
+
+## Threading-Modell
+
+Genau ein Muster: Hintergrundarbeit über `BackgroundTaskRunner.run(fn, on_done)`; jede
+State-/Widget-Mutation aus einem Worker läuft über `App._marshal_to_ui` (`root.after(0, …)`,
+gegen `TclError` abgesichert, falls das Fenster zwischenzeitlich zu ist). Keine direkten
+`threading.Thread`-Aufrufe in `ui.py` mehr.
+
+## Daten- & Persistenz-Schicht
+
+- `storage.py` — Ist-Zeiten (JSON, Schlüssel = ISO-Datum). `reservations.py` — Reservierungen
+  (zukünftige Soll-Zeiten, eigenes Konzept). `settings.py` — Einstellungen mit Defaults.
+- `conflicts_store.py` — lokale Sync-Konfliktliste. `category_defaults.py` — Default-Kategorien.
+- `sync.py` — pure Sync-Logik (LWW-Merge, Konflikterkennung); enthält ein **Duplikat** von
+  `SYNCED_SETTING_KEYS` (muss konsistent zu `settings.py` bleiben). `share.py` — Export/Import
+  als Share-JSON.
+
+## Google-Integration (alle Wrapper mit Lazy-Imports für CI ohne requirements.txt)
+
+`mail.py` (Gmail/OAuth, `token.json`/`credentials.json`), `drive.py` (Drive appDataFolder-Sync),
+`gcal.py` (Calendar), `reservations_sync.py` (Abgleich Reservierungen ↔ Kalender). Alle teilen
+denselben OAuth-Token; Scope-Upgrade erzwingt frischen Consent.
+
+## Berichte & Plattform/Infra
+
+- `report.py` — HTML-Mail + PDF (xhtml2pdf **lazy**), gruppiert pro ISO-KW.
+- `theme.py`/`tooltip.py` — UI-Hilfen (Farben/Fonts/themed Dialoge, `_hover`-Overlays).
+- `time_utils.py` — Stunden, KW-Labels, `format_iso_date`/`format_iso_datetime`.
+- `holidays_de.py`, `paths.py` (`get_base_path` Frozen-vs-Repo), `autostart.py`, `updater.py`
+  (GitHub-Releases, stdlib-only, 1×/Tag), `platform_open.py`, `logging_setup.py`, `tray.py`,
+  `version.py` (einzige Versions-Quelle).
+
+## Dialoge (`src/dialogs/`)
+
+Modale Tk-Dialoge, von `App` geroutet (Klick-Modell: Linksklick = bearbeiten, Rechtsklick =
+löschen — siehe Root-`CLAUDE.md`): `entry_dialog` (Tages-Dialog, rein zum Speichern),
+`send_dialog`, `settings_dialog`, `share_dialog`, `import_dialog`, `category_dialog`,
+`conflicts_dialog`.
+
+## Wo gehört neuer Code hin?
+
+- Rendering/Zell-Logik → `grid_renderer.py`. Neuer Hintergrund-Task → `background_tasks.py`
+  (über `run()`). Sync-Verhalten → `sync_orchestrator.py`. Reine Persistenz/Logik → der
+  passende Store bzw. `sync.py`/`share.py` (Tk-frei, gut testbar).
+- In `App` (ui.py) bleibt nur Koordination: Datum/View-State, Chrome-Aufbau, Dialog-Routing,
+  Navigation, das `_marshal_to_ui`/`_refresh`-Glue. Wächst eine Verantwortlichkeit dort, ist
+  das das Signal für die nächste Komponente — und für ein Update dieser Datei.

--- a/src/background_tasks.py
+++ b/src/background_tasks.py
@@ -34,7 +34,10 @@ class BackgroundTaskRunner:
         def worker():
             result = fn()
             if on_done is not None:
-                self._marshal(lambda: on_done(result))
+                # Lokale Bindung: Pyright traegt das None-Narrowing sonst nicht
+                # in die Closure (reportOptionalCall-FP).
+                done = on_done
+                self._marshal(lambda: done(result))
         threading.Thread(target=worker, daemon=True).start()
 
     def refresh_token(self, on_auth_error, on_error):

--- a/src/grid_renderer.py
+++ b/src/grid_renderer.py
@@ -45,7 +45,7 @@ class GridRenderer:
         self._reservations_active = reservations_active  # () -> bool
         # Rendering-State:
         self.grid_container = None
-        self._grid_frames = None
+        self._grid_frames = []
         self._active_grid_idx = 0
         self._grid_frame = None
         self._header_label = None
@@ -54,12 +54,13 @@ class GridRenderer:
         self._suppress_geometry = False
         self._last_refresh_view = None
         self._last_refresh_columns = None
-        # Transienter Datum/View-Stand (von refresh gesetzt):
-        self._view_mode = None
-        self._year = None
-        self._month = None
-        self._iso_year = None
-        self._current_week = None
+        # Transienter Datum/View-Stand (von refresh gesetzt; Defaults nur
+        # Platzhalter, refresh() ueberschreibt sie vor jedem Render).
+        self._view_mode = "month"
+        self._year = 0
+        self._month = 0
+        self._iso_year = 0
+        self._current_week = 0
 
     def build_grid(self, parent):
         # Double-Buffer: zwei dauerhafte Frames im selben Grid-Slot. Refresh
@@ -84,7 +85,8 @@ class GridRenderer:
         self._header_label = header_label
         self._footer_label = footer_label
 
-    def refresh(self, view_mode, year, month, iso_year, current_week):
+    def refresh(self, view_mode: str, year: int, month: int,
+                iso_year: int, current_week: int):
         self._view_mode = view_mode
         self._year = year
         self._month = month
@@ -124,7 +126,8 @@ class GridRenderer:
                 width = max(self._fixed_width or 0, self._root.winfo_reqwidth())
                 self._root.geometry(f"{width}x{self._root.winfo_reqheight()}")
 
-    def measure_max_width(self, view_mode, year, month, iso_year, current_week):
+    def measure_max_width(self, view_mode: str, year: int, month: int,
+                          iso_year: int, current_week: int):
         """Pre-warm: rendert alle 4 (view × show_weekend)-Kombinationen einmal
         in den versteckten Backbuffer und merkt die maximale reqwidth intern
         (self._fixed_width). show_weekend wird über _data temporär mutiert

--- a/src/grid_renderer.py
+++ b/src/grid_renderer.py
@@ -1,0 +1,633 @@
+"""Kalender-/Grid-Rendering der App (Monats-/Wochenansicht, Zelltypen,
+Double-Buffer). Eigenständig herausgelöst aus dem App-God-Object (#49).
+
+Tk-nutzend, aber kein src.ui-Import. Datum/View ist NICHT Renderer-Eigentum:
+es kommt per refresh(...)/measure_max_width(...)-Parametern; App bleibt die
+Quelle (von _navigate/_set_view mutiert)."""
+
+import calendar
+import datetime
+import platform
+import tkinter as tk
+
+from src.time_utils import (
+    DAYS_DE, MONTHS_DE,
+    calculate_hours, get_week_dates, get_week_label, week_spans_months,
+)
+from src.holidays_de import get_holidays
+from src.tooltip import attach_tooltip
+from src.theme import (
+    BG, CELL_BG, WEEKEND_BG, ACCENT, TEXT, TEXT_MUTED,
+    ENTRY_BG, WEEKEND_ENTRY_BG, WEEKEND_FG,
+    HOLIDAY_BG, HOLIDAY_BG_HOVER, HOLIDAY_ACCENT,
+    RESERVATION_ACCENT, TODAY_ACCENT,
+    CELL_BG_HOVER, WEEKEND_BG_HOVER, ENTRY_BG_HOVER, WEEKEND_ENTRY_BG_HOVER,
+    FONT, FONT_BOLD, FONT_TINY, FONT_SMALL, FONT_HEADER, FONT_HEADER_SMALL,
+    _should_show_delete_button,
+)
+
+# Probe-Label-Geometrie zur Zellgrößen-Messung (aus ui.py übernommen).
+PROBE_WIDTH_WIDE = 12
+PROBE_WIDTH_NARROW = 8
+PROBE_HEIGHT = 3
+
+
+class GridRenderer:
+    def __init__(self, root, storage, settings, reservation_store, conflicts_store,
+                 on_cell_click, on_cell_right_click, reservations_active):
+        self._root = root
+        self._storage = storage
+        self._settings = settings
+        self._reservation_store = reservation_store
+        self._conflicts_store = conflicts_store
+        self._on_cell_click = on_cell_click            # (date_str) -> None
+        self._on_cell_right_click = on_cell_right_click  # (date_str) -> None
+        self._reservations_active = reservations_active  # () -> bool
+        # Rendering-State:
+        self.grid_container = None
+        self._grid_frames = None
+        self._active_grid_idx = 0
+        self._grid_frame = None
+        self._header_label = None
+        self._footer_label = None
+        self._fixed_width = None
+        self._suppress_geometry = False
+        self._last_refresh_view = None
+        self._last_refresh_columns = None
+        # Transienter Datum/View-Stand (von refresh gesetzt):
+        self._view_mode = None
+        self._year = None
+        self._month = None
+        self._iso_year = None
+        self._current_week = None
+
+    def build_grid(self, parent):
+        # Double-Buffer: zwei dauerhafte Frames im selben Grid-Slot. Refresh
+        # baut in den inaktiven (versteckt unter dem aktiven), dann lift()
+        # tauscht atomar.
+        self.grid_container = tk.Frame(parent, bg=BG)
+        self.grid_container.pack(fill=tk.BOTH, expand=True, padx=10, pady=5)
+        self.grid_container.rowconfigure(0, weight=1)
+        self.grid_container.columnconfigure(0, weight=1)
+        self._grid_frames = []
+        for _ in range(2):
+            f = tk.Frame(self.grid_container, bg=BG)
+            f.grid(row=0, column=0, sticky="nsew")
+            for col in range(7):
+                f.columnconfigure(col, weight=1)
+            self._grid_frames.append(f)
+        self._grid_frames[0].lift()
+        self._active_grid_idx = 0
+        self._grid_frame = self._grid_frames[0]
+
+    def attach_labels(self, header_label, footer_label):
+        self._header_label = header_label
+        self._footer_label = footer_label
+
+    def refresh(self, view_mode, year, month, iso_year, current_week):
+        self._view_mode = view_mode
+        self._year = year
+        self._month = month
+        self._iso_year = iso_year
+        self._current_week = current_week
+        if self._view_mode == "month":
+            # FONT_HEADER (16pt) + width=16 — längste Variante "September 2026".
+            self._header_label.config(
+                text=f"{MONTHS_DE[self._month]} {self._year}",
+                font=FONT_HEADER, width=16,
+            )
+            self._refresh_month()
+        else:
+            # FONT_HEADER_SMALL (12pt) + width=32 — KW-Variante mit Jahreswechsel.
+            self._header_label.config(
+                text=get_week_label(self._iso_year, self._current_week),
+                font=FONT_HEADER_SMALL, width=32,
+            )
+            self._refresh_week()
+        current_cols = self._visible_day_count()
+        view_changed = self._last_refresh_view != self._view_mode
+        cols_changed = self._last_refresh_columns != current_cols
+        if view_changed or cols_changed:
+            self._last_refresh_view = self._view_mode
+            self._last_refresh_columns = current_cols
+            # Inactive-Frame komplett ersetzen umgeht Tks reqheight-Cache.
+            inactive_idx = 1 - self._active_grid_idx
+            self._grid_frames[inactive_idx].destroy()
+            new_inactive = tk.Frame(self.grid_container, bg=BG)
+            new_inactive.grid(row=0, column=0, sticky="nsew")
+            for col in range(7):
+                new_inactive.columnconfigure(col, weight=1 if col < current_cols else 0)
+            self._grid_frames[inactive_idx] = new_inactive
+            self._grid_frames[self._active_grid_idx].lift()
+            self._root.update_idletasks()
+            if not self._suppress_geometry:
+                width = max(self._fixed_width or 0, self._root.winfo_reqwidth())
+                self._root.geometry(f"{width}x{self._root.winfo_reqheight()}")
+
+    def measure_max_width(self, view_mode, year, month, iso_year, current_week):
+        """Pre-warm: rendert alle 4 (view × show_weekend)-Kombinationen einmal
+        in den versteckten Backbuffer und merkt die maximale reqwidth intern
+        (self._fixed_width). show_weekend wird über _data temporär mutiert
+        (kein Disk-Save) und wiederhergestellt; _suppress_geometry verhindert
+        den Resize während der Messung. Läuft vor mainloop()."""
+        saved_weekend = self._settings.get("show_weekend")
+        max_w = 0
+        self._suppress_geometry = True
+        try:
+            for view in ("month", "week"):
+                for weekend in (True, False):
+                    self._settings._data["show_weekend"] = weekend
+                    self._last_refresh_view = None
+                    self._last_refresh_columns = None
+                    self.refresh(view, year, month, iso_year, current_week)
+                    self._root.update_idletasks()
+                    w = self._root.winfo_reqwidth()
+                    if w > max_w:
+                        max_w = w
+        finally:
+            self._suppress_geometry = False
+            self._settings._data["show_weekend"] = saved_weekend
+            self._last_refresh_view = None
+            self._last_refresh_columns = None
+        self._fixed_width = max_w
+        return max_w
+
+    def _visible_day_count(self):
+        """Sichtbare Wochentag-Spalten (5 bei show_weekend=False, sonst 7).
+
+        Wird von _build_grid_header und den Refresh-Pfaden als einzige
+        Quelle der Wahrheit konsultiert.
+        """
+        return 7 if self._settings.get("show_weekend") else 5
+
+    def _build_grid_header(self, parent):
+        n = self._visible_day_count()
+        for col, day_name in enumerate(DAYS_DE[:n]):
+            fg = TEXT_MUTED if col < 5 else WEEKEND_FG
+            tk.Label(
+                parent, text=day_name, font=FONT_BOLD, bg=BG, fg=fg,
+            ).grid(row=0, column=col, sticky="nsew", padx=2, pady=2)
+
+    def _build_entry_cell(self, parent, date_str, day_text, entry, is_weekend, pad,
+                          cell_size=None, time_font=FONT_TINY):
+        bg = WEEKEND_ENTRY_BG if is_weekend else ENTRY_BG
+        hover_bg = WEEKEND_ENTRY_BG_HOVER if is_weekend else ENTRY_BG_HOVER
+        cell = tk.Frame(
+            parent, bg=bg, relief=tk.SOLID,
+            highlightbackground=ACCENT, highlightthickness=1, cursor="hand2",
+        )
+        if cell_size is not None:
+            # Pixel-fixiert wie die Feiertagszelle — sonst weitet die Zeit-Zeile
+            # ("HH:MM-HH:MM" in FONT_SMALL) die Spalte auf und der Header-Reflow
+            # lässt den Monatsnamen flackern, sobald Einträge dazukommen.
+            cell.config(width=cell_size[0], height=cell_size[1])
+            cell.pack_propagate(False)
+        day_lbl = tk.Label(
+            cell, text=day_text, font=FONT,
+            bg=bg, fg=TEXT, cursor="hand2",
+        )
+        day_lbl.pack(pady=(pad, 0))
+        # time_font default FONT_TINY (7pt) damit "HH:MM-HH:MM" in die
+        # pixel-fixierte Standardzelle (width=8 in FONT) reinpasst. Wenn der
+        # Caller eine breitere Zelle nutzt (z.B. bei ausgeblendeten Wochenenden
+        # mit width=11), kann eine größere Schrift übergeben werden.
+        slots = entry.get("slots", [])
+        if slots:
+            first = slots[0]
+            time_text = f"{first['start']}-{first['end']}"
+            if len(slots) > 1:
+                time_text += f"  +{len(slots) - 1}"
+        else:
+            time_text = ""
+        time_lbl = tk.Label(
+            cell, text=time_text,
+            font=time_font, bg=bg, fg=TEXT_MUTED, cursor="hand2",
+        )
+        time_lbl.pack(pady=(0, pad))
+        for w in (cell, day_lbl, time_lbl):
+            w.bind("<Button-1>", lambda e, d=date_str: self._on_cell_click(d))
+            w.bind("<Button-3>", lambda e, d=date_str: self._on_cell_right_click(d))
+            w.bind("<Enter>", lambda e, c=cell, dl=day_lbl, tl=time_lbl, hb=hover_bg: self._hover(c, hb, dl, tl))
+            w.bind("<Leave>", lambda e, c=cell, dl=day_lbl, tl=time_lbl, ob=bg: self._hover(c, ob, dl, tl))
+        return cell
+
+    @staticmethod
+    def _fmt_slot_line(slot):
+        """Eine Tooltip-Zeile für einen Slot: 'HH:MM-HH:MM  Kategorie'
+        (Kategorie weggelassen, wenn leer)."""
+        kat = f"  {slot['kategorie']}" if slot.get("kategorie") else ""
+        return f"{slot['start']}-{slot['end']}{kat}"
+
+    def _add_reservation_marker(self, cell):
+        """Runder violetter Eck-Punkt auf einer Ist-Zeitzelle, die zusätzlich
+        eine Reservierung hat. Ein Canvas-Oval statt eines Text-Bullets — „•"
+        rendert je nach Font als kaum sichtbarer Fleck; das Oval gibt einen
+        sauber gerundeten, größenkontrollierten Punkt. place() überlagert die
+        gepackten Kind-Widgets. Der Marker wird als cell._reservation_marker
+        getaggt, damit _hover seinen Hintergrund beim Hover mitfärbt."""
+        box, dot = 12, 7
+        marker = tk.Canvas(
+            cell, width=box, height=box, bg=cell.cget("bg"),
+            highlightthickness=0, cursor="hand2",
+        )
+        inset = (box - dot) // 2
+        marker.create_oval(
+            inset, inset, inset + dot, inset + dot,
+            fill=RESERVATION_ACCENT, outline="",
+        )
+        marker.place(relx=1.0, x=-3, y=3, anchor="ne")
+        cell._reservation_marker = marker
+
+    def _add_delete_button(self, cell, date_str):
+        """macOS-only: kleines ✕ oben links, das den Lösch-Pfad auslöst.
+
+        <Button-3> ist auf macOS unzuverlässig (Sekundärklick je nach Tk-Version
+        <Button-2>/Control-Klick); dieser Button gibt dort einen verlässlichen
+        Lösch-Auslöser, ohne den Linksklick-Dialog mit Lösch-Buttons zu belasten.
+        Klick ruft denselben _on_cell_right_click-Pfad wie der Win/Linux-Rechtsklick
+        (Ja/Nein bzw. Slot-Auswahl). Getaggt als cell._delete_button, damit
+        _hover seinen Hintergrund beim Hover mitfärbt."""
+        bg = cell.cget("bg")
+        btn = tk.Label(
+            cell, text="✕", font=FONT_TINY, bg=bg, fg=TEXT_MUTED, cursor="hand2",
+        )
+        btn.place(relx=0.0, x=3, y=2, anchor="nw")
+        # "break" stoppt jede Propagation, damit der Klick nicht zusätzlich als
+        # Zell-Linksklick (Bearbeiten-Dialog) durchschlägt.
+        btn.bind("<Button-1>",
+                 lambda e, d=date_str: (self._on_cell_right_click(d), "break")[1])
+        # fg-Hover (rot als Lösch-Affordance) steuert der Button selbst; den bg
+        # färbt _hover mit der Zelle.
+        btn.bind("<Enter>", lambda e: btn.config(fg=ACCENT))
+        btn.bind("<Leave>", lambda e: btn.config(fg=TEXT_MUTED))
+        cell._delete_button = btn
+
+    def _build_empty_cell(self, parent, date_str, day_text, is_weekend, cell_size):
+        bg = WEEKEND_BG if is_weekend else CELL_BG
+        hover_bg = WEEKEND_BG_HOVER if is_weekend else CELL_BG_HOVER
+        fg = WEEKEND_FG if is_weekend else TEXT
+        # Pixel-fixiert auf dieselbe Außengröße wie Entry-/Holiday-Zellen, damit
+        # die per sticky="nsew"+weight gestreckten Spalten unabhängig vom Inhalt
+        # gleich breit bleiben.
+        # Breite OHNE Aufschlag: die reqwidth muss exakt der der gefüllten Zellen
+        # entsprechen (die mit width=cell_size[0]+highlightthickness=1 gebaut
+        # werden). Tk zählt den 1-px-Highlight-Rand hier NICHT zur reqwidth, also
+        # ist deren reqwidth ebenfalls cell_size[0]. Ein früher gesetztes +2
+        # machte leere Spalten 2 px breiter als Eintragsspalten — in der
+        # Wochenansicht (1 Zelle pro Spalte) verschob das die Spaltenbreiten
+        # gegenüber der Monatsansicht (dort mittelt sich der Unterschied über die
+        # 6 Zeilen weg). Höhe +2 kompensiert den Rand der gefüllten Zellen
+        # vertikal und betrifft die Spaltenbreite nicht.
+        cell = tk.Frame(parent, bg=bg, cursor="hand2")
+        cell.config(width=cell_size[0], height=cell_size[1] + 2)
+        cell.pack_propagate(False)
+        day_lbl = tk.Label(
+            cell, text=day_text, font=FONT, bg=bg, fg=fg, cursor="hand2",
+        )
+        day_lbl.pack(expand=True)
+        for w in (cell, day_lbl):
+            w.bind("<Button-1>", lambda e, d=date_str: self._on_cell_click(d))
+            w.bind("<Button-3>", lambda e, d=date_str: self._on_cell_right_click(d))
+            w.bind("<Enter>", lambda e, c=cell, dl=day_lbl, hb=hover_bg: self._hover(c, hb, dl))
+            w.bind("<Leave>", lambda e, c=cell, dl=day_lbl, ob=bg: self._hover(c, ob, dl))
+        return cell
+
+    def _build_day_cell(self, parent, date_str, day_text, day_date, is_weekend,
+                        entry, holidays_map, pad,
+                        holiday_max_len, cell_size, conflict_dates=None,
+                        entry_time_font=FONT_TINY, holiday_name_font=FONT_SMALL,
+                        reservation=None):
+        """Dispatcht auf Entry-, Holiday- oder Empty-Zelle.
+
+        reservation: optionales {start, end} für den Tag. Eine Reservierung
+        ändert den Zelltyp NICHT — sie wird ausschließlich als kleiner
+        violetter Eck-Punkt (plus Tooltip) auf die ohnehin gebaute Zelle
+        gelegt. Ein Tag mit nur einer Reservierung sieht also aus wie ein
+        leerer Tag (bzw. Feiertag) mit Punkt.
+        """
+        is_holiday = day_date in holidays_map
+        if entry:
+            cell = self._build_entry_cell(
+                parent, date_str, day_text, entry, is_weekend, pad,
+                cell_size=cell_size, time_font=entry_time_font,
+            )
+        elif is_holiday:
+            cell = self._build_holiday_cell(
+                parent, day_text=day_text,
+                name=holidays_map[day_date], max_name_len=holiday_max_len,
+                on_click=lambda d=date_str: self._on_cell_click(d),
+                on_right_click=lambda d=date_str: self._on_cell_right_click(d),
+                cell_size=cell_size,
+                name_font=holiday_name_font,
+                # Bei zusätzlicher Reservierung übernimmt der Reservierungs-
+                # Tooltip unten den Feiertagsnamen — sonst klebten zwei
+                # unabhängige Tooltips am selben Widget (s. attach_tooltip).
+                name_tooltip=reservation is None,
+            )
+        else:
+            cell = self._build_empty_cell(
+                parent, date_str, day_text, is_weekend, cell_size,
+            )
+
+        # Reservierung ist ein reiner Overlay-Marker (Eck-Punkt) — sie ändert
+        # den Zelltyp nicht. Genau EIN attach_tooltip pro Zelle (Mehrfachaufruf
+        # erzeugt überlappende Tooltips); deshalb alle relevanten Infos
+        # (mehrere Arbeitszeit-Slots, Reservierung, Feiertag) in einen
+        # kombinierten Tooltip. Ein Feiertag-OHNE-Eintrag/-Reservierung zeigt
+        # seinen Namen weiterhin als Zelltext (Holiday-Zelle) bzw. eigenen
+        # Tooltip (name_tooltip) und kommt hier NICHT rein.
+        tip_parts = []
+        if entry and len(entry.get("slots", [])) > 1:
+            tip_parts.append(
+                "Arbeitszeit:\n"
+                + "\n".join(self._fmt_slot_line(s) for s in entry["slots"]))
+        if reservation is not None:
+            self._add_reservation_marker(cell)
+            tip_parts.append(
+                "Reservierung:\n"
+                + "\n".join(self._fmt_slot_line(s) for s in reservation.get("slots", [])))
+        if is_holiday and (reservation is not None or entry):
+            tip_parts.append(f"Feiertag: {holidays_map[day_date]}")
+        if tip_parts:
+            attach_tooltip(cell, "\n".join(tip_parts))
+
+        # macOS-only Lösch-Button (✕) oben links, sobald der Tag löschbare
+        # Einheiten hat (Ist-Zeit ODER aktive Reservierung). reservation wird
+        # nur bei aktivem Kalender-Sync übergeben (vgl. _add_reservation_marker),
+        # daher deckt `reservation is not None` die aktive Reservierung ab.
+        if _should_show_delete_button(
+            platform.system() == "Darwin", bool(entry), reservation is not None
+        ):
+            self._add_delete_button(cell, date_str)
+
+        # Heutigen Tag mit blauem Rahmen hervorheben. Vor dem Konflikt-Block,
+        # damit ein Konflikt (orange) auf demselben Tag den Rand gewinnt.
+        if day_date == datetime.date.today():
+            cell.configure(highlightbackground=TODAY_ACCENT, highlightthickness=2)
+
+        if conflict_dates and date_str in conflict_dates:
+            cell.configure(highlightbackground="orange", highlightthickness=2)
+            attach_tooltip(cell, "Konflikt — bitte auflösen")
+
+        return cell
+
+    def _get_inactive_grid(self):
+        """Liefert das versteckte Grid-Frame (Double-Buffer-Backbuffer).
+        Children, Row- und Column-Config werden zurückgesetzt. Nur sichtbare
+        Spalten erhalten weight=1 — ausgeblendete (Sa/So bei show_weekend=False)
+        würden sonst den vom Header/Footer geforderten Extra-Platz absorbieren
+        und einen Leerraum-Streifen rechts neben Fr produzieren."""
+        inactive = self._grid_frames[1 - self._active_grid_idx]
+        for child in list(inactive.winfo_children()):
+            child.destroy()
+        for row in range(8):
+            inactive.rowconfigure(row, minsize=0, weight=0)
+        n = self._visible_day_count()
+        for col in range(7):
+            inactive.columnconfigure(col, weight=1 if col < n else 0)
+        return inactive
+
+    def _activate_grid(self, frame):
+        """Hebt das eben gefüllte Backbuffer-Frame nach vorne. Der bisherige
+        Front-Buffer bleibt als Backbuffer hinten — keine Destroy-Lücke."""
+        frame.lift()
+        self._active_grid_idx = 1 - self._active_grid_idx
+        self._grid_frame = frame
+
+    def _update_footer(self, total_hours):
+        rate = self._settings.get("hourly_rate") or 0
+        total_rounded = round(total_hours, 2)
+        if rate > 0:
+            brutto = round(total_hours * rate, 2)
+            self._footer_label.config(
+                text=f"Gesamt: {total_rounded}h  —  {brutto:.2f} € brutto"
+            )
+        else:
+            self._footer_label.config(text=f"Gesamt: {total_rounded}h")
+
+    def _entry_hours(self, entry):
+        return round(sum(
+            calculate_hours(s["start"], s["end"], pause_minutes=s.get("pause", 0))
+            for s in entry.get("slots", [])
+        ), 2)
+
+    def _dates_with_unresolved_conflicts(self):
+        """Gibt die Menge der ISO-Datums-Strings zurück, für die ungelöste
+        Konflikte vom Typ 'entry' vorliegen."""
+        if not self._conflicts_store:
+            return set()
+        return {
+            c["key"] for c in self._conflicts_store.get_all()
+            if c.get("kind") == "entry" and not c.get("resolved")
+        }
+
+    def _cell_layout_metrics(self, frame):
+        """Misst die natuerliche Pixelgroesse einer Standard-Tageszelle (Probe-
+        Label) und liefert die layout-abhaengigen Groessen.
+
+        Bei ausgeblendetem Wochenende (5 statt 7 Spalten) bleibt mehr Horizontal-
+        platz pro Spalte: breitere Zellen und groessere Zeit-/Feiertagsschrift
+        (FONT statt FONT_SMALL), damit z.B. '09:30-17:00' bequem lesbar bleibt.
+        Holiday-Zellen werden spaeter auf `cell_size` fixiert, damit lange
+        Feiertagsnamen die Spalte nicht aufweiten (Header-Reflow/Flackern)."""
+        wide_cells = not self._settings.get("show_weekend")
+        probe_width = PROBE_WIDTH_WIDE if wide_cells else PROBE_WIDTH_NARROW
+        entry_time_font = FONT if wide_cells else FONT_SMALL
+        holiday_name_font = FONT if wide_cells else FONT_SMALL
+        probe = tk.Label(frame, text="", font=FONT, width=probe_width, height=PROBE_HEIGHT)
+        probe.update_idletasks()
+        cell_size = (probe.winfo_reqwidth(), probe.winfo_reqheight())
+        probe.destroy()
+        return cell_size, entry_time_font, holiday_name_font, wide_cells
+
+    def _refresh_month(self):
+        # In den versteckten Backbuffer bauen, dann via lift() in den Vordergrund
+        # holen — verhindert sichtbare leere Fläche zwischen Refreshes.
+        new_frame = self._get_inactive_grid()
+        self._build_grid_header(new_frame)
+
+        cal = calendar.Calendar(firstweekday=0)
+        entries = self._storage.get_all()
+        reservations = (
+            self._reservation_store.get_all() if self._reservations_active() else {})
+        total_hours = 0.0
+
+        state = self._settings.get("state")
+        holidays_map = get_holidays(state, self._year) if state else {}
+
+        cell_size, entry_time_font, holiday_name_font, wide_cells = \
+            self._cell_layout_metrics(new_frame)
+
+        # Auf 6 Wochen padden, damit die Fensterhöhe zwischen Monaten konstant
+        # bleibt und `geometry("")` in `refresh` keinen sichtbaren Resize auslöst.
+        n = self._visible_day_count()
+        weeks = cal.monthdayscalendar(self._year, self._month)
+        # Bei ausgeblendetem Wochenende: führende Wochen verwerfen, deren
+        # sichtbarer Anteil (Mo–Fr) komplett aus 0 besteht — sonst entsteht
+        # eine sichtbar leere erste Zeile, wenn der Monat am Sa/So beginnt.
+        if n < 7:
+            while weeks and not any(weeks[0][:n]):
+                weeks.pop(0)
+        while len(weeks) < 6:
+            weeks.append([0] * 7)
+
+        # Einmal pro Render berechnen, nicht pro Zelle.
+        conflict_dates = self._dates_with_unresolved_conflicts()
+
+        for row, week in enumerate(weeks, start=1):
+            for col, day in enumerate(week[:n]):
+                if day == 0:
+                    tk.Label(new_frame, text="", bg=BG, relief=tk.FLAT).grid(
+                        row=row, column=col, sticky="nsew", padx=2, pady=2)
+                    continue
+
+                date_str = f"{self._year}-{self._month:02d}-{day:02d}"
+                day_date = datetime.date(self._year, self._month, day)
+                entry = entries.get(date_str)
+                if entry:
+                    total_hours += self._entry_hours(entry)
+
+                cell = self._build_day_cell(
+                    new_frame, date_str, str(day), day_date,
+                    is_weekend=col >= 5, entry=entry, holidays_map=holidays_map,
+                    pad=4,
+                    # Bei schmalen Zellen (7-Spalten-Modus) kürzer trunkieren,
+                    # damit der padx=4-Innenraum der Holiday-Zelle erhalten bleibt.
+                    holiday_max_len=12 if wide_cells else 9,
+                    cell_size=cell_size,
+                    conflict_dates=conflict_dates,
+                    entry_time_font=entry_time_font,
+                    holiday_name_font=holiday_name_font,
+                    reservation=reservations.get(date_str),
+                )
+                cell.grid(row=row, column=col, sticky="nsew", padx=2, pady=2)
+
+        row_min_h = cell_size[1] + 4  # +4 für pady=2 oben/unten
+        for row in range(1, 7):
+            new_frame.rowconfigure(row, minsize=row_min_h)
+
+        self._activate_grid(new_frame)
+        self._update_footer(total_hours)
+
+    def _refresh_week(self):
+        new_frame = self._get_inactive_grid()
+        self._build_grid_header(new_frame)
+
+        dates = get_week_dates(self._iso_year, self._current_week)
+        entries = self._storage.get_all()
+        reservations = (
+            self._reservation_store.get_all() if self._reservations_active() else {})
+        total_hours = 0.0
+        spans = week_spans_months(self._iso_year, self._current_week)
+        state = self._settings.get("state")
+        holidays_map: dict[datetime.date, str] = {}
+        if state:
+            for y in {dates[0].year, dates[-1].year}:
+                holidays_map.update(get_holidays(state, y))
+
+        cell_size, entry_time_font, holiday_name_font, wide_cells = \
+            self._cell_layout_metrics(new_frame)
+
+        n = self._visible_day_count()
+        # Einmal pro Render berechnen, nicht pro Zelle.
+        conflict_dates = self._dates_with_unresolved_conflicts()
+
+        for col, day_date in enumerate(dates[:n]):
+            date_str = day_date.isoformat()
+            entry = entries.get(date_str)
+            if entry:
+                total_hours += self._entry_hours(entry)
+            day_text = f"{day_date.day}.{day_date.month}." if spans else str(day_date.day)
+
+            cell = self._build_day_cell(
+                new_frame, date_str, day_text, day_date,
+                is_weekend=col >= 5, entry=entry, holidays_map=holidays_map,
+                # pad=4 wie in der Monatsansicht, damit die vertikale Anordnung
+                # von Tagesziffer und Zeitzeile beim View-Wechsel nicht springt.
+                pad=4,
+                # 18 war zu lang für die gerenderte Spaltenbreite — "Christi
+                # Himmelfa…" lief über den Zellenrand hinaus. Werte unten
+                # passen zu den effektiv gestreckten Spalten in beiden Modi.
+                holiday_max_len=14 if wide_cells else 12,
+                cell_size=cell_size,
+                conflict_dates=conflict_dates,
+                entry_time_font=entry_time_font,
+                holiday_name_font=holiday_name_font,
+                reservation=reservations.get(date_str),
+            )
+            cell.grid(row=1, column=col, sticky="nsew", padx=2, pady=2)
+
+        self._activate_grid(new_frame)
+        self._update_footer(total_hours)
+
+    @staticmethod
+    def _truncate(text: str, max_len: int) -> str:
+        if len(text) <= max_len:
+            return text
+        return text[: max_len - 1] + "…"
+
+    def _build_holiday_cell(self, parent, day_text, name, max_name_len, on_click,
+                             cell_size=None, name_font=FONT_SMALL,
+                             name_tooltip=True, on_right_click=None):
+        """Grüne Feiertagszelle. Layout analog zur Eintragszelle.
+
+        cell_size: optional (width_px, height_px). Wenn gesetzt, wird der Frame
+        auf diese Pixel-Größe fixiert (verhindert Aufweitung der Spalte durch
+        längere Namen — relevant für die Wochenansicht).
+        name_font: Schriftart für den Feiertagsnamen. Default FONT_SMALL (8pt);
+        bei breiteren Zellen (Wochenenden ausgeblendet) kann FONT übergeben werden.
+        name_tooltip: ob bei abgeschnittenem Namen ein Voll-Namen-Tooltip
+        angehängt wird. False, wenn der Aufrufer selbst einen Tooltip setzt
+        (Doppel-Tooltip am selben Widget vermeiden).
+        """
+        cell = tk.Frame(
+            parent, bg=HOLIDAY_BG, relief=tk.SOLID,
+            highlightbackground=HOLIDAY_ACCENT, highlightthickness=1,
+            cursor="hand2",
+        )
+        if cell_size is not None:
+            cell.config(width=cell_size[0], height=cell_size[1])
+            cell.pack_propagate(False)
+        day_lbl = tk.Label(
+            cell, text=day_text, font=FONT,
+            bg=HOLIDAY_BG, fg=TEXT, cursor="hand2",
+        )
+        day_lbl.pack(pady=(4, 0))
+        truncated = self._truncate(name, max_name_len)
+        name_lbl = tk.Label(
+            cell, text=truncated,
+            font=name_font, bg=HOLIDAY_BG, fg=TEXT_MUTED, cursor="hand2",
+        )
+        # padx=4 für sichtbare Innenränder, sonst klebt der Feiertagsname an
+        # den Zellrändern. Caller sorgt mit passendem max_name_len dafür,
+        # dass der Text in die verbleibende Breite passt.
+        name_lbl.pack(pady=(0, 4), padx=4)
+
+        for w in (cell, day_lbl, name_lbl):
+            w.bind("<Button-1>", lambda e: on_click())
+            if on_right_click is not None:
+                w.bind("<Button-3>", lambda e: on_right_click())
+            w.bind("<Enter>", lambda e, c=cell, dl=day_lbl, nl=name_lbl:
+                self._hover(c, HOLIDAY_BG_HOVER, dl, nl))
+            w.bind("<Leave>", lambda e, c=cell, dl=day_lbl, nl=name_lbl:
+                self._hover(c, HOLIDAY_BG, dl, nl))
+        if name_tooltip and truncated != name:
+            # Geteilter Tooltip über alle drei Widgets — _Tooltip trackt sie
+            # gemeinsam, sodass Pointer-Wechsel zwischen Frame und Child-
+            # Labels den Tooltip nicht schließt/neu öffnet.
+            attach_tooltip((cell, day_lbl, name_lbl), f"Feiertag: {name}")
+        return cell
+
+    @staticmethod
+    def _hover(frame, bg, *labels):
+        """Faerbt Zelle + uebergebene Labels beim Hover. Die Eck-Overlays
+        (_reservation_marker, macOS-_delete_button) werden mitgefaerbt, sonst
+        bleibt ein andersfarbiges Rechteck stehen. Nur bg — die fg des
+        Loesch-Buttons steuert dessen eigener Enter/Leave-Handler."""
+        frame.config(bg=bg)
+        for lbl in labels:
+            lbl.config(bg=bg)
+        for attr in ("_reservation_marker", "_delete_button"):
+            w = getattr(frame, attr, None)
+            if w is not None:
+                w.config(bg=bg)

--- a/src/tray.py
+++ b/src/tray.py
@@ -164,12 +164,16 @@ class TrayIcon:
         try:
             from pystray._util import win32
             handle = getattr(self._icon, "_icon_handle", None)
-            if not handle:
+            # _message ist eine pystray-Interne (nicht im Type-Stub) — wie
+            # _icon_handle per getattr holen: entfernt die Pylance-Warnung und
+            # faellt sauber auf Standard-notify() zurueck, falls sie fehlt.
+            send_message = getattr(self._icon, "_message", None)
+            if not handle or send_message is None:
                 return False
             # Konstanten sind in pystrays win32-Util nicht definiert.
             NIIF_USER = 0x00000004
             NIIF_LARGE_ICON = 0x00000020
-            self._icon._message(
+            send_message(
                 win32.NIM_MODIFY,
                 win32.NIF_INFO,
                 szInfo=message,

--- a/src/ui.py
+++ b/src/ui.py
@@ -1,7 +1,6 @@
 # src/ui.py
 import tkinter as tk
 from tkinter import messagebox
-import calendar
 import ctypes
 import datetime
 import logging
@@ -9,29 +8,21 @@ import os
 import platform
 import time
 from src.time_utils import (
-    DAYS_DE, MONTHS_DE,
-    calculate_hours, format_iso_date, get_week_dates, get_week_label, week_spans_months,
+    format_iso_date, get_week_dates,
 )
-from src.holidays_de import get_holidays
-from src.tooltip import attach_tooltip
 
 from src.version import VERSION, version_label
 
 from src.background_tasks import BackgroundTaskRunner
+from src.grid_renderer import GridRenderer
 from src.sync_orchestrator import _classify_sync_error, SyncOrchestrator
 from src.update_banner import UpdateBanner
 from src.dialogs.entry_dialog import open_entry_dialog
 from src.dialogs.send_dialog import open_send_dialog
 from src.dialogs.settings_dialog import open_settings_dialog
 from src.theme import (
-    BG, CELL_BG, WEEKEND_BG, ACCENT, TEXT, TEXT_MUTED,
-    _should_show_delete_button,
-    ENTRY_BG, WEEKEND_ENTRY_BG, WEEKEND_FG,
-    HOLIDAY_BG, HOLIDAY_BG_HOVER, HOLIDAY_ACCENT,
-    RESERVATION_ACCENT, TODAY_ACCENT,
-    FONT, FONT_BOLD, FONT_HEADER, FONT_HEADER_SMALL, FONT_FOOTER, FONT_SMALL, FONT_TINY,
-    CELL_BG_HOVER, WEEKEND_BG_HOVER, ENTRY_BG_HOVER, WEEKEND_ENTRY_BG_HOVER,
-    apply_dark_titlebar, themed_askyesno, themed_ask_delete_choice, themed_showinfo,
+    BG, ACCENT, TEXT, TEXT_MUTED,
+    FONT_HEADER, FONT_FOOTER, FONT_SMALL, apply_dark_titlebar, themed_askyesno, themed_ask_delete_choice, themed_showinfo,
     icon_button, secondary_button, set_toggle_active, toggle_button,
     _stray_click_suppressed,
 )
@@ -54,12 +45,6 @@ def _delete_action(slots, selected, prefix):
     if not keep:
         return "delete", None
     return "save", keep
-
-
-# Probe-Label-Geometrie zur Zellgroessen-Messung (Month- und Week-Render teilen sie).
-PROBE_WIDTH_WIDE = 12    # ausgeblendetes Wochenende -> breitere Zellen
-PROBE_WIDTH_NARROW = 8   # 7-Spalten-Modus
-PROBE_HEIGHT = 3
 
 
 class App:
@@ -133,9 +118,15 @@ class App:
             self.root, self.storage, self.settings, self.conflicts_store,
             self.base_path, self._bg, self._refresh, lambda: self._tray,
         )
+        self._renderer = GridRenderer(
+            self.root, self.storage, self.settings, self.reservation_store,
+            self.conflicts_store, self._open_dialog, self._delete_day,
+            self._reservations_active,
+        )
         self._build_header()
-        self._build_grid()
+        self._renderer.build_grid(self.root)
         self._build_footer()
+        self._renderer.attach_labels(self.header_label, self.footer_label)
         self._sync.attach_widgets(
             self.sync_button, self.sync_status_label, self._next_button)
         self._sync.update_status_label()
@@ -151,7 +142,8 @@ class App:
         # (view × show_weekend) einmal in den Backbuffer rendern, max reqwidth
         # observen. Das Fenster ist noch nicht gemappt (mainloop nicht
         # gestartet) — keine sichtbaren Zwischenzustände.
-        self._fixed_width = self._measure_max_width()
+        self._renderer.measure_max_width(
+            self.view_mode, self.year, self.month, self.iso_year, self.current_week)
         self._refresh()
         self._bg.refresh_token(
             on_auth_error=lambda msg: themed_showinfo(
@@ -167,7 +159,7 @@ class App:
         )
         self._bg.fetch_sender_email()
         self._update_banner = UpdateBanner(
-            self.root, self.settings, lambda: self.grid_container)
+            self.root, self.settings, lambda: self._renderer.grid_container)
         self._bg.check_update(on_result=self._update_banner.handle_check_result)
         self._bg.reconcile_on_start(on_ok=self._refresh)
         self.root.protocol("WM_DELETE_WINDOW", self._on_close)
@@ -254,26 +246,6 @@ class App:
         self.sync_button = icon_button(frame, "\u27f3", self._sync.on_sync_clicked)
         self.sync_status_label = tk.Label(frame, text="", bg=BG, fg=TEXT_MUTED, font=FONT_SMALL)
 
-    def _build_grid(self):
-        # Double-Buffer: zwei dauerhafte Frames im selben Grid-Slot. Refresh
-        # baut in den inaktiven (versteckt unter dem aktiven), dann lift()
-        # tauscht atomar. So nie sichtbar leerer Hintergrund zwischen Destroy
-        # und Pack.
-        self.grid_container = tk.Frame(self.root, bg=BG)
-        self.grid_container.pack(fill=tk.BOTH, expand=True, padx=10, pady=5)
-        self.grid_container.rowconfigure(0, weight=1)
-        self.grid_container.columnconfigure(0, weight=1)
-        self.grid_frames = []
-        for _ in range(2):
-            f = tk.Frame(self.grid_container, bg=BG)
-            f.grid(row=0, column=0, sticky="nsew")
-            for col in range(7):
-                f.columnconfigure(col, weight=1)
-            self.grid_frames.append(f)
-        self.grid_frames[0].lift()
-        self._active_grid_idx = 0
-        self.grid_frame = self.grid_frames[0]  # Alias auf aktiven Frame
-
     def _build_footer(self):
         footer_frame = tk.Frame(self.root, bg=BG)
         footer_frame.pack(fill=tk.X, padx=10, pady=(0, 10))
@@ -314,41 +286,6 @@ class App:
     def _on_tab_toggle_view(self, _event=None):
         self._set_view("week" if self.view_mode == "month" else "month")
         return "break"
-
-    def _measure_max_width(self):
-        """Pre-warm: rendert alle 4 (view × show_weekend)-Kombinationen einmal
-        in den versteckten Backbuffer und gibt die maximale reqwidth zurück.
-        Läuft vor `mainloop()` — Zwischenzustände sind nie sichtbar.
-
-        Settings werden direkt über `_data` mutiert (kein Disk-Save) und am
-        Ende wiederhergestellt. `_suppress_geometry` verhindert den
-        Resize-Call im _refresh-Pfad während der Messung.
-        """
-        saved_view = self.view_mode
-        saved_weekend = self.settings.get("show_weekend")
-        max_w = 0
-        self._suppress_geometry = True
-        try:
-            for view in ("month", "week"):
-                for weekend in (True, False):
-                    self.view_mode = view
-                    self.settings._data["show_weekend"] = weekend
-                    # Force-rebuild über Tracking-Reset — sonst greift der
-                    # view_changed/cols_changed-Shortcut in _refresh.
-                    self._last_refresh_view = None
-                    self._last_refresh_columns = None
-                    self._refresh()
-                    self.root.update_idletasks()
-                    w = self.root.winfo_reqwidth()
-                    if w > max_w:
-                        max_w = w
-        finally:
-            self._suppress_geometry = False
-            self.view_mode = saved_view
-            self.settings._data["show_weekend"] = saved_weekend
-            self._last_refresh_view = None
-            self._last_refresh_columns = None
-        return max_w
 
     def _set_view(self, mode):
         if mode == self.view_mode:
@@ -479,547 +416,8 @@ class App:
             pass
 
     def _refresh(self):
-        if self.view_mode == "month":
-            # FONT_HEADER (16pt) + width=16 — längste Variante "September 2026"
-            # (14 Zeichen) passt rein.
-            self.header_label.config(
-                text=f"{MONTHS_DE[self.month]} {self.year}",
-                font=FONT_HEADER, width=16,
-            )
-            self._refresh_month()
-        else:
-            # FONT_HEADER_SMALL (12pt) + width=32 — die längste Variante
-            # mit Jahreswechsel "KW 53 · 30.12.2025 – 05.01.2026" (31 Zeichen)
-            # passt in 16pt nicht ins Fenster (7 × Standardzelle), daher
-            # in der Wochenansicht kleinerer Header-Font.
-            self.header_label.config(
-                text=get_week_label(self.iso_year, self.current_week),
-                font=FONT_HEADER_SMALL, width=32,
-            )
-            self._refresh_week()
-        # Geometry nur beim First-Render, bei View-Wechsel und bei Wechsel der
-        # sichtbaren Spaltenzahl (show_weekend-Toggle) neu setzen. Innerhalb
-        # derselben Kombination ist die natürliche Größe konstant; ein erneuter
-        # `geometry("")`-Aufruf triggert trotzdem einen WM-Repaint und erzeugt
-        # sichtbares Flackern.
-        current_cols = self._visible_day_count()
-        view_changed = getattr(self, "_last_refresh_view", None) != self.view_mode
-        cols_changed = getattr(self, "_last_refresh_columns", None) != current_cols
-        if view_changed or cols_changed:
-            self._last_refresh_view = self.view_mode
-            self._last_refresh_columns = current_cols
-            # Beim View- oder Spalten-Wechsel hält der jetzt-inaktive Buffer
-            # noch den alten Layout-Stand. Children destroyen + rowconfigure
-            # zurücksetzen reicht NICHT: Tk's reqheight-Cache des Frames bleibt
-            # auf der alten Höhe, `grid_container.reqheight = max(active,
-            # inactive)` zieht das Window-Resize hoch. Den Inactive-Frame
-            # komplett ersetzen umgeht den Cache — frischer Frame hat
-            # reqheight = 0.
-            inactive_idx = 1 - self._active_grid_idx
-            self.grid_frames[inactive_idx].destroy()
-            new_inactive = tk.Frame(self.grid_container, bg=BG)
-            new_inactive.grid(row=0, column=0, sticky="nsew")
-            for col in range(7):
-                new_inactive.columnconfigure(col, weight=1 if col < current_cols else 0)
-            self.grid_frames[inactive_idx] = new_inactive
-            # Frisch erstellter Frame liegt in der Stacking-Order obenauf und
-            # würde den aktiven Frame verdecken — active wieder nach vorn.
-            self.grid_frames[self._active_grid_idx].lift()
-            self.root.update_idletasks()
-            # Tk schrumpft Toplevels auf Windows nicht zuverlässig via
-            # `geometry("")` — explizit auf reqsize setzen erzwingt Resize.
-            # Breite wird auf den beim Start gemessenen Max-Wert gepinnt,
-            # damit View-/Weekend-Toggle die Fensterbreite nicht ändern.
-            # Während der Initial-Messung (_measure_max_width) suppress geometry,
-            # sonst flackert das Fenster beim Probing.
-            if not getattr(self, "_suppress_geometry", False):
-                width = max(
-                    getattr(self, "_fixed_width", 0),
-                    self.root.winfo_reqwidth(),
-                )
-                self.root.geometry(
-                    f"{width}x{self.root.winfo_reqheight()}"
-                )
-
-    def _visible_day_count(self):
-        """Sichtbare Wochentag-Spalten (5 bei show_weekend=False, sonst 7).
-
-        Wird von _build_grid_header und den Refresh-Pfaden als einzige
-        Quelle der Wahrheit konsultiert.
-        """
-        return 7 if self.settings.get("show_weekend") else 5
-
-    def _build_grid_header(self, parent):
-        n = self._visible_day_count()
-        for col, day_name in enumerate(DAYS_DE[:n]):
-            fg = TEXT_MUTED if col < 5 else WEEKEND_FG
-            tk.Label(
-                parent, text=day_name, font=FONT_BOLD, bg=BG, fg=fg,
-            ).grid(row=0, column=col, sticky="nsew", padx=2, pady=2)
-
-    def _build_entry_cell(self, parent, date_str, day_text, entry, is_weekend, pad,
-                          cell_size=None, time_font=FONT_TINY):
-        bg = WEEKEND_ENTRY_BG if is_weekend else ENTRY_BG
-        hover_bg = WEEKEND_ENTRY_BG_HOVER if is_weekend else ENTRY_BG_HOVER
-        cell = tk.Frame(
-            parent, bg=bg, relief=tk.SOLID,
-            highlightbackground=ACCENT, highlightthickness=1, cursor="hand2",
-        )
-        if cell_size is not None:
-            # Pixel-fixiert wie die Feiertagszelle — sonst weitet die Zeit-Zeile
-            # ("HH:MM-HH:MM" in FONT_SMALL) die Spalte auf und der Header-Reflow
-            # lässt den Monatsnamen flackern, sobald Einträge dazukommen.
-            cell.config(width=cell_size[0], height=cell_size[1])
-            cell.pack_propagate(False)
-        day_lbl = tk.Label(
-            cell, text=day_text, font=FONT,
-            bg=bg, fg=TEXT, cursor="hand2",
-        )
-        day_lbl.pack(pady=(pad, 0))
-        # time_font default FONT_TINY (7pt) damit "HH:MM-HH:MM" in die
-        # pixel-fixierte Standardzelle (width=8 in FONT) reinpasst. Wenn der
-        # Caller eine breitere Zelle nutzt (z.B. bei ausgeblendeten Wochenenden
-        # mit width=11), kann eine größere Schrift übergeben werden.
-        slots = entry.get("slots", [])
-        if slots:
-            first = slots[0]
-            time_text = f"{first['start']}-{first['end']}"
-            if len(slots) > 1:
-                time_text += f"  +{len(slots) - 1}"
-        else:
-            time_text = ""
-        time_lbl = tk.Label(
-            cell, text=time_text,
-            font=time_font, bg=bg, fg=TEXT_MUTED, cursor="hand2",
-        )
-        time_lbl.pack(pady=(0, pad))
-        for w in (cell, day_lbl, time_lbl):
-            w.bind("<Button-1>", lambda e, d=date_str: self._open_dialog(d))
-            w.bind("<Button-3>", lambda e, d=date_str: self._delete_day(d))
-            w.bind("<Enter>", lambda e, c=cell, dl=day_lbl, tl=time_lbl, hb=hover_bg: self._hover(c, hb, dl, tl))
-            w.bind("<Leave>", lambda e, c=cell, dl=day_lbl, tl=time_lbl, ob=bg: self._hover(c, ob, dl, tl))
-        return cell
-
-    @staticmethod
-    def _fmt_slot_line(slot):
-        """Eine Tooltip-Zeile für einen Slot: 'HH:MM-HH:MM  Kategorie'
-        (Kategorie weggelassen, wenn leer)."""
-        kat = f"  {slot['kategorie']}" if slot.get("kategorie") else ""
-        return f"{slot['start']}-{slot['end']}{kat}"
-
-    def _add_reservation_marker(self, cell):
-        """Runder violetter Eck-Punkt auf einer Ist-Zeitzelle, die zusätzlich
-        eine Reservierung hat. Ein Canvas-Oval statt eines Text-Bullets — „•"
-        rendert je nach Font als kaum sichtbarer Fleck; das Oval gibt einen
-        sauber gerundeten, größenkontrollierten Punkt. place() überlagert die
-        gepackten Kind-Widgets. Der Marker wird als cell._reservation_marker
-        getaggt, damit _hover seinen Hintergrund beim Hover mitfärbt."""
-        box, dot = 12, 7
-        marker = tk.Canvas(
-            cell, width=box, height=box, bg=cell.cget("bg"),
-            highlightthickness=0, cursor="hand2",
-        )
-        inset = (box - dot) // 2
-        marker.create_oval(
-            inset, inset, inset + dot, inset + dot,
-            fill=RESERVATION_ACCENT, outline="",
-        )
-        marker.place(relx=1.0, x=-3, y=3, anchor="ne")
-        cell._reservation_marker = marker
-
-    def _add_delete_button(self, cell, date_str):
-        """macOS-only: kleines ✕ oben links, das den Lösch-Pfad auslöst.
-
-        <Button-3> ist auf macOS unzuverlässig (Sekundärklick je nach Tk-Version
-        <Button-2>/Control-Klick); dieser Button gibt dort einen verlässlichen
-        Lösch-Auslöser, ohne den Linksklick-Dialog mit Lösch-Buttons zu belasten.
-        Klick ruft denselben _delete_day-Pfad wie der Win/Linux-Rechtsklick
-        (Ja/Nein bzw. Slot-Auswahl). Getaggt als cell._delete_button, damit
-        _hover seinen Hintergrund beim Hover mitfärbt."""
-        bg = cell.cget("bg")
-        btn = tk.Label(
-            cell, text="✕", font=FONT_TINY, bg=bg, fg=TEXT_MUTED, cursor="hand2",
-        )
-        btn.place(relx=0.0, x=3, y=2, anchor="nw")
-        # "break" stoppt jede Propagation, damit der Klick nicht zusätzlich als
-        # Zell-Linksklick (Bearbeiten-Dialog) durchschlägt.
-        btn.bind("<Button-1>",
-                 lambda e, d=date_str: (self._delete_day(d), "break")[1])
-        # fg-Hover (rot als Lösch-Affordance) steuert der Button selbst; den bg
-        # färbt _hover mit der Zelle.
-        btn.bind("<Enter>", lambda e: btn.config(fg=ACCENT))
-        btn.bind("<Leave>", lambda e: btn.config(fg=TEXT_MUTED))
-        cell._delete_button = btn
-
-    def _build_empty_cell(self, parent, date_str, day_text, is_weekend, cell_size):
-        bg = WEEKEND_BG if is_weekend else CELL_BG
-        hover_bg = WEEKEND_BG_HOVER if is_weekend else CELL_BG_HOVER
-        fg = WEEKEND_FG if is_weekend else TEXT
-        # Pixel-fixiert auf dieselbe Außengröße wie Entry-/Holiday-Zellen, damit
-        # die per sticky="nsew"+weight gestreckten Spalten unabhängig vom Inhalt
-        # gleich breit bleiben.
-        # Breite OHNE Aufschlag: die reqwidth muss exakt der der gefüllten Zellen
-        # entsprechen (die mit width=cell_size[0]+highlightthickness=1 gebaut
-        # werden). Tk zählt den 1-px-Highlight-Rand hier NICHT zur reqwidth, also
-        # ist deren reqwidth ebenfalls cell_size[0]. Ein früher gesetztes +2
-        # machte leere Spalten 2 px breiter als Eintragsspalten — in der
-        # Wochenansicht (1 Zelle pro Spalte) verschob das die Spaltenbreiten
-        # gegenüber der Monatsansicht (dort mittelt sich der Unterschied über die
-        # 6 Zeilen weg). Höhe +2 kompensiert den Rand der gefüllten Zellen
-        # vertikal und betrifft die Spaltenbreite nicht.
-        cell = tk.Frame(parent, bg=bg, cursor="hand2")
-        cell.config(width=cell_size[0], height=cell_size[1] + 2)
-        cell.pack_propagate(False)
-        day_lbl = tk.Label(
-            cell, text=day_text, font=FONT, bg=bg, fg=fg, cursor="hand2",
-        )
-        day_lbl.pack(expand=True)
-        for w in (cell, day_lbl):
-            w.bind("<Button-1>", lambda e, d=date_str: self._open_dialog(d))
-            w.bind("<Button-3>", lambda e, d=date_str: self._delete_day(d))
-            w.bind("<Enter>", lambda e, c=cell, dl=day_lbl, hb=hover_bg: self._hover(c, hb, dl))
-            w.bind("<Leave>", lambda e, c=cell, dl=day_lbl, ob=bg: self._hover(c, ob, dl))
-        return cell
-
-    def _build_day_cell(self, parent, date_str, day_text, day_date, is_weekend,
-                        entry, holidays_map, pad,
-                        holiday_max_len, cell_size, conflict_dates=None,
-                        entry_time_font=FONT_TINY, holiday_name_font=FONT_SMALL,
-                        reservation=None):
-        """Dispatcht auf Entry-, Holiday- oder Empty-Zelle.
-
-        reservation: optionales {start, end} für den Tag. Eine Reservierung
-        ändert den Zelltyp NICHT — sie wird ausschließlich als kleiner
-        violetter Eck-Punkt (plus Tooltip) auf die ohnehin gebaute Zelle
-        gelegt. Ein Tag mit nur einer Reservierung sieht also aus wie ein
-        leerer Tag (bzw. Feiertag) mit Punkt.
-        """
-        is_holiday = day_date in holidays_map
-        if entry:
-            cell = self._build_entry_cell(
-                parent, date_str, day_text, entry, is_weekend, pad,
-                cell_size=cell_size, time_font=entry_time_font,
-            )
-        elif is_holiday:
-            cell = self._build_holiday_cell(
-                parent, day_text=day_text,
-                name=holidays_map[day_date], max_name_len=holiday_max_len,
-                on_click=lambda d=date_str: self._open_dialog(d),
-                on_right_click=lambda d=date_str: self._delete_day(d),
-                cell_size=cell_size,
-                name_font=holiday_name_font,
-                # Bei zusätzlicher Reservierung übernimmt der Reservierungs-
-                # Tooltip unten den Feiertagsnamen — sonst klebten zwei
-                # unabhängige Tooltips am selben Widget (s. attach_tooltip).
-                name_tooltip=reservation is None,
-            )
-        else:
-            cell = self._build_empty_cell(
-                parent, date_str, day_text, is_weekend, cell_size,
-            )
-
-        # Reservierung ist ein reiner Overlay-Marker (Eck-Punkt) — sie ändert
-        # den Zelltyp nicht. Genau EIN attach_tooltip pro Zelle (Mehrfachaufruf
-        # erzeugt überlappende Tooltips); deshalb alle relevanten Infos
-        # (mehrere Arbeitszeit-Slots, Reservierung, Feiertag) in einen
-        # kombinierten Tooltip. Ein Feiertag-OHNE-Eintrag/-Reservierung zeigt
-        # seinen Namen weiterhin als Zelltext (Holiday-Zelle) bzw. eigenen
-        # Tooltip (name_tooltip) und kommt hier NICHT rein.
-        tip_parts = []
-        if entry and len(entry.get("slots", [])) > 1:
-            tip_parts.append(
-                "Arbeitszeit:\n"
-                + "\n".join(self._fmt_slot_line(s) for s in entry["slots"]))
-        if reservation is not None:
-            self._add_reservation_marker(cell)
-            tip_parts.append(
-                "Reservierung:\n"
-                + "\n".join(self._fmt_slot_line(s) for s in reservation.get("slots", [])))
-        if is_holiday and (reservation is not None or entry):
-            tip_parts.append(f"Feiertag: {holidays_map[day_date]}")
-        if tip_parts:
-            attach_tooltip(cell, "\n".join(tip_parts))
-
-        # macOS-only Lösch-Button (✕) oben links, sobald der Tag löschbare
-        # Einheiten hat (Ist-Zeit ODER aktive Reservierung). reservation wird
-        # nur bei aktivem Kalender-Sync übergeben (vgl. _add_reservation_marker),
-        # daher deckt `reservation is not None` die aktive Reservierung ab.
-        if _should_show_delete_button(
-            platform.system() == "Darwin", bool(entry), reservation is not None
-        ):
-            self._add_delete_button(cell, date_str)
-
-        # Heutigen Tag mit blauem Rahmen hervorheben. Vor dem Konflikt-Block,
-        # damit ein Konflikt (orange) auf demselben Tag den Rand gewinnt.
-        if day_date == datetime.date.today():
-            cell.configure(highlightbackground=TODAY_ACCENT, highlightthickness=2)
-
-        if conflict_dates and date_str in conflict_dates:
-            cell.configure(highlightbackground="orange", highlightthickness=2)
-            attach_tooltip(cell, "Konflikt — bitte auflösen")
-
-        return cell
-
-    def _get_inactive_grid(self):
-        """Liefert das versteckte Grid-Frame (Double-Buffer-Backbuffer).
-        Children, Row- und Column-Config werden zurückgesetzt. Nur sichtbare
-        Spalten erhalten weight=1 — ausgeblendete (Sa/So bei show_weekend=False)
-        würden sonst den vom Header/Footer geforderten Extra-Platz absorbieren
-        und einen Leerraum-Streifen rechts neben Fr produzieren."""
-        inactive = self.grid_frames[1 - self._active_grid_idx]
-        for child in list(inactive.winfo_children()):
-            child.destroy()
-        for row in range(8):
-            inactive.rowconfigure(row, minsize=0, weight=0)
-        n = self._visible_day_count()
-        for col in range(7):
-            inactive.columnconfigure(col, weight=1 if col < n else 0)
-        return inactive
-
-    def _activate_grid(self, frame):
-        """Hebt das eben gefüllte Backbuffer-Frame nach vorne. Der bisherige
-        Front-Buffer bleibt als Backbuffer hinten — keine Destroy-Lücke."""
-        frame.lift()
-        self._active_grid_idx = 1 - self._active_grid_idx
-        self.grid_frame = frame
-
-    def _update_footer(self, total_hours):
-        rate = self.settings.get("hourly_rate") or 0
-        total_rounded = round(total_hours, 2)
-        if rate > 0:
-            brutto = round(total_hours * rate, 2)
-            self.footer_label.config(
-                text=f"Gesamt: {total_rounded}h  —  {brutto:.2f} € brutto"
-            )
-        else:
-            self.footer_label.config(text=f"Gesamt: {total_rounded}h")
-
-    def _entry_hours(self, entry):
-        return round(sum(
-            calculate_hours(s["start"], s["end"], pause_minutes=s.get("pause", 0))
-            for s in entry.get("slots", [])
-        ), 2)
-
-    def _dates_with_unresolved_conflicts(self):
-        """Gibt die Menge der ISO-Datums-Strings zurück, für die ungelöste
-        Konflikte vom Typ 'entry' vorliegen."""
-        if not self.conflicts_store:
-            return set()
-        return {
-            c["key"] for c in self.conflicts_store.get_all()
-            if c.get("kind") == "entry" and not c.get("resolved")
-        }
-
-    def _cell_layout_metrics(self, frame):
-        """Misst die natuerliche Pixelgroesse einer Standard-Tageszelle (Probe-
-        Label) und liefert die layout-abhaengigen Groessen.
-
-        Bei ausgeblendetem Wochenende (5 statt 7 Spalten) bleibt mehr Horizontal-
-        platz pro Spalte: breitere Zellen und groessere Zeit-/Feiertagsschrift
-        (FONT statt FONT_SMALL), damit z.B. '09:30-17:00' bequem lesbar bleibt.
-        Holiday-Zellen werden spaeter auf `cell_size` fixiert, damit lange
-        Feiertagsnamen die Spalte nicht aufweiten (Header-Reflow/Flackern)."""
-        wide_cells = not self.settings.get("show_weekend")
-        probe_width = PROBE_WIDTH_WIDE if wide_cells else PROBE_WIDTH_NARROW
-        entry_time_font = FONT if wide_cells else FONT_SMALL
-        holiday_name_font = FONT if wide_cells else FONT_SMALL
-        probe = tk.Label(frame, text="", font=FONT, width=probe_width, height=PROBE_HEIGHT)
-        probe.update_idletasks()
-        cell_size = (probe.winfo_reqwidth(), probe.winfo_reqheight())
-        probe.destroy()
-        return cell_size, entry_time_font, holiday_name_font, wide_cells
-
-    def _refresh_month(self):
-        # In den versteckten Backbuffer bauen, dann via lift() in den Vordergrund
-        # holen — verhindert sichtbare leere Fläche zwischen Refreshes.
-        new_frame = self._get_inactive_grid()
-        self._build_grid_header(new_frame)
-
-        cal = calendar.Calendar(firstweekday=0)
-        entries = self.storage.get_all()
-        reservations = (
-            self.reservation_store.get_all() if self._reservations_active() else {})
-        total_hours = 0.0
-
-        state = self.settings.get("state")
-        holidays_map = get_holidays(state, self.year) if state else {}
-
-        cell_size, entry_time_font, holiday_name_font, wide_cells = \
-            self._cell_layout_metrics(new_frame)
-
-        # Auf 6 Wochen padden, damit die Fensterhöhe zwischen Monaten konstant
-        # bleibt und `geometry("")` in `_refresh` keinen sichtbaren Resize auslöst.
-        n = self._visible_day_count()
-        weeks = cal.monthdayscalendar(self.year, self.month)
-        # Bei ausgeblendetem Wochenende: führende Wochen verwerfen, deren
-        # sichtbarer Anteil (Mo–Fr) komplett aus 0 besteht — sonst entsteht
-        # eine sichtbar leere erste Zeile, wenn der Monat am Sa/So beginnt.
-        if n < 7:
-            while weeks and not any(weeks[0][:n]):
-                weeks.pop(0)
-        while len(weeks) < 6:
-            weeks.append([0] * 7)
-
-        # Einmal pro Render berechnen, nicht pro Zelle.
-        conflict_dates = self._dates_with_unresolved_conflicts()
-
-        for row, week in enumerate(weeks, start=1):
-            for col, day in enumerate(week[:n]):
-                if day == 0:
-                    tk.Label(new_frame, text="", bg=BG, relief=tk.FLAT).grid(
-                        row=row, column=col, sticky="nsew", padx=2, pady=2)
-                    continue
-
-                date_str = f"{self.year}-{self.month:02d}-{day:02d}"
-                day_date = datetime.date(self.year, self.month, day)
-                entry = entries.get(date_str)
-                if entry:
-                    total_hours += self._entry_hours(entry)
-
-                cell = self._build_day_cell(
-                    new_frame, date_str, str(day), day_date,
-                    is_weekend=col >= 5, entry=entry, holidays_map=holidays_map,
-                    pad=4,
-                    # Bei schmalen Zellen (7-Spalten-Modus) kürzer trunkieren,
-                    # damit der padx=4-Innenraum der Holiday-Zelle erhalten bleibt.
-                    holiday_max_len=12 if wide_cells else 9,
-                    cell_size=cell_size,
-                    conflict_dates=conflict_dates,
-                    entry_time_font=entry_time_font,
-                    holiday_name_font=holiday_name_font,
-                    reservation=reservations.get(date_str),
-                )
-                cell.grid(row=row, column=col, sticky="nsew", padx=2, pady=2)
-
-        row_min_h = cell_size[1] + 4  # +4 für pady=2 oben/unten
-        for row in range(1, 7):
-            new_frame.rowconfigure(row, minsize=row_min_h)
-
-        self._activate_grid(new_frame)
-        self._update_footer(total_hours)
-
-    def _refresh_week(self):
-        new_frame = self._get_inactive_grid()
-        self._build_grid_header(new_frame)
-
-        dates = get_week_dates(self.iso_year, self.current_week)
-        entries = self.storage.get_all()
-        reservations = (
-            self.reservation_store.get_all() if self._reservations_active() else {})
-        total_hours = 0.0
-        spans = week_spans_months(self.iso_year, self.current_week)
-        state = self.settings.get("state")
-        holidays_map: dict[datetime.date, str] = {}
-        if state:
-            for y in {dates[0].year, dates[-1].year}:
-                holidays_map.update(get_holidays(state, y))
-
-        cell_size, entry_time_font, holiday_name_font, wide_cells = \
-            self._cell_layout_metrics(new_frame)
-
-        n = self._visible_day_count()
-        # Einmal pro Render berechnen, nicht pro Zelle.
-        conflict_dates = self._dates_with_unresolved_conflicts()
-
-        for col, day_date in enumerate(dates[:n]):
-            date_str = day_date.isoformat()
-            entry = entries.get(date_str)
-            if entry:
-                total_hours += self._entry_hours(entry)
-            day_text = f"{day_date.day}.{day_date.month}." if spans else str(day_date.day)
-
-            cell = self._build_day_cell(
-                new_frame, date_str, day_text, day_date,
-                is_weekend=col >= 5, entry=entry, holidays_map=holidays_map,
-                # pad=4 wie in der Monatsansicht, damit die vertikale Anordnung
-                # von Tagesziffer und Zeitzeile beim View-Wechsel nicht springt.
-                pad=4,
-                # 18 war zu lang für die gerenderte Spaltenbreite — "Christi
-                # Himmelfa…" lief über den Zellenrand hinaus. Werte unten
-                # passen zu den effektiv gestreckten Spalten in beiden Modi.
-                holiday_max_len=14 if wide_cells else 12,
-                cell_size=cell_size,
-                conflict_dates=conflict_dates,
-                entry_time_font=entry_time_font,
-                holiday_name_font=holiday_name_font,
-                reservation=reservations.get(date_str),
-            )
-            cell.grid(row=1, column=col, sticky="nsew", padx=2, pady=2)
-
-        self._activate_grid(new_frame)
-        self._update_footer(total_hours)
-
-    @staticmethod
-    def _truncate(text: str, max_len: int) -> str:
-        if len(text) <= max_len:
-            return text
-        return text[: max_len - 1] + "…"
-
-    def _build_holiday_cell(self, parent, day_text, name, max_name_len, on_click,
-                             cell_size=None, name_font=FONT_SMALL,
-                             name_tooltip=True, on_right_click=None):
-        """Grüne Feiertagszelle. Layout analog zur Eintragszelle.
-
-        cell_size: optional (width_px, height_px). Wenn gesetzt, wird der Frame
-        auf diese Pixel-Größe fixiert (verhindert Aufweitung der Spalte durch
-        längere Namen — relevant für die Wochenansicht).
-        name_font: Schriftart für den Feiertagsnamen. Default FONT_SMALL (8pt);
-        bei breiteren Zellen (Wochenenden ausgeblendet) kann FONT übergeben werden.
-        name_tooltip: ob bei abgeschnittenem Namen ein Voll-Namen-Tooltip
-        angehängt wird. False, wenn der Aufrufer selbst einen Tooltip setzt
-        (Doppel-Tooltip am selben Widget vermeiden).
-        """
-        cell = tk.Frame(
-            parent, bg=HOLIDAY_BG, relief=tk.SOLID,
-            highlightbackground=HOLIDAY_ACCENT, highlightthickness=1,
-            cursor="hand2",
-        )
-        if cell_size is not None:
-            cell.config(width=cell_size[0], height=cell_size[1])
-            cell.pack_propagate(False)
-        day_lbl = tk.Label(
-            cell, text=day_text, font=FONT,
-            bg=HOLIDAY_BG, fg=TEXT, cursor="hand2",
-        )
-        day_lbl.pack(pady=(4, 0))
-        truncated = self._truncate(name, max_name_len)
-        name_lbl = tk.Label(
-            cell, text=truncated,
-            font=name_font, bg=HOLIDAY_BG, fg=TEXT_MUTED, cursor="hand2",
-        )
-        # padx=4 für sichtbare Innenränder, sonst klebt der Feiertagsname an
-        # den Zellrändern. Caller sorgt mit passendem max_name_len dafür,
-        # dass der Text in die verbleibende Breite passt.
-        name_lbl.pack(pady=(0, 4), padx=4)
-
-        for w in (cell, day_lbl, name_lbl):
-            w.bind("<Button-1>", lambda e: on_click())
-            if on_right_click is not None:
-                w.bind("<Button-3>", lambda e: on_right_click())
-            w.bind("<Enter>", lambda e, c=cell, dl=day_lbl, nl=name_lbl:
-                self._hover(c, HOLIDAY_BG_HOVER, dl, nl))
-            w.bind("<Leave>", lambda e, c=cell, dl=day_lbl, nl=name_lbl:
-                self._hover(c, HOLIDAY_BG, dl, nl))
-        if name_tooltip and truncated != name:
-            # Geteilter Tooltip über alle drei Widgets — _Tooltip trackt sie
-            # gemeinsam, sodass Pointer-Wechsel zwischen Frame und Child-
-            # Labels den Tooltip nicht schließt/neu öffnet.
-            attach_tooltip((cell, day_lbl, name_lbl), f"Feiertag: {name}")
-        return cell
-
-    @staticmethod
-    def _hover(frame, bg, *labels):
-        """Faerbt Zelle + uebergebene Labels beim Hover. Die Eck-Overlays
-        (_reservation_marker, macOS-_delete_button) werden mitgefaerbt, sonst
-        bleibt ein andersfarbiges Rechteck stehen. Nur bg — die fg des
-        Loesch-Buttons steuert dessen eigener Enter/Leave-Handler."""
-        frame.config(bg=bg)
-        for lbl in labels:
-            lbl.config(bg=bg)
-        for attr in ("_reservation_marker", "_delete_button"):
-            w = getattr(frame, attr, None)
-            if w is not None:
-                w.config(bg=bg)
+        self._renderer.refresh(
+            self.view_mode, self.year, self.month, self.iso_year, self.current_week)
 
     def _delete_day(self, date_str):
         """Rechtsklick-Löschen für einen Tag. Löscht NIE ohne Bestätigung.
@@ -1058,13 +456,13 @@ class App:
                 options.append(("entry:all", "Arbeitszeit"))
             else:
                 for i, s in enumerate(entry_slots):
-                    options.append((f"entry:{i}", f"Arbeitszeit  {self._fmt_slot_line(s)}"))
+                    options.append((f"entry:{i}", f"Arbeitszeit  {GridRenderer._fmt_slot_line(s)}"))
         if res_slots:
             if len(res_slots) == 1:
                 options.append(("reservation:all", "Reservierung"))
             else:
                 for i, s in enumerate(res_slots):
-                    options.append((f"reservation:{i}", f"Reservierung  {self._fmt_slot_line(s)}"))
+                    options.append((f"reservation:{i}", f"Reservierung  {GridRenderer._fmt_slot_line(s)}"))
 
         if len(options) == 1:
             kind = "Arbeitszeit" if options[0][0].startswith("entry") else "Reservierung"

--- a/src/ui.py
+++ b/src/ui.py
@@ -22,7 +22,7 @@ from src.dialogs.send_dialog import open_send_dialog
 from src.dialogs.settings_dialog import open_settings_dialog
 from src.theme import (
     BG, ACCENT, TEXT, TEXT_MUTED,
-    FONT_HEADER, FONT_FOOTER, FONT_SMALL, apply_dark_titlebar, themed_askyesno, themed_ask_delete_choice, themed_showinfo,
+    FONT_HEADER, FONT_FOOTER, FONT_SMALL, apply_dark_titlebar, themed_askyesno, themed_ask_delete_choice, themed_showerror, themed_showinfo,
     icon_button, secondary_button, set_toggle_active, toggle_button,
     _stray_click_suppressed,
 )
@@ -350,7 +350,8 @@ class App:
 
         if want_tray and self._tray is None:
             if not is_supported():
-                messagebox.showinfo(
+                themed_showinfo(
+                    self.root,
                     "Infobereich-Icon",
                     "Das Minimieren in den Infobereich ist auf dieser Plattform "
                     "nicht zuverlässig nutzbar (typisch Linux). Option wurde "
@@ -376,7 +377,8 @@ class App:
                 tray.start()
             except Exception as e:
                 logging.getLogger(__name__).exception("Tray-Start fehlgeschlagen")
-                messagebox.showerror(
+                themed_showerror(
+                    self.root,
                     "Infobereich-Icon",
                     f"Tray-Icon konnte nicht gestartet werden:\n\n{e}",
                 )

--- a/tests/test_grid_renderer.py
+++ b/tests/test_grid_renderer.py
@@ -1,0 +1,73 @@
+"""GridRenderer: reine Helfer ohne Tk (statics + Methoden, die nur settings/
+conflicts_store lesen)."""
+
+from unittest.mock import MagicMock
+
+from src.time_utils import calculate_hours
+from src.grid_renderer import GridRenderer
+
+
+def _renderer(show_weekend=True, conflicts=None):
+    settings = MagicMock(get=lambda k, d=None: {"show_weekend": show_weekend}.get(k, d))
+    cstore = MagicMock(get_all=lambda: conflicts) if conflicts is not None else None
+    return GridRenderer(
+        root=object(), storage=object(), settings=settings,
+        reservation_store=None, conflicts_store=cstore,
+        on_cell_click=lambda d: None, on_cell_right_click=lambda d: None,
+        reservations_active=lambda: False,
+    )
+
+
+def test_fmt_slot_line_with_category():
+    assert GridRenderer._fmt_slot_line(
+        {"start": "08:00", "end": "12:00", "kategorie": "Büro"}) == "08:00-12:00  Büro"
+
+
+def test_fmt_slot_line_without_category():
+    assert GridRenderer._fmt_slot_line(
+        {"start": "08:00", "end": "12:00"}) == "08:00-12:00"
+
+
+def test_truncate_clips_long_text():
+    assert GridRenderer._truncate("Donnerstag", 5) == "Donn…"
+
+
+def test_truncate_keeps_short_text():
+    assert GridRenderer._truncate("Mo", 5) == "Mo"
+
+
+def test_entry_hours_sums_slots():
+    entry = {"slots": [
+        {"start": "08:00", "end": "12:00", "pause": 0},
+        {"start": "13:00", "end": "17:00", "pause": 0},
+    ]}
+    expected = round(
+        calculate_hours("08:00", "12:00", pause_minutes=0)
+        + calculate_hours("13:00", "17:00", pause_minutes=0), 2)
+    assert _renderer()._entry_hours(entry) == expected == 8.0
+
+
+def test_entry_hours_subtracts_pause():
+    entry = {"slots": [{"start": "08:00", "end": "12:00", "pause": 30}]}
+    assert _renderer()._entry_hours(entry) == 3.5
+
+
+def test_visible_day_count_with_weekend():
+    assert _renderer(show_weekend=True)._visible_day_count() == 7
+
+
+def test_visible_day_count_without_weekend():
+    assert _renderer(show_weekend=False)._visible_day_count() == 5
+
+
+def test_dates_with_unresolved_conflicts_filters_entry_kind():
+    conflicts = [
+        {"key": "2026-06-01", "kind": "entry", "resolved": False},
+        {"key": "2026-06-02", "kind": "entry", "resolved": True},
+        {"key": "2026-06-03", "kind": "reservation", "resolved": False},
+    ]
+    assert _renderer(conflicts=conflicts)._dates_with_unresolved_conflicts() == {"2026-06-01"}
+
+
+def test_dates_with_unresolved_conflicts_none_store():
+    assert _renderer()._dates_with_unresolved_conflicts() == set()

--- a/tests/test_ui_hover.py
+++ b/tests/test_ui_hover.py
@@ -1,6 +1,6 @@
 """_hover faerbt Frame, uebergebene Labels und vorhandene Eck-Overlays."""
 
-from src.ui import App
+from src.grid_renderer import GridRenderer
 
 
 class _FakeWidget:
@@ -13,7 +13,7 @@ class _FakeWidget:
 
 def test_hover_colors_frame_and_labels():
     frame, day, time = _FakeWidget(), _FakeWidget(), _FakeWidget()
-    App._hover(frame, "#123456", day, time)
+    GridRenderer._hover(frame, "#123456", day, time)
     assert frame.bg == "#123456"
     assert day.bg == "#123456"
     assert time.bg == "#123456"
@@ -23,13 +23,13 @@ def test_hover_colors_overlay_widgets_when_present():
     frame = _FakeWidget()
     frame._reservation_marker = _FakeWidget()
     frame._delete_button = _FakeWidget()
-    App._hover(frame, "#abcdef")
+    GridRenderer._hover(frame, "#abcdef")
     assert frame._reservation_marker.bg == "#abcdef"
     assert frame._delete_button.bg == "#abcdef"
 
 
 def test_hover_without_overlays_does_not_fail():
     frame, day = _FakeWidget(), _FakeWidget()
-    App._hover(frame, "#000000", day)
+    GridRenderer._hover(frame, "#000000", day)
     assert frame.bg == "#000000"
     assert day.bg == "#000000"


### PR DESCRIPTION
> ⚠️ **Stacked auf #70 → #71 → #72** — bitte in dieser Reihenfolge mergen. Dieser Branch zweigt von `refactor/ui-update-banner` (#72) ab; bis #70–#72 in `master` sind, enthält der Diff hier auch deren Commits.

**Abschluss von #49** (vierter und letzter Extraktions-Schritt der ui.py-Entflechtung, nach `BackgroundTaskRunner` #70, `SyncOrchestrator` #71, `UpdateBanner` #72).

## Problem

Das Kalender-/Grid-Rendering war der eigentliche God-Object-Kern in `App` (~600 Zeilen): Monats-/Wochenansicht, alle Zelltypen, Double-Buffer, Geometrie.

## Lösung

Neues Modul **`src/grid_renderer.py`** mit der Komponente **`GridRenderer`** — der komplette Rendering-State (Double-Buffer-Frames, Geometrie-Tracking) + alle Bau-/Refresh-Methoden:
- Stores (`storage`/`settings`/`reservation_store`/`conflicts_store`) per Konstruktor.
- **Datum/View bleibt App-Eigentum** (von `_navigate`/`_set_view` mutiert) und wird per `refresh(view_mode, year, month, iso_year, current_week)` übergeben — kein Dual-State.
- Interaktion injiziert: `on_cell_click` (= `_open_dialog`), `on_cell_right_click` (= `_delete_day`), `reservations_active`.
- `header_label`/`footer_label` bleiben App-erzeugt, werden per `attach_labels` beschrieben; `measure_max_width` behält das Pre-Mainloop-Probing.

`App._refresh` wird ein **dünner Shim**, der an `renderer.refresh(...)` delegiert — alle bestehenden Aufrufer und Callbacks (`on_refresh`/`on_ok`) bleiben unverändert. 21 Rendering-Methoden + 3 Konstanten aus `App` entfernt, 27 ungenutzte Imports getrimmt. `App` ist jetzt ein schlanker Koordinator über die vier Komponenten + Interaktions-/Navigations-/Chrome-Schicht.

## Tests & Verifikation

- Neu `tests/test_grid_renderer.py` (ohne Tk): reine Helfer (`_entry_hours`, `_visible_day_count`, `_dates_with_unresolved_conflicts`, `_truncate`, `_fmt_slot_line`). `tests/test_ui_hover.py` migriert.
- Volle Suite: **549 passed, 1 skipped**. `ruff check .` sauber.
- **Manuelle Screenshot-Abnahme** (Rendering ist nicht headless-testbar): Monats- *und* Wochenansicht rendern nach der Extraktion unverändert — Grid, Wochentags-Header, Entry-/Holiday-/Empty-Zellen, Footer-Summe, Update-Banner, Weekend-/View-Toggle, Navigation.

## Ergebnis #49

`src/ui.py`: **1541 → ~530 Zeilen** über vier PRs. Verbleibende `App`-Verantwortung: Koordination + Dialog-Routing/Navigation/Chrome. Damit ist die ui.py-Entflechtung von #49 abgeschlossen.

## Doku

Enthält Design-Spec + Implementierungsplan unter `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
