### PR TITLE
fix(report): PDF-Stundentabelle kollabiert die linken Spalten nicht mehr

### DIFF
--- a/src/report.py
+++ b/src/report.py
@@ -16,9 +16,20 @@ def _esc_multiline(text):
 
 COLUMN_LABELS = ["Datum", "Tag", "Kategorie", "Start", "Ende", "Stunden"]
 
+# Explizite Spaltenbreiten (Summe 100%) für die 6-spaltige Stundentabelle.
+# Browser layouten automatisch (E-Mail-HTML braucht keine Breiten), xhtml2pdf
+# dagegen kollabiert mit den colspan-Zeilen (KW-Header/Summen) die linken
+# Spalten ineinander. <colgroup>/<col width> ignoriert xhtml2pdf, und eine
+# width-Angabe nur am Header reicht nicht — die Breiten müssen an *jeder*
+# regulären 6-Spalten-Zelle (Header + Datenzeilen) stehen, damit ReportLab
+# trotz der SPAN-Zeilen ein konsistentes Raster bildet. Daher führt nur
+# PDF_STYLE Breiten, HTML_STYLE leere.
+_PDF_COL_WIDTHS = ["15%", "8%", "25%", "16%", "16%", "20%"]
+
 # Style-Dict pro Render-Ziel. Felder werden direkt als CSS-Strings in die
 # Inline-Styles der Zellen geschrieben.
 HTML_STYLE = {
+    "col_widths":  ["", "", "", "", "", ""],
     "table_extra": "border-radius:8px;overflow:hidden;",
     "th_row":      "background:#1e293b;",
     "th_cell":     "padding:10px 14px;text-align:left;color:#94a3b8;font-size:12px;font-weight:600;text-transform:uppercase;letter-spacing:0.05em;",
@@ -41,6 +52,7 @@ HTML_STYLE = {
 }
 
 PDF_STYLE = {
+    "col_widths":  _PDF_COL_WIDTHS,
     "table_extra": "",
     "th_row":      "background:#1e293b;",
     "th_cell":     "padding:8px 12px;text-align:left;color:#ffffff;font-size:11px;font-weight:600;text-transform:uppercase;",
@@ -143,6 +155,7 @@ def _week_block(iso_year, iso_week, week_entries, style):
     """Render einen Wochen-Block: KW-Header, je Slot eine Zeile, Tages-Subtotal
     bei >1 Slot, Wochensumme. Returns (rows_html, week_total)."""
     s = style
+    cw = [f"width:{w};" if w else "" for w in s["col_widths"]]
     rows = [
         f"<tr style='{s['kw_row']}'>"
         f"<td colspan='6' style='{s['kw_cell']}'>{get_week_label(iso_year, iso_week)}</td>"
@@ -166,12 +179,12 @@ def _week_block(iso_year, iso_week, week_entries, style):
             day_cell = weekday if sidx == 0 else ""
             rows.append(
                 f"<tr style='{row_bg}'>"
-                f"<td style='{td}{s['c_date']}'>{date_cell}</td>"
-                f"<td style='{td}{s['c_day']}'>{day_cell}</td>"
-                f"<td style='{td}{s['c_kat']}'>{_esc(slot.get('kategorie') or '')}</td>"
-                f"<td style='{td}{s['c_time']}'>{slot['start']}</td>"
-                f"<td style='{td}{s['c_time']}'>{slot['end']}</td>"
-                f"<td style='{td}{s['c_hours']}'>{hours}h</td>"
+                f"<td style='{td}{cw[0]}{s['c_date']}'>{date_cell}</td>"
+                f"<td style='{td}{cw[1]}{s['c_day']}'>{day_cell}</td>"
+                f"<td style='{td}{cw[2]}{s['c_kat']}'>{_esc(slot.get('kategorie') or '')}</td>"
+                f"<td style='{td}{cw[3]}{s['c_time']}'>{slot['start']}</td>"
+                f"<td style='{td}{cw[4]}{s['c_time']}'>{slot['end']}</td>"
+                f"<td style='{td}{cw[5]}{s['c_hours']}'>{hours}h</td>"
                 f"</tr>"
             )
         if len(slots) > 1:
@@ -205,7 +218,8 @@ def _build_table(groups, style):
     total = round(total, 2)
 
     th_cells = "".join(
-        f'<th style="{s["th_cell"]}">{label}</th>' for label in COLUMN_LABELS
+        f'<th style="{s["th_cell"]}{f"width:{w};" if w else ""}">{label}</th>'
+        for label, w in zip(COLUMN_LABELS, s["col_widths"])
     )
 
     table = (

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -311,6 +311,47 @@ def test_pdf_category_filter_applied():
     assert "HO" not in captured_html["html"]
 
 
+def test_pdf_table_defines_explicit_column_widths():
+    """xhtml2pdf berechnet Spaltenbreiten nicht wie ein Browser und kollabiert
+    bei width:100%-Tabellen mit colspan-Zeilen die linken Spalten ineinander.
+    Die Breiten (Summe 100%) müssen daher an *jeder* regulären 6-Spalten-Zelle
+    stehen — am Header UND an den Datenzeilen, sonst greift der Workaround
+    wegen der SPAN-Zeilen nicht."""
+    from src import report as report_mod
+    entries = {"2026-03-23": _e("08:00", "16:00")}
+    captured_html = {}
+
+    class FakePisa:
+        @staticmethod
+        def CreatePDF(html_str, dest):
+            captured_html["html"] = html_str
+            return MagicMock(err=0)
+
+    fake_xhtml2pdf = MagicMock()
+    fake_xhtml2pdf.pisa = FakePisa
+
+    with patch.dict("sys.modules", {"xhtml2pdf": fake_xhtml2pdf}):
+        report_mod.generate_pdf(datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries)
+
+    html = captured_html["html"]
+    widths = ["15%", "8%", "25%", "16%", "16%", "20%"]
+    assert sum(int(w.rstrip("%")) for w in widths) == 100
+    for w in set(widths):
+        assert f"width:{w};" in html
+    # nicht nur am Header: die Datumsspalte (15%) taucht auch in der Datenzeile auf
+    assert html.count("width:15%;") >= 2
+
+
+def test_email_html_has_no_column_widths():
+    """Die E-Mail-HTML-Tabelle bleibt ohne feste Spaltenbreiten (Browser
+    layouten selbst) — der xhtml2pdf-Workaround darf nur das PDF betreffen.
+    (width:100% am <table> ist erlaubt, nur die Spaltenbreiten dürfen fehlen.)"""
+    entries = {"2026-03-23": _e("08:00", "16:00")}
+    html, _ = generate_report(datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries)
+    for w in ["15%", "8%", "25%", "16%", "20%"]:
+        assert f"width:{w};" not in html
+
+
 from src.report import total_hours
 
 


### PR DESCRIPTION
## Problem

Im PDF-Export (`feat/pdf-export`) überlappen die linken Spalten der Stundentabelle ineinander — *Datum / Tag / Kategorie / Start* werden auf nahezu null Breite gedrückt (`01.06l2026Office09:00`), während *Ende* und *Stunden* den gesamten restlichen Platz bekommen. Der **Inhalt** ist korrekt, nur das **Layout** ist kaputt.

Ursache ist der Tabellen-Mechanismus von **ReportLab** unter xhtml2pdf: bei `width:100%`-Tabellen mit `colspan`-Zeilen (KW-Header, Tages-/Wochen-/Gesamtsummen) verteilt er die Spaltenbreiten nicht wie ein Browser und kollabiert die ersten Spalten (SPAN-Bug).

## Untersuchung

Empirisch durch Rendern echter PDFs verifiziert:

- `<colgroup>`/`<col width>` → **ignoriert** von xhtml2pdf (PDF byte-identisch)
- `width` nur an den Header-Zellen → Tabelle wird schmaler, linke Spalten kollabieren **weiterhin**
- `width` an **jeder** regulären 6-Spalten-Zelle (Header **und** Datenzeilen) → **korrektes** Raster ✅

## Fix

Explizite Spaltenbreiten (Summe 100% — Datum 15, Tag 8, Kategorie 25, Start 16, Ende 16, Stunden 20) an allen regulären 6-Spalten-Zellen. Die `colspan`-Zeilen brauchen keine Breite und erben das so erzwungene Raster.

Style-getrieben über `PDF_STYLE`/`HTML_STYLE`: **nur das PDF** führt Breiten, die **E-Mail-HTML-Tabelle bleibt unverändert** (Browser layouten selbst).

| Vorher | Nachher |
|--------|---------|
| Datum/Tag/Kategorie/Start überlappen, Rest zu breit | Alle 6 Spalten sauber getrennt, volle Breite |

## Tests

- `test_pdf_table_defines_explicit_column_widths` — neu: PDF führt alle 6 Breiten (Summe 100%) an Header **und** Datenzeilen
- `test_email_html_has_no_column_widths` — neu: E-Mail-HTML bleibt ohne feste Spaltenbreiten
- gesamte `tests/test_report.py` grün (41 passed), `ruff check` sauber
- Visuell verifiziert durch Vorher/Nachher-Rendering eines vollen Monats-PDFs (inkl. Multi-Slot-Tage und Kategorie-Summentabelle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
