### PR TITLE
fix(macos): pystray-Tray-Crash beheben, natives NSStatusItem-Backend (dormant) (#88)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,16 @@ jobs:
       - run: pip install pytest "holidays==0.99" google-api-python-client google-auth google-auth-oauthlib
       - run: pytest tests/
 
+  test-macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.10'
+      - run: pip install pytest "holidays==0.99" google-api-python-client google-auth google-auth-oauthlib pyobjc-framework-Cocoa
+      - run: pytest tests/
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,7 +162,8 @@ Lokal: `pytest` aus dem Repo-Root. Alle Tests müssen vor dem PR-Merge grün sei
 - `src/reservations.py` — Reservierungen (zukünftige Soll-Zeiten, eigenes Konzept neben Ist-Zeiten)
 - `src/reservations_sync.py` — Abgleich der Reservierungen mit einem Google Kalender
 - `src/gcal.py` — Google-Calendar-API-Wrapper (lazy Imports wie `drive.py`, wegen CI ohne `requirements.txt`)
-- `src/tray.py` — Infobereich-Icon (Minimize-to-Tray, Windows + macOS)
+- `src/tray.py` — Infobereich-Icon (Minimize-to-Tray); Plattform-Fassade über pystray (Windows) und `tray_mac.py` (macOS)
+- `src/tray_mac.py` — natives macOS-Tray (NSStatusItem, Main-Thread) als Backend von `tray.py`; macOS-Tray ist bis zum Mac-Gate dormant (Opt-in `ZEIT_MACOS_TRAY=1`, #88)
 - `src/time_utils.py` — Stundenberechnung, KW-Labels
 - `src/holidays_de.py` — Feiertags-Lookup (über `holidays`-Lib)
 - `src/paths.py` — `get_base_path()` dispatched über `platform.system()` und Frozen- vs. Repo-Modus

--- a/build.py
+++ b/build.py
@@ -135,6 +135,11 @@ def build_macos():
         "-D",
         "--icon", "assets/margenheld-icon.icns",
         "--osx-bundle-identifier", "com.margenheld.zeiterfassung",
+        # tray_mac.py importiert AppKit/Foundation lazy → explizit bündeln,
+        # sonst fehlt PyObjC im DMG und das native Tray fällt still aus (#88).
+        "--collect-all", "objc",
+        "--collect-all", "AppKit",
+        "--collect-all", "Foundation",
     ])
     subprocess.run(cmd, check=True)
     generate_third_party_notices()

--- a/docs/superpowers/plans/2026-06-30-macos-native-tray.md
+++ b/docs/superpowers/plans/2026-06-30-macos-native-tray.md
@@ -1,0 +1,791 @@
+# Natives macOS-Tray (NSStatusItem) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** macOS-Tray ohne den pystray-Daemon-Thread-Crash (#88) — natives `NSStatusItem` auf dem Main-Thread, hinter der bestehenden `TrayIcon`-Fassade, in ausgelieferten Builds dormant (opt-in) bis zum manuellen Mac-Gate.
+
+**Architecture:** `TrayIcon` wird zur Fassade, die per `platform.system()` ein Backend wählt: Windows → bestehender pystray-Pfad (verbatim in `_PystrayBackend`), macOS → neues `MacTrayBackend` in `src/tray_mac.py` (PyObjC, lazy importiert, kein Thread, keine zweite NSApplication). Ein pures `build_menu_model` speist den macOS-Renderer und die Tests; der Windows-Pfad bleibt inline unverändert.
+
+**Tech Stack:** Python 3.10, Tkinter, pystray (Windows, unverändert), PyObjC (`pyobjc-framework-Cocoa`, macOS-only), pytest.
+
+**Design-Spec:** `docs/superpowers/specs/2026-06-30-macos-native-tray-design.md` — bei Abweichungen gilt die Spec.
+
+## Global Constraints
+
+- **Dependency:** `pyobjc-framework-Cocoa>=10.0; sys_platform == "darwin"` — exakt diese Zeile, mit Marker (hält `pip install` auf Linux/Windows sauber).
+- **Lazy PyObjC:** `src/tray_mac.py` importiert PyObjC (`objc`, `AppKit`, `Foundation`) **nur innerhalb von Methoden**, nie auf Modulebene. Modulebene = stdlib + `from src.tray import build_menu_model`. Grund: CI importiert `src.ui → src.tray → (dispatch) src.tray_mac` auf Linux.
+- **Callback-Hülle (Klasse-(i)-Schutz):** *jeder* von AppKit aufgerufene Python-Callback (Action, `menuNeedsUpdate_`, Notify) umschließt seinen Body restlos mit `try/except` (swallow + log). Kein Python-Throw darf in einen ObjC-Frame zurück.
+- **macOS dormant-Default:** `is_supported()` liefert auf macOS nur True, wenn `ZEIT_MACOS_TRAY=1` gesetzt ist (opt-in für den Mac-Tester). Der Default-an-Flip ist ein **separater PR nach bestandenem Mac-Gate** — NICHT Teil dieses Plans.
+- **Windows unangetastet:** der pystray-Pfad wird **verbatim** in `_PystrayBackend` verschoben, kein Verhaltenswechsel. Kein natives Windows-/Linux-Tray.
+- **Commit-Typen englisch** (`fix:`/`test:`/`build:`/`ci:`/`docs:`), Body Deutsch ok. Module als `python -m`, Imports absolut (`from src...`).
+
+---
+
+### Task 1: `is_supported()`-Staging + Opt-in
+
+**Files:**
+- Modify: `src/tray.py:11-24` (Imports + `is_supported`)
+- Test: `tests/test_tray.py` (neu)
+
+**Interfaces:**
+- Produces: `is_supported() -> bool`; `_macos_tray_opt_in() -> bool` (liest Env `ZEIT_MACOS_TRAY`).
+
+- [ ] **Step 1: Write the failing test**
+
+`tests/test_tray.py` (neue Datei):
+
+```python
+# tests/test_tray.py
+import pytest
+
+from src import tray
+
+
+@pytest.mark.parametrize("system,optin,expected", [
+    ("Windows", None, True),
+    ("Linux", None, False),
+    ("Darwin", None, False),   # dormant-Default
+    ("Darwin", "1", True),     # opt-in für den Mac-Tester
+])
+def test_is_supported_staging(system, optin, expected, monkeypatch):
+    monkeypatch.setattr("src.tray.platform.system", lambda: system)
+    if optin is None:
+        monkeypatch.delenv("ZEIT_MACOS_TRAY", raising=False)
+    else:
+        monkeypatch.setenv("ZEIT_MACOS_TRAY", optin)
+    assert tray.is_supported() is expected
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_tray.py -v`
+Expected: FAIL — `Darwin/None` ergibt True (alter Code), erwartet False.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/tray.py` den Kopf (Zeilen 11-13) um `import platform` ergänzen:
+
+```python
+import logging
+import os
+import platform
+import threading
+```
+
+`is_supported()` (Zeilen 16-24) ersetzen durch:
+
+```python
+def _macos_tray_opt_in():
+    """macOS-Tray ist bis zum bestandenen Mac-Gate dormant: nur aktiv, wenn der
+    Tester ZEIT_MACOS_TRAY=1 setzt. Default-an-Flip = separater PR (s. Spec)."""
+    return os.environ.get("ZEIT_MACOS_TRAY") == "1"
+
+
+def is_supported():
+    """Kann auf diesem System ein Tray-Icon gezeigt werden?
+
+    Windows → True. Linux → False (uneinheitlich). macOS → nur mit Opt-in
+    (dormant-Default, s. _macos_tray_opt_in). Aufrufer kann unabhängig davon
+    `try/except` machen, falls das Backend zur Laufzeit doch fehlschlägt.
+    """
+    system = platform.system()
+    if system == "Windows":
+        return True
+    if system == "Darwin":
+        return _macos_tray_opt_in()
+    return False
+```
+
+Den **lokalen** `import platform` innerhalb von `is_supported` (alte Zeile 23) damit entfernen.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_tray.py -v`
+Expected: PASS (4 Parametrierungen grün).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tray.py tests/test_tray.py
+git commit -m "fix(tray): macOS-Tray default off, opt-in via ZEIT_MACOS_TRAY (#88)"
+```
+
+---
+
+### Task 2: Pures `build_menu_model`
+
+**Files:**
+- Modify: `src/tray.py` (neue Top-Level-Funktion + namedtuple, nach `is_supported`)
+- Test: `tests/test_tray.py` (anhängen)
+
+**Interfaces:**
+- Consumes: nichts.
+- Produces:
+  - `MenuEntry = namedtuple("MenuEntry", ["kind", "label", "callback", "visible"])` — `kind` ∈ {`"item"`, `"separator"`}; bei Separator sind `label/callback/visible = None`.
+  - `build_menu_model(on_show, on_quit, actions) -> list[MenuEntry]` — `actions` ist Liste von `(label, callback, visible)` (wie `TrayIcon.__init__`). Reihenfolge: Anzeigen, Separator, Aktionen, Separator (nur falls Aktionen), Beenden.
+
+- [ ] **Step 1: Write the failing test**
+
+`tests/test_tray.py` anhängen:
+
+```python
+def test_build_menu_model_structure():
+    from src.tray import build_menu_model
+    show = lambda: None
+    quit_ = lambda: None
+    vis = lambda: True
+    actions = [("Senden", lambda: None, None), ("Sync", lambda: None, vis)]
+    model = build_menu_model(show, quit_, actions)
+    assert [(e.kind, e.label) for e in model] == [
+        ("item", "Anzeigen"),
+        ("separator", None),
+        ("item", "Senden"),
+        ("item", "Sync"),
+        ("separator", None),
+        ("item", "Beenden"),
+    ]
+    assert model[0].callback is show
+    assert model[-1].callback is quit_
+    sync = next(e for e in model if e.label == "Sync")
+    assert sync.visible is vis
+
+
+def test_build_menu_model_no_actions_single_separator():
+    from src.tray import build_menu_model
+    model = build_menu_model(lambda: None, lambda: None, [])
+    assert [e.kind for e in model] == ["item", "separator", "item"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_tray.py -k build_menu_model -v`
+Expected: FAIL — `ImportError: cannot import name 'build_menu_model'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/tray.py` oben den Import ergänzen und die Funktion direkt nach `is_supported()` einfügen:
+
+```python
+from collections import namedtuple
+```
+
+```python
+MenuEntry = namedtuple("MenuEntry", ["kind", "label", "callback", "visible"])
+
+
+def build_menu_model(on_show, on_quit, actions):
+    """Backend-agnostisches Menü-Modell (pure, ohne AppKit/pystray) aus den
+    Tray-Aktionen. Speist den macOS-Renderer (src/tray_mac.py) und die Tests;
+    der Windows-Pfad baut sein pystray-Menü weiter inline.
+
+    `actions`: Liste (label, callback, visible). `callback` ist 0-arg und
+    marshallt selbst auf den Tk-Thread. `visible` ist None (immer sichtbar) oder
+    eine 0-arg-Callable → Bool (dynamische Sichtbarkeit).
+    """
+    entries = [
+        MenuEntry("item", "Anzeigen", on_show, None),
+        MenuEntry("separator", None, None, None),
+    ]
+    for label, callback, visible in actions:
+        entries.append(MenuEntry("item", label, callback, visible))
+    if actions:
+        entries.append(MenuEntry("separator", None, None, None))
+    entries.append(MenuEntry("item", "Beenden", on_quit, None))
+    return entries
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_tray.py -k build_menu_model -v`
+Expected: PASS (2 Tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tray.py tests/test_tray.py
+git commit -m "feat(tray): pure build_menu_model als Backend-Naht"
+```
+
+---
+
+### Task 3: Natives `MacTrayBackend` (`src/tray_mac.py`) + Dependency
+
+**Files:**
+- Create: `src/tray_mac.py`
+- Modify: `requirements.txt` (eine Zeile)
+- Test: `tests/test_tray_mac.py` (neu)
+
+**Interfaces:**
+- Consumes: `src.tray.build_menu_model`, `src.tray.MenuEntry`.
+- Produces:
+  - `_safe(fn) -> None` — ruft 0-arg `fn` auf, schluckt + loggt jede Exception (Klasse-(i)-Schutz).
+  - `MacTrayBackend(base_path, on_show, on_quit, actions=None)` mit `.start()`, `.stop()`, `.notify(message, title="Zeiterfassung")`. Gleiche Konstruktor-Signatur wie `_PystrayBackend` (Task 4) — die Fassade instanziiert beide identisch.
+
+- [ ] **Step 1: Add the dependency**
+
+`requirements.txt` am Ende ergänzen:
+
+```
+pyobjc-framework-Cocoa>=10.0; sys_platform == "darwin"
+```
+
+- [ ] **Step 2: Write the failing test**
+
+`tests/test_tray_mac.py` (neu):
+
+```python
+# tests/test_tray_mac.py
+import platform
+import threading
+
+import pytest
+
+
+def test_safe_swallows_callback_exceptions():
+    """Klasse-(i)-Schutz: _safe lässt keine Python-Exception durch (läuft auf
+    jeder Plattform — reines Python)."""
+    from src.tray_mac import _safe
+    calls = []
+    _safe(lambda: calls.append("ok"))
+    _safe(lambda: (_ for _ in ()).throw(ValueError("boom")))  # raises
+    assert calls == ["ok"]  # zweiter Aufruf wirft NICHT durch
+
+
+@pytest.mark.skipif(
+    platform.system() != "Darwin",
+    reason="natives NSStatusItem nur auf macOS (im test-macos-Job)",
+)
+def test_native_backend_constructs_no_thread_and_tears_down():
+    """In-Process-Smoke (nur macOS): Backend unter Tk-Root konstruieren, KEIN
+    Thread, Menü gerendert, sauber abbauen. Skippt, wenn der Runner keinen
+    Status-Bar-/Display-Zugriff hat (statt falsch rot)."""
+    import tkinter
+    from src.tray_mac import MacTrayBackend
+
+    try:
+        root = tkinter.Tk()
+    except Exception:
+        pytest.skip("kein Tk/Display auf dem Runner")
+    root.withdraw()
+
+    before = threading.active_count()
+    backend = MacTrayBackend(
+        base_path=".",
+        on_show=lambda: None,
+        on_quit=lambda: None,
+        actions=[("Sync", lambda: None, lambda: True)],
+    )
+    try:
+        try:
+            backend.start()
+        except Exception:
+            pytest.skip("Status-Bar auf dem Runner nicht verfügbar")
+        # Bug-Guard (#88): natives Backend startet KEINEN Daemon-Thread
+        assert threading.active_count() == before
+        # Menü gerendert: Anzeigen | sep | Sync | sep | Beenden = 5 Items
+        assert backend._menu.numberOfItems() == 5
+    finally:
+        backend.stop()
+        assert backend._status_item is None  # idempotenter Teardown
+        root.destroy()
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `pytest tests/test_tray_mac.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'src.tray_mac'`. (Auf Windows/Linux skippt der zweite Test ohnehin.)
+
+- [ ] **Step 4: Write the implementation**
+
+`src/tray_mac.py` (neu):
+
+```python
+# src/tray_mac.py
+"""Natives macOS-Tray (NSStatusItem) — Backend für TrayIcon (#88).
+
+Der frühere pystray-Daemon-Thread treibt auf macOS eine zweite NSApplication an
+und kollidiert mit der von Tk getriebenen → Crash beim Fenster-Mappen. Dieses
+Backend hängt stattdessen ein NSStatusItem SYNCHRON auf dem Main-Thread an die
+geteilte NSApplication, die Tk ohnehin treibt — kein Thread, keine zweite NSApp.
+
+PyObjC wird LAZY in den Methoden importiert: Modulebene bleibt stdlib-only, damit
+src.ui → src.tray → (dispatch) src.tray_mac auf Linux/Windows importierbar bleibt
+(die CI importiert src.ui). Siehe Spec 2026-06-30-macos-native-tray-design.md.
+"""
+
+import logging
+import os
+
+from src.tray import build_menu_model
+
+logger = logging.getLogger(__name__)
+
+
+def _safe(fn):
+    """0-arg-Callback aufrufen, ohne dass eine Python-Exception in einen
+    ObjC-Frame zurückläuft (Klasse-(i)-Schutz, s. Spec). JEDER von AppKit
+    aufgerufene Callback läuft hierdurch."""
+    try:
+        fn()
+    except Exception:
+        logger.exception("macOS-Tray-Callback-Fehler (geschluckt)")
+
+
+class MacTrayBackend:
+    """NSStatusItem-Backend mit derselben Lifecycle-API wie _PystrayBackend."""
+
+    def __init__(self, base_path, on_show, on_quit, actions=None):
+        self.base_path = base_path
+        self._on_show = on_show
+        self._on_quit = on_quit
+        self._actions = actions or []
+        # STARKE Referenzen halten — sonst GC → Icon verschwindet/Crash.
+        self._status_item = None
+        self._menu = None
+        self._delegate = None
+        self._dynamic_items = []  # [(NSMenuItem, visible_callable)]
+
+    def _load_image(self):
+        from AppKit import NSImage
+        png = os.path.join(self.base_path, "assets", "margenheld-icon.png")
+        if not os.path.exists(png):
+            return None
+        image = NSImage.alloc().initByReferencingFile_(png)
+        if image is not None:
+            image.setSize_((18, 18))  # Menübar-Höhe
+        return image
+
+    def start(self):
+        from AppKit import (
+            NSStatusBar, NSMenu, NSMenuItem, NSVariableStatusItemLength,
+        )
+        from Foundation import NSObject
+
+        model = build_menu_model(self._on_show, self._on_quit, self._actions)
+
+        callbacks = {}            # representedObject-Key -> 0-arg-Callback
+        dynamic_items = []        # [(NSMenuItem, visible_callable)]
+
+        # Delegate LAZY definieren: NSObject-Subklasse braucht Foundation, und
+        # die Methoden schließen über callbacks/dynamic_items (free vars).
+        class _TrayDelegate(NSObject):
+            def invoke_(self, sender):
+                cb = callbacks.get(str(sender.representedObject()))
+                if cb is not None:
+                    _safe(cb)
+
+            def menuNeedsUpdate_(self, menu):
+                # live-Sichtbarkeit: visible-Callables vor jedem Öffnen auswerten
+                for item, vis in dynamic_items:
+                    try:
+                        item.setHidden_(not bool(vis()))
+                    except Exception:
+                        logger.exception(
+                            "macOS-Tray-Sichtbarkeit-Fehler (geschluckt)")
+
+        delegate = _TrayDelegate.alloc().init()
+
+        menu = NSMenu.alloc().init()
+        menu.setAutoenablesItems_(False)
+        menu.setDelegate_(delegate)
+
+        for idx, entry in enumerate(model):
+            if entry.kind == "separator":
+                menu.addItem_(NSMenuItem.separatorItem())
+                continue
+            item = NSMenuItem.alloc().initWithTitle_action_keyEquivalent_(
+                entry.label, "invoke:", "",
+            )
+            item.setTarget_(delegate)
+            item.setRepresentedObject_(str(idx))
+            callbacks[str(idx)] = entry.callback
+            if entry.visible is not None:
+                dynamic_items.append((item, entry.visible))
+            menu.addItem_(item)
+
+        status_item = NSStatusBar.systemStatusBar().statusItemWithLength_(
+            NSVariableStatusItemLength)
+        image = self._load_image()
+        button = status_item.button()
+        if image is not None and button is not None:
+            button.setImage_(image)
+        elif button is not None:
+            button.setTitle_("Z")  # Last-Resort, falls PNG fehlt
+        status_item.setMenu_(menu)
+
+        # Refs festhalten (Reihenfolge egal; alle bis stop() leben lassen).
+        self._delegate = delegate
+        self._menu = menu
+        self._dynamic_items = dynamic_items
+        self._status_item = status_item
+
+    def notify(self, message, title="Zeiterfassung"):
+        """best-effort: NSUserNotification (deprecated, aber leichtgewichtig).
+        ALLE Fehler geschluckt — Toast ist kosmetisch, Sync bleibt unberührt.
+
+        Kein expliziter Main-Thread-Dispatch: der einzige Aufrufer
+        (sync_orchestrator._on_tray_done) ist ein on_done-Callback und läuft
+        bereits über _marshal_to_ui auf dem Tk-/Main-Thread (verifiziert)."""
+        try:
+            from Foundation import (
+                NSUserNotification, NSUserNotificationCenter,
+            )
+            note = NSUserNotification.alloc().init()
+            note.setTitle_(title or "Zeiterfassung")
+            note.setInformativeText_(message)
+            NSUserNotificationCenter.defaultUserNotificationCenter() \
+                .deliverNotification_(note)
+        except Exception:
+            logger.exception("macOS-Tray-Notify fehlgeschlagen (geschluckt)")
+
+    def stop(self):
+        """Entfernt das Status-Item und löst die Referenzen. Idempotent."""
+        if self._status_item is not None:
+            try:
+                from AppKit import NSStatusBar
+                NSStatusBar.systemStatusBar().removeStatusItem_(
+                    self._status_item)
+            except Exception:
+                logger.exception("macOS-Tray stop fehlgeschlagen")
+        self._status_item = None
+        self._menu = None
+        self._delegate = None
+        self._dynamic_items = []
+```
+
+> **Hinweis (unverifiziert bis Mac-Gate):** Exakte PyObjC-Selektor-Signaturen
+> (`invoke:` als `b"v@:@"`, `menuNeedsUpdate:`), Closure-Verhalten der
+> Delegate-Methoden und ob Tks Runloop das Menü serviced, werden erst auf einem
+> Mac final bestätigt (Klasse-(ii), s. Spec). Der Code ist die vorgeschlagene
+> Implementierung; bei Abweichung auf dem Mac nachziehen.
+
+- [ ] **Step 5: Run test to verify it passes (lokal)**
+
+Run: `pytest tests/test_tray_mac.py -v`
+Expected: `test_safe_swallows_callback_exceptions` PASS; der native Smoke `SKIPPED` (non-Darwin). Zusätzlich Import prüfen:
+Run: `python -c "import src.tray_mac; print('import ok')"`
+Expected: `import ok` (Modul lädt ohne PyObjC, weil lazy).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/tray_mac.py tests/test_tray_mac.py requirements.txt
+git commit -m "feat(tray): natives macOS NSStatusItem-Backend (dormant, #88)"
+```
+
+---
+
+### Task 4: `TrayIcon`-Fassade + Backend-Dispatch
+
+**Files:**
+- Modify: `src/tray.py` (TrayIcon → Fassade; bestehende pystray-Logik → `_PystrayBackend`; neu `_select_backend`)
+- Test: `tests/test_tray.py` (anhängen)
+
+**Interfaces:**
+- Consumes: `MacTrayBackend` (Task 3, lazy importiert), `_PystrayBackend` (hier).
+- Produces:
+  - `_select_backend(system) -> type | None` — `"Windows"` → `_PystrayBackend`, `"Darwin"` → `MacTrayBackend`, sonst `None`.
+  - `_PystrayBackend(base_path, on_show, on_quit, actions=None)` — die heutige `TrayIcon`-Implementierung, verbatim.
+  - `TrayIcon(base_path, on_show, on_quit, actions=None)` — Fassade: `start()` wählt+instanziiert+startet das Backend, `stop()`/`notify()` delegieren. Öffentliche API unverändert (ui.py/sync_orchestrator nutzen sie weiter).
+
+- [ ] **Step 1: Write the failing test**
+
+`tests/test_tray.py` anhängen:
+
+```python
+def test_select_backend_dispatch():
+    from src.tray import _select_backend, _PystrayBackend
+    from src.tray_mac import MacTrayBackend
+    assert _select_backend("Windows") is _PystrayBackend
+    assert _select_backend("Darwin") is MacTrayBackend
+    assert _select_backend("Linux") is None
+
+
+def test_facade_instantiates_and_delegates(monkeypatch):
+    """Fassade wählt das Backend, instanziiert mit denselben Args und delegiert
+    start/stop/notify — plattformunabhängig über ein Fake-Backend."""
+    from src import tray
+
+    seen = {}
+
+    class FakeBackend:
+        def __init__(self, base_path, on_show, on_quit, actions=None):
+            seen["init"] = (base_path, on_show, on_quit, actions)
+
+        def start(self):
+            seen["start"] = True
+
+        def stop(self):
+            seen["stop"] = True
+
+        def notify(self, message, title="Zeiterfassung"):
+            seen["notify"] = (message, title)
+
+    monkeypatch.setattr("src.tray._select_backend", lambda system: FakeBackend)
+
+    show, quit_ = (lambda: None), (lambda: None)
+    acts = [("Sync", lambda: None, None)]
+    icon = tray.TrayIcon("base", on_show=show, on_quit=quit_, actions=acts)
+    icon.start()
+    assert seen["init"] == ("base", show, quit_, acts)
+    assert seen["start"] is True
+    icon.notify("hallo")
+    assert seen["notify"] == ("hallo", "Zeiterfassung")
+    icon.stop()
+    assert seen["stop"] is True
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_tray.py -k "select_backend or facade" -v`
+Expected: FAIL — `cannot import name '_select_backend' / '_PystrayBackend'`.
+
+- [ ] **Step 3: Refactor `src/tray.py`**
+
+a) Die **bestehende** `class TrayIcon` in `class _PystrayBackend` umbenennen — Body **unverändert** (start/stop/notify/_load_image/_wrap_action/_wrap_visible/_notify_with_icon bleiben wortgleich). Nur die Zeile `class TrayIcon:` → `class _PystrayBackend:` und im Docstring „pystray-Backend (Windows)" vermerken.
+
+b) Direkt nach `is_supported()`/`build_menu_model` die Dispatch-Funktion einfügen:
+
+```python
+def _select_backend(system):
+    """Backend-Klasse nach Plattform. macOS lazy, damit PyObjC nicht in den
+    Linux/Windows-Importpfad gerät."""
+    if system == "Windows":
+        return _PystrayBackend
+    if system == "Darwin":
+        from src.tray_mac import MacTrayBackend
+        return MacTrayBackend
+    return None
+```
+
+c) Eine **neue** schlanke `TrayIcon`-Fassade ans Dateiende anfügen:
+
+```python
+class TrayIcon:
+    """Plattform-Fassade: wählt per platform.system() das Backend
+    (_PystrayBackend auf Windows, MacTrayBackend auf macOS) und delegiert.
+    Öffentliche API (start/stop/notify) unverändert."""
+
+    def __init__(self, base_path, on_show, on_quit, actions=None):
+        self.base_path = base_path
+        self._on_show = on_show
+        self._on_quit = on_quit
+        self._actions = actions or []
+        self._backend = None
+
+    def start(self):
+        """Startet das plattformspezifische Backend. Wirft dessen Exception
+        durch (synchron) — Aufrufer (_apply_tray_setting) fängt und fällt auf
+        Tray-Verzicht zurück."""
+        backend_cls = _select_backend(platform.system())
+        if backend_cls is None:
+            raise RuntimeError("Tray auf dieser Plattform nicht unterstützt")
+        backend = backend_cls(
+            self.base_path, self._on_show, self._on_quit, self._actions)
+        backend.start()
+        self._backend = backend  # erst nach erfolgreichem start halten
+
+    def notify(self, message, title="Zeiterfassung"):
+        if self._backend is not None:
+            self._backend.notify(message, title)
+
+    def stop(self):
+        if self._backend is not None:
+            self._backend.stop()
+            self._backend = None
+```
+
+- [ ] **Step 4: Run the new tests to verify they pass**
+
+Run: `pytest tests/test_tray.py -v`
+Expected: PASS (is_supported, build_menu_model, select_backend, facade).
+
+- [ ] **Step 5: Run the full suite for regressions**
+
+Run: `pytest tests/ -q`
+Expected: PASS — insbesondere `tests/test_sync_orchestrator.py` (nutzt `_tray`/`notify`/`stop`) und `tests/test_ui_*` bleiben grün. Bricht etwas, ist die Fassaden-API von der alten abgewichen → angleichen.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/tray.py tests/test_tray.py
+git commit -m "refactor(tray): TrayIcon als Plattform-Fassade, pystray in _PystrayBackend (#88)"
+```
+
+---
+
+### Task 5: macOS-Build — PyObjC collecten
+
+**Files:**
+- Modify: `build.py:131-139` (`build_macos`, PyInstaller-Args)
+
+**Interfaces:**
+- Consumes/Produces: keine Code-Schnittstelle (Build-Config).
+
+- [ ] **Step 1: Modify `build_macos`**
+
+In `build.py::build_macos` die `_pyinstaller_common(...)`-Argliste um die pyobjc-Collect-Flags ergänzen (lazy importierte AppKit/Foundation übersieht PyInstallers statische Analyse sonst). Aus:
+
+```python
+    cmd = _pyinstaller_common([
+        "--windowed",
+        "-D",
+        "--icon", "assets/margenheld-icon.icns",
+        "--osx-bundle-identifier", "com.margenheld.zeiterfassung",
+    ])
+```
+
+wird:
+
+```python
+    cmd = _pyinstaller_common([
+        "--windowed",
+        "-D",
+        "--icon", "assets/margenheld-icon.icns",
+        "--osx-bundle-identifier", "com.margenheld.zeiterfassung",
+        # tray_mac.py importiert AppKit/Foundation lazy → explizit bündeln,
+        # sonst fehlt PyObjC im DMG und das native Tray fällt still aus (#88).
+        "--collect-all", "objc",
+        "--collect-all", "AppKit",
+        "--collect-all", "Foundation",
+    ])
+```
+
+(Nur `build_macos` — Windows/Linux-Build unverändert.)
+
+- [ ] **Step 2: Verify the file parses and contains the flags**
+
+Run: `python -c "import ast; ast.parse(open('build.py').read()); print('parse ok')"`
+Expected: `parse ok`.
+Run: `grep -c "collect-all\", \"AppKit" build.py`
+Expected: `1`.
+
+> Echte Verifikation (PyObjC vollständig im DMG) ist erst der macOS-DMG-Build + Mac-Gate, nicht hier automatisierbar.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add build.py
+git commit -m "build(macos): PyObjC (objc/AppKit/Foundation) ins DMG collecten (#88)"
+```
+
+---
+
+### Task 6: CI — `test-macos`-Job
+
+**Files:**
+- Modify: `.github/workflows/test.yml` (neuer Job neben `test`/`lint`)
+
+**Interfaces:**
+- Consumes: `tests/test_tray_mac.py` (Smoke läuft nur auf Darwin), `pyobjc-framework-Cocoa`.
+
+- [ ] **Step 1: Add the job**
+
+In `.github/workflows/test.yml` nach dem `test`-Job (vor `lint`) einfügen:
+
+```yaml
+  test-macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.10'
+      - run: pip install pytest "holidays==0.99" google-api-python-client google-auth google-auth-oauthlib pyobjc-framework-Cocoa
+      - run: pytest tests/
+```
+
+(Gleiche Deps wie der Linux-`test`-Job + `pyobjc-framework-Cocoa`; kein `pystray`/`Pillow` nötig, da macOS das native Backend nutzt. Der native Smoke in `test_tray_mac.py` läuft hier, skippt bei fehlendem Status-Bar-Zugriff.)
+
+- [ ] **Step 2: Verify the YAML parses**
+
+Run: `python -c "import yaml; yaml.safe_load(open('.github/workflows/test.yml')); print('yaml ok')"`
+Expected: `yaml ok`. (Falls PyYAML fehlt: `pip install pyyaml`.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/test.yml
+git commit -m "ci: test-macos-Job (pyobjc-Import, Dispatch, In-Process-Smoke) (#88)"
+```
+
+---
+
+### Task 7: Doku nachziehen
+
+**Files:**
+- Modify: `src/tray.py` (Modul-Docstring)
+- Modify: `src/CLAUDE.md` (Infra-Liste)
+- Modify: `CLAUDE.md` (Struktur-Modul-Liste)
+
+**Interfaces:** keine.
+
+- [ ] **Step 1: `src/tray.py`-Modul-Docstring aktualisieren**
+
+Den Modul-Docstring (Zeilen 2-9) so fassen, dass er Fassade + zwei Backends beschreibt. Ersetzen durch:
+
+```python
+"""System-Tray-Icon — Plattform-Fassade über zwei Backends.
+
+`TrayIcon` wählt per platform.system(): Windows → `_PystrayBackend` (pystray im
+Daemon-Thread, UI-Aktionen via `root.after(0, …)` auf den Tk-Thread). macOS →
+`MacTrayBackend` (src/tray_mac.py): natives NSStatusItem SYNCHRON auf dem
+Main-Thread, KEIN Thread, keine zweite NSApplication (Fix #88). macOS ist bis zum
+manuellen Mac-Gate dormant (Opt-in `ZEIT_MACOS_TRAY=1`, s. is_supported). Linux
+hat kein Tray. `build_menu_model` ist die backend-agnostische, testbare Naht.
+"""
+```
+
+- [ ] **Step 2: `src/CLAUDE.md` ergänzen**
+
+Im Abschnitt „Berichte & Plattform/Infra" die `tray.py`-Erwähnung um `tray_mac.py` erweitern. Die Zeile mit `tray.py` (in der Aufzählung `holidays_de.py`, `paths.py`, … `tray.py`, `version.py`) so ändern, dass nach `tray.py` ergänzt wird: `tray.py`/`tray_mac.py` (macOS-NSStatusItem-Backend, Fassade in `tray.py`).
+
+Konkret die bestehende Zeile
+
+```
+  (GitHub-Releases, stdlib-only, 1×/Tag), `platform_open.py`, `logging_setup.py`, `tray.py`,
+```
+
+ersetzen durch
+
+```
+  (GitHub-Releases, stdlib-only, 1×/Tag), `platform_open.py`, `logging_setup.py`,
+  `tray.py` (Fassade) + `tray_mac.py` (natives macOS-NSStatusItem-Backend, #88),
+```
+
+- [ ] **Step 3: Root-`CLAUDE.md`-Modulliste ergänzen**
+
+In der „## Struktur"-Aufzählung direkt nach der `src/tray.py`-Zeile eine Zeile einfügen:
+
+```
+- `src/tray_mac.py` — natives macOS-Tray (NSStatusItem, Main-Thread) als Backend von `tray.py`; macOS-Tray ist bis zum Mac-Gate dormant (Opt-in `ZEIT_MACOS_TRAY=1`, #88)
+```
+
+- [ ] **Step 4: Verify docs render (kein Code-Test)**
+
+Run: `git diff --stat`
+Expected: `src/tray.py`, `src/CLAUDE.md`, `CLAUDE.md` geändert.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tray.py src/CLAUDE.md CLAUDE.md
+git commit -m "docs(tray): Fassade + macOS-Backend + dormant-Staging dokumentieren (#88)"
+```
+
+---
+
+## Nach dem Plan: CHANGELOG / Version / Release
+
+- **CHANGELOG.md / `src/version.py`:** Dieser Branch behebt #88 (macOS-Tray default aus, natives Backend dormant). Beim PR die Version + CHANGELOG nach dem Release-Prozess (Root-`CLAUDE.md`) setzen — nicht Teil der Code-Tasks, da rein Release-Mechanik.
+- **Default-an-Flip (separater PR):** Nach bestandenem manuellem Mac-Gate `is_supported()` auf macOS unconditional True. Required Release-Gate — nicht in diesem Plan.
+
+## Manuelles Mac-Gate (required vor dem Flip-PR)
+
+Mit `ZEIT_MACOS_TRAY=1` auf einem Mac, `minimize_to_tray` aktiv:
+1. App starten → Tray-Icon erscheint in der Menübar.
+2. Klick aufs Icon → Menü öffnet (Anzeigen | Senden/Teilen/Export/Sync | Beenden).
+3. „Anzeigen", jede Quick-Action, „Beenden" lösen die richtige Aktion aus.
+4. Sync an/aus schalten → Sync-Eintrag erscheint/verschwindet live.
+5. **Kein Crash** beim „Google neu verbinden" und beim Sync-/Kalender-Aktivieren bei aktivem Tray (= Klasse-(ii)-Prüfung, der eigentliche #88-Beweis).
+6. Fenster schließen → minimiert ins Tray; „Beenden" beendet sauber (Sync-Push).

--- a/docs/superpowers/specs/2026-06-30-macos-native-tray-design.md
+++ b/docs/superpowers/specs/2026-06-30-macos-native-tray-design.md
@@ -1,0 +1,241 @@
+# Design: Natives macOS-Tray (NSStatusItem) statt pystray-Daemon-Thread
+
+Datum: 2026-06-30
+Branch: `fix/macos-tray-mainthread-crash`
+Issue: #88
+
+## Problem
+
+`src/tray.py::TrayIcon.start()` startet pystray auf **allen** Plattformen in
+einem Daemon-Thread (`threading.Thread(target=icon.run, daemon=True)`). Auf
+macOS ist das laut pystray-Doku unzulässig: `Icon.run()` muss auf dem
+Main-Thread laufen und treibt eine eigene `NSApplication`. Tkinter treibt auf
+macOS **dieselbe** geteilte `NSApplication` bereits exklusiv vom Main-Thread.
+Es treiben also zwei Threads dieselbe NSApp — sobald das nächste Tk-Fenster
+gemappt wird (der `themed_showinfo`-Bestätigungsdialog nach „Google neu
+verbinden" bzw. `on_change → _apply_tray_setting` beim Sync-/Kalender-Aktivieren,
+das das Tray neu startet), kollidiert der AppKit-Zustand → ObjC-Exception →
+`-[NSApplication _crashOnException:]` → Crash. Der Google-Schritt ist nur der
+**Auslöser**, die Ursache ist der Daemon-Thread.
+
+Voraussetzung für den Crash: „Beim Schließen in den Infobereich minimieren"
+(Tray) ist aktiv. Diagnose abgeleitet aus dem macOS-Crash-Report + Code +
+pystray-Primärdoku (Issue #88), nicht lokal reproduziert.
+
+## Ziel
+
+Das Minimize-to-Tray bleibt auf macOS **erhalten** (volle Plattform-Parität),
+ohne den Crash. Dazu wird auf macOS kein pystray-Daemon-Thread mehr gestartet,
+sondern ein natives `NSStatusItem` **synchron auf dem Main-Thread** an die von
+Tk getriebene `NSApplication` gehängt (keine zweite NSApp, kein zweiter Thread,
+kein zweiter Runloop). Damit ist die Zwei-Threads-eine-NSApp-Kollision per
+Konstruktion ausgeschlossen.
+
+**Windows bleibt unangetastet** — dort läuft weiter der bestehende
+pystray-Daemon-Thread-Pfad (verifiziert funktionierend, null Regressionsrisiko).
+Linux hat wie bisher kein Tray (`is_supported()` → False).
+
+Projekt-Designregel: „bestmöglich gleich auf allen drei Plattformen; wenn nicht
+möglich, exklusive Anpassung." Hier ist die Anpassung der macOS-exklusive
+Backend-Wechsel hinter einer gemeinsamen Fassade.
+
+## Architektur (Ansatz A: Plattform-Dispatch hinter `TrayIcon`-Fassade)
+
+`tray.py::TrayIcon` bleibt die **öffentliche Fassade** mit unveränderter API
+(`is_supported`, `start`, `stop`, `notify`). Intern wählt sie das Backend nach
+`platform.system()`:
+
+- **Windows** → bestehender pystray-Pfad (Daemon-Thread, Icon-Toast). Code
+  unverändert, nur in eine interne Backend-Einheit gefasst.
+- **macOS** → neues natives Backend in **`src/tray_mac.py`** (eigenes Modul,
+  PyObjC **lazy** importiert).
+
+Begründung eigenes Modul: hält die PyObjC-Imports **vollständig** aus dem
+Linux/Windows-Importpfad heraus (die Test-CI importiert `src.ui → src.tray`).
+Spiegelt das vorhandene Lazy-Import-Muster der Google-Wrapper (`gcal.py`,
+`drive.py`).
+
+### Testbarkeits-Schnitt (pures Modell vs. nativer Renderer)
+
+Das macOS-Backend wird in zwei Teile getrennt:
+
+1. **Reines Menü-Modell** (pure Python, kein AppKit) — leitet aus den `actions`
+   die Menüstruktur ab: Einträge, Reihenfolge, Separatoren, welcher Eintrag eine
+   dynamische `visible`-Callable trägt. **Auf jeder Plattform unit-testbar**
+   (Linux-CI, Windows).
+2. **Dünner nativer Renderer** (`src/tray_mac.py`) — macht aus dem Modell
+   NSMenu/NSMenuItem/NSStatusItem, hält die starken Referenzen, wired Target/
+   Action. Nur dieser Teil ist macOS-only und erst auf einem Mac visuell
+   verifizierbar.
+
+So liegen Backend-Auswahl und Menü-Logik in der CI-testbaren Naht; nur das nackte
+AppKit-Rendering bleibt „blind".
+
+## Verhalten
+
+### Menü
+
+Identisch zum heutigen: **Anzeigen** | — | **Senden / Teilen / Export / Sync** |
+— | **Beenden**. Auf macOS öffnet ein Klick auf das Status-Item das Menü;
+„Anzeigen" ist schlicht der erste Eintrag (keine Linksklick-vs-Rechtsklick-
+Konvention für Status-Items — wie pystray-darwin es auch handhabt). Die
+Callbacks sind dieselben wie heute und marshallen bereits selbst per
+`root.after(0, …)` auf den Tk-Thread; die nativen Action-Methoden feuern ohnehin
+auf dem Main-Thread, das Marshalling bleibt korrekt.
+
+### Dynamische Sichtbarkeit (Sync-Eintrag)
+
+Der Sync-Eintrag ist nur sichtbar, wenn `sync_enabled`. Umsetzung **live** über
+einen `NSMenu`-Delegate (`menuNeedsUpdate_`), der vor jedem Öffnen die
+`visible`-Callable neu auswertet und `item.setHidden_(…)` setzt — **echte
+Windows-Parität** (Eintrag erscheint/verschwindet sofort beim Umschalten),
+besser als pystray-darwins Einmal-Snapshot. Fallback bei Komplikationen:
+Snapshot beim Aufbau (= heutiges, im Docstring als akzeptabel dokumentiertes
+Verhalten).
+
+### Threading
+
+Kein Daemon-Thread auf macOS. `_apply_tray_setting` (ui.py) läuft bereits immer
+auf dem UI-/Main-Thread (aus `__init__` und dem Settings-`on_change`) und ist
+die einzige Stelle, die `tray.start()` ruft — das Status-Item wird dort synchron
+auf dem Main-Thread erzeugt. An `ui.py` ändert sich dadurch (fast) nichts; die
+Fassade kapselt den Dispatch.
+
+### `notify()` (Sync-Toasts)
+
+`notify()` ist vertraglich schon **fehlertolerant**. Auf macOS: **best-effort,
+nie fatal** — minimaler nativer Versuch (`NSUserNotification`, leichtgewichtig,
+kein Entitlement), **alle** Fehler geschluckt, defensiv auf den Main-Thread
+dispatcht. Bleibt es auf neueren macOS still, funktioniert der Sync trotzdem —
+nur ohne Toast. Die einzige „blinde" Funktionalität ist damit kosmetisch.
+
+### Graceful Fallback
+
+Wirft das native Setup **irgendeine** Exception, propagiert sie wie heute aus
+`start()`. `_apply_tray_setting` fängt das bereits, zeigt `themed_showerror` und
+schaltet `minimize_to_tray` ab. Kein Crash, schlimmstenfalls kein Tray.
+
+## Betroffene Stellen
+
+1. **`src/tray.py` — Fassade + Backend-Dispatch.**
+   - `is_supported()` bleibt `Windows`/`Darwin` → True (Verhalten unverändert,
+     aber Darwin ist jetzt echt unterstützt).
+   - Reine Selektor-Funktion (z. B. `_select_backend(system)`), die das
+     Backend nach `platform.system()` wählt — als pure Funktion testbar.
+   - `start()/stop()/notify()` delegieren an das aktive Backend. Windows-Pfad
+     (pystray, Daemon-Thread, `_notify_with_icon`) wandert unverändert in die
+     interne Windows-Backend-Einheit.
+   - Pures Menü-Modell aus `actions` ableiten — speist den macOS-Renderer und
+     die Tests. Der Windows-Pfad baut sein pystray-Menü weiter inline wie heute
+     (kein Verhaltens-/Code-Wechsel dort).
+
+2. **`src/tray_mac.py` — neues Modul, natives Backend.**
+   - Lazy: `import objc`, `from AppKit import NSStatusBar, NSImage, NSMenu,
+     NSMenuItem, NSVariableStatusItemLength`, `from Foundation import NSObject`.
+   - `NSObject`-Delegate-Subklasse hält die Python-Callbacks; Menüeinträge
+     targeten sie per Selektor. Implementiert `menuNeedsUpdate_` für live-
+     Sichtbarkeit.
+   - Status-Item: `NSStatusBar.systemStatusBar().statusItemWithLength_(…)`,
+     Button-Image aus `assets/margenheld-icon.png` (→ NSImage, ~18 px),
+     `setMenu_(menu)`.
+   - Hält starke Referenzen (Item, Menu, Delegate) auf `self` (sonst GC →
+     Icon verschwindet/Crash).
+   - `stop()`: `removeStatusItem_` + Referenzen lösen. Idempotent.
+   - `notify()`: best-effort `NSUserNotification`, alle Fehler geschluckt.
+
+3. **`requirements.txt` — Dependency mit Plattform-Marker.**
+   `pyobjc-framework-Cocoa>=10.0; sys_platform == "darwin"` (Meta-Paket: zieht
+   `objc` + `Foundation` + `AppKit`). Marker hält `pip install` auf
+   Linux/Windows sauber — Test-CI und Windows-Build sehen pyobjc nie.
+
+4. **`build.py::build_macos` — PyInstaller-Collecting.**
+   Da `src/tray_mac.py` AppKit/Foundation **lazy** importiert, übersieht die
+   statische Analyse die Module gern. Im macOS-Build explizit collecten (analog
+   `--collect-all pystray`), z. B. `--collect-all objc --collect-all AppKit
+   --collect-all Foundation` bzw. nötige `--hidden-import`. Exakter Satz beim
+   Plan/Umsetzung gegen die aktuelle pyobjc-Version fixieren. Windows/Linux-Build
+   unverändert. (`THIRD-PARTY-NOTICES` nehmen pyobjc auf dem Mac-Build über
+   pip-licenses automatisch mit.)
+
+5. **`.github/workflows/test.yml` — neuer Job `test-macos`.**
+   `macos-latest`, Python 3.10, installiert `pytest` + `pyobjc-framework-Cocoa`
+   + die Google-Libs (Tests importieren `src.ui`), läuft `pytest tests/`.
+   Bestätigt pyobjc-Import, `src.tray_mac`-Import und Backend-Auswahl auf echtem
+   macOS — **nicht** die visuelle Sichtbarkeit/Interaktion des Icons. Separater
+   Job, damit der Linux-Pfad nicht an der macOS-Queue hängt.
+
+6. **`tray.py`-Docstrings + ggf. `CLAUDE.md`/`src/CLAUDE.md`.**
+   Der Klassen-Docstring beschreibt aktuell das pystray-darwin-Snapshot-Verhalten
+   und „Linux hat kein Tray". Anpassen: macOS nutzt jetzt das native Backend mit
+   live-Sichtbarkeit. `tray.py` in der Modul-Liste um `tray_mac.py` ergänzen.
+
+## Fehlerbehandlung / Edge Cases
+
+- **Setup-Fehler nativ:** Exception aus `start()` → bestehender
+  `_apply_tray_setting`-Fang (Toast + Feature aus). Kein neuer Pfad nötig.
+- **Referenz-GC:** Item/Menu/Delegate werden auf dem Backend-Objekt gehalten;
+  das Backend hängt an `App._tray`. Solange `App._tray` lebt, leben die Refs.
+- **`stop()` Idempotenz:** wie heute mehrfach aufrufbar; `removeStatusItem_` nur
+  wenn Item vorhanden.
+- **`notify()` vom Worker-Thread:** AppKit-Notify muss auf den Main-Thread —
+  das Backend dispatcht defensiv (bzw. no-op bei Fehler). Sync bleibt unberührt.
+- **Quit-Pfad:** `App._quit_with_sync_push` ruft `tray.stop()` vor
+  `root.destroy()` — Reihenfolge bleibt; nativ entfernt `stop()` nur das
+  Status-Item, kein Thread-Join nötig (es gibt keinen Thread mehr).
+
+## Tests
+
+Rot→grün-Naht (auf jeder Plattform lauffähig, sofern nicht anders vermerkt):
+
+1. `is_supported()` → True auf Darwin & Windows, False auf Linux
+   (`platform.system()` gemockt). Verhalten festgeschrieben.
+2. **Backend-Dispatch:** `_select_backend("Darwin")` → natives Backend,
+   `_select_backend("Windows")` → pystray-Backend.
+3. **Bug-Guard:** auf macOS startet der Pfad **keinen** `threading.Thread` —
+   das native Backend ist thread-los. Encodiert den Fix, Regression-Guard gegen
+   Wieder-Einführung des Crashes.
+4. **Menü-Modell:** aus Beispiel-`actions` ergibt sich die erwartete Struktur
+   (Einträge, Reihenfolge, Separatoren, Sync-Eintrag als „dynamisch" markiert).
+
+Nicht unit-testbar (→ CI-Import + manueller Mac-Test):
+- Die nativen AppKit-Aufrufe (NSStatusItem erscheint, Menü öffnet, Klicks lösen
+  Callbacks, live-Sichtbarkeit, notify-Toast) und die Crash-Abwesenheit selbst.
+
+## Verifikation / Übergabe
+
+- **CI (jetzt):** `test-macos`-Job bestätigt Build-/Import-/Dispatch-Korrektheit
+  auf macOS.
+- **Manueller Mac-Test (später, offen):** Tray-Icon sichtbar; Menü öffnet;
+  „Anzeigen"/„Beenden"/Quick-Actions funktionieren; **kein Crash** beim „Google
+  neu verbinden" und beim Sync-/Kalender-Aktivieren mit aktivem Minimize-to-Tray;
+  Sync-Eintrag erscheint/verschwindet mit `sync_enabled`. Bis dieser Test
+  gelaufen ist, gilt „funktioniert auf macOS" als **unverifiziert**.
+
+Übergabe (schwerer Loop):
+- **VERHALTEN:** macOS-Tray läuft nativ (NSStatusItem, Main-Thread) statt
+  pystray-Daemon-Thread; Windows/Linux unverändert.
+- **RISIKO:** Bricht es, dann am ehesten beim Mac-Test — entweder Tk-Runloop
+  serviced das Status-Item-Menü nicht (unbelegte Annahme, s. u.) oder PyInstaller
+  bündelt pyobjc nicht vollständig. Beides degradiert dank Fallback zu „kein
+  Tray", nicht zu Crash. Windows trägt null Risiko.
+- **TEST:** manuelle Mac-Checkliste oben.
+
+## Offene Annahme (irreduzibles Risiko)
+
+Keine Primärquelle belegt, dass Tks `mainloop` ein an die geteilte NSApp
+gehängtes `NSStatusItem`-Menü ausreichend serviced (das Standalone-PyObjC-Muster
+treibt seinen eigenen `AppHelper.runEventLoop()`, den wir bewusst **nicht**
+nutzen). Die PyObjC-API selbst (systemStatusBar, statusItemWithLength_, setMenu_,
+Main-Thread-/Retain-Pflicht, Target/Action) ist primärbelegt. Die Integration
+ist nur auf einem Mac final verifizierbar — bei Fehlschlag greift der Fallback,
+und der dokumentierte Rückfallweg ist Issue-Option 1 (Tray auf macOS deaktivieren).
+
+## Bewusst nicht enthalten (YAGNI)
+
+- Kein Ersatz von pystray auf Windows (Ansatz B) — nur macOS bekommt das native
+  Backend.
+- Kein `run_detached`-Weg (Ansatz C / Issue-Option 2) — der NSApp-Konflikt bleibt.
+- Kein voller `UNUserNotificationCenter`-Notify mit Authorization/Entitlements —
+  notify bleibt best-effort.
+- Keine Änderung am Klick-/Lösch-Modell oder an Win/Linux-Verhalten.
+- Kein natives Windows-Tray, kein Linux-Tray.

--- a/docs/superpowers/specs/2026-06-30-macos-native-tray-design.md
+++ b/docs/superpowers/specs/2026-06-30-macos-native-tray-design.md
@@ -24,12 +24,19 @@ pystray-Primärdoku (Issue #88), nicht lokal reproduziert.
 
 ## Ziel
 
-Das Minimize-to-Tray bleibt auf macOS **erhalten** (volle Plattform-Parität),
-ohne den Crash. Dazu wird auf macOS kein pystray-Daemon-Thread mehr gestartet,
-sondern ein natives `NSStatusItem` **synchron auf dem Main-Thread** an die von
-Tk getriebene `NSApplication` gehängt (keine zweite NSApp, kein zweiter Thread,
-kein zweiter Runloop). Damit ist die Zwei-Threads-eine-NSApp-Kollision per
-Konstruktion ausgeschlossen.
+Das Minimize-to-Tray soll auf macOS **erhalten** werden (volle Plattform-
+Parität), ohne den Crash. Dazu wird auf macOS kein pystray-Daemon-Thread mehr
+gestartet, sondern ein natives `NSStatusItem` **synchron auf dem Main-Thread** an
+die von Tk getriebene `NSApplication` gehängt (keine zweite NSApp, kein zweiter
+Thread, kein zweiter Runloop). Damit ist die Zwei-Threads-eine-NSApp-Kollision
+per Konstruktion ausgeschlossen.
+
+**Gestaged, weil ohne Mac nicht verifizierbar:** Das native Backend landet
+vollständig, wird aber in ausgelieferten Builds **dormant** gehalten (macOS-Tray
+default **aus** = interim Issue-Option 1, Crash sofort weg) und erst nach
+bestandenem manuellem Mac-Gate per Flip default-an. Siehe „Auslieferungs-Default
+& Rollout". So sagt der Merge ehrlich „Crash behoben", ohne einen unverifizierten
+nativen Pfad an alle Mac-Nutzer auszuliefern.
 
 **Windows bleibt unangetastet** — dort läuft weiter der bestehende
 pystray-Daemon-Thread-Pfad (verifiziert funktionierend, null Regressionsrisiko).
@@ -109,19 +116,46 @@ kein Entitlement), **alle** Fehler geschluckt, defensiv auf den Main-Thread
 dispatcht. Bleibt es auf neueren macOS still, funktioniert der Sync trotzdem —
 nur ohne Toast. Die einzige „blinde" Funktionalität ist damit kosmetisch.
 
-### Graceful Fallback
+### Fallback & Crash-Garantie (präzise gefasst)
 
-Wirft das native Setup **irgendeine** Exception, propagiert sie wie heute aus
-`start()`. `_apply_tray_setting` fängt das bereits, zeigt `themed_showerror` und
-schaltet `minimize_to_tray` ab. Kein Crash, schlimmstenfalls kein Tray.
+Der Python-Fallback deckt **nur synchron** geworfene Exceptions: wirft das native
+Setup (`statusItemWithLength_`, `setMenu_`, Image-Load …) synchron an der
+PyObjC-Bridge, propagiert das wie heute aus `start()` → `_apply_tray_setting`
+fängt es, zeigt `themed_showerror` und schaltet `minimize_to_tray` ab. Kein
+Crash, schlimmstenfalls kein Tray.
+
+**Was der Fallback NICHT deckt:** Eine Exception, die *innerhalb* von AppKits
+Event-Processing entsteht (Menü-Tracking, Lazy-Draw, Target/Action-Dispatch,
+Notify), läuft nicht durch einen Python-Frame → `-[NSApplication
+_crashOnException:]` → SIGTRAP, am `try/except` vorbei. Diese async-Crash-Fläche
+zerfällt in zwei Klassen:
+
+- **(i) Python-Exceptions in unseren Callbacks** (Action-Methoden,
+  `menuNeedsUpdate_`, Notify): **konstruktiv ausgeschlossen** — verbindliche
+  Implementierungsregel: *jeder* von AppKit aufgerufene Python-Callback umschließt
+  seinen gesamten Body mit einem restlosen `try/except` (swallow + log). Kein
+  Python-Throw darf je in einen ObjC-Frame zurück.
+- **(ii) AppKit-interne Exceptions** (Threading-/Runloop-Missbrauch): aus Python
+  **nicht** abfangbar (AppKit ist nicht exception-safe; einmal entrollt =
+  undefinierter Zustand). Nur auf einem Mac verifizierbar.
+
+**Garantie also präzise:** Klasse (i) ist by construction crash-frei; Klasse (ii)
+bleibt **unbewiesen bis zum Mac-Gate** — deshalb der dormant-Default (s.
+„Auslieferungs-Default & Rollout"). Kein unconditional „nie Crash".
 
 ## Betroffene Stellen
 
 1. **`src/tray.py` — Fassade + Backend-Dispatch.**
-   - `is_supported()` bleibt `Windows`/`Darwin` → True (Verhalten unverändert,
-     aber Darwin ist jetzt echt unterstützt).
+   - `is_supported()`: **Windows → True**, **Linux → False** (unverändert),
+     **macOS → False, solange der Opt-in-Schalter nicht gesetzt ist** (interim
+     dormant-Default, s. Rollout). Opt-in z. B. über Env-Var `ZEIT_MACOS_TRAY=1`
+     (oder verstecktes Setting), damit der Mac-Tester das native Backend
+     aktivieren kann, ohne es default an alle auszuliefern. Der spätere Flip nach
+     bestandenem Mac-Gate macht macOS unconditional True.
    - Reine Selektor-Funktion (z. B. `_select_backend(system)`), die das
-     Backend nach `platform.system()` wählt — als pure Funktion testbar.
+     Backend nach `platform.system()` wählt — als pure Funktion testbar. Wird
+     **unabhängig** von `is_supported()` getestet, damit der native Dispatch auch
+     bei dormantem Default in der CI exerciert wird.
    - `start()/stop()/notify()` delegieren an das aktive Backend. Windows-Pfad
      (pystray, Daemon-Thread, `_notify_with_icon`) wandert unverändert in die
      interne Windows-Backend-Einheit.
@@ -142,6 +176,9 @@ schaltet `minimize_to_tray` ab. Kein Crash, schlimmstenfalls kein Tray.
      Icon verschwindet/Crash).
    - `stop()`: `removeStatusItem_` + Referenzen lösen. Idempotent.
    - `notify()`: best-effort `NSUserNotification`, alle Fehler geschluckt.
+   - **Callback-Hülle:** jeder von AppKit aufgerufene Python-Callback (Action,
+     `menuNeedsUpdate_`, Notify) umschließt seinen Body restlos mit `try/except`
+     (swallow + log) — Klasse-(i)-Schutz, siehe „Fallback & Crash-Garantie".
 
 3. **`requirements.txt` — Dependency mit Plattform-Marker.**
    `pyobjc-framework-Cocoa>=10.0; sys_platform == "darwin"` (Meta-Paket: zieht
@@ -159,10 +196,14 @@ schaltet `minimize_to_tray` ab. Kein Crash, schlimmstenfalls kein Tray.
 
 5. **`.github/workflows/test.yml` — neuer Job `test-macos`.**
    `macos-latest`, Python 3.10, installiert `pytest` + `pyobjc-framework-Cocoa`
-   + die Google-Libs (Tests importieren `src.ui`), läuft `pytest tests/`.
-   Bestätigt pyobjc-Import, `src.tray_mac`-Import und Backend-Auswahl auf echtem
-   macOS — **nicht** die visuelle Sichtbarkeit/Interaktion des Icons. Separater
-   Job, damit der Linux-Pfad nicht an der macOS-Queue hängt.
+   + die Google-Libs (Tests importieren `src.ui`), läuft `pytest tests/`. Geht
+   über Import/Dispatch hinaus: ein **In-Process-Smoke** (s. Tests) konstruiert
+   das native Backend unter einer laufenden Tk-Root, ruft jeden Action-Callback
+   direkt auf, toggelt die Sichtbarkeit und baut wieder ab — fängt
+   Verdrahtungs-/Lifecycle-/Target-Action-Fehler und Klasse-(i)-Exceptions.
+   **Nicht** beweisbar: user-sichtbares Icon, echtes Menü-Öffnen per Klick und
+   Klasse-(ii)-Absenz (→ Mac-Gate). Separater Job, damit der Linux-Pfad nicht an
+   der macOS-Queue hängt.
 
 6. **`tray.py`-Docstrings + ggf. `CLAUDE.md`/`src/CLAUDE.md`.**
    Der Klassen-Docstring beschreibt aktuell das pystray-darwin-Snapshot-Verhalten
@@ -187,38 +228,74 @@ schaltet `minimize_to_tray` ab. Kein Crash, schlimmstenfalls kein Tray.
 
 Rot→grün-Naht (auf jeder Plattform lauffähig, sofern nicht anders vermerkt):
 
-1. `is_supported()` → True auf Darwin & Windows, False auf Linux
-   (`platform.system()` gemockt). Verhalten festgeschrieben.
+1. **`is_supported()`** (`platform.system()` + Opt-in-Schalter gemockt):
+   Windows → True; Linux → False; macOS **ohne** Opt-in → False (dormant-Default),
+   macOS **mit** Opt-in → True. Schreibt den Staging-Default fest.
 2. **Backend-Dispatch:** `_select_backend("Darwin")` → natives Backend,
-   `_select_backend("Windows")` → pystray-Backend.
+   `_select_backend("Windows")` → pystray-Backend. Unabhängig von `is_supported()`.
 3. **Bug-Guard:** auf macOS startet der Pfad **keinen** `threading.Thread` —
-   das native Backend ist thread-los. Encodiert den Fix, Regression-Guard gegen
-   Wieder-Einführung des Crashes.
+   das native Backend ist thread-los. Encodiert den Fix; muss gegen den alten
+   Code (Daemon-Thread) **rot** sein, gegen den neuen grün.
 4. **Menü-Modell:** aus Beispiel-`actions` ergibt sich die erwartete Struktur
    (Einträge, Reihenfolge, Separatoren, Sync-Eintrag als „dynamisch" markiert).
+5. **In-Process-Smoke (nur macOS, im `test-macos`-Job):** unter einer Tk-Root das
+   native Backend konstruieren, jeden Action-Callback direkt aufrufen,
+   Sichtbarkeit togglen, `stop()` — assertet **keine** Exception. Exerciert
+   Target/Action-Verdrahtung, Retain/Lifecycle und Klasse-(i)-Schutz. Skippt
+   sauber, falls der Runner keinen Status-Bar-Zugriff hat (statt falsch rot).
 
-Nicht unit-testbar (→ CI-Import + manueller Mac-Test):
-- Die nativen AppKit-Aufrufe (NSStatusItem erscheint, Menü öffnet, Klicks lösen
-  Callbacks, live-Sichtbarkeit, notify-Toast) und die Crash-Abwesenheit selbst.
+Nicht (auch nicht im macOS-Job) automatisiert testbar — nur **manuelles Mac-Gate**:
+- User-sichtbares Icon, Menü-Öffnen per echtem Klick, live-Sichtbarkeit visuell,
+  notify-Toast, und vor allem **Klasse-(ii)-Crash-Absenz** beim Google-Reconnect /
+  Sync-Aktivieren mit aktivem Tray.
+
+## Auslieferungs-Default & Rollout (Staging)
+
+Weil das Mac-Gate jetzt nicht fahrbar ist und Klasse-(ii)-Crashes nicht aus
+Python abfangbar sind, wird das native Backend **dormant** ausgeliefert:
+
+1. **Merge-Zustand (jetzt):** macOS-Tray **aus** by default (`is_supported()` →
+   False auf macOS ohne Opt-in). Effektiv interim Issue-Option 1 → der Crash ist
+   ab Merge weg. Bestehende Mac-Nutzer mit `minimize_to_tray=True` bekommen beim
+   nächsten Start die vorhandene „auf dieser Plattform nicht nutzbar"-Meldung und
+   das Feature wird abgeschaltet (kein Crash).
+2. **Verifikations-Zustand:** Der Mac-Tester setzt den Opt-in-Schalter
+   (`ZEIT_MACOS_TRAY=1`), baut/startet die Branch und fährt das Mac-Gate (s.
+   Verifikation). Das native Backend wird so exerciert, ohne es an Endnutzer
+   auszuliefern.
+3. **Flip (nach bestandenem Gate):** Ein separater, kleiner PR macht macOS in
+   `is_supported()` unconditional True (Default an). **Required Release-Gate:**
+   dieser Flip darf erst mergen, wenn das manuelle Mac-Gate dokumentiert grün ist.
+
+Damit liefert dieser Branch **Issue-Option 1 als sofortigen, sicheren Default**
+**und** das native Backend (Option 3) **fertig, aber gestaged** — die Crash-
+Behebung hängt nicht an einer unverifizierten Annahme.
 
 ## Verifikation / Übergabe
 
-- **CI (jetzt):** `test-macos`-Job bestätigt Build-/Import-/Dispatch-Korrektheit
-  auf macOS.
-- **Manueller Mac-Test (später, offen):** Tray-Icon sichtbar; Menü öffnet;
-  „Anzeigen"/„Beenden"/Quick-Actions funktionieren; **kein Crash** beim „Google
-  neu verbinden" und beim Sync-/Kalender-Aktivieren mit aktivem Minimize-to-Tray;
-  Sync-Eintrag erscheint/verschwindet mit `sync_enabled`. Bis dieser Test
-  gelaufen ist, gilt „funktioniert auf macOS" als **unverifiziert**.
+- **CI (jetzt):** `test-macos`-Job — Import, Dispatch und In-Process-Smoke (s.
+  Tests). Bestätigt Verdrahtung/Lifecycle/Klasse-(i), **nicht** Sichtbarkeit oder
+  Klasse-(ii)-Crash-Absenz.
+- **Manuelles Mac-Gate (REQUIRED, blockiert den Default-an-Flip):** Mit Opt-in
+  (`ZEIT_MACOS_TRAY=1`) auf einem Mac: Tray-Icon sichtbar; Menü öffnet per Klick;
+  „Anzeigen"/„Beenden"/Quick-Actions funktionieren; Sync-Eintrag erscheint/
+  verschwindet live mit `sync_enabled`; notify-Toast (falls Backend ihn zeigt);
+  und **kein Crash** beim „Google neu verbinden" sowie beim Sync-/Kalender-
+  Aktivieren mit aktivem Tray. Der `is_supported()`-Flip auf macOS-default-an darf
+  **erst mergen**, wenn dieses Gate dokumentiert grün ist. Bis dahin gilt
+  „funktioniert auf macOS" als **unverifiziert** — und wird default nicht
+  ausgeliefert.
 
 Übergabe (schwerer Loop):
-- **VERHALTEN:** macOS-Tray läuft nativ (NSStatusItem, Main-Thread) statt
-  pystray-Daemon-Thread; Windows/Linux unverändert.
-- **RISIKO:** Bricht es, dann am ehesten beim Mac-Test — entweder Tk-Runloop
-  serviced das Status-Item-Menü nicht (unbelegte Annahme, s. u.) oder PyInstaller
-  bündelt pyobjc nicht vollständig. Beides degradiert dank Fallback zu „kein
-  Tray", nicht zu Crash. Windows trägt null Risiko.
-- **TEST:** manuelle Mac-Checkliste oben.
+- **VERHALTEN:** Merge liefert macOS-Tray **default aus** (Crash weg, interim
+  Issue-Option 1) + das native NSStatusItem-Backend **dormant/opt-in**.
+  Windows/Linux unverändert. Default-an erst per separatem Flip nach Mac-Gate.
+- **RISIKO:** Der Default-Pfad (Tray aus) trägt **kein** Crash-Risiko. Im Opt-in/
+  Flip-Pfad bricht es am ehesten bei (ii) — Tk-Runloop serviced das Menü nicht /
+  AppKit-interne Exception — oder PyInstaller bündelt pyobjc unvollständig. (i)
+  ist konstruktiv abgefangen; (ii) ist genau das, was das Mac-Gate prüft. Windows
+  trägt null Risiko.
+- **TEST:** In-Process-Smoke (CI) + manuelles Mac-Gate (oben) vor dem Flip.
 
 ## Offene Annahme (irreduzibles Risiko)
 
@@ -227,8 +304,12 @@ gehängtes `NSStatusItem`-Menü ausreichend serviced (das Standalone-PyObjC-Must
 treibt seinen eigenen `AppHelper.runEventLoop()`, den wir bewusst **nicht**
 nutzen). Die PyObjC-API selbst (systemStatusBar, statusItemWithLength_, setMenu_,
 Main-Thread-/Retain-Pflicht, Target/Action) ist primärbelegt. Die Integration
-ist nur auf einem Mac final verifizierbar — bei Fehlschlag greift der Fallback,
-und der dokumentierte Rückfallweg ist Issue-Option 1 (Tray auf macOS deaktivieren).
+ist nur auf einem Mac final verifizierbar.
+
+**Wichtig:** Schlägt diese Annahme fehl, ist das **kein** ausgelieferter Crash —
+der dormant-Default (Tray aus) hält den unverifizierten Pfad von Endnutzern fern,
+bis das Mac-Gate ihn freigibt. Bestätigt sich die Annahme nicht, bleibt der
+dokumentierte Endzustand Issue-Option 1 (macOS-Tray aus), und der Flip entfällt.
 
 ## Bewusst nicht enthalten (YAGNI)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pyinstaller>=6.0.0
 holidays==0.99
 pystray>=0.19.0,<0.20
 Pillow>=10.0.0
+pyobjc-framework-Cocoa>=10.0; sys_platform == "darwin"

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -110,7 +110,8 @@ denselben OAuth-Token; Scope-Upgrade erzwingt frischen Consent.
 - `theme.py`/`tooltip.py` — UI-Hilfen (Farben/Fonts/themed Dialoge, `_hover`-Overlays).
 - `time_utils.py` — Stunden, KW-Labels, `format_iso_date`/`format_iso_datetime`.
 - `holidays_de.py`, `paths.py` (`get_base_path` Frozen-vs-Repo), `autostart.py`, `updater.py`
-  (GitHub-Releases, stdlib-only, 1×/Tag), `platform_open.py`, `logging_setup.py`, `tray.py`,
+  (GitHub-Releases, stdlib-only, 1×/Tag), `platform_open.py`, `logging_setup.py`,
+  `tray.py` (Fassade) + `tray_mac.py` (natives macOS-NSStatusItem-Backend, #88),
   `version.py` (einzige Versions-Quelle).
 
 ## Dialoge (`src/dialogs/`)

--- a/src/tray.py
+++ b/src/tray.py
@@ -10,18 +10,29 @@ zurück.
 
 import logging
 import os
+import platform
 import threading
+
+
+def _macos_tray_opt_in():
+    """macOS-Tray ist bis zum bestandenen Mac-Gate dormant: nur aktiv, wenn der
+    Tester ZEIT_MACOS_TRAY=1 setzt. Default-an-Flip = separater PR (s. Spec)."""
+    return os.environ.get("ZEIT_MACOS_TRAY") == "1"
 
 
 def is_supported():
     """Kann auf diesem System ein Tray-Icon gezeigt werden?
 
-    Conservative: True für Windows und macOS, False für Linux (uneinheitlich).
-    Aufrufer kann unabhängig davon `try/except` machen, falls pystray zur
-    Laufzeit doch fehlschlägt.
+    Windows → True. Linux → False (uneinheitlich). macOS → nur mit Opt-in
+    (dormant-Default, s. _macos_tray_opt_in). Aufrufer kann unabhängig davon
+    `try/except` machen, falls das Backend zur Laufzeit doch fehlschlägt.
     """
-    import platform
-    return platform.system() in ("Windows", "Darwin")
+    system = platform.system()
+    if system == "Windows":
+        return True
+    if system == "Darwin":
+        return _macos_tray_opt_in()
+    return False
 
 
 class TrayIcon:

--- a/src/tray.py
+++ b/src/tray.py
@@ -1,11 +1,12 @@
 # src/tray.py
-"""System-Tray-Icon (Windows Notification Area / macOS Menu Bar).
+"""System-Tray-Icon — Plattform-Fassade über zwei Backends.
 
-Bewusst minimal: pystray läuft in eigenem Daemon-Thread, UI-Aktionen werden
-via `root.after(0, ...)` auf den Tk-Thread marshallt. Auf Linux ist die
-Verfügbarkeit WM-abhängig — wenn pystray-Backend fehlschlägt, gilt das
-Feature als nicht verfügbar und der Caller fällt auf normales Schließverhalten
-zurück.
+`TrayIcon` wählt per platform.system(): Windows → `_PystrayBackend` (pystray im
+Daemon-Thread, UI-Aktionen via `root.after(0, …)` auf den Tk-Thread). macOS →
+`MacTrayBackend` (src/tray_mac.py): natives NSStatusItem SYNCHRON auf dem
+Main-Thread, KEIN Thread, keine zweite NSApplication (Fix #88). macOS ist bis zum
+manuellen Mac-Gate dormant (Opt-in `ZEIT_MACOS_TRAY=1`, s. is_supported). Linux
+hat kein Tray. `build_menu_model` ist die backend-agnostische, testbare Naht.
 """
 
 import logging

--- a/src/tray.py
+++ b/src/tray.py
@@ -60,11 +60,26 @@ def build_menu_model(on_show, on_quit, actions):
     return entries
 
 
-class TrayIcon:
-    """Wrapper um pystray.Icon mit Tk-freundlicher Lifecycle-API.
+def _select_backend(system):
+    """Backend-Klasse nach Plattform. macOS lazy, damit PyObjC nicht in den
+    Linux/Windows-Importpfad gerät."""
+    if system == "Windows":
+        return _PystrayBackend
+    if system == "Darwin":
+        from src.tray_mac import MacTrayBackend
+        return MacTrayBackend
+    return None
 
-    Nutzung:
-        tray = TrayIcon(base_path, on_show=show_fn, on_quit=quit_fn)
+
+class _PystrayBackend:
+    """pystray-Backend (Windows). Tk-freundliche Lifecycle-API.
+
+    Wird von der TrayIcon-Fassade auf Windows gewählt (auf macOS läuft das
+    native MacTrayBackend, s. tray_mac.py). Body unverändert ggü. dem früheren
+    monolithischen TrayIcon.
+
+    Nutzung (intern, über die Fassade):
+        backend = _PystrayBackend(base_path, on_show=show_fn, on_quit=quit_fn)
         tray.start()
         ...
         tray.stop()
@@ -231,3 +246,37 @@ class TrayIcon:
             except Exception:
                 pass
             self._icon = None
+
+
+class TrayIcon:
+    """Plattform-Fassade: wählt per platform.system() das Backend
+    (_PystrayBackend auf Windows, MacTrayBackend auf macOS) und delegiert.
+    Öffentliche API (start/stop/notify) unverändert."""
+
+    def __init__(self, base_path, on_show, on_quit, actions=None):
+        self.base_path = base_path
+        self._on_show = on_show
+        self._on_quit = on_quit
+        self._actions = actions or []
+        self._backend = None
+
+    def start(self):
+        """Startet das plattformspezifische Backend. Wirft dessen Exception
+        durch (synchron) — Aufrufer (_apply_tray_setting) fängt und fällt auf
+        Tray-Verzicht zurück."""
+        backend_cls = _select_backend(platform.system())
+        if backend_cls is None:
+            raise RuntimeError("Tray auf dieser Plattform nicht unterstützt")
+        backend = backend_cls(
+            self.base_path, self._on_show, self._on_quit, self._actions)
+        backend.start()
+        self._backend = backend  # erst nach erfolgreichem start halten
+
+    def notify(self, message, title="Zeiterfassung"):
+        if self._backend is not None:
+            self._backend.notify(message, title)
+
+    def stop(self):
+        if self._backend is not None:
+            self._backend.stop()
+            self._backend = None

--- a/src/tray.py
+++ b/src/tray.py
@@ -12,6 +12,7 @@ import logging
 import os
 import platform
 import threading
+from collections import namedtuple
 
 
 def _macos_tray_opt_in():
@@ -33,6 +34,30 @@ def is_supported():
     if system == "Darwin":
         return _macos_tray_opt_in()
     return False
+
+
+MenuEntry = namedtuple("MenuEntry", ["kind", "label", "callback", "visible"])
+
+
+def build_menu_model(on_show, on_quit, actions):
+    """Backend-agnostisches Menü-Modell (pure, ohne AppKit/pystray) aus den
+    Tray-Aktionen. Speist den macOS-Renderer (src/tray_mac.py) und die Tests;
+    der Windows-Pfad baut sein pystray-Menü weiter inline.
+
+    `actions`: Liste (label, callback, visible). `callback` ist 0-arg und
+    marshallt selbst auf den Tk-Thread. `visible` ist None (immer sichtbar) oder
+    eine 0-arg-Callable → Bool (dynamische Sichtbarkeit).
+    """
+    entries = [
+        MenuEntry("item", "Anzeigen", on_show, None),
+        MenuEntry("separator", None, None, None),
+    ]
+    for label, callback, visible in actions:
+        entries.append(MenuEntry("item", label, callback, visible))
+    if actions:
+        entries.append(MenuEntry("separator", None, None, None))
+    entries.append(MenuEntry("item", "Beenden", on_quit, None))
+    return entries
 
 
 class TrayIcon:

--- a/src/tray_mac.py
+++ b/src/tray_mac.py
@@ -1,0 +1,151 @@
+# src/tray_mac.py
+"""Natives macOS-Tray (NSStatusItem) — Backend für TrayIcon (#88).
+
+Der frühere pystray-Daemon-Thread treibt auf macOS eine zweite NSApplication an
+und kollidiert mit der von Tk getriebenen → Crash beim Fenster-Mappen. Dieses
+Backend hängt stattdessen ein NSStatusItem SYNCHRON auf dem Main-Thread an die
+geteilte NSApplication, die Tk ohnehin treibt — kein Thread, keine zweite NSApp.
+
+PyObjC wird LAZY in den Methoden importiert: Modulebene bleibt stdlib-only, damit
+src.ui → src.tray → (dispatch) src.tray_mac auf Linux/Windows importierbar bleibt
+(die CI importiert src.ui). Siehe Spec 2026-06-30-macos-native-tray-design.md.
+"""
+
+import logging
+import os
+
+from src.tray import build_menu_model
+
+logger = logging.getLogger(__name__)
+
+
+def _safe(fn):
+    """0-arg-Callback aufrufen, ohne dass eine Python-Exception in einen
+    ObjC-Frame zurückläuft (Klasse-(i)-Schutz, s. Spec). JEDER von AppKit
+    aufgerufene Callback läuft hierdurch."""
+    try:
+        fn()
+    except Exception:
+        logger.exception("macOS-Tray-Callback-Fehler (geschluckt)")
+
+
+class MacTrayBackend:
+    """NSStatusItem-Backend mit derselben Lifecycle-API wie _PystrayBackend."""
+
+    def __init__(self, base_path, on_show, on_quit, actions=None):
+        self.base_path = base_path
+        self._on_show = on_show
+        self._on_quit = on_quit
+        self._actions = actions or []
+        # STARKE Referenzen halten — sonst GC → Icon verschwindet/Crash.
+        self._status_item = None
+        self._menu = None
+        self._delegate = None
+        self._dynamic_items = []  # [(NSMenuItem, visible_callable)]
+
+    def _load_image(self):
+        from AppKit import NSImage
+        png = os.path.join(self.base_path, "assets", "margenheld-icon.png")
+        if not os.path.exists(png):
+            return None
+        image = NSImage.alloc().initByReferencingFile_(png)
+        if image is not None:
+            image.setSize_((18, 18))  # Menübar-Höhe
+        return image
+
+    def start(self):
+        from AppKit import (
+            NSStatusBar, NSMenu, NSMenuItem, NSVariableStatusItemLength,
+        )
+        from Foundation import NSObject
+
+        model = build_menu_model(self._on_show, self._on_quit, self._actions)
+
+        callbacks = {}            # representedObject-Key -> 0-arg-Callback
+        dynamic_items = []        # [(NSMenuItem, visible_callable)]
+
+        # Delegate LAZY definieren: NSObject-Subklasse braucht Foundation, und
+        # die Methoden schließen über callbacks/dynamic_items (free vars).
+        class _TrayDelegate(NSObject):
+            def invoke_(self, sender):
+                cb = callbacks.get(str(sender.representedObject()))
+                if cb is not None:
+                    _safe(cb)
+
+            def menuNeedsUpdate_(self, menu):
+                # live-Sichtbarkeit: visible-Callables vor jedem Öffnen auswerten
+                for item, vis in dynamic_items:
+                    try:
+                        item.setHidden_(not bool(vis()))
+                    except Exception:
+                        logger.exception(
+                            "macOS-Tray-Sichtbarkeit-Fehler (geschluckt)")
+
+        delegate = _TrayDelegate.alloc().init()
+
+        menu = NSMenu.alloc().init()
+        menu.setAutoenablesItems_(False)
+        menu.setDelegate_(delegate)
+
+        for idx, entry in enumerate(model):
+            if entry.kind == "separator":
+                menu.addItem_(NSMenuItem.separatorItem())
+                continue
+            item = NSMenuItem.alloc().initWithTitle_action_keyEquivalent_(
+                entry.label, "invoke:", "",
+            )
+            item.setTarget_(delegate)
+            item.setRepresentedObject_(str(idx))
+            callbacks[str(idx)] = entry.callback
+            if entry.visible is not None:
+                dynamic_items.append((item, entry.visible))
+            menu.addItem_(item)
+
+        status_item = NSStatusBar.systemStatusBar().statusItemWithLength_(
+            NSVariableStatusItemLength)
+        image = self._load_image()
+        button = status_item.button()
+        if image is not None and button is not None:
+            button.setImage_(image)
+        elif button is not None:
+            button.setTitle_("Z")  # Last-Resort, falls PNG fehlt
+        status_item.setMenu_(menu)
+
+        # Refs festhalten (Reihenfolge egal; alle bis stop() leben lassen).
+        self._delegate = delegate
+        self._menu = menu
+        self._dynamic_items = dynamic_items
+        self._status_item = status_item
+
+    def notify(self, message, title="Zeiterfassung"):
+        """best-effort: NSUserNotification (deprecated, aber leichtgewichtig).
+        ALLE Fehler geschluckt — Toast ist kosmetisch, Sync bleibt unberührt.
+
+        Kein expliziter Main-Thread-Dispatch: der einzige Aufrufer
+        (sync_orchestrator._on_tray_done) ist ein on_done-Callback und läuft
+        bereits über _marshal_to_ui auf dem Tk-/Main-Thread (verifiziert)."""
+        try:
+            from Foundation import (
+                NSUserNotification, NSUserNotificationCenter,
+            )
+            note = NSUserNotification.alloc().init()
+            note.setTitle_(title or "Zeiterfassung")
+            note.setInformativeText_(message)
+            NSUserNotificationCenter.defaultUserNotificationCenter() \
+                .deliverNotification_(note)
+        except Exception:
+            logger.exception("macOS-Tray-Notify fehlgeschlagen (geschluckt)")
+
+    def stop(self):
+        """Entfernt das Status-Item und löst die Referenzen. Idempotent."""
+        if self._status_item is not None:
+            try:
+                from AppKit import NSStatusBar
+                NSStatusBar.systemStatusBar().removeStatusItem_(
+                    self._status_item)
+            except Exception:
+                logger.exception("macOS-Tray stop fehlgeschlagen")
+        self._status_item = None
+        self._menu = None
+        self._delegate = None
+        self._dynamic_items = []

--- a/tests/test_tray.py
+++ b/tests/test_tray.py
@@ -21,9 +21,16 @@ def test_is_supported_staging(system, optin, expected, monkeypatch):
 
 def test_build_menu_model_structure():
     from src.tray import build_menu_model
-    show = lambda: None
-    quit_ = lambda: None
-    vis = lambda: True
+
+    def show():
+        return None
+
+    def quit_():
+        return None
+
+    def vis():
+        return True
+
     actions = [("Senden", lambda: None, None), ("Sync", lambda: None, vis)]
     model = build_menu_model(show, quit_, actions)
     assert [(e.kind, e.label) for e in model] == [

--- a/tests/test_tray.py
+++ b/tests/test_tray.py
@@ -44,3 +44,45 @@ def test_build_menu_model_no_actions_single_separator():
     from src.tray import build_menu_model
     model = build_menu_model(lambda: None, lambda: None, [])
     assert [e.kind for e in model] == ["item", "separator", "item"]
+
+
+def test_select_backend_dispatch():
+    from src.tray import _select_backend, _PystrayBackend
+    from src.tray_mac import MacTrayBackend
+    assert _select_backend("Windows") is _PystrayBackend
+    assert _select_backend("Darwin") is MacTrayBackend
+    assert _select_backend("Linux") is None
+
+
+def test_facade_instantiates_and_delegates(monkeypatch):
+    """Fassade wählt das Backend, instanziiert mit denselben Args und delegiert
+    start/stop/notify — plattformunabhängig über ein Fake-Backend."""
+    from src import tray
+
+    seen = {}
+
+    class FakeBackend:
+        def __init__(self, base_path, on_show, on_quit, actions=None):
+            seen["init"] = (base_path, on_show, on_quit, actions)
+
+        def start(self):
+            seen["start"] = True
+
+        def stop(self):
+            seen["stop"] = True
+
+        def notify(self, message, title="Zeiterfassung"):
+            seen["notify"] = (message, title)
+
+    monkeypatch.setattr("src.tray._select_backend", lambda system: FakeBackend)
+
+    show, quit_ = (lambda: None), (lambda: None)
+    acts = [("Sync", lambda: None, None)]
+    icon = tray.TrayIcon("base", on_show=show, on_quit=quit_, actions=acts)
+    icon.start()
+    assert seen["init"] == ("base", show, quit_, acts)
+    assert seen["start"] is True
+    icon.notify("hallo")
+    assert seen["notify"] == ("hallo", "Zeiterfassung")
+    icon.stop()
+    assert seen["stop"] is True

--- a/tests/test_tray.py
+++ b/tests/test_tray.py
@@ -1,0 +1,19 @@
+# tests/test_tray.py
+import pytest
+
+from src import tray
+
+
+@pytest.mark.parametrize("system,optin,expected", [
+    ("Windows", None, True),
+    ("Linux", None, False),
+    ("Darwin", None, False),   # dormant-Default
+    ("Darwin", "1", True),     # opt-in für den Mac-Tester
+])
+def test_is_supported_staging(system, optin, expected, monkeypatch):
+    monkeypatch.setattr("src.tray.platform.system", lambda: system)
+    if optin is None:
+        monkeypatch.delenv("ZEIT_MACOS_TRAY", raising=False)
+    else:
+        monkeypatch.setenv("ZEIT_MACOS_TRAY", optin)
+    assert tray.is_supported() is expected

--- a/tests/test_tray.py
+++ b/tests/test_tray.py
@@ -17,3 +17,30 @@ def test_is_supported_staging(system, optin, expected, monkeypatch):
     else:
         monkeypatch.setenv("ZEIT_MACOS_TRAY", optin)
     assert tray.is_supported() is expected
+
+
+def test_build_menu_model_structure():
+    from src.tray import build_menu_model
+    show = lambda: None
+    quit_ = lambda: None
+    vis = lambda: True
+    actions = [("Senden", lambda: None, None), ("Sync", lambda: None, vis)]
+    model = build_menu_model(show, quit_, actions)
+    assert [(e.kind, e.label) for e in model] == [
+        ("item", "Anzeigen"),
+        ("separator", None),
+        ("item", "Senden"),
+        ("item", "Sync"),
+        ("separator", None),
+        ("item", "Beenden"),
+    ]
+    assert model[0].callback is show
+    assert model[-1].callback is quit_
+    sync = next(e for e in model if e.label == "Sync")
+    assert sync.visible is vis
+
+
+def test_build_menu_model_no_actions_single_separator():
+    from src.tray import build_menu_model
+    model = build_menu_model(lambda: None, lambda: None, [])
+    assert [e.kind for e in model] == ["item", "separator", "item"]

--- a/tests/test_tray_mac.py
+++ b/tests/test_tray_mac.py
@@ -1,0 +1,54 @@
+# tests/test_tray_mac.py
+import platform
+import threading
+
+import pytest
+
+
+def test_safe_swallows_callback_exceptions():
+    """Klasse-(i)-Schutz: _safe lässt keine Python-Exception durch (läuft auf
+    jeder Plattform — reines Python)."""
+    from src.tray_mac import _safe
+    calls = []
+    _safe(lambda: calls.append("ok"))
+    _safe(lambda: (_ for _ in ()).throw(ValueError("boom")))  # raises
+    assert calls == ["ok"]  # zweiter Aufruf wirft NICHT durch
+
+
+@pytest.mark.skipif(
+    platform.system() != "Darwin",
+    reason="natives NSStatusItem nur auf macOS (im test-macos-Job)",
+)
+def test_native_backend_constructs_no_thread_and_tears_down():
+    """In-Process-Smoke (nur macOS): Backend unter Tk-Root konstruieren, KEIN
+    Thread, Menü gerendert, sauber abbauen. Skippt, wenn der Runner keinen
+    Status-Bar-/Display-Zugriff hat (statt falsch rot)."""
+    import tkinter
+    from src.tray_mac import MacTrayBackend
+
+    try:
+        root = tkinter.Tk()
+    except Exception:
+        pytest.skip("kein Tk/Display auf dem Runner")
+    root.withdraw()
+
+    before = threading.active_count()
+    backend = MacTrayBackend(
+        base_path=".",
+        on_show=lambda: None,
+        on_quit=lambda: None,
+        actions=[("Sync", lambda: None, lambda: True)],
+    )
+    try:
+        try:
+            backend.start()
+        except Exception:
+            pytest.skip("Status-Bar auf dem Runner nicht verfügbar")
+        # Bug-Guard (#88): natives Backend startet KEINEN Daemon-Thread
+        assert threading.active_count() == before
+        # Menü gerendert: Anzeigen | sep | Sync | sep | Beenden = 5 Items
+        assert backend._menu.numberOfItems() == 5
+    finally:
+        backend.stop()
+        assert backend._status_item is None  # idempotenter Teardown
+        root.destroy()


### PR DESCRIPTION
## Was & Warum

#88: Auf macOS startet pystray in einem Daemon-Thread eine zweite NSApplication und kollidiert mit der von Tk getriebenen → Crash (`-[NSApplication _crashOnException:]` / SIGTRAP) beim Fenster-Mappen nach „Google neu verbinden" bzw. beim Sync-/Kalender-Aktivieren mit aktivem Minimize-to-Tray.

`TrayIcon` wird zur **Plattform-Fassade**: Windows behält den pystray-Pfad (`_PystrayBackend`, verbatim verschoben), macOS bekommt ein natives `NSStatusItem`-Backend (`src/tray_mac.py`) **synchron auf dem Main-Thread** — kein Thread, keine zweite NSApplication. `build_menu_model` ist die backend-agnostische, testbare Naht.

## Staging (wichtig)

Der macOS-Tray wird **dormant** ausgeliefert: Default **aus** (`is_supported()` → macOS nur mit Opt-in `ZEIT_MACOS_TRAY=1`). Damit ist der Crash ab Merge weg (interim = Tray auf macOS aus, = Issue-Option 1), ohne einen unverifizierten nativen Pfad an alle Mac-Nutzer auszuliefern. Der Default-an-Flip ist ein **separater PR nach bestandenem manuellem Mac-Gate** → #96.

## VERHALTEN / RISIKO / TEST

- **VERHALTEN:** macOS-Tray default aus (Crash weg) + natives Backend dormant/opt-in. Windows/Linux unverändert.
- **RISIKO:** Default-Pfad (Tray aus) trägt kein Crash-Risiko. Klasse-(i) (Python-Exceptions in unseren AppKit-Callbacks) ist konstruktiv via Catch-all-Hülle abgefangen; Klasse-(ii) (AppKit-intern / ob Tks Runloop das NSStatusItem-Menü serviced) ist nur auf einem Mac verifizierbar → #96. Windows null Risiko (verbatim).
- **TEST:** `pytest` 623 passed / 2 skipped, `ruff` sauber. Neuer `test-macos`-CI-Job (pyobjc-Import, Dispatch, In-Process-Smoke unter Tk-Root). Visuelle/Interaktions-Verifikation: manuelles Mac-Gate (#96).

## Doku

- Spec: `docs/superpowers/specs/2026-06-30-macos-native-tray-design.md`
- Plan: `docs/superpowers/plans/2026-06-30-macos-native-tray.md`

## Offen für diesen PR (Release-Mechanik)

- [ ] `src/version.py` + `CHANGELOG.md` + `release:*`-Label, falls dieser Fix released werden soll — bewusst noch **nicht** gesetzt.

Closes #88. Mac-Gate: #96.

🤖 Generated with [Claude Code](https://claude.com/claude-code)