### PR TITLE
test(settings): Save-Pfad-Logik aus Dialog extrahieren und headless testen (Closes #51)

### DIFF
--- a/src/dialogs/settings_dialog.py
+++ b/src/dialogs/settings_dialog.py
@@ -19,8 +19,8 @@ from src.theme import (
     themed_askyesno, themed_showinfo, themed_showwarning, themed_showerror,
 )
 from src.dialogs.category_dialog import open_category_dialog
-from src.holidays_de import STATES
-from src.settings import WEEKDAY_KEYS, SYNCED_SETTING_KEYS
+from src.holidays_de import STATES, code_for_state_label
+from src.settings import WEEKDAY_KEYS, parse_hourly_rate, resolve_calendar_id
 from src.time_utils import format_iso_date
 from src.time_utils import DAYS_DE, validate_entry
 
@@ -741,17 +741,8 @@ def open_settings_dialog(parent, settings, base_path, on_change, *,
                 )
                 return
 
-        rate_str = rate_var.get().strip()
-        try:
-            hourly_rate = float(rate_str) if rate_str else 0.0
-        except ValueError:
-            hourly_rate = 0.0
-
-        selected_label = state_var.get()
-        selected_code = next(
-            (code for code, lbl in STATES if lbl == selected_label),
-            "",
-        )
+        hourly_rate = parse_hourly_rate(rate_var.get())
+        selected_code = code_for_state_label(state_var.get())
 
         updates = {
             "autostart": new_autostart,
@@ -771,19 +762,14 @@ def open_settings_dialog(parent, settings, base_path, on_change, *,
         for key in WEEKDAY_KEYS:
             updates[f"default_start_{key}"] = start_vars[key].get()
             updates[f"default_end_{key}"] = end_vars[key].get()
-        synced_updates = {k: v for k, v in updates.items() if k in SYNCED_SETTING_KEYS}
-        plain_updates = {k: v for k, v in updates.items() if k not in SYNCED_SETTING_KEYS}
-        for key, value in synced_updates.items():
-            settings.set_synced(key, value)
-        if plain_updates:
-            settings.set_many(plain_updates)
+        settings.apply_updates(updates)
         # Kalender-Auswahl: Klarname zurück auf ID mappen, als Sync-Setting
         # speichern (reist über die Drive-Settings-Sync mit). Nur wenn die
         # Kalenderliste schon geladen ist (cal_map gefüllt) — sonst würde ein
         # vorschnelles "Speichern" fälschlich "primary" festschreiben.
         if settings.get("gcal_enabled") and cal_map:
-            selected_cal_id = cal_map.get(
-                cal_var.get(), settings.get("gcal_calendar_id") or "primary")
+            selected_cal_id = resolve_calendar_id(
+                cal_map, cal_var.get(), settings.get("gcal_calendar_id"))
             if selected_cal_id != settings.get("gcal_calendar_id"):
                 settings.set_synced("gcal_calendar_id", selected_cal_id)
         on_change()

--- a/src/holidays_de.py
+++ b/src/holidays_de.py
@@ -25,6 +25,13 @@ STATES: list[tuple[str, str]] = [
 _VALID_CODES = {code for code, _ in STATES if code}
 
 
+def code_for_state_label(label: str) -> str:
+    """Mappt ein im Settings-Dialog gewähltes State-Klartext-Label (z.B.
+    "Bayern") zurück auf den Bundesland-Code ("BY"). Unbekanntes Label oder die
+    "— kein Bundesland —"-Option → "" (kein Bundesland)."""
+    return next((code for code, lbl in STATES if lbl == label), "")
+
+
 @lru_cache(maxsize=64)
 def _holidays_cached(state_code: str, year: int) -> dict[date, str]:
     import holidays

--- a/src/settings.py
+++ b/src/settings.py
@@ -111,6 +111,42 @@ def _utc_now_iso():
     return datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
+# --- Reine Helfer für den Settings-Dialog-Save-Pfad (ohne Tk, headless testbar,
+# extrahiert aus settings_dialog.save_settings, Issue #51). settings.py bleibt
+# bewusst stdlib-only — kein holidays/google-Import (sync.py importiert dieses
+# Modul, vgl. Issue #48). Das State-Label→Code-Mapping lebt deshalb in
+# holidays_de.code_for_state_label, nicht hier.
+
+
+def parse_hourly_rate(raw):
+    """Parst die Stundensatz-Eingabe (String) zu float. Leer/nur Whitespace oder
+    ungültig → 0.0 (bewusst tolerant: der Dialog soll bei Tippfehlern nicht
+    blocken). Komma-Dezimal wird nicht unterstützt (float() wirft → 0.0)."""
+    raw = (raw or "").strip()
+    if not raw:
+        return 0.0
+    try:
+        return float(raw)
+    except ValueError:
+        return 0.0
+
+
+def split_synced_updates(updates):
+    """Partitioniert ein updates-Dict in (synced, plain) anhand
+    SYNCED_SETTING_KEYS. synced reist per Drive-Sync mit (set_synced), plain
+    bleibt gerätelokal (set_many)."""
+    synced = {k: v for k, v in updates.items() if k in SYNCED_SETTING_KEYS}
+    plain = {k: v for k, v in updates.items() if k not in SYNCED_SETTING_KEYS}
+    return synced, plain
+
+
+def resolve_calendar_id(cal_map, selected_label, current_id):
+    """Mappt den im Dialog gewählten Kalender-Klarnamen über cal_map zurück auf
+    die Kalender-ID. Unbekanntes Label → bisheriger Wert, ersatzweise
+    "primary" (nie leer, damit der gcal-Abgleich einen gültigen Kalender hat)."""
+    return cal_map.get(selected_label, current_id or "primary")
+
+
 class Settings:
     def __init__(self, filepath="settings.json"):
         self.filepath = filepath
@@ -212,6 +248,17 @@ class Settings:
             "device_id": self.device_id_for_sync,
         }
         self._save_to_disk()
+
+    def apply_updates(self, updates):
+        """Routet ein updates-Dict aus dem Settings-Dialog auf den korrekten
+        Persistenz-Pfad: Keys in SYNCED_SETTING_KEYS über set_synced (je ein
+        Per-Field-Stempel + Disk-Write), der Rest in einem set_many. Single
+        Entry-Point für den Dialog-Save (Issue #51)."""
+        synced, plain = split_synced_updates(updates)
+        for key, value in synced.items():
+            self.set_synced(key, value)
+        if plain:
+            self.set_many(plain)
 
     def get_synced_doc(self):
         """{key: {value, modified_at, device_id}} — Eingabe für den Sync-Merge.

--- a/tests/test_holidays_de.py
+++ b/tests/test_holidays_de.py
@@ -53,3 +53,21 @@ def test_returned_dict_is_independent_copy():
     h1[date(2099, 1, 1)] = "MUTATION"
     h2 = get_holidays("BY", 2026)
     assert date(2099, 1, 1) not in h2
+
+
+# --- code_for_state_label (Issue #51: extrahiert aus settings_dialog) ---
+
+
+def test_code_for_state_label_known():
+    from src.holidays_de import code_for_state_label
+    assert code_for_state_label("Bayern") == "BY"
+
+
+def test_code_for_state_label_empty_option_maps_to_empty_code():
+    from src.holidays_de import code_for_state_label
+    assert code_for_state_label("— kein Bundesland —") == ""
+
+
+def test_code_for_state_label_unknown_label_is_empty():
+    from src.holidays_de import code_for_state_label
+    assert code_for_state_label("Atlantis") == ""

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -477,3 +477,96 @@ def test_category_times_non_dict_falls_back_to_default(tmp_path, caplog):
         s = Settings(path)
     assert s.get("category_times") == {}
     assert any("category_times" in rec.message for rec in caplog.records)
+
+
+# --- Issue #51: aus settings_dialog.save_settings extrahierte pure Logik ---
+
+
+def test_parse_hourly_rate_valid():
+    from src.settings import parse_hourly_rate
+    assert parse_hourly_rate("12.5") == 12.5
+
+
+def test_parse_hourly_rate_empty_or_blank_is_zero():
+    from src.settings import parse_hourly_rate
+    assert parse_hourly_rate("") == 0.0
+    assert parse_hourly_rate("   ") == 0.0
+
+
+def test_parse_hourly_rate_strips_whitespace():
+    from src.settings import parse_hourly_rate
+    assert parse_hourly_rate("  8  ") == 8.0
+
+
+def test_parse_hourly_rate_invalid_is_zero():
+    from src.settings import parse_hourly_rate
+    # Tolerantes Parsen (Dialog soll bei Tippfehlern nicht blocken).
+    assert parse_hourly_rate("abc") == 0.0
+    # Aktuelles Verhalten: Komma-Dezimal wird NICHT unterstützt (float() wirft) → 0.0.
+    assert parse_hourly_rate("12,5") == 0.0
+
+
+def test_split_synced_updates_partitions_by_whitelist():
+    from src.settings import split_synced_updates
+    updates = {
+        "recipient": "a@b.de",   # synced
+        "name": "X",             # synced
+        "autostart": True,       # plain
+        "default_pause": 30,     # plain
+    }
+    synced, plain = split_synced_updates(updates)
+    assert synced == {"recipient": "a@b.de", "name": "X"}
+    assert plain == {"autostart": True, "default_pause": 30}
+
+
+def test_split_synced_updates_empty():
+    from src.settings import split_synced_updates
+    assert split_synced_updates({}) == ({}, {})
+
+
+def test_apply_updates_routes_synced_per_key_and_plain_in_one_call():
+    from unittest.mock import MagicMock
+    settings = MagicMock()
+    updates = {
+        "recipient": "a@b.de", "name": "X",   # synced
+        "autostart": True, "default_pause": 30,  # plain
+    }
+    Settings.apply_updates(settings, updates)
+    synced_calls = {c.args for c in settings.set_synced.call_args_list}
+    assert synced_calls == {("recipient", "a@b.de"), ("name", "X")}
+    settings.set_many.assert_called_once_with({"autostart": True, "default_pause": 30})
+
+
+def test_apply_updates_no_plain_skips_set_many():
+    from unittest.mock import MagicMock
+    settings = MagicMock()
+    Settings.apply_updates(settings, {"recipient": "a@b.de"})
+    settings.set_synced.assert_called_once_with("recipient", "a@b.de")
+    settings.set_many.assert_not_called()
+
+
+def test_apply_updates_persists_routing_on_real_settings(tmp_settings):
+    # End-to-end gegen echte Settings: synced-Key bekommt Sync-Metadaten,
+    # plain-Key nicht.
+    tmp_settings.apply_updates({"recipient": "a@b.de", "autostart": True})
+    assert tmp_settings.get("recipient") == "a@b.de"
+    assert tmp_settings.get("autostart") is True
+    assert "recipient" in tmp_settings.get_synced_doc()
+    assert "autostart" not in tmp_settings.get_synced_doc()
+
+
+def test_resolve_calendar_id_selected_label_in_map():
+    from src.settings import resolve_calendar_id
+    cal_map = {"Privat": "cal_123", "Arbeit": "cal_456"}
+    assert resolve_calendar_id(cal_map, "Arbeit", "cal_123") == "cal_456"
+
+
+def test_resolve_calendar_id_unknown_label_falls_back_to_current():
+    from src.settings import resolve_calendar_id
+    assert resolve_calendar_id({}, "Weg", "cal_current") == "cal_current"
+
+
+def test_resolve_calendar_id_unknown_and_no_current_is_primary():
+    from src.settings import resolve_calendar_id
+    assert resolve_calendar_id({}, "Weg", "") == "primary"
+    assert resolve_calendar_id({}, "Weg", None) == "primary"


### PR DESCRIPTION
Closes #51

## Problem

Die pure Logik im `settings_dialog.save_settings`-Callback (Rate-Parsing, State-Label→Code-Mapping, Synced/Plain-Routing, Kalender-ID-Auflösung) war inline im Tk-Callback und damit ungetestet.

## Lösung — Extract-Function + headless Tests

Die Logik wandert in benannte, **Tk-freie** Funktionen:

| Helfer | Modul |
|---|---|
| `parse_hourly_rate` | `src/settings.py` |
| `split_synced_updates` + `Settings.apply_updates` | `src/settings.py` |
| `resolve_calendar_id` | `src/settings.py` |
| `code_for_state_label` | `src/holidays_de.py` |

`save_settings` ruft jetzt nur noch diese Helfer auf — dünner Tk-Glue, **kein Verhaltenswechsel**.

**Wichtig (Issue #48-Vertrag):** Das State-Mapping liegt bewusst in `holidays_de.py` (wo `STATES` lebt) und **nicht** in `settings.py`. `settings.py` muss stdlib-only bleiben, sonst zöge der `sync → settings`-Import die `holidays`-Lib und bräche im CI ohne `requirements.txt`.

## Scope-Hinweis

Bewusst nur `settings_dialog` (abgestimmt). `import_dialog`/`send_dialog` sind nicht Teil dieses PRs.

**Entry-Validierung** (ein Akzeptanzkriterium) war bereits erfüllt: `validate_slots`/`validate_entry` sind längst in `time_utils.py` extrahiert und in `test_time_calc.py` getestet (23 Assertions). Kein neuer Code nötig.

## Akzeptanzkriterien

- [x] Validierungs-/Parsing-Logik der Dialoge in testbare Funktionen extrahiert
- [x] Tests für Settings-Save-Pfad (`apply_updates`, gemockt + echt) und Entry-Validierung (vorbestehend)
- [x] Keine Tkinter-Display-Abhängigkeit in den neuen Tests

## Verify

- 15 neue Tests rot→grün (alle headless).
- Volle Suite: `582 passed, 1 skipped` (vorher 567 → +15). `ruff check .` sauber (bestätigt auch keine undefinierten/ungenutzten Namen im refactorten Dialog).

## Verhalten / Risiko

Kein Laufzeit-Verhalten geändert. `save_settings` ist ein Tk-Callback und wird headless nicht ausgeführt — abgesichert über Zeile-für-Zeile-Äquivalenz, `ruff` (F821/F401) und die Tests der extrahierten Funktionen. Manueller QA-Pfad: Settings-Dialog → Stundensatz/Bundesland/Synced- + Plain-Feld ändern → Speichern → erneut öffnen (alles persistiert); Zweitgerät: Synced-Felder kommen an, Plain (Autostart) nicht.

Kein Versionsbump / kein `release:*`-Label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
