### PR TITLE
fix(dialogs): saubere User-Dialoge auf das App-Theme umstellen

### DIFF
--- a/src/dialogs/conflicts_dialog.py
+++ b/src/dialogs/conflicts_dialog.py
@@ -1,9 +1,8 @@
 # src/dialogs/conflicts_dialog.py
 import tkinter as tk
-from tkinter import messagebox
 
 from src import sync
-from src.theme import apply_app_icon
+from src.theme import apply_app_icon, themed_showerror
 from src.time_utils import format_iso_datetime
 
 
@@ -116,7 +115,7 @@ class ConflictsDialog:
             sync.resolve_conflict(c["id"], chosen, self.conflicts_store,
                                   self.storage, self.settings, device_id)
         except Exception as e:
-            messagebox.showerror("Konflikt-Resolution fehlgeschlagen", str(e))
+            themed_showerror(self.top, "Konflikt-Resolution fehlgeschlagen", str(e))
             return
         self._refresh_list()
         self.btn_a.config(state="disabled")

--- a/src/dialogs/send_dialog.py
+++ b/src/dialogs/send_dialog.py
@@ -14,7 +14,7 @@ from src.theme import (
     apply_app_icon, apply_combobox_style, apply_dark_titlebar,
     attach_unfocus_on_click, center_dialog_on_parent,
     disable_min_max, dark_combo, primary_button, secondary_button,
-    themed_showinfo,
+    themed_showerror, themed_showinfo,
 )
 
 
@@ -216,14 +216,14 @@ def open_send_dialog(parent, storage, settings, base_path):
             date_from = datetime.date(int(from_year.get()), int(from_month.get()), int(from_day.get()))
             date_to = datetime.date(int(to_year.get()), int(to_month.get()), int(to_day.get()))
         except ValueError:
-            messagebox.showerror("Ungültiges Datum", "Bitte ein gültiges Datum eingeben.", parent=dialog)
+            themed_showerror(dialog, "Ungültiges Datum", "Bitte ein gültiges Datum eingeben.")
             return
 
         if date_from > date_to:
-            messagebox.showerror(
+            themed_showerror(
+                dialog,
                 "Ungültiger Zeitraum",
                 "Das Von-Datum muss vor dem Bis-Datum liegen.",
-                parent=dialog,
             )
             return
 
@@ -241,10 +241,10 @@ def open_send_dialog(parent, storage, settings, base_path):
         )
 
         if html is None:
-            messagebox.showinfo(
+            themed_showinfo(
+                dialog,
                 "Keine Einträge",
                 f"Keine Einträge für {date_from.strftime('%d.%m.%Y')} – {date_to.strftime('%d.%m.%Y')} vorhanden.",
-                parent=dialog,
             )
             return
 
@@ -288,20 +288,20 @@ def open_send_dialog(parent, storage, settings, base_path):
                 f"Bericht für {label} wurde an {recipient} gesendet.",
             )
         except FileNotFoundError as e:
-            messagebox.showerror("Fehler", str(e), parent=dialog)
+            themed_showerror(dialog, "Fehler", str(e))
         except Exception as e:
             # Trace landet immer im Logfile. Bei einem reinen Offline-Fehler
             # zeigen wir dem Nutzer aber eine verständliche Meldung statt des
             # kryptischen Tracebacks — das ist kein Bug, sondern fehlendes Netz.
             logging.getLogger(__name__).exception("Senden fehlgeschlagen")
             if is_offline_error(e):
-                messagebox.showerror(
+                themed_showerror(
+                    dialog,
                     "Keine Internetverbindung",
                     "Der Bericht konnte nicht gesendet werden, weil keine "
                     "Verbindung zum Internet besteht.\n\n"
                     "Bitte prüfe deine Internetverbindung und versuche es "
                     "dann erneut.",
-                    parent=dialog,
                 )
             else:
                 messagebox.showerror(

--- a/src/dialogs/settings_dialog.py
+++ b/src/dialogs/settings_dialog.py
@@ -714,10 +714,10 @@ def open_settings_dialog(parent, settings, base_path, on_change, *,
         for key, lbl in zip(WEEKDAY_KEYS, DAYS_DE):
             ok, msg = validate_entry(start_vars[key].get(), end_vars[key].get())
             if not ok:
-                messagebox.showerror(
+                themed_showerror(
+                    dialog,
                     "Standard-Arbeitszeit ungültig",
                     f"{lbl}: {msg}",
-                    parent=dialog,
                 )
                 return
 
@@ -734,10 +734,10 @@ def open_settings_dialog(parent, settings, base_path, on_change, *,
                 else:
                     disable_autostart()
             except Exception as e:
-                messagebox.showerror(
+                themed_showerror(
+                    dialog,
                     "Autostart-Fehler",
                     f"Autostart konnte nicht geändert werden:\n{e}",
-                    parent=dialog,
                 )
                 return
 

--- a/src/dialogs/share_dialog.py
+++ b/src/dialogs/share_dialog.py
@@ -15,7 +15,7 @@ from src.theme import (
     apply_app_icon, apply_dark_titlebar, attach_unfocus_on_click,
     center_dialog_on_parent, disable_min_max,
     dark_entry, primary_button, secondary_button,
-    set_primary_button_enabled, themed_showinfo,
+    set_primary_button_enabled, themed_showerror, themed_showinfo,
 )
 
 
@@ -32,11 +32,11 @@ def open_share_dialog(parent, storage, settings, base_path, reservation_store=No
         reservation_store.get_all() if reservation_store is not None else {})
 
     if not entries and not reservations:
-        messagebox.showinfo(
+        themed_showinfo(
+            parent,
             "Nichts zum Teilen",
             "Es sind weder Arbeitszeiten noch Reservierungen zum Teilen "
             "vorhanden.",
-            parent=parent,
         )
         return
 
@@ -146,10 +146,10 @@ def open_share_dialog(parent, storage, settings, base_path, reservation_store=No
             return
         share_recipient = recipient_var.get().strip()
         if not share_recipient:
-            messagebox.showerror(
+            themed_showerror(
+                dialog,
                 "Empfänger fehlt",
                 "Bitte eine E-Mail-Adresse angeben.",
-                parent=dialog,
             )
             return
         sender_email = settings.get("sender_email") or ""
@@ -205,17 +205,17 @@ def open_share_dialog(parent, storage, settings, base_path, reservation_store=No
                 f"{what} wurden an {share_recipient} gesendet.",
             )
         except FileNotFoundError as e:
-            messagebox.showerror("Fehler", str(e), parent=dialog)
+            themed_showerror(dialog, "Fehler", str(e))
         except Exception as e:
             logging.getLogger(__name__).exception("Teilen fehlgeschlagen")
             if is_offline_error(e):
-                messagebox.showerror(
+                themed_showerror(
+                    dialog,
                     "Keine Internetverbindung",
                     "Die Daten konnten nicht gesendet werden, weil keine "
                     "Verbindung zum Internet besteht.\n\n"
                     "Bitte prüfe deine Internetverbindung und versuche es "
                     "dann erneut.",
-                    parent=dialog,
                 )
             else:
                 messagebox.showerror(


### PR DESCRIPTION
## Problem

Mehrere benutzerseitige Dialoge (Senden, Teilen, Einstellungen, Konflikte) nutzten das native helle `tkinter.messagebox`-Design und brachen optisch mit der dunklen App.

## Lösung

Die **sauberen, benutzerseitigen** Info-/Fehler-Dialoge laufen jetzt über die gebrandeten `themed_showinfo`/`themed_showerror`-Helfer (12 Stellen):
- `send_dialog` (5): Ungültiges Datum, Ungültiger Zeitraum, Keine Einträge, Fehler (credentials.json), Keine Internetverbindung
- `share_dialog` (4): Nichts zum Teilen, Empfänger fehlt, Fehler, Keine Internetverbindung
- `settings_dialog` (2): Standard-Arbeitszeit ungültig, Autostart-Fehler
- `conflicts_dialog` (1): Konflikt-Resolution fehlgeschlagen (`messagebox`-Import dadurch ungenutzt → entfernt)

**Bewusst nativ bleiben** die 9 Roh-Traceback-Fehlerdialoge (`f"…{traceback.format_exc()}"`): der gebrandete Dialog ist nicht scrollbar/resizable (`wraplength=380`), ein langer Traceback würde ihn unbrauchbar groß machen — analog zur bestehenden `_show_sync_error`-Konvention.

## Verifikation

- Volle Suite grün (507 passed, 1 skipped), `ruff check .` sauber, Import-Smokes OK.
- Verbleibende native `messagebox` pro Datei = exakt die Traceback-Fälle: conflicts 0, send 2, share 1, settings 6.

## Scope

Unabhängig vom laufenden ui.py-Refactoring-Stack (#70–#73): berührt nur die vier eigenständigen Dialog-Dateien (vom Refactoring nicht angefasst) → konfliktfrei, direkt gegen `master`.

Der „Synchronisation deaktiviert"-Hinweis (lebt nach dem Refactoring in `sync_orchestrator`) und die zwei Tray-Dialoge (in der umgebauten `ui.py`) werden separat auf ihren Stack-Branches gethemt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
