### PR TITLE
feat(export): Kategorie-Aufschlüsselung im Bericht optional schalten

### DIFF
--- a/src/dialogs/export_dialog.py
+++ b/src/dialogs/export_dialog.py
@@ -59,7 +59,8 @@ def open_export_dialog(parent, storage, settings):
         try:
             pdf_bytes = generate_pdf(
                 date_from, date_to, entries,
-                name=settings.get("name"), categories=categories)
+                name=settings.get("name"), categories=categories,
+                category_breakdown=picker.get_category_breakdown())
         except Exception as e:
             logging.getLogger(__name__).exception("PDF-Erzeugung fehlgeschlagen")
             messagebox.showerror(

--- a/src/dialogs/period_picker.py
+++ b/src/dialogs/period_picker.py
@@ -33,10 +33,11 @@ class _PeriodPickerHandle:
     """Lese-Schnittstelle auf die Picker-Widgets, ohne dass der Aufrufer die
     Tk-Vars kennt."""
 
-    def __init__(self, from_vars, to_vars, category_vars):
+    def __init__(self, from_vars, to_vars, category_vars, breakdown_var):
         self._from = from_vars        # (day_var, month_var, year_var)
         self._to = to_vars            # (day_var, month_var, year_var)
         self._cats = category_vars    # {kategorie: BooleanVar}
+        self._breakdown = breakdown_var  # BooleanVar
 
     def get_range(self):
         try:
@@ -50,6 +51,10 @@ class _PeriodPickerHandle:
 
     def get_categories(self):
         return selected_category_filter({k: v.get() for k, v in self._cats.items()})
+
+    def get_category_breakdown(self):
+        """True = "Summe je Kategorie"-Tabelle in den Bericht aufnehmen."""
+        return bool(self._breakdown.get())
 
 
 def build_period_picker(parent, storage, settings, on_change=None):
@@ -127,11 +132,22 @@ def build_period_picker(parent, storage, settings, on_change=None):
                 highlightthickness=0, bd=0, anchor="w",
             ).pack(anchor="w")
 
-    handle = _PeriodPickerHandle(from_vars, to_vars, category_vars)
+    # Schalter: Gesamtstunden nach Kategorie aufschlüsseln. Default aus —
+    # standardmäßig zeigt der Bericht nur das Gesamt, die "Summe je Kategorie"-
+    # Tabelle ist opt-in. Greift in PDF-Export und Mail-Versand gleichermaßen.
+    breakdown_var = tk.BooleanVar(value=False)
+    tk.Checkbutton(
+        frame, text="Nach Kategorie aufschlüsseln", variable=breakdown_var,
+        font=FONT, bg=BG, fg=TEXT, selectcolor=CELL_BG,
+        activebackground=BG, activeforeground=TEXT,
+        highlightthickness=0, bd=0, anchor="w",
+    ).grid(row=3, column=0, columnspan=6, padx=10, pady=(0, 4), sticky="w")
+
+    handle = _PeriodPickerHandle(from_vars, to_vars, category_vars, breakdown_var)
 
     # Live-Vorschau (Gesamtstunden über den Build-Zeit-Snapshot all_entries).
     total_label = tk.Label(frame, text="", font=FONT, bg=BG, fg=TEXT)
-    total_label.grid(row=3, column=0, columnspan=6, padx=10, pady=(0, 8), sticky="w")
+    total_label.grid(row=4, column=0, columnspan=6, padx=10, pady=(0, 8), sticky="w")
 
     def _update_total(*_):
         df, dt = handle.get_range()

--- a/src/dialogs/send_dialog.py
+++ b/src/dialogs/send_dialog.py
@@ -112,6 +112,7 @@ def open_send_dialog(parent, storage, settings, base_path):
         # sich bei offenem Dialog geändert haben (Hintergrund-Drive-Sync).
         entries = storage.get_all()
         categories = picker.get_categories()
+        category_breakdown = picker.get_category_breakdown()
 
         html, total = generate_report(
             date_from, date_to, entries,
@@ -119,6 +120,7 @@ def open_send_dialog(parent, storage, settings, base_path):
             content=settings.get("mail_content"),
             closing=settings.get("mail_closing"),
             categories=categories,
+            category_breakdown=category_breakdown,
         )
 
         if html is None:
@@ -133,7 +135,8 @@ def open_send_dialog(parent, storage, settings, base_path):
 
         try:
             pdf_bytes = generate_pdf(date_from, date_to, entries, name=settings.get("name"),
-                                     categories=categories)
+                                     categories=categories,
+                                     category_breakdown=category_breakdown)
             service = get_gmail_service(
                 credentials_path, token_path,
                 sync_enabled=settings.get("sync_enabled"),

--- a/src/report.py
+++ b/src/report.py
@@ -259,11 +259,13 @@ def _build_category_summary(range_entries, style):
 
 
 def generate_report(date_from, date_to, all_entries, greeting="", content="",
-                    closing="", categories=None):
+                    closing="", categories=None, category_breakdown=True):
     """Generate an HTML email report with greeting, content, table, category
     summary, and closing.
 
     categories: None = alle; sonst Menge von Kategorie-Strings ('' = ohne).
+    category_breakdown: True = "Summe je Kategorie"-Tabelle anhängen (Default,
+    bisheriges Verhalten); False = weglassen, nur das Gesamt der Tagestabelle.
     Returns (html, total) tuple, or (None, 0) if no entries.
     """
     range_entries = _filter_entries(date_from, date_to, all_entries)
@@ -275,7 +277,10 @@ def generate_report(date_from, date_to, all_entries, greeting="", content="",
     label = f"{date_from.strftime('%d.%m.%Y')} – {date_to.strftime('%d.%m.%Y')}"
     groups = _group_by_week(range_entries)
     table, total = _build_table(groups, HTML_STYLE)
-    category_summary = _build_category_summary(range_entries, HTML_STYLE)
+    category_summary = (
+        _build_category_summary(range_entries, HTML_STYLE)
+        if category_breakdown else ""
+    )
 
     greeting_filled = _apply_placeholders(_esc_multiline(greeting), label, total)
     content_filled = _apply_placeholders(_esc_multiline(content), label, total)
@@ -300,8 +305,13 @@ def generate_report(date_from, date_to, all_entries, greeting="", content="",
     return html_out, total
 
 
-def generate_pdf(date_from, date_to, all_entries, name="", categories=None):
-    """Generate a PDF of the time tracking table. Returns PDF bytes, or None if no entries."""
+def generate_pdf(date_from, date_to, all_entries, name="", categories=None,
+                 category_breakdown=True):
+    """Generate a PDF of the time tracking table. Returns PDF bytes, or None if no entries.
+
+    category_breakdown: True = "Summe je Kategorie"-Tabelle anhängen (Default);
+    False = weglassen, nur das Gesamt der Tagestabelle.
+    """
     from xhtml2pdf import pisa
 
     range_entries = _filter_entries(date_from, date_to, all_entries)
@@ -313,7 +323,10 @@ def generate_pdf(date_from, date_to, all_entries, name="", categories=None):
     label = f"{date_from.strftime('%d.%m.%Y')} – {date_to.strftime('%d.%m.%Y')}"
     groups = _group_by_week(range_entries)
     table, _ = _build_table(groups, PDF_STYLE)
-    category_summary = _build_category_summary(range_entries, PDF_STYLE)
+    category_summary = (
+        _build_category_summary(range_entries, PDF_STYLE)
+        if category_breakdown else ""
+    )
 
     name_html = (
         f"<p style='color:#111827;font-size:13px;margin:0 0 2px 0;font-weight:600;'>{_esc(name)}</p>"

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -311,6 +311,55 @@ def test_pdf_category_filter_applied():
     assert "HO" not in captured_html["html"]
 
 
+def test_category_breakdown_default_includes_summary():
+    """Default (category_breakdown nicht gesetzt) = aufgeschlüsselt: 'Büro'
+    erscheint zweimal — in der Tageszeile UND in der Kategorie-Summentabelle."""
+    entries = {"2026-03-23": _e("08:00", "16:00", 0, "Büro")}
+    html, _ = generate_report(datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries)
+    assert html.count("Büro") == 2
+
+
+def test_category_breakdown_false_hides_summary_keeps_total():
+    """category_breakdown=False lässt die 'Summe je Kategorie'-Tabelle weg;
+    die Tagestabelle inkl. Gesamt bleibt unverändert."""
+    entries = {"2026-03-23": _e("08:00", "16:00", 0, "Büro")}
+    html, total = generate_report(
+        datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries,
+        category_breakdown=False)
+    # Tagestabelle + Gesamt bleiben
+    assert "23.03.2026" in html
+    assert "Gesamt" in html
+    assert "8.0h" in html
+    assert total == 8.0
+    # 'Büro' nur noch in der Tageszeile, nicht mehr in einer Summentabelle
+    assert html.count("Büro") == 1
+
+
+def test_pdf_category_breakdown_false_hides_summary():
+    """generate_pdf respektiert category_breakdown=False."""
+    from src import report as report_mod
+    entries = {"2026-03-23": _e("08:00", "16:00", 0, "Büro")}
+    captured_html = {}
+
+    class FakePisa:
+        @staticmethod
+        def CreatePDF(html_str, dest):
+            captured_html["html"] = html_str
+            return MagicMock(err=0)
+
+    fake_xhtml2pdf = MagicMock()
+    fake_xhtml2pdf.pisa = FakePisa
+
+    with patch.dict("sys.modules", {"xhtml2pdf": fake_xhtml2pdf}):
+        report_mod.generate_pdf(
+            datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries,
+            category_breakdown=False)
+
+    html = captured_html["html"]
+    assert html.count("Büro") == 1
+    assert "Gesamt" in html
+
+
 from src.report import total_hours
 
 


### PR DESCRIPTION
## Was & warum

Im Export-/Sende-Dialog kann man jetzt wählen, ob die Gesamtstunden der gewählten Kategorien **nur als Gesamtsumme** ausgegeben werden oder zusätzlich **nach Kategorie aufgeschlüsselt** (die „Summe je Kategorie"-Tabelle). Bisher war die Aufschlüsselung immer fix dabei.

## Umsetzung

**UI — `period_picker.py`** (geteilt von PDF-Export und Mail-Versand):
Neue Checkbox **„Nach Kategorie aufschlüsseln"** unter den Kategorien, Default **aus**. Handle: `get_category_breakdown() -> bool`.

**Report — `report.py`**:
`generate_report(...)` und `generate_pdf(...)` bekommen `category_breakdown=True` (Default `True` = bisheriges Verhalten → bestehende Aufrufer/Tests unverändert).
- `True` → „Summe je Kategorie"-Tabelle wie bisher
- `False` → Tabelle entfällt; Tag-für-Tag-Tabelle inkl. `Gesamt` bleibt unverändert

**Verdrahtung:** `export_dialog` (PDF) und `send_dialog` (HTML-Mail **und** PDF-Anhang) übergeben den Picker-Wert — UI-Default ist damit „ohne Aufschlüsselung", beide Ausgaben konsistent.

| Aufschlüsselung aus (Default) | Aufschlüsselung an |
|-------------------------------|--------------------|
| nur `Gesamt 144.0h` | `Gesamt` + Homeoffice/Office/(ohne Kategorie) |

## Tests

- `test_category_breakdown_default_includes_summary` — Default = aufgeschlüsselt
- `test_category_breakdown_false_hides_summary_keeps_total` — `False` lässt Kategorie-Tabelle weg, Tagestabelle + Gesamt bleiben
- `test_pdf_category_breakdown_false_hides_summary` — gleiches für den PDF-Pfad
- gesamte `tests/test_report.py` + `tests/test_period_picker.py` grün (47 passed), `ruff check` sauber
- Visuell verifiziert (Monats-PDF mit Flag an/aus); Tk-Smoke-Test: Picker-Default `False`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
