### PR TITLE
fix(reservierung): keine Reservierung für vergangene Tage per Linksklick

### DIFF
--- a/src/dialogs/entry_dialog.py
+++ b/src/dialogs/entry_dialog.py
@@ -14,6 +14,19 @@ from src.theme import (
 from src.time_utils import validate_slots
 
 
+def reservation_block_visible(day, today, *, has_reservation=False):
+    """Ob der Reservierungs-Block im Tages-Dialog erscheint.
+
+    Regel: nur an heutigen/zukünftigen Tagen. An vergangenen Tagen wird KEIN
+    Block gezeigt — bewusst auch dann nicht, wenn dort bereits eine Reservierung
+    existiert (`has_reservation`): Per Linksklick lässt sich in der Vergangenheit
+    keine (zusätzliche) Reservierung anlegen, der Dialog zeigt dort nur die
+    Arbeitszeit. Eine alte Reservierung aufräumen läuft über den Rechtsklick im
+    Kalender. Reservierungen sind per Definition zukünftige Soll-Zeiten.
+    """
+    return day >= today
+
+
 def open_entry_dialog(parent, date_str, storage, settings, on_change,
                       reservation_store=None, trigger_reconcile=None):
     """Modaler Dialog zum Bearbeiten von Ist-Zeit und Reservierung eines Tages.
@@ -52,8 +65,8 @@ def open_entry_dialog(parent, date_str, storage, settings, on_change,
     existing_reservation = (
         reservation_store.get(date_str) if reservation_store is not None else None
     )
-    show_reservation = reservation_store is not None and (
-        day >= datetime.date.today() or existing_reservation is not None
+    show_reservation = reservation_store is not None and reservation_block_visible(
+        day, datetime.date.today(), has_reservation=existing_reservation is not None
     )
 
     categories = settings.get("categories") or []

--- a/tests/test_entry_dialog.py
+++ b/tests/test_entry_dialog.py
@@ -1,0 +1,22 @@
+import datetime
+
+from src.dialogs.entry_dialog import reservation_block_visible
+
+
+TODAY = datetime.date(2026, 6, 26)
+
+
+def test_reservation_block_hidden_for_past_day():
+    """Vergangene Tage: kein Reservierungs-Block — auch nicht, wenn dort bereits
+    eine Reservierung liegt. Linksklick darf keine neue Reservierung anlegen."""
+    assert reservation_block_visible(datetime.date(2026, 6, 25), TODAY) is False
+    assert reservation_block_visible(datetime.date(2026, 6, 25), TODAY,
+                                     has_reservation=True) is False
+
+
+def test_reservation_block_visible_today():
+    assert reservation_block_visible(TODAY, TODAY) is True
+
+
+def test_reservation_block_visible_future():
+    assert reservation_block_visible(datetime.date(2026, 6, 27), TODAY) is True


### PR DESCRIPTION
## Problem

Der Reservierungs-Block im Tages-Dialog erschien auch an **vergangenen** Tagen, sobald dort bereits eine Reservierung lag:

```python
show_reservation = reservation_store is not None and (
    day >= datetime.date.today() or existing_reservation is not None
)
```

Über den `or existing_reservation`-Zweig ließen sich per **„+ Slot"** neue Reservierungs-Slots in der Vergangenheit anlegen und speichern (`save_reservation` prüft das Datum nicht). Das widerspricht dem Konzept „Reservierung = zukünftige Soll-Zeit".

## Fix

Der Block wird jetzt **ausschließlich an heutigen/zukünftigen Tagen** gezeigt — auch wenn an einem vergangenen Tag bereits eine Reservierung existiert. An vergangenen Tagen zeigt der Linksklick-Dialog nur noch die **Arbeitszeit**; eine alte Reservierung aufräumen läuft weiterhin über den **Rechtsklick** im Kalender (unverändertes Lösch-Modell).

Die Datums-Regel steckt jetzt in einer reinen, getesteten Helper-Funktion `reservation_block_visible(day, today, *, has_reservation)` (analog zu `selected_category_filter`), statt inline im Dialog — und ist damit gegen Regression abgesichert.

## Tests (TDD)

- `test_reservation_block_hidden_for_past_day` — vergangener Tag → kein Block, auch mit bereits vorhandener Reservierung
- `test_reservation_block_visible_today` / `_future` — heute & Zukunft → Block sichtbar
- gesamte Suite grün (609 passed), `ruff check` sauber

## Nicht Teil dieses PRs (bewusst)

`ReservationStore.save()` bleibt ohne Datums-Guard; andere Schreibpfade (Share-Import, gcal-Reconcile) sind nicht betroffen. Falls Defense-in-depth auf Storage-Ebene gewünscht ist, gerne als separater PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
