### PR TITLE
fix(ui): Update-Banner schneidet Footer nicht mehr ab (#92)

### DIFF
--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -49,6 +49,10 @@ Rendering der Monats-/Wochenansicht inkl. Double-Buffer und Fenster-Geometrie.
   (`build_grid(parent)`); `header_label`/`footer_label` werden in `App._build_header`/
   `_build_footer` erzeugt und per `attach_labels(...)` nachgereicht (der Renderer beschreibt
   sie). `measure_max_width(...)` pinnt vor `mainloop()` die Fensterbreite (4-Kombi-Probing).
+- **Fenster-Geometrie:** `repin_geometry()` setzt Breite (≥ gemessenes Maximum) und Höhe
+  (aktuelle reqheight) neu auf das fixe Fenster. Genutzt vom View-/Spalten-Wechsel in
+  `refresh()` **und** extern vom `UpdateBanner` (als `on_resize`), dessen Ein-/Ausblenden
+  die nötige Höhe ändert, ohne View/Spalten zu wechseln. `resizable(False, False)` bleibt.
 - `_fmt_slot_line` ist `@staticmethod`; `App._delete_day` ruft es als
   `GridRenderer._fmt_slot_line(...)` (bleibt in App, nutzt aber den Renderer-Static).
 
@@ -75,6 +79,8 @@ Tests genutzt). Reine Formatier-Helfer `_status_text`/`_tray_toast` sind ohne Tk
 Banner über dem Kalender (anzeigen/Download/ausblenden). `handle_check_result(release, newer)`
 ist das `on_result` von `BackgroundTaskRunner.check_update`. Pack-Anker **lazy** über
 `get_anchor=lambda: App._renderer.grid_container` (Grid existiert erst nach dem Build).
+`on_resize` (= `App._renderer.repin_geometry`) wird in `_show`/`_dismiss` aufgerufen, damit
+das fixe Fenster auf die geänderte Banner-Höhe nachzieht (sonst Footer abgeschnitten, #92).
 
 ## Threading-Modell
 

--- a/src/grid_renderer.py
+++ b/src/grid_renderer.py
@@ -121,10 +121,24 @@ class GridRenderer:
                 new_inactive.columnconfigure(col, weight=1 if col < current_cols else 0)
             self._grid_frames[inactive_idx] = new_inactive
             self._grid_frames[self._active_grid_idx].lift()
-            self._root.update_idletasks()
-            if not self._suppress_geometry:
-                width = max(self._fixed_width or 0, self._root.winfo_reqwidth())
-                self._root.geometry(f"{width}x{self._root.winfo_reqheight()}")
+            self.repin_geometry()
+
+    def repin_geometry(self):
+        """Pinnt Fensterbreite (>= gemessenes Maximum) und -höhe (aktuelle
+        reqheight) neu auf die fixe Geometrie.
+
+        Aufrufer: der View-/Spalten-Wechsel in refresh() **und** das Ein-/
+        Ausblenden des Update-Banners (UpdateBanner._show/_dismiss über einen
+        injizierten Callback) — der ändert die nötige Höhe, ohne dass sich View
+        oder Spaltenzahl ändern, würde also sonst nicht nachgeführt und liefe
+        unter dem fixen Fenster über (#92). Das Fenster bleibt
+        resizable(False, False); gewachsen/geschrumpft wird nur kontrolliert
+        hier. Während der Vorab-Messung (measure_max_width) unterdrückt
+        _suppress_geometry den Resize."""
+        self._root.update_idletasks()
+        if not self._suppress_geometry:
+            width = max(self._fixed_width or 0, self._root.winfo_reqwidth())
+            self._root.geometry(f"{width}x{self._root.winfo_reqheight()}")
 
     def measure_max_width(self, view_mode: str, year: int, month: int,
                           iso_year: int, current_week: int):

--- a/src/ui.py
+++ b/src/ui.py
@@ -161,7 +161,8 @@ class App:
         )
         self._bg.fetch_sender_email()
         self._update_banner = UpdateBanner(
-            self.root, self.settings, lambda: self._renderer.grid_container)
+            self.root, self.settings, lambda: self._renderer.grid_container,
+            on_resize=self._renderer.repin_geometry)
         self._bg.check_update(on_result=self._update_banner.handle_check_result)
         self._bg.reconcile_on_start(on_ok=self._refresh)
         self.root.protocol("WM_DELETE_WINDOW", self._on_close)

--- a/src/update_banner.py
+++ b/src/update_banner.py
@@ -15,10 +15,15 @@ from src.updater import pick_asset_url, today_iso
 
 
 class UpdateBanner:
-    def __init__(self, root, settings, get_anchor):
+    def __init__(self, root, settings, get_anchor, on_resize=lambda: None):
         self._root = root
         self._settings = settings
         self._get_anchor = get_anchor    # lambda: App.grid_container
+        # Wird beim Ein-/Ausblenden aufgerufen, damit das fixe Fenster seine
+        # Höhe an die geänderte Banner-Präsenz anpasst (sonst schneidet das
+        # nicht-resizable Fenster den Footer ab, #92). Default no-op hält den
+        # Banner unabhängig vom Renderer testbar.
+        self._on_resize = on_resize
         self._banner = None              # Frame oder None (None = nicht sichtbar)
 
     def handle_check_result(self, release, newer):
@@ -67,6 +72,12 @@ class UpdateBanner:
             label_padx=14, label_pady=2,
         ).pack(side=tk.RIGHT, padx=8, pady=4)
 
+        # Der Banner sitzt zwischen Header und Grid und braucht zusätzliche
+        # Höhe. Das Fenster ist fix (resizable(False, False)) und wächst nur
+        # über einen kontrollierten Geometry-Pin — den hier anstoßen, sonst
+        # läuft der Inhalt unten über und der Footer wird abgeschnitten (#92).
+        self._on_resize()
+
     def _open_download(self, release):
         url = pick_asset_url(
             release.assets, platform.system(), release.version,
@@ -78,3 +89,6 @@ class UpdateBanner:
         if self._banner is not None:
             self._banner.destroy()
             self._banner = None
+        # Höhe zurückpinnen (Gegenstück zu _show): das fixe Fenster soll wieder
+        # auf die Höhe ohne Banner schrumpfen.
+        self._on_resize()

--- a/tests/test_update_banner.py
+++ b/tests/test_update_banner.py
@@ -81,3 +81,32 @@ def test_open_download_falls_back_to_html_url(monkeypatch):
                      get_anchor=lambda: object())
     b._open_download(_release(html_url="https://example/r"))
     assert opened == ["https://example/r"]
+
+
+def test_show_triggers_resize(monkeypatch):
+    # Banner einblenden muss die Fenstergeometrie neu pinnen, sonst wächst das
+    # fixe Fenster (resizable(False, False)) nicht und der zuletzt gepackte
+    # Footer (Summen-Zeile) wird abgeschnitten (#92).
+    monkeypatch.setattr(ub.tk, "Frame", lambda *a, **k: MagicMock())
+    monkeypatch.setattr(ub.tk, "Label", lambda *a, **k: MagicMock())
+    monkeypatch.setattr(ub, "label_button", lambda *a, **k: MagicMock())
+    monkeypatch.setattr(ub, "attach_tooltip", lambda *a, **k: None)
+    resized = []
+    b = UpdateBanner(root=object(), settings=_FakeSettings(),
+                     get_anchor=lambda: object(),
+                     on_resize=lambda: resized.append(True))
+    b._show(_release())
+    assert resized == [True]
+
+
+def test_dismiss_triggers_resize():
+    # Banner ausblenden muss die Geometrie zurückpinnen, damit das Fenster
+    # wieder auf die Höhe ohne Banner schrumpft (Gegenstück zu _show).
+    resized = []
+    b = UpdateBanner(root=object(), settings=_FakeSettings(),
+                     get_anchor=lambda: object(),
+                     on_resize=lambda: resized.append(True))
+    b._banner = MagicMock()
+    b._dismiss("1.2.0")
+    assert b._banner is None
+    assert resized == [True]


### PR DESCRIPTION
## Problem (#92)

Sobald der Update-Banner über dem Kalender erscheint, wurde die **Summen-Zeile im Footer abgeschnitten**. Ursache: Die Fensterhöhe wird nur beim View-/Spalten-Wechsel in `grid_renderer.refresh()` neu gepinnt. Der Banner kommt asynchron danach, ohne eigenen Re-Pin — das nicht-resizable Fenster (`resizable(False, False)`) wuchs nicht und der zuletzt gepackte Footer lief unten über. (Ein Monats-/Wochenwechsel „reparierte" es scheinbar, weil das der einzige Re-Pin-Pfad war.)

## Lösung

- `grid_renderer.py` — Geometrie-Pin aus `refresh()` in öffentliche `repin_geometry()` extrahiert (Verhalten byte-genau erhalten, inkl. `_suppress_geometry`-Gate).
- `update_banner.py` — `on_resize`-Callback (Default no-op); `_show()`/`_dismiss()` stoßen den Re-Pin an.
- `ui.py` — `on_resize=self._renderer.repin_geometry` injiziert.
- `src/CLAUDE.md` — Verträge (GridRenderer/UpdateBanner) nachgezogen.

`resizable(False, False)` bleibt unangetastet — die Höhe wird weiterhin nur kontrolliert gepinnt, jetzt zusätzlich ums Banner; zwischen Monaten konstant, Monat↔Woche resized wie bisher by design.

## Verifikation

- `pytest` → 614 passed, 1 skipped; 2 neue Tk-freie Verhaltenstests (Show/Dismiss → Resize), rot→grün.
- `ruff check` → sauber.
- Echtes-Tk-Smoke: Fenster 257→297px beim Banner (Footer nicht abgeschnitten), zurück auf 257px beim Ausblenden.
- Manuell getestet (Banner ein-/ausblenden, Footer sichtbar).

Fixes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)
