### PR TITLE
fix(report): Kategorie-Summentabelle bei nur unkategorisierten Slots weglassen

### DIFF
--- a/src/report.py
+++ b/src/report.py
@@ -224,14 +224,18 @@ def _build_table(groups, style):
 def _build_category_summary(range_entries, style):
     """„Summe je Kategorie"-Tabelle über den (gefilterten) Zeitraum. Leerer
     String ('' = keine Kategorie) wird als '(ohne Kategorie)' ans Ende
-    sortiert. Liefert '' wenn keine Slots vorhanden."""
+    sortiert. Liefert '' wenn keine Slots vorhanden — oder wenn alle Slots
+    unkategorisiert sind (dann wäre die Tabelle nur die Gesamtsumme)."""
     s = style
     totals = {}
     for entry in range_entries.values():
         for slot in entry["slots"]:
             kat = slot.get("kategorie") or ""
             totals[kat] = totals.get(kat, 0.0) + _slot_hours(slot)
-    if not totals:
+    # Keine Slots, oder ausschließlich unkategorisierte: die Tabelle bestünde
+    # dann nur aus der "(ohne Kategorie)"-Zeile = exakt die ohnehin gezeigte
+    # Gesamtsumme. Weglassen, statt eine leere Pseudo-Aufschlüsselung zu zeigen.
+    if not totals or set(totals) == {""}:
         return ""
 
     td = s["td_base"]

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -86,10 +86,22 @@ def test_category_summary_block():
     assert "4.0h" in html
 
 
-def test_category_summary_uncategorized_label():
+def test_category_summary_suppressed_when_only_uncategorized():
+    """Sind alle Slots ohne Kategorie, ist die Kategorie-Summentabelle
+    bedeutungslos (nur eine Zeile = Gesamtsumme) und wird weggelassen."""
     entries = {"2026-03-23": _e("08:00", "16:00")}  # kategorie ""
     html, _ = generate_report(datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries)
+    assert "(ohne Kategorie)" not in html
+
+
+def test_category_summary_shown_when_mixed():
+    """Sobald mindestens eine echte Kategorie existiert, erscheint die Tabelle
+    inklusive der (ohne Kategorie)-Zeile für die unkategorisierten Slots."""
+    entries = {"2026-03-23": {"slots": [_slot("08:00", "12:00", 0, "Büro"),
+                                         _slot("13:00", "17:00", 0, "")]}}
+    html, _ = generate_report(datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries)
     assert "(ohne Kategorie)" in html
+    assert "Büro" in html
 
 
 def test_category_filter_includes_only_selected():


### PR DESCRIPTION
## Problem

Beim PDF-Export und Mail-Versand erscheint die „Summe je Kategorie"-Tabelle auch dann, wenn **keiner** der Slots im Zeitraum einer Kategorie zugeordnet ist. Sie besteht dann aus einer einzigen Zeile `(ohne Kategorie) → X h` — also exakt der Gesamtsumme, die direkt darüber ohnehin als „Gesamt" steht.

Das ist besonders verwirrend, wenn zwar Kategorien definiert sind (z.B. *Homeoffice*, *Office*), aber kein Eintrag einer davon zugewiesen ist: Die Aufschlüsselung suggeriert Inhalt, zeigt aber nur eine leere Pseudo-Kategorie.

| Vorher | Nachher |
|--------|---------|
| Tabelle mit einziger Zeile `(ohne Kategorie)` | Tabelle wird weggelassen |

## Fix

`_build_category_summary` liefert nun auch dann `""`, wenn die einzige vorkommende „Kategorie" der leere String ist (`set(totals) == {""}`). Sobald **mindestens eine echte** Kategorie existiert, erscheint die Tabelle unverändert — inkl. der `(ohne Kategorie)`-Zeile für gemischte Zeiträume.

## Tests (TDD)

- `test_category_summary_suppressed_when_only_uncategorized` — neu, reine Unkategorisiert-Zeiträume zeigen keine Tabelle
- `test_category_summary_shown_when_mixed` — neu, gemischte Zeiträume zeigen Tabelle inkl. `(ohne Kategorie)`
- `test_category_summary_uncategorized_label` (alt) entsprechend ersetzt
- gesamte `tests/test_report.py` grün (40 passed), `ruff check` sauber

🤖 Generated with [Claude Code](https://claude.com/claude-code)
