### PR TITLE
feat: Standardzeiten pro Kategorie wahlweise tageweise (pro Wochentag) (#84)

### DIFF
--- a/docs/superpowers/plans/2026-06-30-kategorie-standardzeiten-tageweise.md
+++ b/docs/superpowers/plans/2026-06-30-kategorie-standardzeiten-tageweise.md
@@ -1,0 +1,909 @@
+# Kategorie-Standardzeiten tageweise — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `category_times` pro Kategorie wahlweise „allgemein" (ein Satz) oder „tageweise" (Start/Ende pro Wochentag), mit Per-Feld-Fallback auf die globalen Wochentags-Defaults.
+
+**Architecture:** Reine Logik in `category_defaults.py` (`resolve_slot_defaults`) und `dialogs/category_dialog.py` (`collect_categories`, neu: `row_defaults_from_entry`, `categories_losing_per_day`) — Tk-frei und voll getestet. Der Tk-Dialog ist nur Wiring (Modus-Toggle, ausklappbares Per-Tag-Grid, Downgrade-Confirm). Ein Sync-Schema-Bump v3→v4 schützt die neue Struktur vor Plättung durch Altclients.
+
+**Tech Stack:** Python 3 (stdlib + `tkinter`), `pytest`. Keine neuen Dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-06-30-kategorie-standardzeiten-tageweise-design.md`
+
+## Global Constraints
+
+- **`mode` fehlt ⇒ „allgemein".** Nur der literale String `"per_day"` aktiviert den tageweise-Pfad; jeder andere/fehlende Wert ist allgemein.
+- **Pause ist EIN Wert pro Kategorie** (top-level `pause`), nie pro Tag.
+- **Per-Feld/-Tag-Fallback:** leeres/fehlendes Feld (Start/Ende/Pause/Tag) → globaler Wochentags-Standard für genau dieses Feld. `pause=0` ist gültig und bleibt erhalten.
+- `category_times` ist **bereits** in `SYNCED_SETTING_KEYS` (`settings.py:11`) — **nicht anfassen**. Die Liste lebt nur in `settings.py`; `sync.py` importiert sie (kein Duplikat).
+- **Nur `sync.SCHEMA_VERSION`** wird gebumpt (3→4). `share.SCHEMA_VERSION` ist ein separates Schema und bleibt 3.
+- `days`-Keys = `WEEKDAY_KEYS` aus `settings.py` (`("mon","tue","wed","thu","fri","sat","sun")`, Index = `datetime.weekday()`).
+- `STANDARD = "(Standard)"` (Sentinel in `category_dialog.py`) markiert „kein eigener Wert"; `_clean_field` macht daraus `None`.
+- CI (`test.yml`) installiert nur `pytest`, `holidays==0.99`, google-libs — kein `requirements.txt`. Pure Tests laufen ohne Tk-Display; Tk-Importe sind in der Testumgebung verfügbar (Tests importieren `src.ui`).
+- Commits: englischer Typ (`feat:`/`refactor:`/`test:`), Body deutsch ok; jeder Commit endet mit `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+
+---
+
+## File Structure
+
+- `src/category_defaults.py` — **modify**: `resolve_slot_defaults` bekommt `weekday_key` + per_day-Zweig.
+- `src/dialogs/entry_dialog.py` — **modify**: beide `resolve_slot_defaults`-Aufrufe reichen `weekday_key` durch.
+- `src/dialogs/category_dialog.py` — **modify**: `collect_categories` (mode/days) + **neu** `row_defaults_from_entry`, `categories_losing_per_day` + UI-Wiring.
+- `src/sync.py` — **modify**: `SCHEMA_VERSION = 4`; `migrate_doc_to_v3` → `migrate_doc_to_current`.
+- `src/main.py` — **modify**: 3 Aufrufstellen auf den neuen Funktionsnamen.
+- Tests: `tests/test_category_defaults.py`, `tests/test_category_dialog.py`, `tests/test_sync.py`, `tests/test_storage_migration.py`.
+
+Task-Abhängigkeiten: Task 1, 2, 5 sind unabhängig. Task 3 nutzt `collect_categories` (Task 2). Task 4 ist unabhängig. Task 6 (UI) nutzt Task 2–4.
+
+---
+
+## Task 1: `resolve_slot_defaults` um Wochentag + per_day-Zweig erweitern
+
+**Files:**
+- Modify: `src/category_defaults.py`
+- Modify: `src/dialogs/entry_dialog.py` (zwei Aufrufstellen — sonst bricht der Aufruf)
+- Test: `tests/test_category_defaults.py`
+
+**Interfaces:**
+- Produces: `resolve_slot_defaults(category_times, kategorie, weekday_key, g_start, g_end, g_pause) -> (start, end, pause)`. `weekday_key` ist ein `WEEKDAY_KEYS`-String; im per_day-Modus wählt er `days[weekday_key]`, sonst irrelevant.
+
+- [ ] **Step 1: Bestehende Tests auf die neue Signatur ziehen + per_day-Fälle ergänzen**
+
+In `tests/test_category_defaults.py` die 9 Bestandstests um den `weekday_key`-Parameter erweitern (Wert egal, da sie alle den general-Pfad treffen — `"mon"` einsetzen). Beispiel der Umstellung:
+
+```python
+G = ("08:00", "16:00", 30)  # globale (start, end, pause)
+
+
+def test_unknown_category_falls_back_to_global():
+    assert resolve_slot_defaults({}, "Office", "mon", *G) == ("08:00", "16:00", 30)
+
+
+def test_full_category_overrides_all_fields():
+    times = {"Office": {"start": "09:00", "end": "17:00", "pause": 45}}
+    assert resolve_slot_defaults(times, "Office", "mon", *G) == ("09:00", "17:00", 45)
+```
+
+(Analog für die übrigen 7 Bestandstests: `"mon"` als drittes Argument einfügen.)
+
+Neue per_day-Tests anhängen:
+
+```python
+PD = {
+    "Homeoffice": {
+        "mode": "per_day",
+        "pause": 0,
+        "days": {
+            "mon": {"start": "09:00", "end": "18:00"},
+            "fri": {"start": "09:00", "end": "14:00"},
+        },
+    }
+}
+
+
+def test_per_day_picks_weekday_set():
+    assert resolve_slot_defaults(PD, "Homeoffice", "mon", *G) == ("09:00", "18:00", 0)
+    assert resolve_slot_defaults(PD, "Homeoffice", "fri", *G) == ("09:00", "14:00", 0)
+
+
+def test_per_day_missing_day_falls_back_to_global():
+    # sat ist nicht in days → globaler Wochentags-Standard, Pause aus top-level
+    assert resolve_slot_defaults(PD, "Homeoffice", "sat", *G) == ("08:00", "16:00", 0)
+
+
+def test_per_day_missing_field_in_day_falls_back():
+    times = {"X": {"mode": "per_day", "days": {"mon": {"start": "07:00"}}}}
+    # end fehlt → global; pause fehlt top-level → global
+    assert resolve_slot_defaults(times, "X", "mon", *G) == ("07:00", "16:00", 30)
+
+
+def test_per_day_corrupt_days_falls_back():
+    assert resolve_slot_defaults({"X": {"mode": "per_day", "days": "kaputt"}},
+                                 "X", "mon", *G) == ("08:00", "16:00", 30)
+    assert resolve_slot_defaults({"X": {"mode": "per_day"}},
+                                 "X", "mon", *G) == ("08:00", "16:00", 30)
+
+
+def test_mode_other_than_per_day_uses_general_path():
+    times = {"X": {"mode": "general", "start": "10:00"}}
+    assert resolve_slot_defaults(times, "X", "mon", *G) == ("10:00", "16:00", 30)
+```
+
+- [ ] **Step 2: Tests laufen lassen — müssen fehlschlagen**
+
+Run: `pytest tests/test_category_defaults.py -v`
+Expected: FAIL — die Bestandstests scheitern an der alten Signatur (zu viele Argumente), die neuen an fehlender per_day-Logik.
+
+- [ ] **Step 3: `resolve_slot_defaults` implementieren**
+
+In `src/category_defaults.py` die Funktion ersetzen:
+
+```python
+def resolve_slot_defaults(category_times, kategorie, weekday_key,
+                          g_start, g_end, g_pause):
+    """(start, end, pause) für einen Slot der Kategorie am gegebenen Wochentag.
+
+    - mode == "per_day": Start/Ende aus days[weekday_key] (Per-Feld-Fallback auf
+      g_start/g_end), Pause aus top-level "pause".
+    - sonst (mode fehlt / != "per_day"): heutiger Ein-Satz-Pfad.
+    Per-Feld-Fallback auf die globalen Werte überall, wo ein Feld leer/None/
+    ungültig oder Kategorie/Tag unbekannt ist. pause=0 bleibt gültig.
+    """
+    entry = category_times.get(kategorie) if isinstance(category_times, dict) else None
+    if not isinstance(entry, dict):
+        return g_start, g_end, g_pause
+
+    if entry.get("mode") == "per_day":
+        days = entry.get("days")
+        day = days.get(weekday_key) if isinstance(days, dict) else None
+        if not isinstance(day, dict):
+            day = {}
+        start = day.get("start") or g_start
+        end = day.get("end") or g_end
+    else:
+        start = entry.get("start") or g_start
+        end = entry.get("end") or g_end
+
+    pause = entry.get("pause")
+    if pause is None or pause == "":
+        pause = g_pause
+    else:
+        try:
+            pause = int(pause)
+        except (TypeError, ValueError):
+            pause = g_pause
+
+    return start, end, pause
+```
+
+- [ ] **Step 4: Tests laufen lassen — müssen bestehen**
+
+Run: `pytest tests/test_category_defaults.py -v`
+Expected: PASS (alle, inkl. der 9 angepassten + 5 neuen).
+
+- [ ] **Step 5: Die zwei Aufrufstellen in `entry_dialog.py` anpassen**
+
+`src/dialogs/entry_dialog.py` — im Ist-Slot (`on_cat_change`, derzeit ~`:123`):
+
+```python
+        def on_cat_change(*_a):
+            t_start, t_end, t_pause = resolve_slot_defaults(
+                category_times, kv.get().strip(), weekday_key,
+                default_start, default_end, default_pause,
+            )
+```
+
+Im Reservierungs-Slot (`on_cat_change`, derzeit ~`:233`):
+
+```python
+            def on_cat_change(*_a):
+                # Reservierungen haben keine Pause → nur Start/Ende anwenden.
+                t_start, t_end, _ = resolve_slot_defaults(
+                    category_times, kv.get().strip(), weekday_key,
+                    default_start, default_end, default_pause,
+                )
+```
+
+(`weekday_key` ist im Funktions-Scope bereits definiert, `entry_dialog.py:48`.)
+
+- [ ] **Step 6: Import-Smoke — entry_dialog lädt mit neuer Signatur**
+
+Run: `python -c "import src.dialogs.entry_dialog"`
+Expected: kein Fehler (keine Ausgabe).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/category_defaults.py src/dialogs/entry_dialog.py tests/test_category_defaults.py
+git commit -m "$(cat <<'EOF'
+feat(category-times): resolve_slot_defaults mit Wochentag + per_day-Zweig
+
+weekday_key wählt im per_day-Modus den Tagessatz; general-Pfad unverändert.
+entry_dialog reicht weekday_key durch.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: `collect_categories` um Modus + Per-Tag-Grid erweitern
+
+**Files:**
+- Modify: `src/dialogs/category_dialog.py`
+- Test: `tests/test_category_dialog.py`
+
+**Interfaces:**
+- Consumes: `_clean_field`, `WEEKDAY_KEYS`, `STANDARD` (bereits im Modul).
+- Produces: `collect_categories(rows) -> (categories, category_times)`. Jede `row` ist `{"name", "mode", "start", "end", "pause", "days"}` mit `days = {tag: {"start","end"}}` (Roh-Strings/STANDARD). `mode` ist `"general"` oder `"per_day"`.
+
+- [ ] **Step 1: Neue Tests für den per_day-Build schreiben**
+
+In `tests/test_category_dialog.py` den `_row`-Helfer um `mode`/`days` erweitern und Tests anhängen. **Bestehende** `_row`-Aufrufe liefern `mode="general"` als Default — die Bestandstests bleiben dadurch gültig:
+
+```python
+def _row(name, start=STANDARD, end=STANDARD, pause=STANDARD,
+         mode="general", days=None):
+    return {"name": name, "start": start, "end": end, "pause": pause,
+            "mode": mode, "days": days or {}}
+
+
+def _pd_days(**kw):
+    """kw wie mon=("09:00","18:00") → {"mon": {"start":..,"end":..}}."""
+    return {k: {"start": v[0], "end": v[1]} for k, v in kw.items()}
+
+
+def test_per_day_row_builds_nested_entry():
+    rows = [_row("Homeoffice", mode="per_day", pause="0",
+                 days=_pd_days(mon=("09:00", "18:00"), fri=("09:00", "14:00")))]
+    cats, times = collect_categories(rows)
+    assert cats == ["Homeoffice"]
+    assert times == {"Homeoffice": {
+        "mode": "per_day", "pause": 0,
+        "days": {"mon": {"start": "09:00", "end": "18:00"},
+                 "fri": {"start": "09:00", "end": "14:00"}},
+    }}
+
+
+def test_per_day_empty_fields_drop_out():
+    rows = [_row("X", mode="per_day",
+                 days=_pd_days(mon=("09:00", STANDARD), tue=(STANDARD, STANDARD)))]
+    _, times = collect_categories(rows)
+    # tue komplett leer entfällt; mon behält nur start
+    assert times == {"X": {"mode": "per_day", "days": {"mon": {"start": "09:00"}}}}
+
+
+def test_per_day_without_any_data_is_dropped():
+    rows = [_row("X", mode="per_day", pause=STANDARD,
+                 days=_pd_days(mon=(STANDARD, STANDARD)))]
+    cats, times = collect_categories(rows)
+    assert cats == ["X"]
+    assert times == {}
+
+
+def test_per_day_with_only_pause_keeps_entry():
+    rows = [_row("X", mode="per_day", pause="45", days={})]
+    _, times = collect_categories(rows)
+    assert times == {"X": {"mode": "per_day", "days": {}, "pause": 45}}
+```
+
+- [ ] **Step 2: Tests laufen lassen — müssen fehlschlagen**
+
+Run: `pytest tests/test_category_dialog.py -v`
+Expected: FAIL — `collect_categories` kennt `mode`/`days` noch nicht (per_day-Tests scheitern; general-Bestandstests bleiben grün).
+
+- [ ] **Step 3: `collect_categories` implementieren**
+
+In `src/dialogs/category_dialog.py` die Funktion ersetzen:
+
+```python
+def collect_categories(rows):
+    """Baut (categories, category_times) aus den Roh-Zeilen.
+
+    rows: [{name, mode, start, end, pause, days}]. mode "per_day" → verschachtelter
+    Eintrag {mode, pause?, days:{tag:{start?,end?}}}; sonst flacher {start?,end?,pause?}.
+    STANDARD/leere Felder entfallen → Per-Feld-Fallback. Leerer Eintrag entfällt ganz.
+    Namen getrimmt, ohne Leere, dedupliziert (erstes Vorkommen gewinnt).
+    """
+    categories = []
+    category_times = {}
+    for row in rows:
+        name = (row.get("name") or "").strip()
+        if not name or name in categories:
+            continue
+        categories.append(name)
+        pause = _clean_field(row.get("pause"))
+
+        if row.get("mode") == "per_day":
+            raw_days = row.get("days") or {}
+            days = {}
+            for key in WEEKDAY_KEYS:
+                d = raw_days.get(key) or {}
+                start = _clean_field(d.get("start"))
+                end = _clean_field(d.get("end"))
+                day_entry = {}
+                if start is not None:
+                    day_entry["start"] = start
+                if end is not None:
+                    day_entry["end"] = end
+                if day_entry:
+                    days[key] = day_entry
+            if not days and pause is None:
+                continue  # leerer per_day-Eintrag → komplett global
+            entry = {"mode": "per_day", "days": days}
+            if pause is not None:
+                entry["pause"] = int(pause)
+            category_times[name] = entry
+        else:
+            entry = {}
+            start = _clean_field(row.get("start"))
+            end = _clean_field(row.get("end"))
+            if start is not None:
+                entry["start"] = start
+            if end is not None:
+                entry["end"] = end
+            if pause is not None:
+                entry["pause"] = int(pause)
+            if entry:
+                category_times[name] = entry
+    return categories, category_times
+```
+
+- [ ] **Step 4: Tests laufen lassen — müssen bestehen**
+
+Run: `pytest tests/test_category_dialog.py -v`
+Expected: PASS (alle Bestands- + neue per_day-Tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/dialogs/category_dialog.py tests/test_category_dialog.py
+git commit -m "$(cat <<'EOF'
+feat(category-times): collect_categories baut per_day-Einträge
+
+mode-Zeilen erzeugen verschachtelte {mode, pause?, days}-Struktur; leere
+per_day-Zeilen entfallen. general-Pfad unverändert.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: `row_defaults_from_entry` (Hydration) + Round-Trip-Beweis
+
+**Files:**
+- Modify: `src/dialogs/category_dialog.py`
+- Test: `tests/test_category_dialog.py`
+
+**Interfaces:**
+- Consumes: `collect_categories` (Task 2), `WEEKDAY_KEYS`, `STANDARD`.
+- Produces: `row_defaults_from_entry(entry) -> {"mode","start","end","pause","days"}` (Roh-Strings/STANDARD, alle 7 Tage in `days`). Umkehrung von `collect_categories` pro Zeile.
+
+- [ ] **Step 1: Hydration- und Round-Trip-Tests schreiben**
+
+In `tests/test_category_dialog.py` anhängen (Import um `row_defaults_from_entry` ergänzen):
+
+```python
+from src.dialogs.category_dialog import (
+    STANDARD, collect_categories, row_defaults_from_entry,
+)
+
+
+def test_hydrate_general_entry():
+    r = row_defaults_from_entry({"start": "09:30", "end": "17:00", "pause": 30})
+    assert r["mode"] == "general"
+    assert (r["start"], r["end"], r["pause"]) == ("09:30", "17:00", "30")
+
+
+def test_hydrate_per_day_entry_fills_all_days():
+    e = {"mode": "per_day", "pause": 0,
+         "days": {"mon": {"start": "09:00", "end": "18:00"}}}
+    r = row_defaults_from_entry(e)
+    assert r["mode"] == "per_day"
+    assert r["pause"] == "0"
+    assert r["days"]["mon"] == {"start": "09:00", "end": "18:00"}
+    # nicht gesetzte Tage → STANDARD in beiden Feldern
+    assert r["days"]["sun"] == {"start": STANDARD, "end": STANDARD}
+
+
+def test_hydrate_corrupt_entry_is_general_standard():
+    r = row_defaults_from_entry("kaputt")
+    assert r["mode"] == "general"
+    assert (r["start"], r["end"], r["pause"]) == (STANDARD, STANDARD, STANDARD)
+
+
+def test_roundtrip_preserves_per_day_entry():
+    e = {"mode": "per_day", "pause": 0,
+         "days": {"mon": {"start": "09:00", "end": "18:00"},
+                  "fri": {"start": "09:00", "end": "14:00"}}}
+    cats, times = collect_categories([{"name": "Homeoffice", **row_defaults_from_entry(e)}])
+    assert cats == ["Homeoffice"]
+    assert times == {"Homeoffice": e}
+
+
+def test_roundtrip_preserves_general_entry():
+    e = {"start": "09:30", "end": "17:00", "pause": 30}
+    _, times = collect_categories([{"name": "Office", **row_defaults_from_entry(e)}])
+    assert times == {"Office": e}
+```
+
+- [ ] **Step 2: Tests laufen lassen — müssen fehlschlagen**
+
+Run: `pytest tests/test_category_dialog.py -k "hydrate or roundtrip" -v`
+Expected: FAIL — `row_defaults_from_entry` existiert nicht (ImportError).
+
+- [ ] **Step 3: `row_defaults_from_entry` implementieren**
+
+In `src/dialogs/category_dialog.py` (nach `collect_categories`) einfügen:
+
+```python
+def row_defaults_from_entry(entry):
+    """category_times[name]-Eintrag → Vorbelegungs-Strings einer Dialog-Zeile.
+
+    {mode, start, end, pause, days} mit Roh-Strings/STANDARD; days enthält ALLE 7
+    Tage (ungesetzt → STANDARD). Umkehrung von collect_categories pro Zeile.
+    Defensiv: Nicht-Dict/korrupt → allgemein, alles STANDARD.
+    """
+    if not isinstance(entry, dict):
+        return {"mode": "general", "start": STANDARD, "end": STANDARD,
+                "pause": STANDARD, "days": {}}
+
+    pause = entry.get("pause")
+    pause_str = str(pause) if pause not in (None, "") else STANDARD
+
+    if entry.get("mode") == "per_day":
+        raw_days = entry.get("days") if isinstance(entry.get("days"), dict) else {}
+        days = {}
+        for key in WEEKDAY_KEYS:
+            d = raw_days.get(key) if isinstance(raw_days.get(key), dict) else {}
+            days[key] = {"start": d.get("start") or STANDARD,
+                         "end": d.get("end") or STANDARD}
+        return {"mode": "per_day", "start": STANDARD, "end": STANDARD,
+                "pause": pause_str, "days": days}
+
+    return {"mode": "general",
+            "start": entry.get("start") or STANDARD,
+            "end": entry.get("end") or STANDARD,
+            "pause": pause_str, "days": {}}
+```
+
+- [ ] **Step 4: Tests laufen lassen — müssen bestehen**
+
+Run: `pytest tests/test_category_dialog.py -v`
+Expected: PASS (alle, inkl. Round-Trip).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/dialogs/category_dialog.py tests/test_category_dialog.py
+git commit -m "$(cat <<'EOF'
+feat(category-times): row_defaults_from_entry + Round-Trip-Test
+
+Pure Hydration als Umkehrung von collect_categories; Round-Trip beweist, dass
+Öffnen+Speichern ohne Änderung einen per_day-Eintrag nicht plättet.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: `categories_losing_per_day` (Basis für den Downgrade-Confirm)
+
+**Files:**
+- Modify: `src/dialogs/category_dialog.py`
+- Test: `tests/test_category_dialog.py`
+
+**Interfaces:**
+- Consumes: `_clean_field`, `WEEKDAY_KEYS`.
+- Produces: `categories_losing_per_day(rows) -> [name, ...]` — Namen der `general`-Zeilen, die noch gesetzte (versteckte) `days`-Felder tragen.
+
+- [ ] **Step 1: Tests schreiben**
+
+In `tests/test_category_dialog.py` anhängen (Import ergänzen):
+
+```python
+from src.dialogs.category_dialog import categories_losing_per_day
+
+
+def test_losing_general_row_with_hidden_days():
+    rows = [_row("X", mode="general",
+                 days=_pd_days(mon=("09:00", "18:00")))]
+    assert categories_losing_per_day(rows) == ["X"]
+
+
+def test_not_losing_general_row_without_days():
+    rows = [_row("X", mode="general")]
+    assert categories_losing_per_day(rows) == []
+
+
+def test_not_losing_active_per_day_row():
+    rows = [_row("X", mode="per_day",
+                 days=_pd_days(mon=("09:00", "18:00")))]
+    assert categories_losing_per_day(rows) == []
+```
+
+- [ ] **Step 2: Tests laufen lassen — müssen fehlschlagen**
+
+Run: `pytest tests/test_category_dialog.py -k losing -v`
+Expected: FAIL — Funktion existiert nicht.
+
+- [ ] **Step 3: Implementieren**
+
+In `src/dialogs/category_dialog.py` einfügen:
+
+```python
+def categories_losing_per_day(rows):
+    """Namen der Zeilen im Modus 'general', die noch >=1 gesetztes (Nicht-
+    STANDARD-)Tagesfeld in 'days' tragen — d.h. versteckte per_day-Daten, die ein
+    Save als allgemein verwerfen würde. Basis für den Downgrade-Confirm."""
+    losing = []
+    for row in rows:
+        name = (row.get("name") or "").strip()
+        if not name or row.get("mode") == "per_day":
+            continue
+        raw_days = row.get("days") or {}
+        for key in WEEKDAY_KEYS:
+            d = raw_days.get(key) or {}
+            if _clean_field(d.get("start")) is not None or _clean_field(d.get("end")) is not None:
+                losing.append(name)
+                break
+    return losing
+```
+
+- [ ] **Step 4: Tests laufen lassen — müssen bestehen**
+
+Run: `pytest tests/test_category_dialog.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/dialogs/category_dialog.py tests/test_category_dialog.py
+git commit -m "$(cat <<'EOF'
+feat(category-times): categories_losing_per_day für Downgrade-Confirm
+
+Pure Logik: welche general-Zeilen tragen noch versteckte Tagesdaten.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Sync-Schema-Bump v3 → v4
+
+**Files:**
+- Modify: `src/sync.py` (`SCHEMA_VERSION`, `migrate_doc_to_v3` → `migrate_doc_to_current`)
+- Modify: `src/main.py` (3 Aufrufstellen)
+- Test: `tests/test_sync.py`, `tests/test_storage_migration.py`
+
+**Interfaces:**
+- Produces: `migrate_doc_to_current(remote_doc)` (vormals `migrate_doc_to_v3`), Verhalten unverändert; `SCHEMA_VERSION == 4`.
+
+- [ ] **Step 1: Alle Verwender von `migrate_doc_to_v3` und `== 3` auflisten**
+
+Run: `git grep -n "migrate_doc_to_v3\|schema_version\"\] == 3\|SCHEMA_VERSION == 3"`
+Expected: Treffer in `src/sync.py` (def), `src/main.py` (3×), `tests/test_sync.py`, `tests/test_storage_migration.py`. Diese Liste ist die Arbeitsgrundlage für Step 3–4.
+
+- [ ] **Step 2: Tests anpassen (rot)**
+
+`tests/test_sync.py`:
+- Import (`~:658`): `migrate_doc_to_v3` → `migrate_doc_to_current`.
+- `test_migrate_doc_to_v3_wraps_flat_entries` → umbenennen `test_migrate_doc_to_current_wraps_flat_entries`; Aufruf `migrate_doc_to_current(doc)`; `assert out["schema_version"] == 4`.
+- `test_migrate_doc_to_v3_is_idempotent_on_v3` → `test_migrate_doc_to_current_is_idempotent`; Aufruf umbenennen; `assert out["schema_version"] == 4`.
+- `~:293` und `~:808`: `assert ...["schema_version"] == 3` → `== 4`.
+- `test_remote_is_newer` (`~:662`): unverändert lassen — nutzt `SCHEMA_VERSION ± 1`/absolute `2`, bleibt korrekt bei 4.
+
+`tests/test_storage_migration.py`:
+- `~:135`: `assert SCHEMA_VERSION == 3` → `== 4`.
+- `~:136`: `assert doc["schema_version"] == 3` → `== 4`.
+
+Run: `pytest tests/test_sync.py tests/test_storage_migration.py -v`
+Expected: FAIL (Name `migrate_doc_to_current` fehlt, `SCHEMA_VERSION` ist noch 3).
+
+- [ ] **Step 3: `sync.py` ändern**
+
+`SCHEMA_VERSION` (`~:24`):
+
+```python
+SCHEMA_VERSION = 4
+```
+
+Funktion umbenennen + Docstring anpassen (Body bleibt — `schema_version` wird über `SCHEMA_VERSION` automatisch 4):
+
+```python
+def migrate_doc_to_current(remote_doc):
+    """Migriert ein älteres Sync-Doc auf das aktuelle Schema (v4): flache Einträge
+    (start/end/pause) werden in eine Slot-Liste gewrappt. Idempotent — Einträge mit
+    `slots` bleiben unangetastet; Tombstones bekommen eine leere Slot-Liste.
+    settings/conflicts/meta bleiben unberührt (per_day-category_times ist additiv in
+    den Settings und braucht keine Doc-Migration).
+
+    Damit absorbiert ein aktueller Client ein älteres (v1–v3) Remote-Doc und zieht es
+    hoch, statt es abzuweisen oder beim Push zu plätten."""
+    entries = remote_doc.get("entries") or {}
+    migrated = {}
+    for date, entry in entries.items():
+        if not isinstance(entry, dict):
+            continue
+        if "slots" in entry:
+            migrated[date] = entry
+            continue
+        if entry.get("deleted"):
+            slots = []
+        else:
+            slots = [{
+                "start": entry.get("start"),
+                "end": entry.get("end"),
+                "pause": entry.get("pause", 0),
+                "kategorie": "",
+            }]
+        migrated[date] = {
+            "slots": slots,
+            "modified_at": entry.get("modified_at"),
+            "device_id": entry.get("device_id"),
+            "deleted": bool(entry.get("deleted", False)),
+        }
+    return {**remote_doc, "schema_version": SCHEMA_VERSION, "entries": migrated}
+```
+
+(`_remote_is_newer` und `NEWER_REMOTE_VERSION_MSG` bleiben **unverändert** — sie greifen über `SCHEMA_VERSION` automatisch für v4.)
+
+- [ ] **Step 4: `main.py` — 3 Aufrufstellen umbenennen**
+
+In `src/main.py` an den drei Stellen (`~:97`, `~:150`, `~:214`):
+
+```python
+            remote_doc = sync.migrate_doc_to_current(remote_doc)
+```
+
+(jeweils `migrate_doc_to_v3` → `migrate_doc_to_current`.)
+
+- [ ] **Step 5: Tests laufen lassen — müssen bestehen**
+
+Run: `pytest tests/test_sync.py tests/test_storage_migration.py -v`
+Expected: PASS.
+
+- [ ] **Step 6: Sicherstellen, dass kein `migrate_doc_to_v3` mehr existiert**
+
+Run: `git grep -n "migrate_doc_to_v3"`
+Expected: keine Treffer.
+
+- [ ] **Step 7: Import-Smoke main.py**
+
+Run: `python -c "import src.main"`
+Expected: kein Fehler.
+
+- [ ] **Step 8: Settings-Roundtrip-Smoke (per_day-Dict lädt/speichert unverändert)**
+
+In `tests/test_settings.py` ergänzen (Import von `Settings` aus `src.settings` ist dort vorhanden):
+
+```python
+def test_per_day_category_times_roundtrips(tmp_path):
+    path = str(tmp_path / "settings.json")
+    s = Settings(path)
+    pd = {"Homeoffice": {"mode": "per_day", "pause": 0,
+                         "days": {"mon": {"start": "09:00", "end": "18:00"}}}}
+    s.set_synced("category_times", pd)
+    # frisch laden → verschachtelte Struktur kommt unverändert zurück (Dict-Passthrough)
+    assert Settings(path).get("category_times") == pd
+```
+
+Run: `pytest tests/test_settings.py::test_per_day_category_times_roundtrips -v`
+Expected: PASS (zeigt: `_coerce`/`_load` lassen den per_day-Dict als Ganzes durch).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/sync.py src/main.py tests/test_sync.py tests/test_storage_migration.py tests/test_settings.py
+git commit -m "$(cat <<'EOF'
+feat(sync): SCHEMA_VERSION 3->4 als Forward-Compat-Guard (#84)
+
+Schützt die neue per_day-category_times-Struktur: Altclients (v3) brechen
+Pull/Push/Compaction via _remote_is_newer sauber ab, statt sie zu plätten.
+migrate_doc_to_v3 -> migrate_doc_to_current (Verhalten unverändert).
+Settings-Roundtrip-Smoke: per_day-Dict lädt/speichert unverändert.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: UI-Wiring im Kategorien-Dialog (Modus-Toggle, Per-Tag-Grid, Confirm)
+
+**Files:**
+- Modify: `src/dialogs/category_dialog.py` (`open_category_dialog` + `add_row` + `on_save`)
+
+**Interfaces:**
+- Consumes: `row_defaults_from_entry` (Task 3), `collect_categories` (Task 2), `categories_losing_per_day` (Task 4), `themed_askyesno` (aus `src.theme`).
+
+Reines Tk-Wiring — die verlustkritische Logik ist in Task 2–4 pure getestet. Kein Unit-Test (Wiring); Verify ist manuell (Step 7). Der bestehende read-only „Pro Tag ▶"-Toggle der Referenzzeile (`category_dialog.py:135–162`) ist die Vorlage für das ausklappbare Grid.
+
+- [ ] **Step 1: `themed_askyesno` importieren**
+
+In `src/dialogs/category_dialog.py` den `from src.theme import (...)`-Block um `themed_askyesno` ergänzen (alphabetisch einsortiert).
+
+- [ ] **Step 2: `add_row` auf Modus-Toggle + Per-Tag-Grid umbauen**
+
+`add_row` nimmt künftig einen vorbereiteten `defaults`-Dict (aus `row_defaults_from_entry`) statt einzelner Argumente. Aufbau pro Zeile:
+
+- Name-Entry (wie bisher).
+- **Modus-Combo** `dark_combo` mit Werten `["Allgemein", "Tageweise"]`, gemappt auf `general`/`per_day`. StringVar `mode_var`.
+- **General-Felder** (Start–Ende-Combos) in einem eigenen Frame `general_frame`.
+- **Pause-Combo** (immer sichtbar, eine pro Zeile).
+- **Per-Tag-Grid** in einem eigenen Frame `day_frame` (7 Zeilen Mo–So, je zwei `dark_combo` Start/Ende), vorbefüllt aus `defaults["days"]`. Die 14 StringVars in `day_vars[tag] = {"start": sv, "end": ev}` halten.
+- `×`-Button (wie bisher).
+
+**Layout:** Die Hauptzeile (`row`) trägt fix `[Name] [Modus] [general_frame] [Pause] [×]`
+nebeneinander (`side=tk.LEFT`). `general_frame` enthält die Start–Ende-Combos; im
+per_day-Modus wird es per `pack_forget()` ausgeblendet und stattdessen `day_frame` (das
+7-Tage-Grid) **unter** der Zeile gezeigt. `day_frame` wird in einem die Zeile umgebenden
+Container nach `row` eingehängt (analog zum bestehenden `daygrid`-Toggle, das per
+`pack(after=std_row, ...)` einklappt, `category_dialog.py:152–162`).
+
+Sichtbarkeit nach `mode_var` (verstecken, **nie** zerstören):
+
+```python
+        def _apply_mode(*_a):
+            if mode_var.get() == "Tageweise":
+                general_frame.pack_forget()
+                day_frame.pack(after=row, anchor="w", pady=(0, 4))
+            else:
+                day_frame.pack_forget()
+                # general_frame wieder an seine Stelle in der Zeile, vor der
+                # Pause-Combo — dieselben pack-Optionen wie beim Erstaufbau:
+                general_frame.pack(in_=row, side=tk.LEFT, padx=2, before=pause_combo)
+
+        mode_combo.bind("<<ComboboxSelected>>", _apply_mode)
+```
+
+`record` trägt alle vom Save gelesenen Vars (Schlüssel **identisch** zu den `on_save`-
+Zugriffen `r["..."]`):
+
+```python
+        record = {"frame": row, "name": nv, "mode": mode_var,
+                  "start": start_var, "end": end_var, "pause": pause_var,
+                  "days": day_vars}
+```
+
+**Spiegelung beim Wechsel auf Tageweise** (nur wenn das Grid noch komplett STANDARD ist, damit ein erneuter Toggle bestehende Tageswerte nicht überschreibt):
+
+```python
+            if mode_var.get() == "Tageweise" and _grid_all_standard(day_vars):
+                for tag in WEEKDAY_KEYS:
+                    day_vars[tag]["start"].set(start_var.get())
+                    day_vars[tag]["end"].set(end_var.get())
+```
+
+**Rückschaltung auf Allgemein:** general-Combo mit dem Montags-Satz vorbefüllen, falls sie noch STANDARD ist:
+
+```python
+            if mode_var.get() == "Allgemein" and start_var.get() == STANDARD:
+                mon = day_vars["mon"]
+                if mon["start"].get() != STANDARD:
+                    start_var.set(mon["start"].get())
+                if mon["end"].get() != STANDARD:
+                    end_var.set(mon["end"].get())
+```
+
+`record` hält jetzt zusätzlich `mode_var` und `day_vars`, damit `on_save` die Zeile vollständig auslesen kann. Initialen Modus aus `defaults["mode"]` setzen, **danach** `_apply_mode()` einmal direkt rufen (Sichtbarkeit herstellen) — `<<ComboboxSelected>>` feuert bei programmatischem `.set()` nicht.
+
+- [ ] **Step 3: Hydration beim Laden auf `row_defaults_from_entry` umstellen**
+
+Die Lade-Schleife (`category_dialog.py:185–194`) ersetzen:
+
+```python
+    if categories:
+        for c in categories:
+            add_row(c, row_defaults_from_entry(category_times.get(c) or {}))
+    else:
+        add_row("", row_defaults_from_entry({}))
+```
+
+(Die `+ Kategorie`-Schaltfläche ruft `add_row("", row_defaults_from_entry({}))`.)
+
+- [ ] **Step 4: `on_save` — Roh-Dicts inkl. mode/days + Downgrade-Confirm**
+
+```python
+    def on_save():
+        raw = []
+        for r in rows:
+            raw.append({
+                "name": r["name"].get(),
+                "mode": "per_day" if r["mode"].get() == "Tageweise" else "general",
+                "start": r["start"].get(),
+                "end": r["end"].get(),
+                "pause": r["pause"].get(),
+                "days": {tag: {"start": v["start"].get(), "end": v["end"].get()}
+                         for tag, v in r["days"].items()},
+            })
+
+        losing = categories_losing_per_day(raw)
+        if losing:
+            names = ", ".join(losing)
+            if not themed_askyesno(
+                dialog, "Tageszeiten verwerfen?",
+                f"Für {names} gehen die tageweise gesetzten Zeiten verloren, "
+                "wenn als „Allgemein" gespeichert wird.\n\nTrotzdem speichern?",
+            ):
+                return
+
+        cats, times = collect_categories(raw)
+        settings.set_synced("categories", cats)
+        settings.set_synced("category_times", times)
+        if on_change is not None:
+            on_change()
+        dialog.destroy()
+```
+
+- [ ] **Step 5: `_grid_all_standard`-Helfer ergänzen** (lokal in `open_category_dialog` oder Modulebene)
+
+```python
+def _grid_all_standard(day_vars):
+    return all(v["start"].get() == STANDARD and v["end"].get() == STANDARD
+               for v in day_vars.values())
+```
+
+- [ ] **Step 6: Voller Testlauf + Lint + Import-Smoke**
+
+Run: `pytest -q`
+Expected: PASS (alle Tests grün).
+
+Run: `ruff check .`
+Expected: keine neuen Findings (`category_dialog.py`, `category_defaults.py`, `sync.py`, `main.py`, `entry_dialog.py`).
+
+Run: `python -c "import src.dialogs.category_dialog"`
+Expected: kein Fehler.
+
+- [ ] **Step 7: Manueller Verify — der echte Verhaltenstest**
+
+Run: `python -m src.main`
+
+1. Kategorien verwalten öffnen → `Homeoffice` auf **Tageweise** stellen → Grid klappt auf, mit gespiegelten Werten vorbefüllt.
+2. Mo–Do `09:00–18:00`, Fr `09:00–14:00`, Sa/So leer lassen → **Speichern**.
+3. `settings.json` prüfen: `category_times["Homeoffice"]` hat `mode:"per_day"`, `days` mit mon–fri, `pause`. `Office_1` unverändert flach.
+4. Tages-Dialog an einem **Montag** öffnen → „+ Slot" → `Homeoffice` wählen → Felder `09:00–18:00`. An einem **Freitag** → `09:00–14:00`. An einem **Samstag** → globaler Standard `08:00–16:00`.
+5. Kategorien-Dialog → `Homeoffice` zurück auf **Allgemein** → **Speichern** → **Confirm** erscheint mit „Homeoffice".
+
+Erwartetes Ergebnis: alle Schritte wie beschrieben.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/dialogs/category_dialog.py
+git commit -m "$(cat <<'EOF'
+feat(category-times): Kategorien-Dialog mit Modus-Toggle + Per-Tag-Grid (#84)
+
+Modus-Umschalter pro Zeile, ausklappbares 7-Tage-Grid (verstecken statt
+zerstören), Hydration via row_defaults_from_entry, Downgrade-Confirm beim
+Speichern. Verlustkritische Logik ist pure getestet.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: CHANGELOG-Eintrag
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Eintrag ergänzen** (Stil/Sektion an die bestehende `CHANGELOG.md` anpassen)
+
+```markdown
+- Standardzeiten pro Kategorie wahlweise tageweise (pro Wochentag) statt nur
+  allgemein konfigurierbar (#84).
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "$(cat <<'EOF'
+docs(changelog): tageweise Kategorie-Standardzeiten (#84)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+> **Release-Mechanik (nicht Teil dieses Plans):** `src/version.py`-Bump + `release:*`-Label am PR steuern den Release-Workflow (siehe Projekt-`CLAUDE.md`). Gehört in den Release-PR, nicht in die Feature-Tasks.
+
+---
+
+## Notizen für die Ausführung
+
+- **Reihenfolge:** Task 1 → 2 → 3 → 4 → 5 → 6 → 7. Task 5 (Sync) ist unabhängig und könnte vorgezogen werden; Task 6 braucht Task 2–4.
+- **Datenmodell-Invariante:** `mode` wird bei „allgemein" **nicht** geschrieben (Bestandseinträge bleiben byte-stabil). Nie `"mode":"general"` persistieren.
+- **Kein Anfassen** von `SYNCED_SETTING_KEYS` (schon korrekt) und `share.SCHEMA_VERSION` (bleibt 3).
+- Bei Tk-Eigenheiten (pack-Reihenfolge, `<<ComboboxSelected>>` feuert nicht bei `.set()`) den bestehenden `category_dialog.py`/`entry_dialog.py`-Stil spiegeln.

--- a/docs/superpowers/specs/2026-06-30-kategorie-standardzeiten-tageweise-design.md
+++ b/docs/superpowers/specs/2026-06-30-kategorie-standardzeiten-tageweise-design.md
@@ -1,0 +1,287 @@
+# Standardzeiten pro Kategorie wahlweise tageweise (pro Wochentag)
+
+**Datum:** 2026-06-30
+**Issue:** #84
+**Baut auf:** `2026-06-21-kategorie-standardzeiten-design.md` (Ein-Satz-Override pro
+Kategorie) und `2026-05-08-per-weekday-default-times-design.md` (globale Defaults
+pro Wochentag).
+
+## Ziel
+
+Pro Kategorie soll der Standardzeiten-Override **wahlweise** sein:
+
+- **Allgemein** (Default, heutiges Verhalten): ein Satz `{start, end, pause}` für die
+  ganze Kategorie. Unverändert abwärtskompatibel.
+- **Tageweise**: Start/Ende **pro Wochentag** Mo–So, analog zu den globalen
+  Standardzeiten. Die **Pause bleibt ein Wert** pro Kategorie (nicht pro Tag —
+  symmetrisch zur globalen `default_pause`, die bewusst nicht pro Tag ist).
+
+Der Per-Feld-Fallback auf die globalen (bereits pro Wochentag bestimmten) Defaults
+bleibt in beiden Modi erhalten. Der Modus wird **pro Kategorie** umgeschaltet.
+
+Begründung: Die globalen Defaults sind schon pro Wochentag (langer Montag, kurzer
+Freitag, Sa/So 0 h). Eine Kategorie mit eigenem Override muss diese Tagesstruktur
+aktuell auf einen Satz kollabieren — das passt nicht für Kategorien mit eigenem
+Wochenrhythmus. Diese Erweiterung zieht die schon global existierende
+Per-Wochentag-Granularität auf die Kategorie-Ebene nach. Die Spec von 2026-06-21 hat
+das explizit als YAGNI ausgeschlossen; dieses Issue holt es als konkreten Bedarf nach.
+
+## Datenmodell
+
+Der bestehende synchronisierte Settings-Key `category_times` (Dict) bleibt, bekommt
+aber **zwei mögliche Eintrags-Formen**, unterschieden am `mode`-Key:
+
+```jsonc
+"category_times": {
+  // Allgemein (= heute, unverändert): KEIN mode-Key
+  "Office_1": { "start": "09:30", "end": "17:00", "pause": 30 },
+
+  // Tageweise: mode-Flag + days-Dict; Pause ist EIN Wert (top-level)
+  "Homeoffice": {
+    "mode": "per_day",
+    "pause": 0,
+    "days": {
+      "mon": { "start": "09:00", "end": "18:00" },
+      "tue": { "start": "09:00", "end": "18:00" },
+      "wed": { "start": "09:00", "end": "18:00" },
+      "thu": { "start": "09:00", "end": "18:00" },
+      "fri": { "start": "09:00", "end": "14:00" }
+      // fehlende Tage (sat/sun) → Fallback auf globalen Wochentags-Standard
+      // fehlendes Feld innerhalb eines Tages → Per-Feld-Fallback auf global
+    }
+  }
+}
+```
+
+**Regeln:**
+
+- **`mode` fehlt ⇒ „allgemein".** Nur der literale String `"per_day"` aktiviert den
+  tageweise-Pfad; jeder andere/fehlende Wert ist allgemein. Das ist die **gesamte**
+  Abwärtskompatibilität: Bestandseinträge tragen kein `mode` und werden ohne jede
+  Transformation weiter als allgemein interpretiert.
+- **Per-Feld/-Tag-Fallback:** Fehlt im tageweise-Modus ein Tag in `days` oder ein
+  Start/Ende innerhalb eines Tages, gilt der globale Wochentags-Standard für genau
+  dieses Feld. `pause` fehlt/leer → globale `default_pause`.
+- `days`-Keys sind `WEEKDAY_KEYS` (`mon`…`sun`, Index = `datetime.weekday()`).
+- `DEFAULTS["category_times"]` bleibt `{}`.
+- `category_times` ist **bereits** in `SYNCED_SETTING_KEYS` (`settings.py:11`) — für
+  #84 ist an der Whitelist **nichts** zu tun. Die Liste lebt **nur** in `settings.py`;
+  `sync.py` **importiert** sie (Single Source of Truth, Issue #48 — kein Duplikat,
+  `sync.py:16–21`). LWW-Merge behandelt den Dict-Wert weiter als Ganzes.
+
+**Kein Lade-Migrationscode nötig.** `Settings._load` → `_coerce` lässt Dict-Werte
+unverändert durch (verifiziert in `settings.py:62–83`, der Dict-Default-Pfad castet
+nicht). Die innere Struktur von `category_times` wird also unverändert geladen und
+gespeichert — Migration ist reine *Interpretations*-Logik in `resolve_slot_defaults`,
+keine Daten-*Transformation* beim Laden.
+
+## Pure Logik
+
+### `src/category_defaults.py::resolve_slot_defaults`
+
+Neuer Parameter `weekday_key` (der Aufrufer kennt ihn bereits):
+
+```python
+def resolve_slot_defaults(category_times, kategorie, weekday_key,
+                          g_start, g_end, g_pause):
+    """(start, end, pause) für einen Slot der Kategorie am gegebenen Wochentag.
+
+    - mode == "per_day": Start/Ende aus days[weekday_key] (Per-Feld-Fallback auf
+      g_start/g_end), Pause aus top-level "pause" (Fallback g_pause).
+    - sonst (mode fehlt / != "per_day"): heutiger Ein-Satz-Pfad, bit-identisch.
+    Per-Feld-Fallback auf die globalen Werte überall, wo ein Feld leer/None/ungültig
+    oder die Kategorie/der Tag unbekannt ist. pause=0 bleibt gültig.
+    """
+```
+
+- `g_start/g_end` sind weiterhin die schon **wochentags-aufgelösten** Globalwerte, die
+  `entry_dialog` aus `default_start_{weekday_key}` reinreicht. `weekday_key` dient
+  hier ausschließlich dazu, den richtigen Tagessatz **innerhalb der Kategorie** zu
+  wählen.
+- Der allgemein-Zweig bleibt verhaltensgleich zu heute; die 9 Bestandstests prüfen
+  weiter dieselben Ergebnisse (nur der zusätzliche Parameter wird in den Aufrufen
+  ergänzt).
+- Defensiv: ist `days` kein Dict oder `days[weekday_key]` kein Dict → kompletter
+  Fallback auf die Globalwerte (kein Crash bei korruptem Eintrag).
+
+### `src/dialogs/category_dialog.py::collect_categories`
+
+Liest pro Zeile zusätzlich den Modus und (bei tageweise) das 7-Tage-Grid:
+
+```python
+# rows-Eintrag (Roh-Strings der Widgets):
+{
+  "name": str,
+  "mode": "general" | "per_day",
+  "start": str, "end": str,          # allgemein-Felder
+  "pause": str,                       # in beiden Modi (eine Pause-Combo)
+  "days": {"mon": {"start": str, "end": str}, ...},  # nur tageweise
+}
+```
+
+- **allgemein:** wie heute — `{start?, end?, pause?}`, STANDARD/leer entfällt.
+- **tageweise:** `{mode:"per_day", pause?, days:{tag:{start?,end?}}}`. In `days`
+  landen nur Tage mit mindestens einem gesetzten (Nicht-STANDARD-)Feld; leere Felder
+  entfallen → Per-Feld-Fallback.
+- **Leerer Eintrag entfällt** (komplett globaler Fallback): allgemein mit allen drei
+  Feldern STANDARD **oder** tageweise ohne ein einziges gesetztes Tagesfeld und ohne
+  Pause → kein `category_times`-Eintrag für diese Kategorie. Hält das Dict schlank,
+  konsistent zum heutigen Verhalten.
+- Namen weiter getrimmt, ohne Leere, dedupliziert (erstes Vorkommen gewinnt).
+
+### `src/dialogs/category_dialog.py::row_defaults_from_entry` (neu, pure)
+
+Umkehrung von `collect_categories` **pro Zeile**: ein `category_times[name]`-Eintrag →
+die Vorbelegungs-Strings einer Dialog-Zeile. Heute liegt diese Hydration inline und
+liest nur flache Felder (`category_dialog.py:185–194`); für `per_day` muss sie Modus,
+Pause **und** alle `days` korrekt zurück in die Widgets bringen.
+
+```python
+def row_defaults_from_entry(entry):
+    """category_times[name]-Eintrag → {mode, start, end, pause, days} (Roh-Strings/
+    STANDARD) zur Widget-Vorbelegung. Fehlende Felder → STANDARD. Defensiv gegen
+    Nicht-Dict / korrupte Struktur (→ allgemein, alles STANDARD)."""
+```
+
+Damit wird der **Round-Trip** Tk-frei prüfbar: ein persistierter Eintrag, durch
+`row_defaults_from_entry` hydriert und unverändert durch `collect_categories` zurück,
+muss **bit-identisch** wieder herauskommen (Schutz gegen die Plättung beim No-op-Save).
+Der Tk-Teil im Dialog ist dann nur noch: Helfer aufrufen → Werte in StringVars/Grid
+gießen.
+
+### `src/dialogs/category_dialog.py::categories_losing_per_day` (neu, pure)
+
+Entscheidet Tk-frei, welche Kategorien beim Speichern Tagesdaten verlören (Basis für
+den Downgrade-Confirm, Finding #84):
+
+```python
+def categories_losing_per_day(rows):
+    """Namen der Zeilen, die im Modus 'general' stehen, aber noch >=1 gesetztes
+    (Nicht-STANDARD-)Tagesfeld in 'days' tragen (= versteckte per_day-Daten, die
+    ein Save als allgemein verwerfen würde). Leere Liste → kein Verlust."""
+```
+
+Greift, weil der Toggle die `days`-Widgets nur versteckt (StringVars bleiben); eine
+frische allgemein-Kategorie hat keine gesetzten `days` → löst nicht aus.
+
+## Entry-Dialog (`src/dialogs/entry_dialog.py`)
+
+`weekday_key` ist bereits vorhanden (`:48`). Beide `resolve_slot_defaults`-Aufrufe
+(`:123` Ist-Slot, `:233` Reservierungs-Slot) reichen ihn zusätzlich durch. Sonst
+**keine** Änderung — der `<<ComboboxSelected>>`-Trigger und das Basis-/Manuell-Modell
+bleiben unverändert. Reservierungen nutzen weiter nur Start/Ende (keine Pause).
+
+## UI — Kategorien-Dialog (`src/dialogs/category_dialog.py`)
+
+Pro Kategorie-Zeile ein Modus-Umschalter. Im tageweise-Modus klappt — analog zum
+**bereits existierenden** „Pro Tag ▶"-Toggle der globalen Referenzzeile
+(`category_dialog.py:135–162`, dort read-only) — ein **editierbares** 7-Tage-Grid auf.
+Das Fenster passt seine Höhe automatisch an (wie der bestehende Toggle).
+
+```
+Allgemein (heute):
+[Name] [Modus: Allgemein ▾] [Start]–[Ende] [Pause] [×]
+
+Tageweise:
+[Name] [Modus: Tageweise ▾] [Pause] [Pro Tag ▼] [×]
+        Mo [09:00]–[18:00]
+        Di [09:00]–[18:00]
+        …                      (leeres Feld = „(Standard)" → globaler Tageswert)
+        So [(Standard)]–[(Standard)]
+```
+
+- Modus-Umschalter als kleine Combo/Toggle pro Zeile (`Allgemein` / `Tageweise`).
+- Pause bleibt **eine** Combo pro Kategorie, auch tageweise (top-level).
+- Jede Zeit-Combo hat weiter `"(Standard)"` als ersten Eintrag (Per-Feld-Fallback);
+  `TIME_VALUES`/`PAUSE_VALUES` werden nicht global mutiert.
+- **Umschalten allgemein → tageweise:** der eine Satz wird auf alle 7 Tage
+  **gespiegelt** (vorbefüllt), damit der Nutzer von sinnvollen Werten aus editiert
+  statt von leer — analog zur globalen Legacy-Spiegelung
+  (`_migrate_legacy_default_times`).
+- **Umschalten tageweise → allgemein:** die allgemein-Combo wird mit dem
+  **Montags-Satz** vorbefüllt (erster Werktag, vorhersehbar). Die Tages-Widgets werden
+  beim Umschalten **versteckt, nicht zerstört** (`pack_forget`, StringVars bleiben) —
+  Toggle hin-und-zurück innerhalb derselben Dialog-Session verliert also **nichts**.
+  Der Modus bestimmt, was **gespeichert** wird: bei „Allgemein" liest
+  `collect_categories` nur die Start/Ende/Pause-Zeile, die (versteckten) `days` werden
+  **nicht** persistiert. Der Verlust tritt damit erst beim tatsächlichen Speichern im
+  allgemein-Modus ein und wird dort durch den **Downgrade-Confirm** (s.u.,
+  `categories_losing_per_day`) abgefangen. Bewusst **kein** persistentes „inaktiv
+  mitschleppen" im JSON (kein Datenmodell-Change, YAGNI).
+- Speichern liest alle Zeilen-Widgets in Roh-Dicts. **Vor** dem Persistieren prüft
+  `categories_losing_per_day(rows)` (pure, s.u.), ob eine Zeile im **allgemein**-Modus
+  noch gesetzte (versteckte) Tagesfelder trägt — dann gingen beim Speichern Tagesdaten
+  verloren. Ist die Liste nicht leer, fragt ein `themed_askyesno` mit den betroffenen
+  Kategorie-Namen nach; bricht der Nutzer ab, wird **nicht** gespeichert. Danach
+  `collect_categories` → `categories` + `category_times` via `set_synced`.
+
+## Sync-Schema-Version (v3 → v4) — Schutz vor Datenverlust
+
+**Problem (verifiziert, Codex-Review #84):** `category_times` wird als ganzer Dict per
+LWW gemergt. Ohne Gegenmaßnahme würde ein **pre-#84-Client** einen `per_day`-Eintrag
+zwar crashfrei laden (top-level `start`/`end` fehlen → graceful Fallback auf global),
+ihn aber bei einem Edit der Kategorie über sein altes `collect_categories` zu einem
+flachen Eintrag **plätten** und zurücksynchronisieren → **stiller, unwiederbringlicher
+Verlust** der Tagesdaten. Ein neuer Parallel-Key hilft nicht: `sync.merge` iteriert
+über die *lokale* `SYNCED_SETTING_KEYS`-Whitelist (`sync.py:184`); einen Key, den der
+alte Client nicht kennt, lässt er beim Push **ganz weg** (Verlust ohne Edit).
+
+**Lösung:** Den etablierten dokumentweiten Forward-Compat-Guard nutzen.
+
+- **`sync.SCHEMA_VERSION = 3 → 4`** (nur der Sync-Wert; `share.SCHEMA_VERSION` ist ein
+  **separates** Schema und bleibt 3).
+- Damit greift `_remote_is_newer` (`sync.py:322`) automatisch: sobald ein #84-Client
+  ein Doc mit `schema_version 4` gepusht hat, brechen Pull/Push/Compaction auf einem
+  pre-#84-Client (v3) sauber ab (`NEWER_REMOTE_VERSION_MSG`) — **kein Merge, kein
+  Überschreiben**. Der alte Client kann die `per_day`-Daten nicht mehr plätten.
+- **Preis (bewusst akzeptiert):** Bei Versions-Skew pausiert der **gesamte** Sync
+  (auch Entries) auf dem Altgerät, bis es aktualisiert ist — exakt das Verhalten, das
+  schon bei v2→v3 etabliert wurde und das `NEWER_REMOTE_VERSION_MSG` dem Nutzer
+  erklärt. Anders als v2→v3 ist #84 kein *struktureller* Bruch (kein Crash), aber der
+  Guard ist der einzige robuste Schutz gegen den Verlustpfad.
+- **`migrate_doc_to_v3` → `migrate_doc_to_current`** umbenennen (Name wird sonst
+  falsch). Die **entry**-Logik bleibt unverändert (v1/v2 flache Einträge → Slots);
+  ein v3-Doc ist vollständig v4-kompatibel (per_day ist additiv/optional in den
+  Settings), wird also idempotent durchgereicht und nur die `schema_version` auf
+  `SCHEMA_VERSION` (=4) gehoben. **Keine** Settings-Migration im Doc nötig.
+- Alle drei Aufrufstellen (`main.py:97/150/214`) rufen die umbenannte Funktion;
+  `_remote_is_newer`/`NEWER_REMOTE_VERSION_MSG` bleiben unverändert.
+
+## Tests
+
+- `tests/test_category_defaults.py`: Signatur um `weekday_key` ergänzen; neue Fälle:
+  - per_day wählt den richtigen Tagessatz (Mo vs. Fr),
+  - fehlender Tag in `days` → globaler Fallback,
+  - fehlendes Start/Ende innerhalb eines Tages → Per-Feld-Fallback,
+  - `pause` top-level greift / fehlt → globale Pause; `pause=0` bleibt,
+  - `mode` fehlt bzw. `mode != "per_day"` → allgemein-Pfad (Bestandsverhalten),
+  - korruptes `days` / Nicht-Dict-Tag → kompletter Fallback.
+- `tests/test_category_dialog.py`: `collect_categories` baut allgemein **und** per_day:
+  - tageweise mit Teil-Tagen, leeren Feldern, pause top-level,
+  - leerer per_day-Eintrag (keine Tagesfelder, keine Pause) entfällt,
+  - allgemein-Pfad unverändert (Bestandstests bleiben).
+- `tests/test_category_dialog.py`: **Round-Trip Hydration↔Serialisierung** (Finding #84):
+  - `row_defaults_from_entry`: per_day-Eintrag → Modus/Pause/alle days korrekt; flacher
+    Eintrag → allgemein; korrupt/Nicht-Dict → allgemein-STANDARD,
+  - **No-op-Erhalt:** `collect_categories([{"name": n, **row_defaults_from_entry(e)}])`
+    liefert `([n], {n: e})` **bit-identisch** für einen persistierten per_day- **und**
+    einen allgemein-Eintrag — beweist, dass Öffnen+Speichern ohne Änderung nichts plättet.
+  - `categories_losing_per_day`: general-Zeile mit gesetzten `days` → Name in Liste;
+    general-Zeile ohne `days` → leer; per_day-Zeile (Modus aktiv) → leer (kein Verlust).
+- Settings/Sync-Smoke: `category_times` mit `per_day`-Struktur synct/lädt unverändert
+  (Dict bleibt als Ganzes).
+- `tests/test_sync.py` / `tests/test_storage_migration.py`: Schema-Bump v3→v4:
+  - `SCHEMA_VERSION == 4`; auf `3` hartcodierte Asserts auf `4` bzw. besser auf
+    `SCHEMA_VERSION` umstellen (`test_sync.py:293,685,808`, `test_storage_migration.py:135–136`),
+  - `migrate_doc_to_v3`-Tests auf den neuen Namen `migrate_doc_to_current` ziehen;
+    Verhalten unverändert (v1/v2-flach → Slots, v3 idempotent, `schema_version`=4),
+  - `test_remote_is_newer` bleibt grün (relativ via `SCHEMA_VERSION ± 1` formuliert).
+
+## Bewusst nicht enthalten (YAGNI)
+
+- **Pause pro Wochentag** — bleibt ein Wert pro Kategorie (symmetrisch zu global).
+  Bei späterem Bedarf separat nachrüstbar (Issue-Notiz, nicht hier).
+- **Persistentes** Mitschleppen der Tagesdaten im JSON nach Speichern im allgemein-
+  Modus (Session-Retention via „verstecken statt zerstören" **plus** Downgrade-Confirm
+  reichen).
+- Profile (Sommer/Winter, Urlaubsmodus) — wie bei den globalen Defaults.

--- a/src/category_defaults.py
+++ b/src/category_defaults.py
@@ -8,19 +8,30 @@ konfiguriert hat. Rein, ohne Tkinter/IO, daher direkt testbar.
 """
 
 
-def resolve_slot_defaults(category_times, kategorie, g_start, g_end, g_pause):
-    """(start, end, pause) für einen Slot der gegebenen Kategorie.
+def resolve_slot_defaults(category_times, kategorie, weekday_key,
+                          g_start, g_end, g_pause):
+    """(start, end, pause) für einen Slot der Kategorie am gegebenen Wochentag.
 
-    Per-Feld-Fallback auf die globalen Werte (g_start/g_end/g_pause), wenn die
-    Kategorie unbekannt ist, keinen Eintrag hat oder das jeweilige Feld leer
-    bzw. ungültig ist. `pause=0` ist ein gültiger Wert und bleibt erhalten.
+    - mode == "per_day": Start/Ende aus days[weekday_key] (Per-Feld-Fallback auf
+      g_start/g_end), Pause aus top-level "pause".
+    - sonst (mode fehlt / != "per_day"): heutiger Ein-Satz-Pfad.
+    Per-Feld-Fallback auf die globalen Werte überall, wo ein Feld leer/None/
+    ungültig oder Kategorie/Tag unbekannt ist. pause=0 bleibt gültig.
     """
     entry = category_times.get(kategorie) if isinstance(category_times, dict) else None
     if not isinstance(entry, dict):
         return g_start, g_end, g_pause
 
-    start = entry.get("start") or g_start
-    end = entry.get("end") or g_end
+    if entry.get("mode") == "per_day":
+        days = entry.get("days")
+        day = days.get(weekday_key) if isinstance(days, dict) else None
+        if not isinstance(day, dict):
+            day = {}
+        start = day.get("start") or g_start
+        end = day.get("end") or g_end
+    else:
+        start = entry.get("start") or g_start
+        end = entry.get("end") or g_end
 
     pause = entry.get("pause")
     if pause is None or pause == "":

--- a/src/category_defaults.py
+++ b/src/category_defaults.py
@@ -1,10 +1,17 @@
 """Pure Logik für Per-Kategorie-Standardzeiten (Start/Ende/Pause).
 
-`category_times` ist ein Dict `{kategorie: {"start", "end", "pause"}}`, parallel
-zur `categories`-Liste in den Settings. Fehlt eine Kategorie oder ein einzelnes
-Feld (leer/None), gilt der globale Standardwert für genau dieses Feld — so
-bleiben die globalen Standardzeiten wirksam, wenn eine Kategorie nichts
-konfiguriert hat. Rein, ohne Tkinter/IO, daher direkt testbar.
+`category_times` ist ein Dict `{kategorie: <Wert>}`, parallel zur `categories`-Liste.
+`<Wert>` hat zwei Formen:
+
+- **Allgemein** (kein ``mode`` oder ``mode != "per_day"``):
+  ``{"start"?: str, "end"?: str, "pause"?: int}`` — ein Satz für alle Wochentage.
+
+- **Per-Wochentag** (``mode == "per_day"``):
+  ``{"mode": "per_day", "pause"?: int, "days": {<weekday>: {"start"?: str, "end"?: str}}}``
+
+In beiden Formen gilt: Fehlt die Kategorie, ein `days`-Eintrag oder ein einzelnes
+Feld (leer/None), greift der globale Standardwert für genau dieses Feld (Per-Feld-
+Fallback). Rein, ohne Tkinter/IO, daher direkt testbar.
 """
 
 

--- a/src/dialogs/category_dialog.py
+++ b/src/dialogs/category_dialog.py
@@ -82,6 +82,36 @@ def collect_categories(rows):
     return categories, category_times
 
 
+def row_defaults_from_entry(entry):
+    """category_times[name]-Eintrag → Vorbelegungs-Strings einer Dialog-Zeile.
+
+    {mode, start, end, pause, days} mit Roh-Strings/STANDARD; days enthält ALLE 7
+    Tage (ungesetzt → STANDARD). Umkehrung von collect_categories pro Zeile.
+    Defensiv: Nicht-Dict/korrupt → allgemein, alles STANDARD.
+    """
+    if not isinstance(entry, dict):
+        return {"mode": "general", "start": STANDARD, "end": STANDARD,
+                "pause": STANDARD, "days": {}}
+
+    pause = entry.get("pause")
+    pause_str = str(pause) if pause not in (None, "") else STANDARD
+
+    if entry.get("mode") == "per_day":
+        raw_days = entry.get("days") if isinstance(entry.get("days"), dict) else {}
+        days = {}
+        for key in WEEKDAY_KEYS:
+            d = raw_days.get(key) if isinstance(raw_days.get(key), dict) else {}
+            days[key] = {"start": d.get("start") or STANDARD,
+                         "end": d.get("end") or STANDARD}
+        return {"mode": "per_day", "start": STANDARD, "end": STANDARD,
+                "pause": pause_str, "days": days}
+
+    return {"mode": "general",
+            "start": entry.get("start") or STANDARD,
+            "end": entry.get("end") or STANDARD,
+            "pause": pause_str, "days": {}}
+
+
 def open_category_dialog(parent, settings, on_change=None):
     categories = list(settings.get("categories") or [])
     category_times = dict(settings.get("category_times") or {})

--- a/src/dialogs/category_dialog.py
+++ b/src/dialogs/category_dialog.py
@@ -33,14 +33,10 @@ def _clean_field(value):
 def collect_categories(rows):
     """Baut (categories, category_times) aus den Roh-Zeilen.
 
-    `rows` ist eine Liste von Dicts mit den Roh-Strings der Combos/Entries:
-    `{"name", "start", "end", "pause"}`.
-
-    - `categories`: Namen in Eingabereihenfolge, getrimmt, ohne Leere,
-      dedupliziert (erstes Vorkommen gewinnt).
-    - `category_times`: `{name: {start?, end?, pause?}}` nur für Namen mit
-      mindestens einem gesetzten (Nicht-Standard-)Feld. Leere/STANDARD-Felder
-      entfallen → Per-Feld-Fallback auf die globalen Standardzeiten.
+    rows: [{name, mode, start, end, pause, days}]. mode "per_day" → verschachtelter
+    Eintrag {mode, pause?, days:{tag:{start?,end?}}}; sonst flacher {start?,end?,pause?}.
+    STANDARD/leere Felder entfallen → Per-Feld-Fallback. Leerer Eintrag entfällt ganz.
+    Namen getrimmt, ohne Leere, dedupliziert (erstes Vorkommen gewinnt).
     """
     categories = []
     category_times = {}
@@ -49,18 +45,40 @@ def collect_categories(rows):
         if not name or name in categories:
             continue
         categories.append(name)
-        entry = {}
-        start = _clean_field(row.get("start"))
-        end = _clean_field(row.get("end"))
         pause = _clean_field(row.get("pause"))
-        if start is not None:
-            entry["start"] = start
-        if end is not None:
-            entry["end"] = end
-        if pause is not None:
-            entry["pause"] = int(pause)
-        if entry:
+
+        if row.get("mode") == "per_day":
+            raw_days = row.get("days") or {}
+            days = {}
+            for key in WEEKDAY_KEYS:
+                d = raw_days.get(key) or {}
+                start = _clean_field(d.get("start"))
+                end = _clean_field(d.get("end"))
+                day_entry = {}
+                if start is not None:
+                    day_entry["start"] = start
+                if end is not None:
+                    day_entry["end"] = end
+                if day_entry:
+                    days[key] = day_entry
+            if not days and pause is None:
+                continue  # leerer per_day-Eintrag → komplett global
+            entry = {"mode": "per_day", "days": days}
+            if pause is not None:
+                entry["pause"] = int(pause)
             category_times[name] = entry
+        else:
+            entry = {}
+            start = _clean_field(row.get("start"))
+            end = _clean_field(row.get("end"))
+            if start is not None:
+                entry["start"] = start
+            if end is not None:
+                entry["end"] = end
+            if pause is not None:
+                entry["pause"] = int(pause)
+            if entry:
+                category_times[name] = entry
     return categories, category_times
 
 

--- a/src/dialogs/category_dialog.py
+++ b/src/dialogs/category_dialog.py
@@ -198,6 +198,7 @@ def open_category_dialog(parent, settings, on_change=None):
     std_row.pack(fill="x", pady=2)
     for text, w, fg in (
         ("Standard", 15, TEXT_MUTED),
+        ("", 10, TEXT_MUTED),  # Spacer für Modus-Spalte
         (std_start, 11, TEXT),
         (std_end, 13, TEXT),
         (std_pause, 11, TEXT),
@@ -291,7 +292,22 @@ def open_category_dialog(parent, settings, on_change=None):
             dark_combo(day_frame, ev, [STANDARD, *TIME_VALUES], width=11).grid(
                 row=i, column=3, padx=2, pady=1)
 
-        def _apply_mode(*_a):
+        # Toggle-Button für das Tages-Grid (analog zur Referenzzeile _toggle_daygrid).
+        # Anfangs nicht gepackt; _apply_mode steuert Sichtbarkeit.
+        row_toggle_holder = {}
+
+        def _toggle_day_row():
+            if day_frame.winfo_ismapped():
+                day_frame.pack_forget()
+                row_toggle_holder["btn"]._label.config(text="Pro Tag ▶")
+            else:
+                day_frame.pack(after=row, anchor="w", pady=(0, 4))
+                row_toggle_holder["btn"]._label.config(text="Pro Tag ▼")
+
+        row_toggle_holder["btn"] = secondary_button(
+            row, "Pro Tag ▶", _toggle_day_row, padx=8, pady=0)
+
+        def _apply_mode(*_a, expand=True):
             if mode_var.get() == "Tageweise":
                 # Allgemeine Werte ins Grid spiegeln, falls Grid noch leer (STANDARD).
                 if _grid_all_standard(day_vars):
@@ -299,7 +315,13 @@ def open_category_dialog(parent, settings, on_change=None):
                         day_vars[tag]["start"].set(start_var.get())
                         day_vars[tag]["end"].set(end_var.get())
                 general_frame.pack_forget()
-                day_frame.pack(after=row, anchor="w", pady=(0, 4))
+                row_toggle_holder["btn"].pack(side=tk.LEFT, padx=2, before=pause_combo)
+                if expand:
+                    day_frame.pack(after=row, anchor="w", pady=(0, 4))
+                    row_toggle_holder["btn"]._label.config(text="Pro Tag ▼")
+                else:
+                    day_frame.pack_forget()
+                    row_toggle_holder["btn"]._label.config(text="Pro Tag ▶")
             else:
                 # Montags-Werte in general zurückschreiben, falls general noch STANDARD.
                 if start_var.get() == STANDARD:
@@ -309,6 +331,7 @@ def open_category_dialog(parent, settings, on_change=None):
                     if mon["end"].get() != STANDARD:
                         end_var.set(mon["end"].get())
                 day_frame.pack_forget()
+                row_toggle_holder["btn"].pack_forget()
                 general_frame.pack(in_=row, side=tk.LEFT,
                                    padx=2, before=pause_combo)
 
@@ -327,8 +350,9 @@ def open_category_dialog(parent, settings, on_change=None):
 
         # Initialen Modus setzen + Sichtbarkeit herstellen.
         # <<ComboboxSelected>> feuert bei programmatischem .set() NICHT.
+        # expand=False: Tageweise-Grid beim Laden eingeklappt (Fenster kompakt).
         mode_var.set("Tageweise" if defaults["mode"] == "per_day" else "Allgemein")
-        _apply_mode()
+        _apply_mode(expand=False)
 
         mode_combo.bind("<<ComboboxSelected>>", _apply_mode)
 

--- a/src/dialogs/category_dialog.py
+++ b/src/dialogs/category_dialog.py
@@ -15,7 +15,7 @@ from src.theme import (
     BG, FONT, FONT_BOLD, PAUSE_VALUES, TEXT, TEXT_MUTED, TIME_VALUES,
     apply_app_icon, apply_dark_titlebar, attach_unfocus_on_click,
     center_dialog_on_parent, dark_combo, dark_entry, disable_min_max,
-    primary_button, secondary_button,
+    primary_button, secondary_button, themed_askyesno,
 )
 from src.time_utils import DAYS_DE
 
@@ -130,6 +130,14 @@ def row_defaults_from_entry(entry):
             "pause": pause_str, "days": {}}
 
 
+def _grid_all_standard(day_vars):
+    """True wenn alle 7 Tages-Start/Ende-Vars noch den STANDARD-Sentinel halten."""
+    return all(
+        v["start"].get() == STANDARD and v["end"].get() == STANDARD
+        for v in day_vars.values()
+    )
+
+
 def open_category_dialog(parent, settings, on_change=None):
     categories = list(settings.get("categories") or [])
     category_times = dict(settings.get("category_times") or {})
@@ -161,6 +169,8 @@ def open_category_dialog(parent, settings, on_change=None):
     head.pack(fill="x")
     tk.Label(head, text="Name", font=FONT, bg=BG, fg=TEXT_MUTED,
              width=15, anchor="w").pack(side=tk.LEFT, padx=2)
+    tk.Label(head, text="Modus", font=FONT, bg=BG, fg=TEXT_MUTED,
+             width=10, anchor="w").pack(side=tk.LEFT, padx=2)
     tk.Label(head, text="Start", font=FONT, bg=BG, fg=TEXT_MUTED,
              width=11, anchor="w").pack(side=tk.LEFT, padx=2)
     tk.Label(head, text="Ende", font=FONT, bg=BG, fg=TEXT_MUTED,
@@ -227,51 +237,139 @@ def open_category_dialog(parent, settings, on_change=None):
             std_row, "Pro Tag ▶", _toggle_daygrid, padx=8, pady=0)
         toggle_holder["btn"].pack(side=tk.LEFT, padx=2)
 
-    def add_row(name="", start=STANDARD, end=STANDARD, pause=STANDARD):
-        row = tk.Frame(rows_frame, bg=BG)
-        row.pack(fill="x", pady=2)
+    def add_row(name="", defaults=None):
+        if defaults is None:
+            defaults = row_defaults_from_entry({})
+
+        # Container hält row + day_frame als Geschwister (pack-Reihenfolge).
+        container = tk.Frame(rows_frame, bg=BG)
+        container.pack(fill="x", pady=2)
+        row = tk.Frame(container, bg=BG)
+        row.pack(fill="x")
+
+        # StringVars
         nv = tk.StringVar(value=name)
-        sv = tk.StringVar(value=start)
-        ev = tk.StringVar(value=end)
-        pv = tk.StringVar(value=pause)
+        mode_var = tk.StringVar()
+        start_var = tk.StringVar(value=defaults["start"])
+        end_var = tk.StringVar(value=defaults["end"])
+        pause_var = tk.StringVar(value=defaults["pause"])
+
+        # Name-Entry
         dark_entry(row, nv, width=15).pack(side=tk.LEFT, padx=2)
-        dark_combo(row, sv, [STANDARD, *TIME_VALUES], width=11).pack(side=tk.LEFT, padx=2)
-        tk.Label(row, text="–", font=FONT, bg=BG, fg=TEXT_MUTED).pack(side=tk.LEFT)
-        dark_combo(row, ev, [STANDARD, *TIME_VALUES], width=11).pack(side=tk.LEFT, padx=2)
-        dark_combo(row, pv, [STANDARD, *PAUSE_VALUES], width=11).pack(side=tk.LEFT, padx=2)
-        record = {"frame": row, "name": nv, "start": sv, "end": ev, "pause": pv}
+        # Modus-Combo
+        mode_combo = dark_combo(row, mode_var, ["Allgemein", "Tageweise"], width=10)
+        mode_combo.pack(side=tk.LEFT, padx=2)
+
+        # general_frame mit Start–Ende — Sichtbarkeit via _apply_mode
+        general_frame = tk.Frame(row, bg=BG)
+        dark_combo(general_frame, start_var,
+                   [STANDARD, *TIME_VALUES], width=11).pack(side=tk.LEFT, padx=2)
+        tk.Label(general_frame, text="–",
+                 font=FONT, bg=BG, fg=TEXT_MUTED).pack(side=tk.LEFT)
+        dark_combo(general_frame, end_var,
+                   [STANDARD, *TIME_VALUES], width=11).pack(side=tk.LEFT, padx=2)
+
+        # Pause-Combo (immer sichtbar, bleibt in row)
+        pause_combo = dark_combo(row, pause_var, [STANDARD, *PAUSE_VALUES], width=11)
+        pause_combo.pack(side=tk.LEFT, padx=2)
+
+        # 7-Tage-Grid — Sichtbarkeit via _apply_mode
+        day_vars = {}
+        day_frame = tk.Frame(container, bg=BG)
+        for i, (key, lbl) in enumerate(zip(WEEKDAY_KEYS, DAYS_DE)):
+            d = (defaults["days"] or {}).get(key) or {}
+            sv = tk.StringVar(value=d.get("start") or STANDARD)
+            ev = tk.StringVar(value=d.get("end") or STANDARD)
+            day_vars[key] = {"start": sv, "end": ev}
+            tk.Label(day_frame, text=lbl, font=FONT, bg=BG, fg=TEXT,
+                     width=4, anchor="w").grid(row=i, column=0,
+                                               padx=(16, 4), pady=1, sticky="w")
+            dark_combo(day_frame, sv, [STANDARD, *TIME_VALUES], width=11).grid(
+                row=i, column=1, padx=2, pady=1)
+            tk.Label(day_frame, text="–", font=FONT, bg=BG, fg=TEXT_MUTED).grid(
+                row=i, column=2, pady=1)
+            dark_combo(day_frame, ev, [STANDARD, *TIME_VALUES], width=11).grid(
+                row=i, column=3, padx=2, pady=1)
+
+        def _apply_mode(*_a):
+            if mode_var.get() == "Tageweise":
+                # Allgemeine Werte ins Grid spiegeln, falls Grid noch leer (STANDARD).
+                if _grid_all_standard(day_vars):
+                    for tag in WEEKDAY_KEYS:
+                        day_vars[tag]["start"].set(start_var.get())
+                        day_vars[tag]["end"].set(end_var.get())
+                general_frame.pack_forget()
+                day_frame.pack(after=row, anchor="w", pady=(0, 4))
+            else:
+                # Montags-Werte in general zurückschreiben, falls general noch STANDARD.
+                if start_var.get() == STANDARD:
+                    mon = day_vars["mon"]
+                    if mon["start"].get() != STANDARD:
+                        start_var.set(mon["start"].get())
+                    if mon["end"].get() != STANDARD:
+                        end_var.set(mon["end"].get())
+                day_frame.pack_forget()
+                general_frame.pack(in_=row, side=tk.LEFT,
+                                   padx=2, before=pause_combo)
+
+        record = {
+            "frame": row, "name": nv, "mode": mode_var,
+            "start": start_var, "end": end_var, "pause": pause_var,
+            "days": day_vars,
+        }
 
         def remove():
-            row.destroy()
+            container.destroy()
             rows.remove(record)
 
         secondary_button(row, "×", remove, padx=8, pady=0).pack(side=tk.LEFT, padx=2)
         rows.append(record)
 
+        # Initialen Modus setzen + Sichtbarkeit herstellen.
+        # <<ComboboxSelected>> feuert bei programmatischem .set() NICHT.
+        mode_var.set("Tageweise" if defaults["mode"] == "per_day" else "Allgemein")
+        _apply_mode()
+
+        mode_combo.bind("<<ComboboxSelected>>", _apply_mode)
+
     if categories:
         for c in categories:
-            t = category_times.get(c) or {}
-            p = t.get("pause")
-            add_row(
-                c,
-                t.get("start") or STANDARD,
-                t.get("end") or STANDARD,
-                str(p) if p not in (None, "") else STANDARD,
-            )
+            add_row(c, row_defaults_from_entry(category_times.get(c) or {}))
     else:
-        add_row()  # eine leere Startzeile
+        add_row("", row_defaults_from_entry({}))
 
     btns = tk.Frame(outer, bg=BG)
     btns.pack(fill="x", pady=(2, 8))
-    secondary_button(btns, "+ Kategorie", lambda: add_row()).pack(side=tk.LEFT, padx=2)
+    secondary_button(
+        btns, "+ Kategorie",
+        lambda: add_row("", row_defaults_from_entry({})),
+    ).pack(side=tk.LEFT, padx=2)
 
     def on_save():
-        raw = [{
-            "name": r["name"].get(),
-            "start": r["start"].get(),
-            "end": r["end"].get(),
-            "pause": r["pause"].get(),
-        } for r in rows]
+        raw = []
+        for r in rows:
+            raw.append({
+                "name": r["name"].get(),
+                "mode": "per_day" if r["mode"].get() == "Tageweise" else "general",
+                "start": r["start"].get(),
+                "end": r["end"].get(),
+                "pause": r["pause"].get(),
+                "days": {
+                    tag: {"start": v["start"].get(), "end": v["end"].get()}
+                    for tag, v in r["days"].items()
+                },
+            })
+
+        losing = categories_losing_per_day(raw)
+        if losing:
+            names = ", ".join(losing)
+            if not themed_askyesno(
+                dialog, "Tageszeiten verwerfen?",
+                f"Für {names} gehen die tageweise gesetzten Zeiten verloren, "
+                "wenn als „Allgemein“ gespeichert wird.\n\nTrotzdem speichern?",
+            ):
+                return
+
         cats, times = collect_categories(raw)
         settings.set_synced("categories", cats)
         settings.set_synced("category_times", times)

--- a/src/dialogs/category_dialog.py
+++ b/src/dialogs/category_dialog.py
@@ -82,6 +82,24 @@ def collect_categories(rows):
     return categories, category_times
 
 
+def categories_losing_per_day(rows):
+    """Namen der Zeilen im Modus 'general', die noch >=1 gesetztes (Nicht-
+    STANDARD-)Tagesfeld in 'days' tragen — d.h. versteckte per_day-Daten, die ein
+    Save als allgemein verwerfen würde. Basis für den Downgrade-Confirm."""
+    losing = []
+    for row in rows:
+        name = (row.get("name") or "").strip()
+        if not name or row.get("mode") == "per_day":
+            continue
+        raw_days = row.get("days") or {}
+        for key in WEEKDAY_KEYS:
+            d = raw_days.get(key) or {}
+            if _clean_field(d.get("start")) is not None or _clean_field(d.get("end")) is not None:
+                losing.append(name)
+                break
+    return losing
+
+
 def row_defaults_from_entry(entry):
     """category_times[name]-Eintrag → Vorbelegungs-Strings einer Dialog-Zeile.
 

--- a/src/dialogs/entry_dialog.py
+++ b/src/dialogs/entry_dialog.py
@@ -121,7 +121,7 @@ def open_entry_dialog(parent, date_str, storage, settings, on_change,
 
         def on_cat_change(*_a):
             t_start, t_end, t_pause = resolve_slot_defaults(
-                category_times, kv.get().strip(),
+                category_times, kv.get().strip(), weekday_key,
                 default_start, default_end, default_pause,
             )
             t_pause = str(t_pause)
@@ -231,7 +231,7 @@ def open_entry_dialog(parent, date_str, storage, settings, on_change,
             def on_cat_change(*_a):
                 # Reservierungen haben keine Pause → nur Start/Ende anwenden.
                 t_start, t_end, _ = resolve_slot_defaults(
-                    category_times, kv.get().strip(),
+                    category_times, kv.get().strip(), weekday_key,
                     default_start, default_end, default_pause,
                 )
                 if sv.get() == base["start"]:

--- a/src/main.py
+++ b/src/main.py
@@ -93,7 +93,7 @@ def _run_pull_in_background(storage, settings, conflicts_store, base, ui_callbac
             return
         # Älteres Remote (v1/v2) wird aufs aktuelle Schema migriert und normal
         # gemergt (absorb-and-upgrade). Dass ältere Geräte ein hochgezogenes
-        # v3-Doc nicht überschreiben, sichert deren Push-Guard (ab v1.15.2).
+        # v4-Doc nicht überschreiben, sichert deren Push-Guard (ab v1.15.2).
         remote_doc = sync.migrate_doc_to_current(remote_doc)
         local_doc = sync.build_local_doc(storage, settings, conflicts_store)
         merged = sync.merge(local_doc, remote_doc, settings.get("last_pull_at") or "")

--- a/src/main.py
+++ b/src/main.py
@@ -94,7 +94,7 @@ def _run_pull_in_background(storage, settings, conflicts_store, base, ui_callbac
         # Älteres Remote (v1/v2) wird aufs aktuelle Schema migriert und normal
         # gemergt (absorb-and-upgrade). Dass ältere Geräte ein hochgezogenes
         # v3-Doc nicht überschreiben, sichert deren Push-Guard (ab v1.15.2).
-        remote_doc = sync.migrate_doc_to_v3(remote_doc)
+        remote_doc = sync.migrate_doc_to_current(remote_doc)
         local_doc = sync.build_local_doc(storage, settings, conflicts_store)
         merged = sync.merge(local_doc, remote_doc, settings.get("last_pull_at") or "")
         sync.apply_merged_doc(merged, storage, settings, conflicts_store)
@@ -147,7 +147,7 @@ def _run_push_blocking(storage, settings, conflicts_store, base, timeout_seconds
                 remote_doc = {"schema_version": 1, "entries": {}, "settings": {}, "conflicts": []}
             # Älteres Remote (v1/v2) absorbieren: aufs aktuelle Schema migrieren,
             # dann mergen — sonst gingen v2-only-Stände beim Upload verloren.
-            remote_doc = sync.migrate_doc_to_v3(remote_doc)
+            remote_doc = sync.migrate_doc_to_current(remote_doc)
             local_doc = sync.build_local_doc(storage, settings, conflicts_store)
             merged = sync.merge(local_doc, remote_doc, settings.get("last_pull_at") or "")
             sync.apply_merged_doc(merged, storage, settings, conflicts_store)
@@ -211,7 +211,7 @@ def _run_compaction_blocking(storage, settings, conflicts_store, base, timeout_s
                               "conflicts": [], "meta": {"gc_watermark": ""}}
 
             # Älteres Remote (v1/v2) absorbieren: aufs aktuelle Schema migrieren.
-            remote_doc = sync.migrate_doc_to_v3(remote_doc)
+            remote_doc = sync.migrate_doc_to_current(remote_doc)
             # 1) normaler Merge des frischen Remote-Stands
             now = sync._utc_now_iso()
             local_doc = sync.build_local_doc(storage, settings, conflicts_store)

--- a/src/sync.py
+++ b/src/sync.py
@@ -21,7 +21,7 @@ import uuid
 from src.settings import SYNCED_SETTING_KEYS
 
 
-SCHEMA_VERSION = 3
+SCHEMA_VERSION = 4
 
 
 NEWER_REMOTE_VERSION_MSG = (
@@ -285,14 +285,15 @@ def compact_local(storage, settings, conflicts_store, now):
     ])
 
 
-def migrate_doc_to_v3(remote_doc):
-    """Migriert ein Sync-Doc auf das aktuelle Schema (v3): flache Einträge
-    (start/end/pause) werden in eine Slot-Liste gewrappt. Idempotent — Einträge,
-    die bereits `slots` tragen, bleiben unangetastet; Tombstones (deleted=True)
-    bekommen eine leere Slot-Liste. settings/conflicts/meta bleiben unberührt.
+def migrate_doc_to_current(remote_doc):
+    """Migriert ein älteres Sync-Doc auf das aktuelle Schema (v4): flache Einträge
+    (start/end/pause) werden in eine Slot-Liste gewrappt. Idempotent — Einträge mit
+    `slots` bleiben unangetastet; Tombstones bekommen eine leere Slot-Liste.
+    settings/conflicts/meta bleiben unberührt (per_day-category_times ist additiv in
+    den Settings und braucht keine Doc-Migration).
 
-    Damit kann ein v3-Client ein älteres (v1/v2) Remote-Doc absorbieren und
-    hochziehen, statt es abzuweisen oder beim Push zu plätten."""
+    Damit absorbiert ein aktueller Client ein älteres (v1–v3) Remote-Doc und zieht es
+    hoch, statt es abzuweisen oder beim Push zu plätten."""
     entries = remote_doc.get("entries") or {}
     migrated = {}
     for date, entry in entries.items():

--- a/tests/test_category_defaults.py
+++ b/tests/test_category_defaults.py
@@ -13,46 +13,88 @@ G = ("08:00", "16:00", 30)  # globale Standardwerte (start, end, pause)
 
 
 def test_unknown_category_falls_back_to_global():
-    assert resolve_slot_defaults({}, "Office", *G) == ("08:00", "16:00", 30)
+    assert resolve_slot_defaults({}, "Office", "mon", *G) == ("08:00", "16:00", 30)
 
 
 def test_empty_category_string_falls_back_to_global():
     times = {"Office": {"start": "09:00", "end": "17:00", "pause": 0}}
-    assert resolve_slot_defaults(times, "", *G) == ("08:00", "16:00", 30)
+    assert resolve_slot_defaults(times, "", "mon", *G) == ("08:00", "16:00", 30)
 
 
 def test_full_category_overrides_all_fields():
     times = {"Office": {"start": "09:00", "end": "17:00", "pause": 45}}
-    assert resolve_slot_defaults(times, "Office", *G) == ("09:00", "17:00", 45)
+    assert resolve_slot_defaults(times, "Office", "mon", *G) == ("09:00", "17:00", 45)
 
 
 def test_per_field_fallback_missing_keys():
     """Fehlende Keys im Eintrag → globaler Fallback pro Feld."""
     times = {"Office": {"start": "09:00"}}
-    assert resolve_slot_defaults(times, "Office", *G) == ("09:00", "16:00", 30)
+    assert resolve_slot_defaults(times, "Office", "mon", *G) == ("09:00", "16:00", 30)
 
 
 def test_per_field_fallback_empty_strings():
     """Leere Strings zählen wie 'nicht gesetzt' → globaler Fallback."""
     times = {"Office": {"start": "", "end": "", "pause": ""}}
-    assert resolve_slot_defaults(times, "Office", *G) == ("08:00", "16:00", 30)
+    assert resolve_slot_defaults(times, "Office", "mon", *G) == ("08:00", "16:00", 30)
 
 
 def test_pause_zero_is_kept_not_treated_as_unset():
     times = {"Office": {"pause": 0}}
-    assert resolve_slot_defaults(times, "Office", *G) == ("08:00", "16:00", 0)
+    assert resolve_slot_defaults(times, "Office", "mon", *G) == ("08:00", "16:00", 0)
 
 
 def test_pause_string_is_coerced_to_int():
     times = {"Office": {"pause": "45"}}
-    assert resolve_slot_defaults(times, "Office", *G) == ("08:00", "16:00", 45)
+    assert resolve_slot_defaults(times, "Office", "mon", *G) == ("08:00", "16:00", 45)
 
 
 def test_pause_garbage_falls_back_to_global():
     times = {"Office": {"pause": "abc"}}
-    assert resolve_slot_defaults(times, "Office", *G) == ("08:00", "16:00", 30)
+    assert resolve_slot_defaults(times, "Office", "mon", *G) == ("08:00", "16:00", 30)
 
 
 def test_non_dict_entry_falls_back_to_global():
     times = {"Office": "kaputt"}
-    assert resolve_slot_defaults(times, "Office", *G) == ("08:00", "16:00", 30)
+    assert resolve_slot_defaults(times, "Office", "mon", *G) == ("08:00", "16:00", 30)
+
+
+# --- per_day-Zweig ---
+
+PD = {
+    "Homeoffice": {
+        "mode": "per_day",
+        "pause": 0,
+        "days": {
+            "mon": {"start": "09:00", "end": "18:00"},
+            "fri": {"start": "09:00", "end": "14:00"},
+        },
+    }
+}
+
+
+def test_per_day_picks_weekday_set():
+    assert resolve_slot_defaults(PD, "Homeoffice", "mon", *G) == ("09:00", "18:00", 0)
+    assert resolve_slot_defaults(PD, "Homeoffice", "fri", *G) == ("09:00", "14:00", 0)
+
+
+def test_per_day_missing_day_falls_back_to_global():
+    # sat ist nicht in days → globaler Wochentags-Standard, Pause aus top-level
+    assert resolve_slot_defaults(PD, "Homeoffice", "sat", *G) == ("08:00", "16:00", 0)
+
+
+def test_per_day_missing_field_in_day_falls_back():
+    times = {"X": {"mode": "per_day", "days": {"mon": {"start": "07:00"}}}}
+    # end fehlt → global; pause fehlt top-level → global
+    assert resolve_slot_defaults(times, "X", "mon", *G) == ("07:00", "16:00", 30)
+
+
+def test_per_day_corrupt_days_falls_back():
+    assert resolve_slot_defaults({"X": {"mode": "per_day", "days": "kaputt"}},
+                                 "X", "mon", *G) == ("08:00", "16:00", 30)
+    assert resolve_slot_defaults({"X": {"mode": "per_day"}},
+                                 "X", "mon", *G) == ("08:00", "16:00", 30)
+
+
+def test_mode_other_than_per_day_uses_general_path():
+    times = {"X": {"mode": "general", "start": "10:00"}}
+    assert resolve_slot_defaults(times, "X", "mon", *G) == ("10:00", "16:00", 30)

--- a/tests/test_category_dialog.py
+++ b/tests/test_category_dialog.py
@@ -3,7 +3,7 @@ beiden persistierten Strukturen: die categories-Liste und das category_times-
 Dict. STANDARD/leere Felder entfallen → Per-Feld-Fallback auf global."""
 
 from src.dialogs.category_dialog import (
-    STANDARD, collect_categories, row_defaults_from_entry,
+    STANDARD, categories_losing_per_day, collect_categories, row_defaults_from_entry,
 )
 
 
@@ -155,3 +155,20 @@ def test_roundtrip_preserves_general_entry():
     e = {"start": "09:30", "end": "17:00", "pause": 30}
     _, times = collect_categories([{"name": "Office", **row_defaults_from_entry(e)}])
     assert times == {"Office": e}
+
+
+def test_losing_general_row_with_hidden_days():
+    rows = [_row("X", mode="general",
+                 days=_pd_days(mon=("09:00", "18:00")))]
+    assert categories_losing_per_day(rows) == ["X"]
+
+
+def test_not_losing_general_row_without_days():
+    rows = [_row("X", mode="general")]
+    assert categories_losing_per_day(rows) == []
+
+
+def test_not_losing_active_per_day_row():
+    rows = [_row("X", mode="per_day",
+                 days=_pd_days(mon=("09:00", "18:00")))]
+    assert categories_losing_per_day(rows) == []

--- a/tests/test_category_dialog.py
+++ b/tests/test_category_dialog.py
@@ -2,7 +2,9 @@
 beiden persistierten Strukturen: die categories-Liste und das category_times-
 Dict. STANDARD/leere Felder entfallen → Per-Feld-Fallback auf global."""
 
-from src.dialogs.category_dialog import STANDARD, collect_categories
+from src.dialogs.category_dialog import (
+    STANDARD, collect_categories, row_defaults_from_entry,
+)
 
 
 def _row(name, start=STANDARD, end=STANDARD, pause=STANDARD,
@@ -115,3 +117,41 @@ def test_per_day_with_only_pause_keeps_entry():
     rows = [_row("X", mode="per_day", pause="45", days={})]
     _, times = collect_categories(rows)
     assert times == {"X": {"mode": "per_day", "days": {}, "pause": 45}}
+
+
+def test_hydrate_general_entry():
+    r = row_defaults_from_entry({"start": "09:30", "end": "17:00", "pause": 30})
+    assert r["mode"] == "general"
+    assert (r["start"], r["end"], r["pause"]) == ("09:30", "17:00", "30")
+
+
+def test_hydrate_per_day_entry_fills_all_days():
+    e = {"mode": "per_day", "pause": 0,
+         "days": {"mon": {"start": "09:00", "end": "18:00"}}}
+    r = row_defaults_from_entry(e)
+    assert r["mode"] == "per_day"
+    assert r["pause"] == "0"
+    assert r["days"]["mon"] == {"start": "09:00", "end": "18:00"}
+    # nicht gesetzte Tage → STANDARD in beiden Feldern
+    assert r["days"]["sun"] == {"start": STANDARD, "end": STANDARD}
+
+
+def test_hydrate_corrupt_entry_is_general_standard():
+    r = row_defaults_from_entry("kaputt")
+    assert r["mode"] == "general"
+    assert (r["start"], r["end"], r["pause"]) == (STANDARD, STANDARD, STANDARD)
+
+
+def test_roundtrip_preserves_per_day_entry():
+    e = {"mode": "per_day", "pause": 0,
+         "days": {"mon": {"start": "09:00", "end": "18:00"},
+                  "fri": {"start": "09:00", "end": "14:00"}}}
+    cats, times = collect_categories([{"name": "Homeoffice", **row_defaults_from_entry(e)}])
+    assert cats == ["Homeoffice"]
+    assert times == {"Homeoffice": e}
+
+
+def test_roundtrip_preserves_general_entry():
+    e = {"start": "09:30", "end": "17:00", "pause": 30}
+    _, times = collect_categories([{"name": "Office", **row_defaults_from_entry(e)}])
+    assert times == {"Office": e}

--- a/tests/test_category_dialog.py
+++ b/tests/test_category_dialog.py
@@ -5,8 +5,15 @@ Dict. STANDARD/leere Felder entfallen → Per-Feld-Fallback auf global."""
 from src.dialogs.category_dialog import STANDARD, collect_categories
 
 
-def _row(name, start=STANDARD, end=STANDARD, pause=STANDARD):
-    return {"name": name, "start": start, "end": end, "pause": pause}
+def _row(name, start=STANDARD, end=STANDARD, pause=STANDARD,
+         mode="general", days=None):
+    return {"name": name, "start": start, "end": end, "pause": pause,
+            "mode": mode, "days": days or {}}
+
+
+def _pd_days(**kw):
+    """kw wie mon=("09:00","18:00") → {"mon": {"start":..,"end":..}}."""
+    return {k: {"start": v[0], "end": v[1]} for k, v in kw.items()}
 
 
 def test_empty_rows_yield_empty_structures():
@@ -74,3 +81,37 @@ def test_multiple_categories_mixed_times():
         "Office": {"start": "09:00", "end": "17:00", "pause": 30},
         "Kunde": {"start": "08:00"},
     }
+
+
+def test_per_day_row_builds_nested_entry():
+    rows = [_row("Homeoffice", mode="per_day", pause="0",
+                 days=_pd_days(mon=("09:00", "18:00"), fri=("09:00", "14:00")))]
+    cats, times = collect_categories(rows)
+    assert cats == ["Homeoffice"]
+    assert times == {"Homeoffice": {
+        "mode": "per_day", "pause": 0,
+        "days": {"mon": {"start": "09:00", "end": "18:00"},
+                 "fri": {"start": "09:00", "end": "14:00"}},
+    }}
+
+
+def test_per_day_empty_fields_drop_out():
+    rows = [_row("X", mode="per_day",
+                 days=_pd_days(mon=("09:00", STANDARD), tue=(STANDARD, STANDARD)))]
+    _, times = collect_categories(rows)
+    # tue komplett leer entfällt; mon behält nur start
+    assert times == {"X": {"mode": "per_day", "days": {"mon": {"start": "09:00"}}}}
+
+
+def test_per_day_without_any_data_is_dropped():
+    rows = [_row("X", mode="per_day", pause=STANDARD,
+                 days=_pd_days(mon=(STANDARD, STANDARD)))]
+    cats, times = collect_categories(rows)
+    assert cats == ["X"]
+    assert times == {}
+
+
+def test_per_day_with_only_pause_keeps_entry():
+    rows = [_row("X", mode="per_day", pause="45", days={})]
+    _, times = collect_categories(rows)
+    assert times == {"X": {"mode": "per_day", "days": {}, "pause": 45}}

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -607,3 +607,13 @@ def test_clamp_ui_scale_invalid_falls_back_to_1():
     from src.settings import clamp_ui_scale
     assert clamp_ui_scale(None) == 1.0
     assert clamp_ui_scale("abc") == 1.0
+
+
+def test_per_day_category_times_roundtrips(tmp_path):
+    path = str(tmp_path / "settings.json")
+    s = Settings(path)
+    pd = {"Homeoffice": {"mode": "per_day", "pause": 0,
+                         "days": {"mon": {"start": "09:00", "end": "18:00"}}}}
+    s.set_synced("category_times", pd)
+    # frisch laden → verschachtelte Struktur kommt unverändert zurück (Dict-Passthrough)
+    assert Settings(path).get("category_times") == pd

--- a/tests/test_storage_migration.py
+++ b/tests/test_storage_migration.py
@@ -132,8 +132,8 @@ def test_migrated_v2_entry_round_trips_through_v3_sync(tmp_path):
 
     # build_local_doc nach Migration -> v3-Doc mit slots
     doc = build_local_doc(old, old_settings, old_conflicts)
-    assert SCHEMA_VERSION == 3
-    assert doc["schema_version"] == 3
+    assert SCHEMA_VERSION == 4
+    assert doc["schema_version"] == 4
     assert doc["entries"]["2026-03-23"]["slots"] == [
         {"start": "08:00", "end": "16:30", "pause": 30, "kategorie": ""}
     ]

--- a/tests/test_storage_migration.py
+++ b/tests/test_storage_migration.py
@@ -130,7 +130,7 @@ def test_migrated_v2_entry_round_trips_through_v3_sync(tmp_path):
     old_settings.device_id_for_sync = "old-dev"
     old_conflicts = ConflictsStore(str(tmp_path / "old-c.json"))
 
-    # build_local_doc nach Migration -> v3-Doc mit slots
+    # build_local_doc nach Migration -> v4-Doc mit slots
     doc = build_local_doc(old, old_settings, old_conflicts)
     assert SCHEMA_VERSION == 4
     assert doc["schema_version"] == 4

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -290,7 +290,7 @@ def test_build_local_doc_includes_storage_settings_conflicts(tmp_path):
     assert "2026-05-14" in doc["entries"]
     assert doc["settings"]["recipient"]["value"] == "a@b.de"
     assert doc["conflicts"][0]["id"] == "c-1"
-    assert doc["schema_version"] == 3
+    assert doc["schema_version"] == 4
 
 
 def test_round_trip_no_loss(tmp_path):
@@ -655,7 +655,7 @@ def test_merge_different_slots_conflict_candidates_carry_slots():
 # --- Forward-Compat (>v3 abweisen) + Absorb/Migration älterer Docs (v1/v2) ---
 
 from src.sync import (
-    NEWER_REMOTE_VERSION_MSG, SCHEMA_VERSION, _remote_is_newer, migrate_doc_to_v3,
+    NEWER_REMOTE_VERSION_MSG, SCHEMA_VERSION, _remote_is_newer, migrate_doc_to_current,
 )
 
 
@@ -667,7 +667,7 @@ def test_remote_is_newer():
     assert _remote_is_newer({"entries": {}}) is False
 
 
-def test_migrate_doc_to_v3_wraps_flat_entries():
+def test_migrate_doc_to_current_wraps_flat_entries():
     doc = {
         "schema_version": 2,
         "entries": {
@@ -681,8 +681,8 @@ def test_migrate_doc_to_v3_wraps_flat_entries():
         "settings": {"recipient": {"value": "x", "modified_at": "t", "device_id": "B"}},
         "conflicts": [], "meta": {"gc_watermark": "wm"},
     }
-    out = migrate_doc_to_v3(doc)
-    assert out["schema_version"] == 3
+    out = migrate_doc_to_current(doc)
+    assert out["schema_version"] == 4
     assert out["entries"]["2026-06-04"]["slots"] == [
         {"start": "08:00", "end": "16:00", "pause": 30, "kategorie": ""}]
     assert out["entries"]["2026-06-05"]["slots"] == []        # Tombstone → leer
@@ -691,13 +691,13 @@ def test_migrate_doc_to_v3_wraps_flat_entries():
     assert out["meta"] == {"gc_watermark": "wm"}
 
 
-def test_migrate_doc_to_v3_is_idempotent_on_v3():
+def test_migrate_doc_to_current_is_idempotent():
     slots = [{"start": "08:00", "end": "16:00", "pause": 0, "kategorie": "X"}]
     v3 = {"schema_version": 3,
           "entries": {"D": {"slots": slots, "modified_at": "t",
                             "device_id": "B", "deleted": False}},
           "settings": {}, "conflicts": [], "meta": {"gc_watermark": ""}}
-    out = migrate_doc_to_v3(v3)
+    out = migrate_doc_to_current(v3)
     assert out["entries"]["D"]["slots"] == slots
 
 
@@ -805,7 +805,7 @@ def test_run_push_absorbs_v2_remote_before_upload(tmp_path, monkeypatch):
     monkeypatch.setattr(drive, "upload", _fake_upload)
     res = main._run_push_blocking(storage, settings, conflicts, str(tmp_path))
     assert res.get("ok") is True
-    assert uploaded["doc"]["schema_version"] == 3
+    assert uploaded["doc"]["schema_version"] == 4
     assert set(uploaded["doc"]["entries"]) == {"2026-06-09", "2026-06-20"}
     assert "slots" in storage.get_all_raw()["2026-06-20"]
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -309,6 +309,31 @@ def test_round_trip_no_loss(tmp_path):
     assert settings.get("name") == "Max"
 
 
+def test_per_day_category_times_survives_sync_cycle(tmp_path):
+    """per_day category_times-Shape überlebt build→merge→apply unverändert (Datenintegrität)."""
+    per_day_value = {
+        "Büro": {
+            "mode": "per_day",
+            "pause": 30,
+            "days": {
+                "mon": {"start": "08:00", "end": "17:00"},
+                "fri": {"start": "09:00", "end": "15:00"},
+            },
+        }
+    }
+    storage = Storage(str(tmp_path / "z.json"), device_id="A")
+    settings = Settings(str(tmp_path / "s.json"))
+    settings.device_id_for_sync = "A"
+    settings.set_synced("category_times", per_day_value)
+    conflicts = ConflictsStore(str(tmp_path / "c.json"))
+
+    local = build_local_doc(storage, settings, conflicts)
+    merged = merge(local, _doc(), "2025-01-01T00:00:00Z")
+    apply_merged_doc(merged, storage, settings, conflicts)
+
+    assert settings.get("category_times") == per_day_value
+
+
 # --- Task 2.8: resolve_conflict ---
 
 def test_resolve_entry_conflict_updates_storage_and_marks_resolved(tmp_path):
@@ -812,7 +837,7 @@ def test_run_push_absorbs_v2_remote_before_upload(tmp_path, monkeypatch):
 
 
 def test_run_compaction_aborts_on_newer_remote(tmp_path, monkeypatch):
-    """Kompaktierung gegen ein neueres Schema (>v3): bricht freundlich ab."""
+    """Kompaktierung gegen ein neueres Schema (>v4): bricht freundlich ab."""
     import src.main as main
     storage = Storage(str(tmp_path / "z.json"), device_id="A")
     settings = Settings(str(tmp_path / "s.json"))

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -652,7 +652,7 @@ def test_merge_different_slots_conflict_candidates_carry_slots():
     assert cand_by_dev["B"]["slots"] == [_slot("09:00", "17:00", 30, "HO")]
 
 
-# --- Forward-Compat (>v3 abweisen) + Absorb/Migration älterer Docs (v1/v2) ---
+# --- Forward-Compat (>v4 abweisen) + Absorb/Migration älterer Docs (v1/v2) ---
 
 from src.sync import (
     NEWER_REMOTE_VERSION_MSG, SCHEMA_VERSION, _remote_is_newer, migrate_doc_to_current,
@@ -698,11 +698,12 @@ def test_migrate_doc_to_current_is_idempotent():
                             "device_id": "B", "deleted": False}},
           "settings": {}, "conflicts": [], "meta": {"gc_watermark": ""}}
     out = migrate_doc_to_current(v3)
+    assert out["schema_version"] == 4
     assert out["entries"]["D"]["slots"] == slots
 
 
 def _newer_remote_bytes():
-    """Remote-Doc eines NEUEREN Schemas (>v3), das dieser Client nicht versteht."""
+    """Remote-Doc eines NEUEREN Schemas (>v4), das dieser Client nicht versteht."""
     return _json.dumps({
         "schema_version": SCHEMA_VERSION + 1,
         "entries": {}, "settings": {}, "conflicts": [],


### PR DESCRIPTION
## Was
Standardzeiten pro Kategorie sind jetzt wahlweise **tageweise** (pro Wochentag) statt nur als ein Satz konfigurierbar — Modus-Schalter pro Kategorie (Allgemein/Tageweise). Schließt #84.

## Datenmodell
`category_times[kat]` ist entweder flach `{start,end,pause}` (allgemein, wie bisher) oder verschachtelt `{mode:"per_day", pause, days:{tag:{start,end}}}`. Fehlt `mode` → allgemein, Bestandsdaten unverändert. Per-Feld/-Tag-Fallback auf die globalen Wochentags-Defaults in beiden Modi; Pause bleibt ein Wert pro Kategorie.

## Sync / Backward-Compat
`sync.SCHEMA_VERSION 3→4`: ein pre-#84-Client pausiert bei Versions-Skew den Sync (bestehender `_remote_is_newer`-Guard), statt einen `per_day`-Eintrag zu plätten. Der allgemein-Pfad ist bit-identisch zu vorher; `share.SCHEMA_VERSION` bleibt 3.

## UI
Kategorien-Dialog: Modus-Umschalter pro Zeile, einklappbares 7-Tage-Grid („Pro Tag ▶/▼"), Downgrade-Confirm beim Verwerfen von Tagesdaten. Tages-Dialog zieht beim Slot-Anlegen den zum Wochentag passenden Satz.

## Tests
- 642 passed, 2 skipped; ruff clean.
- Pure Logik voll getestet: resolve/collect/hydrate/losing + Round-Trip (No-op-Save plättet nicht) + Sync-Cycle (per_day überlebt build→merge→apply).
- Manuelles GUI-QA durchgeführt.

## Hinweis
Kein `release:*`-Label — Versionsbump (`src/version.py`) + CHANGELOG folgen separat im Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)