### PR TITLE
feat(tooltip): Arbeitszeit-Slot schon ab einem Slot im Hover-Tooltip zeigen

### DIFF
--- a/src/grid_renderer.py
+++ b/src/grid_renderer.py
@@ -221,6 +221,37 @@ class GridRenderer:
         kat = f"  {slot['kategorie']}" if slot.get("kategorie") else ""
         return f"{slot['start']}-{slot['end']}{kat}"
 
+    @staticmethod
+    def _build_tooltip_text(entry, reservation, holiday_name):
+        """Baut den kombinierten Hover-Tooltip aus den vorhandenen Einheiten.
+
+        Reine Funktion (Tk-frei, testbar): entscheidet, WELCHE Blöcke der
+        Tooltip enthält und in welcher Reihenfolge. Gibt "" zurück, wenn nichts
+        anzuzeigen ist. Die Zelle zeigt nur Tagnummer + erste Slot-Zeit; der
+        Arbeitszeit-Block erscheint deshalb schon ab EINEM Slot, damit beim
+        Hovern die Kategorie ('Office') sichtbar wird.
+
+        holiday_name: Feiertagsname, falls der Tag ein Feiertag ist, sonst None.
+        Der Feiertag kommt nur in den kombinierten Tooltip, wenn ohnehin ein
+        Eintrag oder eine Reservierung vorhanden ist (sonst zeigt die Holiday-
+        Zelle ihren Namen selbst).
+        """
+        parts = []
+        if entry and entry.get("slots"):
+            parts.append(
+                "Arbeitszeit:\n"
+                + "\n".join(
+                    GridRenderer._fmt_slot_line(s) for s in entry["slots"]))
+        if reservation is not None:
+            parts.append(
+                "Reservierung:\n"
+                + "\n".join(
+                    GridRenderer._fmt_slot_line(s)
+                    for s in reservation.get("slots", [])))
+        if holiday_name and (reservation is not None or entry):
+            parts.append(f"Feiertag: {holiday_name}")
+        return "\n".join(parts)
+
     def _add_reservation_marker(self, cell):
         """Runder violetter Eck-Punkt auf einer Ist-Zeitzelle, die zusätzlich
         eine Reservierung hat. Ein Canvas-Oval statt eines Text-Bullets — „•"
@@ -335,24 +366,18 @@ class GridRenderer:
         # Reservierung ist ein reiner Overlay-Marker (Eck-Punkt) — sie ändert
         # den Zelltyp nicht. Genau EIN attach_tooltip pro Zelle (Mehrfachaufruf
         # erzeugt überlappende Tooltips); deshalb alle relevanten Infos
-        # (mehrere Arbeitszeit-Slots, Reservierung, Feiertag) in einen
-        # kombinierten Tooltip. Ein Feiertag-OHNE-Eintrag/-Reservierung zeigt
-        # seinen Namen weiterhin als Zelltext (Holiday-Zelle) bzw. eigenen
-        # Tooltip (name_tooltip) und kommt hier NICHT rein.
-        tip_parts = []
-        if entry and len(entry.get("slots", [])) > 1:
-            tip_parts.append(
-                "Arbeitszeit:\n"
-                + "\n".join(self._fmt_slot_line(s) for s in entry["slots"]))
+        # (Arbeitszeit-Slots, Reservierung, Feiertag) in einen kombinierten
+        # Tooltip (Textaufbau in _build_tooltip_text). Ein Feiertag-OHNE-
+        # Eintrag/-Reservierung zeigt seinen Namen weiterhin als Zelltext
+        # (Holiday-Zelle) bzw. eigenen Tooltip (name_tooltip) und kommt hier
+        # NICHT rein.
         if reservation is not None:
             self._add_reservation_marker(cell)
-            tip_parts.append(
-                "Reservierung:\n"
-                + "\n".join(self._fmt_slot_line(s) for s in reservation.get("slots", [])))
-        if is_holiday and (reservation is not None or entry):
-            tip_parts.append(f"Feiertag: {holidays_map[day_date]}")
-        if tip_parts:
-            attach_tooltip(cell, "\n".join(tip_parts))
+        tip_text = self._build_tooltip_text(
+            entry, reservation,
+            holidays_map[day_date] if is_holiday else None)
+        if tip_text:
+            attach_tooltip(cell, tip_text)
 
         # macOS-only Lösch-Button (✕) oben links, sobald der Tag löschbare
         # Einheiten hat (Ist-Zeit ODER aktive Reservierung). reservation wird

--- a/tests/test_grid_renderer.py
+++ b/tests/test_grid_renderer.py
@@ -28,6 +28,49 @@ def test_fmt_slot_line_without_category():
         {"start": "08:00", "end": "12:00"}) == "08:00-12:00"
 
 
+def test_tooltip_text_single_slot_shows_category():
+    # Neu: schon bei EINEM Slot erscheint der Arbeitszeit-Block, damit die
+    # Kategorie beim Hovern sichtbar wird (vorher erst ab >1 Slot).
+    entry = {"slots": [{"start": "09:30", "end": "16:00", "kategorie": "Office"}]}
+    assert GridRenderer._build_tooltip_text(entry, None, None) == (
+        "Arbeitszeit:\n09:30-16:00  Office")
+
+
+def test_tooltip_text_single_slot_without_category():
+    entry = {"slots": [{"start": "09:30", "end": "16:00"}]}
+    assert GridRenderer._build_tooltip_text(entry, None, None) == (
+        "Arbeitszeit:\n09:30-16:00")
+
+
+def test_tooltip_text_multi_slot_lists_all():
+    entry = {"slots": [
+        {"start": "08:00", "end": "12:00", "kategorie": "Büro"},
+        {"start": "13:00", "end": "17:00"},
+    ]}
+    assert GridRenderer._build_tooltip_text(entry, None, None) == (
+        "Arbeitszeit:\n08:00-12:00  Büro\n13:00-17:00")
+
+
+def test_tooltip_text_combines_arbeitszeit_and_reservation():
+    entry = {"slots": [{"start": "09:30", "end": "16:00", "kategorie": "Office"}]}
+    reservation = {"slots": [{"start": "18:00", "end": "20:00"}]}
+    assert GridRenderer._build_tooltip_text(entry, reservation, None) == (
+        "Arbeitszeit:\n09:30-16:00  Office\n"
+        "Reservierung:\n18:00-20:00")
+
+
+def test_tooltip_text_empty_when_nothing():
+    assert GridRenderer._build_tooltip_text(None, None, None) == ""
+
+
+def test_tooltip_text_holiday_only_with_entry_or_reservation():
+    entry = {"slots": [{"start": "09:30", "end": "16:00"}]}
+    assert GridRenderer._build_tooltip_text(entry, None, "Neujahr") == (
+        "Arbeitszeit:\n09:30-16:00\nFeiertag: Neujahr")
+    # Feiertag ohne Eintrag/Reservierung -> kein kombinierter Tooltip
+    assert GridRenderer._build_tooltip_text(None, None, "Neujahr") == ""
+
+
 def test_truncate_clips_long_text():
     assert GridRenderer._truncate("Donnerstag", 5) == "Donn…"
 


### PR DESCRIPTION
## Was

Der Hover-Tooltip im Kalender zeigt den **Arbeitszeit-Block jetzt schon ab einem Slot** (vorher erst ab mehr als einem). Damit wird beim Hovern die Kategorie eines einzelnen Slots sichtbar.

- Mit Kategorie:
  ```
  Arbeitszeit:
  09:30-16:00  Office
  ```
- Ohne Kategorie:
  ```
  Arbeitszeit:
  09:30-16:00
  ```

Format ist identisch zur bestehenden Reservierungs-/Mehr-Slot-Anzeige (`_fmt_slot_line`). Reservierungs- und Feiertags-Block sind unverändert.

## Wie

Die Tooltip-Textlogik steckte unteilbar in der Tk-Widget-Erzeugung und war nicht testbar. Sie wandert in den reinen Helfer `GridRenderer._build_tooltip_text(entry, reservation, holiday_name)`; geändert wurde nur die Bedingung `len(slots) > 1` → „mindestens ein Slot". Der `_add_reservation_marker`-Seiteneffekt bleibt in `_build_day_cell`.

## Risiko

Rein additiv im Tooltip-Text. Persistenz, Klick-/Lösch-Modell und Zell-Rendering unberührt. Einzige sichtbare Folge: Tage mit genau einem Slot haben jetzt einen Hover-Tooltip (vorher keinen).

## Test

- 6 neue Tests in `tests/test_grid_renderer.py` (rot→grün): Einzel-Slot mit/ohne Kategorie, Mehr-Slot, Arbeitszeit+Reservierung kombiniert, leer, Feiertag.
- Volle Suite: `567 passed, 1 skipped`. `ruff check` sauber.
- Manueller QA-Pfad: App starten (`python -m src.main`), einen Tag mit genau einer Arbeitszeit + Kategorie anlegen, über die Zelle hovern → Tooltip zeigt `Arbeitszeit:` + `HH:MM-HH:MM  Kategorie`.

Kein Versionsbump / kein `release:*`-Label — bewusst kein Release-Trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
