### PR TITLE
refactor(sync): SYNCED_SETTING_KEYS als Single Source of Truth (Closes #48)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,7 +156,7 @@ Lokal: `pytest` aus dem Repo-Root. Alle Tests müssen vor dem PR-Merge grün sei
 - `src/report.py` — HTML-Mail und PDF (dark/light Theme), gruppiert pro ISO-Kalenderwoche; `xhtml2pdf`-Import ist **lazy** in `generate_pdf` (siehe Tests/CI)
 - `src/mail.py` — Gmail-API-Wrapper (OAuth2, `token.json` / `credentials.json`)
 - `src/drive.py` — Google-Drive-API-Wrapper für den Multi-Device-Sync (`appDataFolder`, Scope `drive.appdata`)
-- `src/sync.py` — Sync-Engine (pure Logik: LWW-Merge der Entries/Settings, Konflikterkennung); enthält ein **Duplikat** von `SYNCED_SETTING_KEYS` (muss konsistent zu `settings.py` bleiben)
+- `src/sync.py` — Sync-Engine (pure Logik: LWW-Merge der Entries/Settings, Konflikterkennung); importiert `SYNCED_SETTING_KEYS` aus `settings.py` (Single Source of Truth, nicht hier neu definieren)
 - `src/conflicts_store.py` — lokale JSON-Persistenz der Sync-Konfliktliste
 - `src/share.py` — Export/Import von Arbeitszeiten als Share-JSON (Teilen per Mail-Anhang)
 - `src/reservations.py` — Reservierungen (zukünftige Soll-Zeiten, eigenes Konzept neben Ist-Zeiten)

--- a/docs/code-quality-improvements.md
+++ b/docs/code-quality-improvements.md
@@ -6,10 +6,10 @@ ist stabil, das hier sind keine Bug-Reports.
 
 ## Duplikate (klein, hoher Effekt)
 
-- [ ] **`SYNCED_SETTING_KEYS` doppelt definiert**
-  `src/settings.py:8` und `src/sync.py:19`. Heute identisch, divergiert beim
-  nächsten Whitelist-Eintrag. In `settings.py` belassen, aus `sync.py` raus
-  und importieren.
+- [x] **`SYNCED_SETTING_KEYS` doppelt definiert** — erledigt (Issue #48)
+  In `settings.py` belassen, aus `sync.py` raus und importiert. Schutz-Test
+  `test_sync_reexports_settings_whitelist` erzwingt jetzt Identität (`is`)
+  statt nur Wertgleichheit.
 
 - [ ] **`_utc_now_iso()` dreifach kopiert**
   `src/storage.py:6`, `src/settings.py:102`, `src/sync.py:25`. Gehört in

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -88,9 +88,9 @@ gegen `TclError` abgesichert, falls das Fenster zwischenzeitlich zu ist). Keine 
 - `storage.py` — Ist-Zeiten (JSON, Schlüssel = ISO-Datum). `reservations.py` — Reservierungen
   (zukünftige Soll-Zeiten, eigenes Konzept). `settings.py` — Einstellungen mit Defaults.
 - `conflicts_store.py` — lokale Sync-Konfliktliste. `category_defaults.py` — Default-Kategorien.
-- `sync.py` — pure Sync-Logik (LWW-Merge, Konflikterkennung); enthält ein **Duplikat** von
-  `SYNCED_SETTING_KEYS` (muss konsistent zu `settings.py` bleiben). `share.py` — Export/Import
-  als Share-JSON.
+- `sync.py` — pure Sync-Logik (LWW-Merge, Konflikterkennung); importiert
+  `SYNCED_SETTING_KEYS` aus `settings.py` (Single Source of Truth, nicht hier neu definieren).
+  `share.py` — Export/Import als Share-JSON.
 
 ## Google-Integration (alle Wrapper mit Lazy-Imports für CI ohne requirements.txt)
 

--- a/src/sync.py
+++ b/src/sync.py
@@ -13,6 +13,13 @@ Doc-Struktur (Sync-File und Zwischenformate):
 import datetime
 import uuid
 
+# SYNCED_SETTING_KEYS lebt als Single Source of Truth in settings.py — hier nur
+# importieren, NICHT erneut definieren. Eine zweite (divergierende) Definition
+# würde dazu führen, dass sync.py einen synchronisierten Key nicht mergt →
+# stiller Datenverlust im Multi-Device-Sync (Issue #48). settings.py ist
+# stdlib-only und importiert sync.py nicht (kein Zyklus, CI-import-sicher).
+from src.settings import SYNCED_SETTING_KEYS
+
 
 SCHEMA_VERSION = 3
 
@@ -36,12 +43,6 @@ def _is_settled_entry(entry, watermark):
 def _is_settled_conflict(conflict, watermark):
     resolved_at = conflict.get("resolved_at") or ""
     return bool(conflict.get("resolved")) and resolved_at != "" and resolved_at < watermark
-
-SYNCED_SETTING_KEYS = (
-    "recipient", "name", "hourly_rate",
-    "mail_subject", "mail_greeting", "mail_content", "mail_closing",
-    "gcal_calendar_id", "categories", "category_times",
-)
 
 
 def _utc_now_iso():

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -403,12 +403,14 @@ def test_gcal_calendar_id_is_synced_setting():
     assert "gcal_calendar_id" in SYNCED_SETTING_KEYS
 
 
-def test_synced_whitelists_in_settings_and_sync_match():
-    """Die Whitelist existiert dupliziert in settings.py und sync.py und
-    muss identisch bleiben — sonst mergt sync.py einen Key nicht."""
+def test_sync_reexports_settings_whitelist():
+    """Single Source of Truth (Issue #48): sync.py definiert die Whitelist nicht
+    mehr selbst, sondern importiert sie aus settings.py. Identität (`is`) erzwingt
+    strukturell, dass keine divergierende Zweitdefinition zurückkehrt — sonst
+    mergt sync.py einen Key nicht (stiller Sync-Datenverlust)."""
     from src.settings import SYNCED_SETTING_KEYS as a
     from src.sync import SYNCED_SETTING_KEYS as b
-    assert set(a) == set(b)
+    assert a is b
 
 
 # --- categories (Multi-Slot-Feature, AP2) ---


### PR DESCRIPTION
Closes #48

## Problem

`SYNCED_SETTING_KEYS` war identisch in `src/settings.py` **und** `src/sync.py` definiert. Divergierten die beiden Listen (ein Key nur in einer ergänzt), mergte `sync.py` den Wert nicht → **stiller Datenverlust** im Multi-Device-Sync. Der bisherige Schutz-Test prüfte nur zur Laufzeit Wertgleichheit, nicht strukturell.

## Lösung

Single Source of Truth: Die Whitelist lebt nur noch in `src/settings.py`; `src/sync.py` **importiert** sie.

- `settings.py` ist stdlib-only und importiert `sync.py` nicht → kein Zyklus, im CI (`test.yml`, ohne `requirements.txt`) import-sicher.
- Public-API `src.sync.SYNCED_SETTING_KEYS` bleibt erhalten (re-export) → bestehende Importeure brechen nicht.

## Schutz-Test verschärft

`test_synced_whitelists_in_settings_and_sync_match` → `test_sync_reexports_settings_whitelist`. Prüft jetzt **Objekt-Identität** (`a is b`) statt nur Wertgleichheit — erzwingt strukturell, dass keine divergierende Zweitdefinition zurückkehrt.

## Akzeptanzkriterien (alle erfüllt)

- [x] `SYNCED_SETTING_KEYS` nur noch einmal definiert (`settings.py`)
- [x] `sync.py` importiert die Liste statt sie zu duplizieren
- [x] Schutz-Test bleibt grün (verschärft auf Identität)
- [x] CI ohne `requirements.txt` läuft

## Verify

- Schutz-Test rot→grün: mit `assert a is b` vor dem Refactor rot (zwei getrennte Tupel), danach grün → beweist echte Deduplikation.
- Volle Suite: `567 passed, 1 skipped`. `ruff check` sauber.
- CI-Constraint im frischen Prozess geprüft: `sync.SYNCED_SETTING_KEYS is settings.SYNCED_SETTING_KEYS` **und** kein Heavy-Import (`xhtml2pdf`/`reportlab`/`google`/…) durch den neuen Import → kein Zyklus, ohne `requirements.txt` importierbar.

## Verhalten / Risiko

Kein Laufzeit-Verhalten geändert — derselbe 10-Key-Sync-Vertrag. Einziges Risiko: die neue Importkante `sync → settings` würde brechen, falls `settings.py` jemals einen Heavy-/Third-Party-Import auf Modulebene bekäme. Heute stdlib-only → sicher.

Kein Versionsbump / kein `release:*`-Label — kein Release-Trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
