### PR TITLE
feat: UI-Skalierungsoption (#78)

### DIFF
--- a/docs/superpowers/plans/2026-06-26-ui-scaling.md
+++ b/docs/superpowers/plans/2026-06-26-ui-scaling.md
@@ -1,0 +1,475 @@
+# UI-Skalierungsoption Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eine Skalierungsoption (Slider 0.75–2.0) in den Einstellungen, die Fonts + Fenstergeometrie gemeinsam hochzieht; gerätelokal gespeichert, sofort per Prozess-Neustart wirksam.
+
+**Architecture:** `tk scaling` wird einmalig beim Start auf System-DPI × Faktor gesetzt (vor dem App-Aufbau) — weil alle Fonts in `theme.py` punkt-basiert sind und `measure_max_width` die Geometrie *misst*, kaskadiert das automatisch. Ein geänderter Faktor wird wirksam, indem `App` den Prozess neu startet (`subprocess.Popen` → Tray-Stop → `root.destroy()`). Pure Helfer (`clamp_ui_scale`, `relaunch_command`) sind headless getestet; die Tk-/Prozess-Integration manuell.
+
+**Tech Stack:** Python 3.11, Tkinter, pytest. Keine neuen Dependencies.
+
+## Global Constraints
+
+- `src/settings.py` bleibt **stdlib-only** (kein holidays/google-Import) — `sync.py` importiert es; CI installiert `requirements.txt` nicht. `clamp_ui_scale` nutzt nur Builtins.
+- Neuer Key `ui_scale` darf **nicht** in `SYNCED_SETTING_KEYS` stehen (gerätespezifisch, reist nicht per Drive).
+- Faktor ist **relativ** zur System-DPI: `tk scaling = base × faktor`. Bei Faktor **1.0** muss das Verhalten **exakt** wie heute sein.
+- Slider intern **Prozent 75–200, Schritt 5** = Faktor **0.75–2.0** in 0.05-Schritten. Faktor wird als Float in `settings.json` gespeichert (z.B. `1.25`).
+- Beim Neustart-Kommando wird `--minimized` aus den Argumenten entfernt.
+- Konversation/UI **Deutsch** (ü ö ä ß korrekt), Code + Commit-Typ **Englisch** (`feat:`/`fix:`/`test:`), Body Deutsch ok.
+- Alle Tests müssen vor PR-Merge grün sein; `ruff check .` sauber.
+- **Kein** Versionsbump / **kein** CHANGELOG-Eintrag / **kein** `release:*`-Label in diesem Plan (Release nur auf Bedarf, wie bei den letzten Feature-PRs).
+
+---
+
+## Dateien-Überblick
+
+| Datei | Änderung |
+|-------|----------|
+| `src/settings.py` | `"ui_scale": 1.0` in `DEFAULTS`; reiner Helfer `clamp_ui_scale`. |
+| `tests/test_settings.py` | Tests für Default, Nicht-Sync, `clamp_ui_scale`. |
+| `src/main.py` | Reiner Helfer `relaunch_command`; `_apply_ui_scaling`; Aufruf in `main()` nach `tk.Tk()`. |
+| `tests/test_main_relaunch.py` | **Neu** — Tests für `relaunch_command`. |
+| `src/ui.py` | `import sys`/`import subprocess`; Methode `App.restart_for_scaling`; `_open_settings` reicht `on_request_restart` durch. |
+| `src/dialogs/settings_dialog.py` | Param `on_request_restart`; „Darstellung"-Slider-Sektion; Save-Logik. |
+
+---
+
+### Task 1: `ui_scale`-Setting + `clamp_ui_scale`
+
+**Files:**
+- Modify: `src/settings.py` (DEFAULTS-Dict endet bei Zeile 56; pure Helfer nach `resolve_calendar_id`, Zeile 147)
+- Test: `tests/test_settings.py`
+
+**Interfaces:**
+- Produces: `clamp_ui_scale(value) -> float` — castet zu float, klemmt auf `[0.75, 2.0]`, nicht-castbar/None → `1.0`. Default-Setting `ui_scale = 1.0`, **nicht** in `SYNCED_SETTING_KEYS`.
+
+- [ ] **Step 1: Failing Tests schreiben**
+
+In `tests/test_settings.py` ans Dateiende anhängen:
+
+```python
+def test_ui_scale_default(tmp_settings):
+    assert tmp_settings.get("ui_scale") == 1.0
+
+
+def test_ui_scale_is_not_synced():
+    # Gerätespezifisch -> darf nicht per Drive synchronisieren.
+    assert "ui_scale" not in SYNCED_SETTING_KEYS
+
+
+def test_clamp_ui_scale_within_range():
+    from src.settings import clamp_ui_scale
+    assert clamp_ui_scale(1.25) == 1.25
+    assert clamp_ui_scale(0.75) == 0.75
+    assert clamp_ui_scale(2.0) == 2.0
+
+
+def test_clamp_ui_scale_below_min_clamps_to_075():
+    from src.settings import clamp_ui_scale
+    assert clamp_ui_scale(0.5) == 0.75
+
+
+def test_clamp_ui_scale_above_max_clamps_to_2():
+    from src.settings import clamp_ui_scale
+    assert clamp_ui_scale(3.0) == 2.0
+
+
+def test_clamp_ui_scale_string_is_cast():
+    from src.settings import clamp_ui_scale
+    assert clamp_ui_scale("1.5") == 1.5
+
+
+def test_clamp_ui_scale_invalid_falls_back_to_1():
+    from src.settings import clamp_ui_scale
+    assert clamp_ui_scale(None) == 1.0
+    assert clamp_ui_scale("abc") == 1.0
+```
+
+- [ ] **Step 2: Tests laufen lassen — müssen fehlschlagen**
+
+Run: `pytest tests/test_settings.py -k "ui_scale" -v`
+Expected: FAIL (`test_ui_scale_default`: KeyError/None; `clamp_ui_scale`-Tests: ImportError „cannot import name 'clamp_ui_scale'").
+
+- [ ] **Step 3: `ui_scale`-Default ergänzen**
+
+In `src/settings.py`, im `DEFAULTS`-Dict (vor der schließenden `}` bei Zeile 56) eine Zeile ergänzen:
+
+```python
+    "category_times": {},
+    "ui_scale": 1.0,
+}
+```
+
+(`ui_scale` **nicht** zu `SYNCED_SETTING_KEYS` hinzufügen — bleibt gerätelokal.)
+
+- [ ] **Step 4: `clamp_ui_scale` implementieren**
+
+In `src/settings.py` nach der Funktion `resolve_calendar_id` (nach Zeile 147) einfügen:
+
+```python
+def clamp_ui_scale(value):
+    """Normalisiert den UI-Skalierungsfaktor defensiv: castet zu float und
+    klemmt auf [0.75, 2.0]. Nicht-castbare Werte (None, Müll-String) → 1.0
+    (Default). Schützt das tk-scaling vor korrupten settings.json-Werten und
+    Slider-Ausreißern."""
+    try:
+        f = float(value)
+    except (TypeError, ValueError):
+        return 1.0
+    return max(0.75, min(2.0, f))
+```
+
+- [ ] **Step 5: Tests laufen lassen — müssen grün sein**
+
+Run: `pytest tests/test_settings.py -k "ui_scale" -v`
+Expected: PASS (7 Tests grün).
+
+- [ ] **Step 6: Volle Settings-Suite + Lint**
+
+Run: `pytest tests/test_settings.py -q && ruff check src/settings.py tests/test_settings.py`
+Expected: alle grün, ruff ohne Findings.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/settings.py tests/test_settings.py
+git commit -m "feat(settings): lokaler ui_scale-Faktor + clamp_ui_scale-Helfer"
+```
+
+---
+
+### Task 2: `relaunch_command`-Helfer
+
+**Files:**
+- Modify: `src/main.py` (modul-level Helfer, nach `_ensure_device_id`, vor `_parse_remote_or_quarantine` — also nach Zeile 36)
+- Test: `tests/test_main_relaunch.py` (**neu**)
+
+**Interfaces:**
+- Produces: `relaunch_command(argv, executable, frozen) -> list[str]` — baut das Neustart-Kommando. `frozen=True` → `[executable, *rest]`; `frozen=False` → `[executable, "-m", "src.main", *rest]`; `rest = argv[1:]` ohne `"--minimized"`.
+
+**Hinweis CI:** `tests/test_main_relaunch.py` importiert `src.main`. Das zieht die `src.ui`-Importkette (inkl. Google-Wrapper) — in CI vorhanden (`test.yml` installiert `google-api-python-client`/`google-auth`/`google-auth-oauthlib`), genau wie beim bestehenden `tests/test_ui_delete.py`. Kein Tk-Root beim Import → display-frei.
+
+- [ ] **Step 1: Failing Tests schreiben**
+
+`tests/test_main_relaunch.py` neu anlegen:
+
+```python
+from src.main import relaunch_command
+
+
+def test_relaunch_command_frozen_uses_executable_directly():
+    cmd = relaunch_command(["app.exe", "--foo"], "app.exe", True)
+    assert cmd == ["app.exe", "--foo"]
+
+
+def test_relaunch_command_repo_uses_module_invocation():
+    cmd = relaunch_command(["src/main.py", "--foo"], "python", False)
+    assert cmd == ["python", "-m", "src.main", "--foo"]
+
+
+def test_relaunch_command_strips_minimized_frozen():
+    cmd = relaunch_command(["app.exe", "--minimized", "--bar"], "app.exe", True)
+    assert cmd == ["app.exe", "--bar"]
+
+
+def test_relaunch_command_strips_minimized_repo():
+    cmd = relaunch_command(["main.py", "--minimized"], "python", False)
+    assert cmd == ["python", "-m", "src.main"]
+```
+
+- [ ] **Step 2: Tests laufen lassen — müssen fehlschlagen**
+
+Run: `pytest tests/test_main_relaunch.py -v`
+Expected: FAIL (ImportError „cannot import name 'relaunch_command'").
+
+- [ ] **Step 3: `relaunch_command` implementieren**
+
+In `src/main.py` nach `_ensure_device_id` (nach Zeile 36) einfügen:
+
+```python
+def relaunch_command(argv, executable, frozen):
+    """Baut das Kommando, um die App neu zu starten (nach UI-Skalierungs-
+    Änderung). Im Frozen-Build ist `executable` die App-Exe selbst; im
+    Repo-Modus wird `python -m src.main` aufgerufen. `--minimized` wird
+    entfernt, weil der Nutzer nach einer interaktiven Skalierungsänderung das
+    Fenster sehen will, nicht ein erneut minimiertes."""
+    rest = [a for a in argv[1:] if a != "--minimized"]
+    if frozen:
+        return [executable] + rest
+    return [executable, "-m", "src.main"] + rest
+```
+
+- [ ] **Step 4: Tests laufen lassen — müssen grün sein**
+
+Run: `pytest tests/test_main_relaunch.py -v`
+Expected: PASS (4 Tests grün).
+
+- [ ] **Step 5: Lint**
+
+Run: `ruff check src/main.py tests/test_main_relaunch.py`
+Expected: keine Findings.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/main.py tests/test_main_relaunch.py
+git commit -m "feat(main): relaunch_command für Neustart nach Skalierungsänderung"
+```
+
+---
+
+### Task 3: Skalierung beim Start anwenden
+
+**Files:**
+- Modify: `src/main.py` — Import-Zeile 21 (`from src.settings import Settings`); neuer Helfer `_apply_ui_scaling`; Aufruf in `main()` zwischen Zeile 277 (`root = tk.Tk()`) und 278 (`app = App(...)`).
+
+**Interfaces:**
+- Consumes: `clamp_ui_scale` aus Task 1; `settings.get("ui_scale")`.
+- Produces: `_apply_ui_scaling(root, factor)` — setzt `tk scaling` auf `base × clamp_ui_scale(factor)`.
+
+**Verifikation:** Keine CI-Tests (braucht echten Tk-Root → kein Display in CI). Die reine Logik (`clamp_ui_scale`) ist in Task 1 getestet; die `tk`-Verdrahtung wird manuell verifiziert (Step 4).
+
+- [ ] **Step 1: Import erweitern**
+
+In `src/main.py` Zeile 21 ändern:
+
+```python
+from src.settings import Settings, clamp_ui_scale
+```
+
+- [ ] **Step 2: `_apply_ui_scaling` implementieren**
+
+In `src/main.py` direkt **vor** `def main():` (vor Zeile 259) einfügen:
+
+```python
+def _apply_ui_scaling(root, factor):
+    """Setzt tk-scaling einmalig auf System-DPI × Faktor. MUSS vor dem Aufbau
+    der App-Widgets laufen, damit measure_max_width die skalierten Fonts misst
+    und die Fenstergeometrie entsprechend pinnt. Bei Faktor 1.0 unverändert
+    (base × 1.0 == base)."""
+    f = clamp_ui_scale(factor)
+    base = float(root.tk.call("tk", "scaling"))
+    root.tk.call("tk", "scaling", base * f)
+```
+
+- [ ] **Step 3: Aufruf in `main()` einfügen**
+
+In `src/main.py`, in `main()`, zwischen `root = tk.Tk()` (Zeile 277) und `app = App(...)` (Zeile 278):
+
+```python
+    root = tk.Tk()
+    _apply_ui_scaling(root, settings.get("ui_scale"))
+    app = App(root, storage, settings, base_path=base, conflicts_store=conflicts_store,
+              reservation_store=reservation_store)
+```
+
+- [ ] **Step 4: Manuell verifizieren**
+
+In `settings.json` (Repo-Root) probeweise `"ui_scale": 1.5` setzen (oder Datei anlegen mit `{"ui_scale": 1.5}`), dann:
+
+Run: `python -m src.main`
+Expected: Das Fenster (Kalender, Fonts, Buttons) erscheint **sichtbar größer** als bei `1.0`. Danach Wert wieder auf `1.0` setzen → Erscheinungsbild identisch zu vorher. Probe-Datei-Änderung anschließend verwerfen (nicht committen).
+
+Run: `ruff check src/main.py`
+Expected: keine Findings.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main.py
+git commit -m "feat(main): ui_scale beim Start auf tk-scaling anwenden"
+```
+
+---
+
+### Task 4: Slider in den Einstellungen + Neustart-Verdrahtung
+
+**Files:**
+- Modify: `src/ui.py` — Imports (nach Zeile 8); neue Methode `restart_for_scaling` (nach `_quit_with_sync_push`, Zeile 557); `_open_settings` (Zeile 323–329).
+- Modify: `src/dialogs/settings_dialog.py` — Import (Zeile 23); Signatur (Zeile 28–30); neue „Darstellung"-Sektion + Reihen-Umnummerierung; `save_settings` (Zeile 713–776).
+
+**Interfaces:**
+- Consumes: `relaunch_command` aus Task 2 (lazy import in `restart_for_scaling`); `clamp_ui_scale` aus Task 1.
+- Produces: `App.restart_for_scaling()`; `open_settings_dialog(..., on_request_restart=None)`.
+
+**Verifikation:** End-to-End manuell (Tk-Slider + Prozess-Neustart, kein Display in CI). Die genutzten reinen Helfer sind in Task 1/2 getestet.
+
+- [ ] **Step 1: ui.py — Imports ergänzen**
+
+In `src/ui.py` nach Zeile 8 (`import time`) zwei Imports ergänzen (alphabetisch einsortiert in den bestehenden Block):
+
+```python
+import subprocess
+import sys
+import time
+```
+
+(Konkret: `import subprocess` und `import sys` zum bestehenden Import-Block hinzufügen — `time` ist bereits da.)
+
+- [ ] **Step 2: ui.py — `restart_for_scaling` implementieren**
+
+In `src/ui.py` direkt nach `_quit_with_sync_push` (nach Zeile 557) einfügen:
+
+```python
+    def restart_for_scaling(self):
+        """Startet die App neu, damit eine geänderte UI-Skalierung greift
+        (tk-scaling wird nur beim Start gesetzt). Erst den neuen Prozess
+        spawnen, dann erst das alte Fenster abbauen — schlägt Popen fehl,
+        bleibt die laufende App vollständig intakt (Tray läuft, Fenster offen)
+        und der Nutzer bekommt einen Hinweis. Kein Sync-Push: der Faktor ist
+        lokal, ein 5-s-Push würde den Neustart nur verzögern."""
+        from src.main import relaunch_command
+        cmd = relaunch_command(
+            sys.argv, sys.executable, getattr(sys, "frozen", False))
+        try:
+            subprocess.Popen(cmd)
+        except Exception:
+            logging.getLogger(__name__).exception(
+                "Neustart für UI-Skalierung fehlgeschlagen")
+            themed_showinfo(
+                self.root,
+                "Neustart nötig",
+                "Die Skalierung wird beim nächsten Start der App wirksam.",
+            )
+            return
+        if self._tray is not None:
+            self._tray.stop()
+        self.root.destroy()
+```
+
+- [ ] **Step 3: ui.py — `_open_settings` reicht den Callback durch**
+
+In `src/ui.py`, im `open_settings_dialog(...)`-Aufruf in `_open_settings` (Zeile 323–329), das Keyword `on_request_restart` ergänzen:
+
+```python
+        open_settings_dialog(
+            self.root, self.settings, self.base_path,
+            on_change=_on_change,
+            conflicts_store=self.conflicts_store,
+            storage=self.storage,
+            reservation_store=self.reservation_store,
+            on_request_restart=self.restart_for_scaling,
+        )
+```
+
+- [ ] **Step 4: settings_dialog.py — Import + Signatur erweitern**
+
+In `src/dialogs/settings_dialog.py` Zeile 23 ändern:
+
+```python
+from src.settings import WEEKDAY_KEYS, clamp_ui_scale, parse_hourly_rate, resolve_calendar_id
+```
+
+Signatur (Zeile 28–30) um den keyword-only Parameter erweitern:
+
+```python
+def open_settings_dialog(parent, settings, base_path, on_change, *,
+                         conflicts_store=None, storage=None,
+                         reservation_store=None, on_request_restart=None):
+```
+
+- [ ] **Step 5: settings_dialog.py — „Darstellung"-Sektion einfügen**
+
+In `src/dialogs/settings_dialog.py` **direkt nach** dem `minimize_to_tray`-Checkbutton-Block (endet Zeile 368, `row=20`) und **vor** dem Synchronisations-Header (Zeile 371) einfügen:
+
+```python
+    # --- Darstellung (UI-Skalierung, gerätelokal) ---
+    display_frame = tk.Frame(dialog, bg=BG)
+    display_frame.grid(row=21, column=0, columnspan=2, padx=10, pady=(16, 4),
+                       sticky="we")
+    tk.Label(
+        display_frame, text="— Darstellung —", font=FONT_BOLD,
+        bg=BG, fg=TEXT_MUTED,
+    ).pack(pady=(0, 4))
+    scale_row = tk.Frame(display_frame, bg=BG)
+    scale_row.pack(fill="x")
+    tk.Label(
+        scale_row, text="Skalierung (%):", font=FONT, bg=BG, fg=TEXT,
+    ).pack(side=tk.LEFT, padx=(0, 8))
+    scale_var = tk.IntVar(value=round(settings.get("ui_scale") * 100))
+    tk.Scale(
+        scale_row, from_=75, to=200, resolution=5, orient=tk.HORIZONTAL,
+        variable=scale_var, length=200,
+        bg=BG, fg=TEXT, troughcolor=CELL_BG, highlightthickness=0,
+        activebackground=ACCENT, bd=0,
+    ).pack(side=tk.LEFT)
+    tk.Label(
+        display_frame, text="Änderung startet die App neu.", font=FONT_SMALL,
+        bg=BG, fg=TEXT_MUTED,
+    ).pack(anchor="w", pady=(2, 0))
+```
+
+- [ ] **Step 6: settings_dialog.py — nachfolgende Grid-Reihen umnummerieren**
+
+Die neue Sektion belegt Reihe 21. Alle folgenden `.grid(... row=N ...)`-Aufrufe um **+1** erhöhen. Konkret diese Werte ändern (current → neu):
+
+- Synchronisation-Header (`row=21` → `row=22`)
+- `cb_sync` (`row=22` → `row=23`)
+- Geräte-ID-Label (`row=23` → `row=24`)
+- „Letzte Synchronisation"-Label (`row=24` → `row=25`)
+- „Konflikte ansehen"-Button (`row=25` → `row=26`)
+- `btn_row` (reconnect/import) (`row=26` → `row=27`)
+- „Sync-Daten kompaktieren"-Button (`row=27` → `row=28`)
+- Google-Kalender-Header (`row=28` → `row=29`)
+- `cb_gcal` (`row=29` → `row=30`)
+- `cal_combo` (`row=30` → `row=31`)
+- „Kalender:"-Label (`row=30` → `row=31`)
+- `cal_status` (`row=31` → `row=32`)
+- `btn_frame` (Speichern/Abbrechen) (`row=32` → `row=33`)
+
+- [ ] **Step 7: settings_dialog.py — Save-Logik ergänzen**
+
+In `save_settings` (Zeile 713). Direkt **vor** dem `updates = {...}`-Dict (vor Zeile 747) den alten Faktor und den neuen lesen:
+
+```python
+        old_scale = settings.get("ui_scale")
+        new_scale = clamp_ui_scale(scale_var.get() / 100)
+```
+
+Im `updates`-Dict (Zeile 747–761) den Eintrag ergänzen:
+
+```python
+            "minimize_to_tray": minimize_to_tray_var.get(),
+            "ui_scale": new_scale,
+        }
+```
+
+Am Ende von `save_settings`, **nach** `dialog.destroy()` (Zeile 776), den Neustart anstoßen:
+
+```python
+        on_change()
+        dialog.destroy()
+        if on_request_restart is not None and new_scale != old_scale:
+            on_request_restart()
+```
+
+(Reihenfolge wichtig: erst `apply_updates` persistiert den Faktor, dann schließt der Dialog, dann startet der neue Prozess — der den frischen Wert liest.)
+
+- [ ] **Step 8: Volle Suite + Lint**
+
+Run: `pytest -q && ruff check .`
+Expected: alle Tests grün (inkl. der bestehenden `tests/test_ui_delete.py`, die `src.ui` importiert — die neuen ui.py/settings_dialog.py-Änderungen dürfen den Import nicht brechen), ruff ohne Findings.
+
+- [ ] **Step 9: Manuell verifizieren (End-to-End)**
+
+Run: `python -m src.main` → Zahnrad → Einstellungen.
+- **Renumber-Kontrolle (wichtig, CI fängt das nicht):** den **gesamten** Dialog von oben bis unten durchsehen — alle Sektionen müssen vollständig und **ohne Überlappung/Lücke** rendern: Gmail-Zugangsdaten, Mail-Vorlage, die vier Anzeige-Checkboxen, **Darstellung**, Synchronisation (Checkbox + Geräte-ID + „Letzte Synchronisation" + ggf. Konflikte/Kompaktieren-Button), Google Kalender (Checkbox + „Kalender:"-Combobox + Status), Button-Reihe (Kategorien/Speichern/Abbrechen). Überlappen zwei Zeilen oder fehlt eine, wurde eine `row=`-Nummer falsch verschoben.
+- „Darstellung"-Sektion erscheint zwischen den Anzeige-Checkboxen und „— Synchronisation —"; Slider steht auf dem gespeicherten Wert (Default 100).
+- Slider auf 125 → „Speichern" → App **startet neu**, Fenster erscheint größer.
+- Einstellungen erneut öffnen, **ohne** den Slider zu ändern → „Speichern" → **kein** Neustart, Dialog schließt normal.
+- Slider zurück auf 100 → Speichern → App startet neu, Erscheinungsbild wie ursprünglich.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/ui.py src/dialogs/settings_dialog.py
+git commit -m "feat(ui): UI-Skalierungs-Slider in den Einstellungen + Neustart"
+```
+
+---
+
+## Self-Review-Notiz (vom Plan-Autor)
+
+- **Spec-Abdeckung:** Mechanik (T3), Persistenz/`clamp` (T1), Slider+Platzierung (T4), Sofort-Neustart+Fallback (T4 `restart_for_scaling`), `relaunch_command`/`--minimized`-Strip (T2). „Bekannte Grenze" (Paddings) ist bewusst kein Task.
+- **Typ-Konsistenz:** `clamp_ui_scale(value)->float` (T1) wird in T3 (`_apply_ui_scaling`) und T4 (`save_settings`) identisch genutzt; `relaunch_command(argv, executable, frozen)->list` (T2) in T4 mit `(sys.argv, sys.executable, getattr(sys,"frozen",False))` aufgerufen.
+- **Nicht im Plan:** Versionsbump, CHANGELOG, `release:*`-Label (Release auf Bedarf).

--- a/docs/superpowers/specs/2026-06-26-ui-scaling-design.md
+++ b/docs/superpowers/specs/2026-06-26-ui-scaling-design.md
@@ -1,0 +1,207 @@
+# UI-Skalierungsoption — Design
+
+Datum: 2026-06-26
+
+Issue: #78
+
+## Problem
+
+Die Fenstergröße ist bewusst **fix** (kein freies Resizing) und soll es
+bleiben. Auf HiDPI-Displays oder kleinen Laptop-Bildschirmen wirkt die App
+dadurch aber **sehr klein** und ist schwer ablesbar. Es fehlt eine
+Möglichkeit, die UI-Größe anzupassen, ohne das Fixed-Window-Modell aufzugeben.
+
+## Scope
+
+Eine **Skalierungsoption** in den Einstellungen: ein Slider, der einen Faktor
+zwischen **0.75 und 2.0** setzt. Der Faktor zieht Schriftgrößen **und**
+Fenstergeometrie gemeinsam hoch — das Fenster bleibt fix, nur eben auf einer
+größeren (bzw. kleineren) Stufe. Der Faktor ist **gerätespezifisch** und wird
+**nicht** über Drive synchronisiert.
+
+Eine geänderte Skalierung wird **sofort** wirksam, indem die App sich selbst
+**neu startet** (das Fenster schließt und öffnet sich in neuer Größe).
+
+**Nicht im Scope (YAGNI):**
+- Automatische DPI-Erkennung als Default (rein manuell; Default = 1.0).
+- Feste Stufen/Presets (es ist ein freier Slider mit Min/Max).
+- Skalierung einzelner Pixel-Paddings (`padx`/`pady`) — siehe „Bekannte
+  Grenze".
+- Live-Skalierung **ohne** Neustart (In-Process-Rebuild).
+
+## Entscheidungen (aus Brainstorming)
+
+- **Skalier-Mechanismus:** `root.tk.call("tk", "scaling", base * faktor)`,
+  **einmalig** beim Start gesetzt — *vor* dem Aufbau der `App`-Widgets. Weil
+  alle Fonts in `theme.py` **punkt-basiert** sind und `measure_max_width` die
+  Fensterbreite *misst* (Probe-Label → `winfo_reqwidth()`), kaskadiert das
+  automatisch: größere Fonts → größere Zellen → größeres Fenster. `theme.py`
+  und `measure_max_width` bleiben **unangetastet**.
+- **Faktor relativ zur System-DPI:** `base = root.tk.call("tk", "scaling")`
+  (vom Tk aus der Bildschirm-DPI initialisiert), multipliziert mit dem
+  Nutzer-Faktor. Bei Faktor **1.0** ist das Verhalten **exakt** wie heute —
+  Bestandsnutzer merken nichts.
+- **Wahl-Mechanik:** freier Slider, begrenzt 0.75–2.0. Intern als
+  **Prozent-Slider 75–200, Schritt 5** umgesetzt (= Faktor 0.75–2.0 in
+  0.05-Schritten) — ganzzahlige Anzeige, keine krummen Float-Zwischenwerte.
+- **Default:** `ui_scale = 1.0`, rein manuell (kein DPI-Auto-Detect).
+- **Persistenz:** neuer lokaler Settings-Key `ui_scale` (Float). **Nicht** in
+  `SYNCED_SETTING_KEYS` — gerätespezifisch wie Autostart/Standardzeiten.
+- **Wirksam ab:** sofort, via **Prozess-Neustart** (nicht In-Process-Rebuild).
+  Der frische Prozess setzt `tk scaling` am natürlichen Punkt vor jedem Widget
+  → identisch zum normalen Start, kein fragiles Re-Wiring von
+  Tray/Grid/Sync-Threads.
+
+## Verworfene Alternativen
+
+- **Font-Punktgrößen in `theme.py` aus dem Faktor berechnen.** `theme.py`
+  müsste Settings beim Import lesen (bricht Headless-Imports/CI, stateful beim
+  Import) und erfasst ttk-Combobox-Interna nicht. → `tk scaling` ist die eine
+  Stelle, die alles Punkt-basierte erfasst.
+- **In-Process-Rebuild (sofort ohne Neustart).** Vermeidet das Schließen/Öffnen
+  des Fensters, ist aber fragil: Tray stop/restart, erneutes Laufen der
+  Startup-Tasks (Token-Refresh, Update-Check, Reconcile, Sync-Pull) und „tk
+  scaling *nach* existierenden Widgets" ist plattformabhängig unsicher. Der
+  Neustart umgeht all das.
+
+## Architektur / Komponenten
+
+### 1 · `src/settings.py`
+
+- Neuer Eintrag in `DEFAULTS`: `"ui_scale": 1.0`. **Nicht** in
+  `SYNCED_SETTING_KEYS`. `_coerce` casted den Float beim Laden automatisch;
+  ein nicht-castbarer Wert fällt auf den Default zurück (bestehende Mechanik).
+- Reiner Helfer `clamp_ui_scale(value)`:
+  - Versucht `float(value)`; bei `TypeError`/`ValueError` → `1.0`.
+  - Klemmt auf `[0.75, 2.0]` (`max(0.75, min(2.0, f))`).
+  - Liefert den geklemmten Float.
+  - Zweck: manuell editierte/korrupte `settings.json`-Werte und die
+    Slider-Eingabe defensiv normalisieren, bevor sie an `tk scaling` gehen.
+
+### 2 · `src/main.py`
+
+- Neuer modul-level Helfer `relaunch_command(argv, executable, frozen)` (rein,
+  headless testbar):
+  - `frozen=True` → `[executable] + rest`
+  - `frozen=False` → `[executable, "-m", "src.main"] + rest`
+  - wobei `rest` = `argv[1:]` **ohne** `"--minimized"` (der Nutzer ändert die
+    Skalierung interaktiv und will das Ergebnis sehen, nicht ein erneut
+    minimiertes Fenster).
+- `main()`: nach `root = tk.Tk()` und **vor** `app = App(...)`:
+  ```python
+  _apply_ui_scaling(root, settings.get("ui_scale"))
+  ```
+  mit lokalem Helfer
+  ```python
+  def _apply_ui_scaling(root, factor):
+      f = clamp_ui_scale(factor)
+      base = root.tk.call("tk", "scaling")
+      root.tk.call("tk", "scaling", base * f)
+  ```
+  (Bei `f == 1.0` ist `base * 1.0 == base` → unverändert.)
+
+### 3 · `src/ui.py` (`App`)
+
+- Neue Methode `restart_for_scaling()` — Reihenfolge so gewählt, dass der
+  Fehlerpfad keinen halben Teardown hinterlässt (erst spawnen, dann erst
+  abbauen):
+  1. Kommando bauen via
+     `relaunch_command(sys.argv, sys.executable, getattr(sys, "frozen", False))`.
+  2. Neuen Prozess starten: `subprocess.Popen(cmd)` in `try/except`.
+  3. **Erst nach erfolgreichem `Popen`:** Tray stoppen (`self._tray.stop()`,
+     falls vorhanden), dann `self.root.destroy()` (altes Fenster schließt,
+     `main()` kehrt zurück, Prozess endet).
+  - **Kein** Sync-Push (der Faktor ist lokal; ein 5-s-Push würde den Neustart
+    nur verzögern). Bewusst abweichend vom normalen Quit-Pfad.
+  - **Fallback:** wirft `Popen` (`OSError`/Sonstiges), bleibt die laufende App
+    **vollständig intakt** (Tray läuft noch, `root` nicht zerstört — weil der
+    Abbau erst *nach* dem Spawn passiert); stattdessen ein themed Hinweis: „Die
+    Skalierung wird beim nächsten Start der App wirksam." → sauberes Degradieren
+    auf „apply on next start", ohne die laufende App zu killen.
+- `_open_settings`: reicht den neuen Callback `on_request_restart` an
+  `open_settings_dialog` durch (= `self.restart_for_scaling`).
+
+### 4 · `src/dialogs/settings_dialog.py`
+
+- Neuer Parameter `on_request_restart` an `open_settings_dialog(...)`
+  (keyword-only, Default `None` → rückwärtskompatibel/headless-tolerant).
+- Neue Sektion „— Darstellung —" (eigener `FONT_BOLD`-Header wie
+  „— Synchronisation —"). **Platzierung:** direkt **nach** der Checkbox „Beim
+  Schließen in den Infobereich minimieren" (`minimize_to_tray`, aktuell Reihe
+  20) und **vor** dem Header „— Synchronisation —" (aktuell Reihe 21). Inhalt:
+  - `tk.Scale`, horizontal, `from_=75, to=200, resolution=5`, Startwert
+    `round(settings.get("ui_scale") * 100)`.
+  - Kurzer Hinweis-Label, dass die Änderung beim Speichern einen Neustart
+    auslöst (`FONT_SMALL`, `TEXT_MUTED`).
+  - Alle nachfolgenden Grid-Reihen (ab „— Synchronisation —", aktuell Reihen
+    21–32) werden um die Anzahl der neuen Reihen nach unten verschoben.
+- `save_settings`:
+  - `old_scale = settings.get("ui_scale")` **vor** dem Write merken.
+  - `new_scale = clamp_ui_scale(scale_var.get() / 100)` ins `updates`-Dict
+    (→ `apply_updates` → lokal via `set_many`, da nicht synced).
+  - Nach `apply_updates(...)`, `on_change()` und `dialog.destroy()`:
+    `if on_request_restart is not None and new_scale != old_scale:
+    on_request_restart()`.
+  - Reihenfolge ist wichtig: erst persistieren (der neue Prozess liest den
+    frischen Wert), dann Dialog schließen, dann Neustart anstoßen.
+
+## Datenfluss
+
+```
+Slider (75–200) ──speichern──> ui_scale (0.75–2.0) in settings.json (lokal)
+                                   │
+                          App.restart_for_scaling()
+                                   │  subprocess.Popen(relaunch_command(...))
+                                   ▼
+                          neuer Prozess: main()
+                                   │  _apply_ui_scaling(root, ui_scale)
+                                   │  tk scaling = base * faktor   (vor App-Widgets)
+                                   ▼
+              App-Aufbau → measure_max_width misst größere Probe-Zellen
+                                   ▼
+                          Fenster pinnt größere Geometrie
+```
+
+## Fehlerbehandlung
+
+- **Korrupter/extremer `ui_scale` in settings.json:** `_coerce` + `clamp_ui_scale`
+  fangen ab → nie ein ungültiger Wert an `tk scaling`.
+- **`Popen` schlägt beim Neustart fehl:** App bleibt am Leben, themed Hinweis
+  „wird beim nächsten Start wirksam" (degradiert, kein Crash, kein
+  verwaistes Fenster).
+- **Sehr hoher Faktor auf kleinem Screen:** das fixe Fenster kann den
+  Bildschirm überragen — bewusste Nutzerentscheidung, der Slider lässt sich
+  zurückdrehen. Kein Schutz nötig.
+
+## Tests
+
+**Headless / TDD (laufen im CI):**
+- `clamp_ui_scale`:
+  - klemmt unter 0.75 auf 0.75, über 2.0 auf 2.0,
+  - lässt 1.0 / 1.25 / 0.75 / 2.0 unverändert,
+  - `None`/Müll-String → 1.0,
+  - `"1.5"` (String) → 1.5.
+- `relaunch_command`:
+  - frozen → `[exe, *argv[1:]]`,
+  - repo → `[python, "-m", "src.main", *argv[1:]]`,
+  - `--minimized` wird in beiden Modi aus den Args entfernt.
+
+**Manuell verifiziert (Tk/Prozess-Ebene, nicht im CI — wie die übrigen
+Dialoge):**
+- Slider rendert in „Darstellung", Startwert = gespeicherter Faktor.
+- Speichern mit geändertem Faktor → App startet neu, Fenster erscheint in
+  neuer Größe, Fonts + Geometrie skaliert.
+- Speichern **ohne** Faktor-Änderung → **kein** Neustart.
+- Faktor 1.0 → identisch zum heutigen Erscheinungsbild.
+- Popen-Fallback (z.B. Executable künstlich unauffindbar) → App lebt, Hinweis
+  erscheint.
+
+## Bekannte Grenze
+
+`tk scaling` vergrößert alle punkt-basierten Fonts (und dadurch die *gemessene*
+Geometrie), aber **feste Pixel-Paddings** (`padx=10`, `pady=8`, …) skalieren
+**nicht** mit. Bei hohen Faktoren (≈200 %) wirkt das Layout dadurch minimal
+kompakter. Bewusst akzeptiert: jedes Padding faktorabhängig zu rechnen wäre
+unverhältnismäßig viel invasive Änderung für einen kleinen optischen Gewinn
+(YAGNI). Die Lesbarkeit — das Ziel des Issues — wird durch die Font-Skalierung
+erreicht.

--- a/src/dialogs/settings_dialog.py
+++ b/src/dialogs/settings_dialog.py
@@ -20,14 +20,14 @@ from src.theme import (
 )
 from src.dialogs.category_dialog import open_category_dialog
 from src.holidays_de import STATES, code_for_state_label
-from src.settings import WEEKDAY_KEYS, parse_hourly_rate, resolve_calendar_id
+from src.settings import WEEKDAY_KEYS, clamp_ui_scale, parse_hourly_rate, resolve_calendar_id
 from src.time_utils import format_iso_date
 from src.time_utils import DAYS_DE, validate_entry
 
 
 def open_settings_dialog(parent, settings, base_path, on_change, *,
                          conflicts_store=None, storage=None,
-                         reservation_store=None):
+                         reservation_store=None, on_request_restart=None):
     """Modal dialog for editing app settings.
 
     on_change is called after a successful save so the calendar can refresh.
@@ -367,11 +367,36 @@ def open_settings_dialog(parent, settings, base_path, on_change, *,
         cursor="hand2",
     ).grid(row=20, column=0, columnspan=2, padx=10, pady=(0, 8), sticky="w")
 
+    # --- Darstellung (UI-Skalierung, gerätelokal) ---
+    display_frame = tk.Frame(dialog, bg=BG)
+    display_frame.grid(row=21, column=0, columnspan=2, padx=10, pady=(16, 4),
+                       sticky="we")
+    tk.Label(
+        display_frame, text="— Darstellung —", font=FONT_BOLD,
+        bg=BG, fg=TEXT_MUTED,
+    ).pack(pady=(0, 4))
+    scale_row = tk.Frame(display_frame, bg=BG)
+    scale_row.pack(fill="x")
+    tk.Label(
+        scale_row, text="Skalierung (%):", font=FONT, bg=BG, fg=TEXT,
+    ).pack(side=tk.LEFT, padx=(0, 8))
+    scale_var = tk.IntVar(value=round(settings.get("ui_scale") * 100))
+    tk.Scale(
+        scale_row, from_=75, to=200, resolution=5, orient=tk.HORIZONTAL,
+        variable=scale_var, length=200,
+        bg=BG, fg=TEXT, troughcolor=CELL_BG, highlightthickness=0,
+        activebackground=ACCENT, bd=0,
+    ).pack(side=tk.LEFT)
+    tk.Label(
+        display_frame, text="Änderung startet die App neu.", font=FONT_SMALL,
+        bg=BG, fg=TEXT_MUTED,
+    ).pack(anchor="w", pady=(2, 0))
+
     # --- Synchronisation (Multi-Device-Sync, Phase 4.6) ---
     tk.Label(
         dialog, text="— Synchronisation —", font=FONT_BOLD,
         bg=BG, fg=TEXT_MUTED,
-    ).grid(row=21, column=0, columnspan=2, padx=10, pady=(16, 4))
+    ).grid(row=22, column=0, columnspan=2, padx=10, pady=(16, 4))
 
     var_sync = tk.BooleanVar(value=settings.get("sync_enabled"))
 
@@ -430,20 +455,20 @@ def open_settings_dialog(parent, settings, base_path, on_change, *,
         cursor="hand2",
         command=_on_sync_toggled,
     )
-    cb_sync.grid(row=22, column=0, columnspan=2, padx=10, pady=(4, 0), sticky="w")
+    cb_sync.grid(row=23, column=0, columnspan=2, padx=10, pady=(4, 0), sticky="w")
 
     device_id = settings.get("device_id") or "(noch nicht gesetzt)"
     device_id_short = device_id[:8] + "…" if len(device_id) > 8 else device_id
     tk.Label(
         dialog, text=f"Geräte-ID: {device_id_short}", font=FONT_SMALL,
         bg=BG, fg=TEXT_MUTED,
-    ).grid(row=23, column=0, columnspan=2, padx=10, pady=(2, 0), sticky="w")
+    ).grid(row=24, column=0, columnspan=2, padx=10, pady=(2, 0), sticky="w")
 
     last = format_iso_date(settings.get("last_pull_at"), fallback="noch nie")
     tk.Label(
         dialog, text=f"Letzte Synchronisation: {last}", font=FONT_SMALL,
         bg=BG, fg=TEXT_MUTED,
-    ).grid(row=24, column=0, columnspan=2, padx=10, pady=(2, 4), sticky="w")
+    ).grid(row=25, column=0, columnspan=2, padx=10, pady=(2, 4), sticky="w")
 
     unresolved = 0
     if conflicts_store is not None:
@@ -458,7 +483,7 @@ def open_settings_dialog(parent, settings, base_path, on_change, *,
             f"Konflikte ansehen ({unresolved})",
             _open_conflicts_dialog,
             padx=12, pady=2,
-        ).grid(row=25, column=0, columnspan=2, padx=10, pady=(0, 8), sticky="w")
+        ).grid(row=26, column=0, columnspan=2, padx=10, pady=(0, 8), sticky="w")
 
     def _open_import_dialog():
         from src.dialogs.import_dialog import open_import_dialog
@@ -473,7 +498,7 @@ def open_settings_dialog(parent, settings, base_path, on_change, *,
         )
 
     btn_row = tk.Frame(dialog, bg=BG)
-    btn_row.grid(row=26, column=0, columnspan=2, padx=10, pady=(4, 8), sticky="w")
+    btn_row.grid(row=27, column=0, columnspan=2, padx=10, pady=(4, 8), sticky="w")
 
     # label_button liefert einen tk.Frame (keine -state-Option) — Doppelklick-
     # Schutz daher über ein Flag statt cb.config(state=...).
@@ -583,13 +608,13 @@ def open_settings_dialog(parent, settings, base_path, on_change, *,
         secondary_button(
             dialog, "Sync-Daten kompaktieren", _on_compact_clicked,
             padx=12, pady=2,
-        ).grid(row=27, column=0, columnspan=2, padx=10, pady=(0, 8), sticky="w")
+        ).grid(row=28, column=0, columnspan=2, padx=10, pady=(0, 8), sticky="w")
 
     # --- Google Kalender (Reservierungen) ---
     tk.Label(
         dialog, text="— Google Kalender —", font=FONT_BOLD,
         bg=BG, fg=TEXT_MUTED,
-    ).grid(row=28, column=0, columnspan=2, padx=10, pady=(16, 4))
+    ).grid(row=29, column=0, columnspan=2, padx=10, pady=(16, 4))
 
     var_gcal = tk.BooleanVar(value=settings.get("gcal_enabled"))
     cb_gcal: tk.Checkbutton | None = None
@@ -600,12 +625,12 @@ def open_settings_dialog(parent, settings, base_path, on_change, *,
     cal_var = tk.StringVar(value=settings.get("gcal_calendar_id") or "primary")
 
     cal_combo = dark_combo(dialog, cal_var, [cal_var.get()], width=30)
-    cal_combo.grid(row=30, column=1, padx=10, pady=4, sticky="w")
+    cal_combo.grid(row=31, column=1, padx=10, pady=4, sticky="w")
     tk.Label(dialog, text="Kalender:", font=FONT, bg=BG, fg=TEXT).grid(
-        row=30, column=0, padx=10, pady=4, sticky="w")
+        row=31, column=0, padx=10, pady=4, sticky="w")
 
     cal_status = tk.Label(dialog, text="", font=FONT_SMALL, bg=BG, fg=TEXT_MUTED)
-    cal_status.grid(row=31, column=0, columnspan=2, padx=10, pady=(0, 4), sticky="w")
+    cal_status.grid(row=32, column=0, columnspan=2, padx=10, pady=(0, 4), sticky="w")
 
     def _populate_calendars(items):
         if not cal_combo.winfo_exists():
@@ -705,7 +730,7 @@ def open_settings_dialog(parent, settings, base_path, on_change, *,
         activebackground=BG, activeforeground=TEXT,
         cursor="hand2", command=_on_gcal_toggled,
     )
-    cb_gcal.grid(row=29, column=0, columnspan=2, padx=10, pady=(4, 0), sticky="w")
+    cb_gcal.grid(row=30, column=0, columnspan=2, padx=10, pady=(4, 0), sticky="w")
 
     if settings.get("gcal_enabled"):
         _load_calendars()
@@ -743,6 +768,8 @@ def open_settings_dialog(parent, settings, base_path, on_change, *,
 
         hourly_rate = parse_hourly_rate(rate_var.get())
         selected_code = code_for_state_label(state_var.get())
+        old_scale = settings.get("ui_scale")
+        new_scale = clamp_ui_scale(scale_var.get() / 100)
 
         updates = {
             "autostart": new_autostart,
@@ -758,6 +785,7 @@ def open_settings_dialog(parent, settings, base_path, on_change, *,
             "show_weekend": show_weekend_var.get(),
             "always_on_top": always_on_top_var.get(),
             "minimize_to_tray": minimize_to_tray_var.get(),
+            "ui_scale": new_scale,
         }
         for key in WEEKDAY_KEYS:
             updates[f"default_start_{key}"] = start_vars[key].get()
@@ -774,9 +802,11 @@ def open_settings_dialog(parent, settings, base_path, on_change, *,
                 settings.set_synced("gcal_calendar_id", selected_cal_id)
         on_change()
         dialog.destroy()
+        if on_request_restart is not None and new_scale != old_scale:
+            on_request_restart()
 
     btn_frame = tk.Frame(dialog, bg=BG)
-    btn_frame.grid(row=32, column=0, columnspan=2, pady=12)
+    btn_frame.grid(row=33, column=0, columnspan=2, pady=12)
 
     secondary_button(
         btn_frame, "Kategorien verwalten",

--- a/src/dialogs/settings_dialog.py
+++ b/src/dialogs/settings_dialog.py
@@ -331,51 +331,59 @@ def open_settings_dialog(parent, settings, base_path, on_change, *,
     placeholder_hint.grid(row=16, column=0, columnspan=2, padx=10, pady=(0, 4))
     mv_widgets.append(placeholder_hint)
 
+    # --- App-Einstellungen (gerätelokale UI-Optionen, einklappbar) ---
+    # Alle Member liegen in app_frame (einem einzigen Grid-Member der Section),
+    # damit der Collapse-Toggle nur diesen Frame ein-/ausblendet und die übrigen
+    # Dialog-Reihen (Synchronisation usw.) unberührt bleiben.
+    app_header, app_widgets, app_toggle = _section_header(
+        "App-Einstellungen", row=17, top_pad=16)
+    app_frame = tk.Frame(dialog, bg=BG)
+    app_frame.grid(row=18, column=0, columnspan=2, padx=10, pady=(0, 4),
+                   sticky="we")
+    app_widgets.append(app_frame)
+
     show_weekend_var = tk.BooleanVar(value=settings.get("show_weekend"))
     tk.Checkbutton(
-        dialog, text="Wochenende (Sa/So) im Kalender anzeigen",
+        app_frame, text="Wochenende (Sa/So) im Kalender anzeigen",
         variable=show_weekend_var, font=FONT,
         bg=BG, fg=TEXT, selectcolor=CELL_BG,
         activebackground=BG, activeforeground=TEXT,
         cursor="hand2",
-    ).grid(row=17, column=0, columnspan=2, padx=10, pady=(8, 0), sticky="w")
+    ).pack(anchor="w")
 
     autostart_var = tk.BooleanVar(value=settings.get("autostart"))
     tk.Checkbutton(
-        dialog, text="Autostart (minimiert bei Anmeldung)",
+        app_frame, text="Autostart (minimiert bei Anmeldung)",
         variable=autostart_var, font=FONT,
         bg=BG, fg=TEXT, selectcolor=CELL_BG,
         activebackground=BG, activeforeground=TEXT,
         cursor="hand2",
-    ).grid(row=18, column=0, columnspan=2, padx=10, pady=(0, 0), sticky="w")
+    ).pack(anchor="w")
 
     always_on_top_var = tk.BooleanVar(value=settings.get("always_on_top"))
     tk.Checkbutton(
-        dialog, text="Immer im Vordergrund",
+        app_frame, text="Immer im Vordergrund",
         variable=always_on_top_var, font=FONT,
         bg=BG, fg=TEXT, selectcolor=CELL_BG,
         activebackground=BG, activeforeground=TEXT,
         cursor="hand2",
-    ).grid(row=19, column=0, columnspan=2, padx=10, pady=(0, 0), sticky="w")
+    ).pack(anchor="w")
 
     minimize_to_tray_var = tk.BooleanVar(value=settings.get("minimize_to_tray"))
     tk.Checkbutton(
-        dialog, text="Beim Schließen in den Infobereich minimieren",
+        app_frame, text="Beim Schließen in den Infobereich minimieren",
         variable=minimize_to_tray_var, font=FONT,
         bg=BG, fg=TEXT, selectcolor=CELL_BG,
         activebackground=BG, activeforeground=TEXT,
         cursor="hand2",
-    ).grid(row=20, column=0, columnspan=2, padx=10, pady=(0, 8), sticky="w")
+    ).pack(anchor="w")
 
     # --- Darstellung (UI-Skalierung, gerätelokal) ---
-    display_frame = tk.Frame(dialog, bg=BG)
-    display_frame.grid(row=21, column=0, columnspan=2, padx=10, pady=(16, 4),
-                       sticky="we")
     tk.Label(
-        display_frame, text="— Darstellung —", font=FONT_BOLD,
+        app_frame, text="— Darstellung —", font=FONT_BOLD,
         bg=BG, fg=TEXT_MUTED,
-    ).pack(pady=(0, 4))
-    scale_row = tk.Frame(display_frame, bg=BG)
+    ).pack(pady=(12, 4))
+    scale_row = tk.Frame(app_frame, bg=BG)
     scale_row.pack(fill="x")
     tk.Label(
         scale_row, text="Skalierung:", font=FONT, bg=BG, fg=TEXT,
@@ -408,7 +416,7 @@ def open_settings_dialog(parent, settings, base_path, on_change, *,
     ).pack(side=tk.LEFT)
     scale_value_label.pack(side=tk.LEFT, padx=(8, 0))
     tk.Label(
-        display_frame, text="Änderung startet die App neu.", font=FONT_SMALL,
+        app_frame, text="Änderung startet die App neu.", font=FONT_SMALL,
         bg=BG, fg=TEXT_MUTED,
     ).pack(anchor="w", pady=(2, 0))
 

--- a/src/dialogs/settings_dialog.py
+++ b/src/dialogs/settings_dialog.py
@@ -3,7 +3,7 @@ import os
 import threading
 import tkinter as tk
 import traceback
-from tkinter import messagebox
+from tkinter import messagebox, ttk
 from typing import Any
 
 from src.autostart import disable_autostart, enable_autostart, resolve_autostart_target
@@ -378,15 +378,35 @@ def open_settings_dialog(parent, settings, base_path, on_change, *,
     scale_row = tk.Frame(display_frame, bg=BG)
     scale_row.pack(fill="x")
     tk.Label(
-        scale_row, text="Skalierung (%):", font=FONT, bg=BG, fg=TEXT,
+        scale_row, text="Skalierung:", font=FONT, bg=BG, fg=TEXT,
     ).pack(side=tk.LEFT, padx=(0, 8))
-    scale_var = tk.IntVar(value=round(settings.get("ui_scale") * 100))
-    tk.Scale(
-        scale_row, from_=75, to=200, resolution=5, orient=tk.HORIZONTAL,
-        variable=scale_var, length=200,
-        bg=BG, fg=TEXT, troughcolor=CELL_BG, highlightthickness=0,
-        activebackground=ACCENT, bd=0,
+
+    # ttk.Scale statt klassischer tk.Scale: das clam-Theme ist via
+    # apply_combobox_style aktiv, klassische tk.Scale rendert unter Windows
+    # einen hellen System-Trough/-Regler, der nicht zum Dark-Theme passt.
+    # Wert wird in einem eigenen Label gezeigt (kein klobiger showvalue-Kasten);
+    # gerastert wird auf 5er-Schritte (= Faktor-Schritt 0.05) beim Anzeigen und
+    # beim Speichern, da ttk.Scale kein resolution kennt.
+    ttk.Style(dialog).configure(
+        "Display.Horizontal.TScale",
+        background=ACCENT, troughcolor=CELL_BG,
+        bordercolor=CELL_BG, darkcolor=ACCENT, lightcolor=ACCENT,
+    )
+    scale_var = tk.DoubleVar(value=round(settings.get("ui_scale") * 100))
+    scale_value_label = tk.Label(
+        scale_row, text=f"{round(scale_var.get() / 5) * 5} %", font=FONT,
+        bg=BG, fg=ACCENT, width=5, anchor="w",
+    )
+
+    def _on_scale(_raw):
+        scale_value_label.config(text=f"{round(scale_var.get() / 5) * 5} %")
+
+    ttk.Scale(
+        scale_row, from_=75, to=200, orient="horizontal",
+        variable=scale_var, command=_on_scale, length=200,
+        style="Display.Horizontal.TScale",
     ).pack(side=tk.LEFT)
+    scale_value_label.pack(side=tk.LEFT, padx=(8, 0))
     tk.Label(
         display_frame, text="Änderung startet die App neu.", font=FONT_SMALL,
         bg=BG, fg=TEXT_MUTED,
@@ -769,7 +789,7 @@ def open_settings_dialog(parent, settings, base_path, on_change, *,
         hourly_rate = parse_hourly_rate(rate_var.get())
         selected_code = code_for_state_label(state_var.get())
         old_scale = settings.get("ui_scale")
-        new_scale = clamp_ui_scale(scale_var.get() / 100)
+        new_scale = clamp_ui_scale((round(scale_var.get() / 5) * 5) / 100)
 
         updates = {
             "autostart": new_autostart,

--- a/src/main.py
+++ b/src/main.py
@@ -36,6 +36,18 @@ def _ensure_device_id(settings) -> str:
     return device_id
 
 
+def relaunch_command(argv, executable, frozen):
+    """Baut das Kommando, um die App neu zu starten (nach UI-Skalierungs-
+    Änderung). Im Frozen-Build ist `executable` die App-Exe selbst; im
+    Repo-Modus wird `python -m src.main` aufgerufen. `--minimized` wird
+    entfernt, weil der Nutzer nach einer interaktiven Skalierungsänderung das
+    Fenster sehen will, nicht ein erneut minimiertes."""
+    rest = [a for a in argv[1:] if a != "--minimized"]
+    if frozen:
+        return [executable] + rest
+    return [executable, "-m", "src.main"] + rest
+
+
 def _parse_remote_or_quarantine(content_bytes, file_id, on_corrupt):
     """Parsed Remote-Bytes als JSON. Bei Fehler ruft on_corrupt(file_id) auf
     und liefert ein leeres Doc."""

--- a/src/main.py
+++ b/src/main.py
@@ -18,7 +18,7 @@ from src.conflicts_store import ConflictsStore
 from src.logging_setup import setup_logging
 from src.paths import get_base_path
 from src.reservations import ReservationStore
-from src.settings import Settings
+from src.settings import Settings, clamp_ui_scale
 from src.storage import Storage
 from src.ui import App
 from src.version import VERSION
@@ -268,6 +268,16 @@ def run_calendar_reconcile(reservation_store, settings, base):
                 "tb": traceback.format_exc()}
 
 
+def _apply_ui_scaling(root, factor):
+    """Setzt tk-scaling einmalig auf System-DPI × Faktor. MUSS vor dem Aufbau
+    der App-Widgets laufen, damit measure_max_width die skalierten Fonts misst
+    und die Fenstergeometrie entsprechend pinnt. Bei Faktor 1.0 unverändert
+    (base × 1.0 == base)."""
+    f = clamp_ui_scale(factor)
+    base = float(root.tk.call("tk", "scaling"))
+    root.tk.call("tk", "scaling", base * f)
+
+
 def main():
     base = get_base_path()
     try:
@@ -287,6 +297,7 @@ def main():
     reservation_store = ReservationStore(os.path.join(base, "reservations.json"))
 
     root = tk.Tk()
+    _apply_ui_scaling(root, settings.get("ui_scale"))
     app = App(root, storage, settings, base_path=base, conflicts_store=conflicts_store,
               reservation_store=reservation_store)
 

--- a/src/settings.py
+++ b/src/settings.py
@@ -53,6 +53,7 @@ DEFAULTS = {
     "last_calendar_sync_at": "",
     "categories": [],
     "category_times": {},
+    "ui_scale": 1.0,
 }
 
 _COERCE_FAILED = object()
@@ -145,6 +146,18 @@ def resolve_calendar_id(cal_map, selected_label, current_id):
     die Kalender-ID. Unbekanntes Label → bisheriger Wert, ersatzweise
     "primary" (nie leer, damit der gcal-Abgleich einen gültigen Kalender hat)."""
     return cal_map.get(selected_label, current_id or "primary")
+
+
+def clamp_ui_scale(value):
+    """Normalisiert den UI-Skalierungsfaktor defensiv: castet zu float und
+    klemmt auf [0.75, 2.0]. Nicht-castbare Werte (None, Müll-String) → 1.0
+    (Default). Schützt das tk-scaling vor korrupten settings.json-Werten und
+    Slider-Ausreißern."""
+    try:
+        f = float(value)
+    except (TypeError, ValueError):
+        return 1.0
+    return max(0.75, min(2.0, f))
 
 
 class Settings:

--- a/src/ui.py
+++ b/src/ui.py
@@ -6,6 +6,8 @@ import datetime
 import logging
 import os
 import platform
+import subprocess
+import sys
 import time
 from src.time_utils import (
     format_iso_date, get_week_dates,
@@ -326,6 +328,7 @@ class App:
             conflicts_store=self.conflicts_store,
             storage=self.storage,
             reservation_store=self.reservation_store,
+            on_request_restart=self.restart_for_scaling,
         )
 
     def _apply_always_on_top(self):
@@ -552,6 +555,31 @@ class App:
         """Push zum Drive (falls aktiv) und App komplett beenden. Wird vom
         normalen X-Klick (ohne Tray) und vom Tray-Menü-„Beenden" aufgerufen."""
         self._sync.push_on_quit()
+        if self._tray is not None:
+            self._tray.stop()
+        self.root.destroy()
+
+    def restart_for_scaling(self):
+        """Startet die App neu, damit eine geänderte UI-Skalierung greift
+        (tk-scaling wird nur beim Start gesetzt). Erst den neuen Prozess
+        spawnen, dann erst das alte Fenster abbauen — schlägt Popen fehl,
+        bleibt die laufende App vollständig intakt (Tray läuft, Fenster offen)
+        und der Nutzer bekommt einen Hinweis. Kein Sync-Push: der Faktor ist
+        lokal, ein 5-s-Push würde den Neustart nur verzögern."""
+        from src.main import relaunch_command
+        cmd = relaunch_command(
+            sys.argv, sys.executable, getattr(sys, "frozen", False))
+        try:
+            subprocess.Popen(cmd)
+        except Exception:
+            logging.getLogger(__name__).exception(
+                "Neustart für UI-Skalierung fehlgeschlagen")
+            themed_showinfo(
+                self.root,
+                "Neustart nötig",
+                "Die Skalierung wird beim nächsten Start der App wirksam.",
+            )
+            return
         if self._tray is not None:
             self._tray.stop()
         self.root.destroy()

--- a/tests/test_main_relaunch.py
+++ b/tests/test_main_relaunch.py
@@ -1,0 +1,21 @@
+from src.main import relaunch_command
+
+
+def test_relaunch_command_frozen_uses_executable_directly():
+    cmd = relaunch_command(["app.exe", "--foo"], "app.exe", True)
+    assert cmd == ["app.exe", "--foo"]
+
+
+def test_relaunch_command_repo_uses_module_invocation():
+    cmd = relaunch_command(["src/main.py", "--foo"], "python", False)
+    assert cmd == ["python", "-m", "src.main", "--foo"]
+
+
+def test_relaunch_command_strips_minimized_frozen():
+    cmd = relaunch_command(["app.exe", "--minimized", "--bar"], "app.exe", True)
+    assert cmd == ["app.exe", "--bar"]
+
+
+def test_relaunch_command_strips_minimized_repo():
+    cmd = relaunch_command(["main.py", "--minimized"], "python", False)
+    assert cmd == ["python", "-m", "src.main"]

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -570,3 +570,40 @@ def test_resolve_calendar_id_unknown_and_no_current_is_primary():
     from src.settings import resolve_calendar_id
     assert resolve_calendar_id({}, "Weg", "") == "primary"
     assert resolve_calendar_id({}, "Weg", None) == "primary"
+
+
+def test_ui_scale_default(tmp_settings):
+    assert tmp_settings.get("ui_scale") == 1.0
+
+
+def test_ui_scale_is_not_synced():
+    # Gerätespezifisch -> darf nicht per Drive synchronisieren.
+    assert "ui_scale" not in SYNCED_SETTING_KEYS
+
+
+def test_clamp_ui_scale_within_range():
+    from src.settings import clamp_ui_scale
+    assert clamp_ui_scale(1.25) == 1.25
+    assert clamp_ui_scale(0.75) == 0.75
+    assert clamp_ui_scale(2.0) == 2.0
+
+
+def test_clamp_ui_scale_below_min_clamps_to_075():
+    from src.settings import clamp_ui_scale
+    assert clamp_ui_scale(0.5) == 0.75
+
+
+def test_clamp_ui_scale_above_max_clamps_to_2():
+    from src.settings import clamp_ui_scale
+    assert clamp_ui_scale(3.0) == 2.0
+
+
+def test_clamp_ui_scale_string_is_cast():
+    from src.settings import clamp_ui_scale
+    assert clamp_ui_scale("1.5") == 1.5
+
+
+def test_clamp_ui_scale_invalid_falls_back_to_1():
+    from src.settings import clamp_ui_scale
+    assert clamp_ui_scale(None) == 1.0
+    assert clamp_ui_scale("abc") == 1.0


### PR DESCRIPTION
## Was

Eine **Skalierungsoption** in den Einstellungen (Issue #78): ein Slider
**0.75–2.0**, der Schriftgrößen **und** Fenstergeometrie gemeinsam hochzieht —
das Fixed-Window-Modell bleibt, nur eben auf einer größeren (bzw. kleineren)
Stufe. Der Faktor ist **gerätelokal** und wird **nicht** über Drive
synchronisiert. Eine Änderung wird **sofort** wirksam: die App startet sich
selbst neu.

## Wie

- **Mechanik:** `tk scaling = System-DPI × Faktor`, **einmalig** vor dem Aufbau
  der App-Widgets gesetzt (`main._apply_ui_scaling`). Weil alle Fonts in
  `theme.py` punkt-basiert sind und `GridRenderer.measure_max_width` die
  Fensterbreite *misst*, kaskadiert das automatisch (größere Fonts → größere
  Zellen → größeres Fenster). `theme.py` und `measure_max_width` bleiben
  **unangetastet**. Bei Faktor 1.0 exakt heutiges Verhalten.
- **Persistenz:** neuer lokaler Key `ui_scale` (Float, Default 1.0) in
  `settings.DEFAULTS`, bewusst **nicht** in `SYNCED_SETTING_KEYS`. Reiner Helfer
  `clamp_ui_scale` klemmt defensiv auf `[0.75, 2.0]`.
- **Sofort wirksam = Prozess-Neustart:** `App.restart_for_scaling` spawnt erst
  den neuen Prozess (`subprocess.Popen` via reinem Helfer `relaunch_command`,
  `--minimized` wird entfernt), und baut erst **nach** erfolgreichem Spawn Tray
  + Fenster ab. Schlägt `Popen` fehl, bleibt die laufende App vollständig intakt
  + Hinweis „wird beim nächsten Start wirksam". Kein Sync-Push (Faktor ist
  lokal).
- **UI:** Slider als themed `ttk.Scale` (clam, ACCENT-Regler, `CELL_BG`-Trough,
  sauberes „100 %"-Label statt showvalue-Box; 5er-Rasterung = Faktor-Schritt
  0.05). Die vier gerätelokalen Checkboxen (Wochenende, Autostart, Immer im
  Vordergrund, Minimize-to-Tray) + der Darstellung-Block liegen jetzt in einer
  **einklappbaren Sektion „App-Einstellungen"** (gleicher ▶/▼-Toggle wie
  Gmail-Zugangsdaten/Mail-Vorlage).

## Tests / Verify

- **Headless/TDD (CI):** `clamp_ui_scale` (Grenzen, String-Cast, None→1.0),
  `relaunch_command` (frozen/repo, `--minimized`-Strip).
- Volle Suite: **603 passed, 1 skipped**. `ruff check .` sauber.
- **Manuell verifiziert** (Tk/Prozess-Ebene, kein Display in CI): Slider →
  Speichern → Neustart in neuer Größe; ohne Änderung → kein Neustart; Faktor 1.0
  identisch zum Ist-Zustand; Slider-Optik + einklappbare „App-Einstellungen".

## Risiko

`tk scaling` skaliert punkt-basierte Fonts (und dadurch die gemessene
Geometrie); feste Pixel-Paddings skalieren nicht mit → bei ~200 % wirkt das
Layout minimal kompakter (bewusst akzeptiert, YAGNI). Der Neustart umgeht
fragiles In-Process-Re-Wiring (Tray/Grid/Sync-Threads) und ist damit robuster.

## Nicht im Scope

Kein Versionsbump / kein CHANGELOG / kein `release:*`-Label (Release auf
Bedarf). Der scrollbare Settings-Dialog ist separat als #86 erfasst.

Closes #78.

Design + Plan: `docs/superpowers/specs/2026-06-26-ui-scaling-design.md`,
`docs/superpowers/plans/2026-06-26-ui-scaling.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
