### PR TITLE
release: v1.16.1 — Tooltip-Fix, Dialog-Theming, ui.py-Entflechtung

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 1.16.1 — 2026-06-25
+
+### Behoben
+- Es wird jetzt zu jedem Zeitpunkt nur **ein Tooltip gleichzeitig** angezeigt —
+  beim schnellen Überfahren mehrerer Elemente bleibt kein zweiter mehr stehen.
+- Import: Die Erfolgsmeldung erscheint wieder zuverlässig, statt gelegentlich
+  mit einem Fehler abzubrechen (der Dialog wurde zu früh geschlossen).
+- Info- und Fehler-Dialoge (Senden, Teilen, Einstellungen, Import, Tray-Einrichtung)
+  erscheinen jetzt einheitlich im App-Design statt als native System-Dialoge.
+
+### Intern
+- Die UI-Schicht (`ui.py`) wurde in eigenständige Komponenten entflochten
+  (Kalender-Rendering, Hintergrund-Tasks, Drive-Sync, Update-Banner) — ohne
+  funktionale Änderung, für bessere Wartbarkeit. Details: [`src/CLAUDE.md`](src/CLAUDE.md).
+- Das OAuth-Token-Handling für Gmail/Drive/Kalender liegt jetzt in einem
+  gemeinsamen Helfer (`src/oauth_utils.py`); Token werden atomar geschrieben.
+
 ## 1.16.0 — 2026-06-23
 
 ### Hinzugefügt

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Zeiterfassung/
 │   ├── reservations.py    # Reservierungen (zukünftige Soll-Zeiten)
 │   ├── reservations_sync.py # Abgleich der Reservierungen mit Google Kalender
 │   ├── gcal.py            # Google-Calendar-API-Wrapper
+│   ├── oauth_utils.py     # Gemeinsame OAuth-Token-Boilerplate (Persistenz, Scope-Upgrade) für mail/drive/gcal
 │   ├── tray.py            # Infobereich-Icon (Minimize-to-Tray)
 │   ├── autostart.py       # Plattformabhängiger Autostart (Windows/macOS/Linux)
 │   ├── updater.py         # GitHub-Releases-Check (stdlib-only, gedrosselt 1×/Tag)

--- a/src/version.py
+++ b/src/version.py
@@ -1,4 +1,4 @@
-VERSION = "1.16.0"
+VERSION = "1.16.1"
 
 # build_info wird beim Build von build.py generiert (gitignored) und von
 # PyInstaller mitgebündelt. Beim Start aus dem Quellcode existiert es nicht —


### PR DESCRIPTION
## Release v1.16.1 (Patch)

Nur **Fixes & Refactoring** seit v1.16.0 — keine funktionalen Neuerungen.

### Behoben
- Nur **ein Tooltip gleichzeitig** anzeigen (#66)
- Import-Erfolgsmeldung erscheint zuverlässig (kein TclError durch zu früh geschlossenen Dialog)
- Info-/Fehler-Dialoge (Senden, Teilen, Einstellungen, Import, Tray) einheitlich im App-Theme

### Intern (ohne sichtbare Änderung)
- `ui.py` in eigenständige Komponenten entflochten — `GridRenderer`, `BackgroundTaskRunner`, `SyncOrchestrator`, `UpdateBanner` (#49)
- OAuth-Token-Handling für Gmail/Drive/Kalender in `src/oauth_utils.py` zentralisiert, atomares Token-Schreiben (#47)

### Release-Mechanik
- `src/version.py` → **1.16.1**
- `CHANGELOG.md` Eintrag ergänzt
- `README.md`: `oauth_utils.py` in der Projektstruktur ergänzt
- Label **`release:patch`** → beim Merge baut & veröffentlicht `release.yml` automatisch das Release `v1.16.1`

### Verifikation
- `pytest` → **561 passed, 1 skipped**
- `ruff check .` → sauber

🤖 Generated with [Claude Code](https://claude.com/claude-code)
