### PR TITLE
fix(tooltip): nur ein Tooltip gleichzeitig anzeigen (Fixes #66)

### DIFF
--- a/src/tooltip.py
+++ b/src/tooltip.py
@@ -33,6 +33,32 @@ def _should_hide_tip(root_state, widget_rects, pointer):
     return True
 
 
+# Genau ein Tooltip darf gleichzeitig sichtbar sein (#66). Die Instanzen kennen
+# einander nicht, daher hält das Modul eine globale Referenz auf das aktuell
+# offene Tooltip: beim Anzeigen eines neuen wird das vorherige sofort geschlossen
+# (sonst hängt es bis zu seinem Close-Delay/Watchdog noch sichtbar herum, wenn
+# der Zeiger schnell über mehrere Elemente fährt).
+_active_tip = None
+
+
+def _set_active_tip(tip):
+    """Macht `tip` zum einzigen sichtbaren Tooltip: schließt ein evtl. anderes
+    aktives und merkt sich `tip`."""
+    global _active_tip
+    prev = _active_tip
+    if prev is not None and prev is not tip:
+        prev._close()  # ruft seinerseits _clear_active_tip(prev)
+    _active_tip = tip
+
+
+def _clear_active_tip(tip):
+    """Entfernt `tip` aus der Registry — aber nur, wenn es das aktive ist
+    (ein bereits abgelöstes Tooltip darf das neue nicht überschreiben)."""
+    global _active_tip
+    if _active_tip is tip:
+        _active_tip = None
+
+
 class _Tooltip:
     """Hover-Tooltip an ein oder mehrere Tk-Widgets binden.
 
@@ -104,6 +130,8 @@ class _Tooltip:
         # Re-Render, Fokuswechsel): solange das Tooltip offen ist, periodisch
         # selbst prüfen, ob es noch sichtbar sein darf.
         self._schedule_watchdog()
+        # Nur eines gleichzeitig (#66): ein evtl. noch offenes anderes schließen.
+        _set_active_tip(self)
 
     def _on_leave(self, _event):
         if self._close_after_id is not None:
@@ -181,6 +209,7 @@ class _Tooltip:
             except tk.TclError:
                 pass
             self.tip = None
+        _clear_active_tip(self)
 
 
 def attach_tooltip(widget_or_widgets, text: str) -> None:

--- a/tests/test_tooltip.py
+++ b/tests/test_tooltip.py
@@ -1,7 +1,54 @@
 # tests/test_tooltip.py
 import tkinter as tk  # noqa: F401 — Import-Smoke wie test_logging_setup; CI hat tkinter
 
+import src.tooltip as tooltip
 from src.tooltip import _should_hide_tip
+
+
+class _FakeTip:
+    """Minimaler Stand-in für _Tooltip — nur das, was die Single-Active-Registry
+    berührt (tk-frei, kein Display nötig)."""
+
+    def __init__(self):
+        self.close_calls = 0
+
+    def _close(self):
+        self.close_calls += 1
+        tooltip._clear_active_tip(self)
+
+
+def _reset_active():
+    tooltip._active_tip = None
+
+
+def test_showing_new_tooltip_closes_previous():
+    # Kern von #66: ein neues Tooltip schließt das vorher sichtbare.
+    _reset_active()
+    a, b = _FakeTip(), _FakeTip()
+    tooltip._set_active_tip(a)
+    tooltip._set_active_tip(b)
+    assert a.close_calls == 1
+    assert b.close_calls == 0
+    assert tooltip._active_tip is b
+
+
+def test_reactivating_same_tooltip_does_not_close_itself():
+    _reset_active()
+    a = _FakeTip()
+    tooltip._set_active_tip(a)
+    tooltip._set_active_tip(a)
+    assert a.close_calls == 0
+    assert tooltip._active_tip is a
+
+
+def test_clear_active_only_clears_when_it_is_the_active_one():
+    _reset_active()
+    a, b = _FakeTip(), _FakeTip()
+    tooltip._set_active_tip(a)
+    tooltip._clear_active_tip(b)  # b ist nicht aktiv -> no-op
+    assert tooltip._active_tip is a
+    tooltip._clear_active_tip(a)
+    assert tooltip._active_tip is None
 
 
 def test_hide_when_minimized_even_if_pointer_over_widget():


### PR DESCRIPTION
## Problem

Es konnten **mehrere Tooltips gleichzeitig** sichtbar sein: jede `_Tooltip`-Instanz
arbeitete isoliert (keine übergreifende Registry). Beim schnellen Hovern über
mehrere Elemente ging ein neues Tooltip per `_show` auf, während das vorherige
noch in seinem Close-Delay (80 ms) bzw. Watchdog-Fenster (200 ms) sichtbar hing.

## Fix

Eine modulweite Single-Active-Registry in `src/tooltip.py`:
- `_show` ruft am Ende `_set_active_tip(self)` → schließt ein evtl. noch offenes
  anderes Tooltip **sofort**.
- `_close` ruft `_clear_active_tip(self)` → deregistriert.

Damit ist global garantiert höchstens **ein** Tooltip gleichzeitig sichtbar.

## Test

- Test zuerst (rot → grün): 3 neue, **tk-freie** Tests (`_FakeTip`, wie der
  bestehende `_should_hide_tip`-Stil) decken die Registry-Logik ab —
  „neues schließt vorheriges", „dasselbe re-aktivieren schließt sich nicht
  selbst", „`_clear` wirkt nur aufs aktive".
- `pytest` lokal: **561 passed, 1 skipped**; `ruff check`: sauber.
- Nicht auto-getestet (bewusst, CI ohne Display): die reale Tk-`_show`→`_close`-Kette.
  Manuelle Gegenprobe: App starten, zügig über mehrere Tooltip-Elemente fahren —
  es steht immer nur eines.

Fixes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)
