### PR TITLE
feat(category-times): Tageweise Kategorie-Standardzeiten + Entry-Dialog-UX (#84)

### DIFF
--- a/src/dialogs/entry_dialog.py
+++ b/src/dialogs/entry_dialog.py
@@ -5,13 +5,35 @@ from src.category_defaults import resolve_slot_defaults
 from src.holidays_de import get_holidays
 from src.settings import WEEKDAY_KEYS
 from src.theme import (
-    BG, FONT, FONT_BOLD, PAUSE_VALUES, TEXT, TEXT_MUTED, TIME_VALUES,
-    apply_app_icon, apply_combobox_style, apply_dark_titlebar,
+    BG, FONT, FONT_BOLD, PAUSE_VALUES, STRAY_CLICK_GUARD_S, TEXT, TEXT_MUTED,
+    TIME_VALUES, apply_app_icon, apply_combobox_style, apply_dark_titlebar,
     attach_unfocus_on_click, center_dialog_on_parent, dark_combo,
-    dark_combo_editable, disable_min_max, primary_button, secondary_button,
-    themed_askyesno, themed_showinfo,
+    disable_min_max, primary_button, secondary_button,
+    set_primary_button_enabled, themed_askyesno, themed_showinfo,
 )
-from src.time_utils import validate_slots
+from src.time_utils import format_iso_weekday_date, validate_slots
+
+# Kategorie am Slot: "" = keine Kategorie. Das Dropdown ist readonly (Anlegen/
+# Bearbeiten von Kategorien läuft über die Einstellungen, nicht per Freitext),
+# darum wird "" als eigener Eintrag "(ohne Kategorie)" gezeigt und beim Speichern
+# wieder auf "" abgebildet. Label konsistent mit report.py/period_picker/share.
+NO_CATEGORY_LABEL = "(ohne Kategorie)"
+
+
+def category_choices(categories):
+    """Werte fürs readonly-Kategorie-Dropdown: '(ohne Kategorie)' zuerst, dann
+    die in den Einstellungen gepflegten Kategorien."""
+    return [NO_CATEGORY_LABEL, *categories]
+
+
+def category_to_display(value):
+    """Gespeicherter Kategoriewert ('' = keine) → Dropdown-Anzeige."""
+    return value if value else NO_CATEGORY_LABEL
+
+
+def category_from_display(display):
+    """Dropdown-Anzeige → gespeicherter Kategoriewert ('(ohne Kategorie)' → '')."""
+    return "" if display == NO_CATEGORY_LABEL else display
 
 
 def reservation_block_visible(day, today, *, has_reservation=False):
@@ -76,7 +98,7 @@ def open_entry_dialog(parent, date_str, storage, settings, on_change,
     default_pause = settings.get("default_pause")
 
     dialog = tk.Toplevel(parent)
-    dialog.title(day.strftime("%d.%m.%Y"))
+    dialog.title(format_iso_weekday_date(date_str))
     dialog.resizable(False, False)
     dialog.grab_set()
     # focus_set() ist nach grab_set() Pflicht, sonst feuern Tastatur-Bindungen
@@ -98,6 +120,27 @@ def open_entry_dialog(parent, date_str, storage, settings, on_change,
     ist_rows_frame = tk.Frame(outer, bg=BG)
     ist_rows_frame.pack(fill="x")
     ist_rows = []  # Liste von {frame, start, end, pause, kategorie}
+    ist_save_btn = None  # wird nach dem Button-Bau gesetzt (s. unten)
+    # "locked" = Button vorübergehend nicht klickbar: (1) kurzer Cooldown direkt
+    # nach dem Öffnen (unten via dialog.after freigegeben), damit ein Doppelklick
+    # auf die Kalenderzelle nicht durchschlägt und bei vorbefüllten Einträgen
+    # sofort speichert; (2) während eines laufenden Speicherns. Flag statt
+    # -state, weil label_button keine -state-Option hat und
+    # set_primary_button_enabled nur die Optik ändert (blockt den Klick nicht).
+    ist_save_locked = {"value": True}
+
+    def refresh_ist_save_state():
+        # Einzige Stelle, die den Enabled-Zustand entscheidet: aktiv, wenn Slots
+        # vorhanden sind UND der Button nicht (Cooldown/Speichern) gesperrt ist.
+        if ist_save_btn is not None:
+            set_primary_button_enabled(
+                ist_save_btn, bool(ist_rows) and not ist_save_locked["value"])
+
+    def unlock_ist_save():
+        # Ende des Öffnen-Cooldowns; Dialog kann zwischenzeitlich zu sein.
+        if dialog.winfo_exists():
+            ist_save_locked["value"] = False
+            refresh_ist_save_state()
 
     def add_ist_row(start, end, pause, kategorie, removable=True):
         row = tk.Frame(ist_rows_frame, bg=BG)
@@ -105,7 +148,7 @@ def open_entry_dialog(parent, date_str, storage, settings, on_change,
         sv = tk.StringVar(value=start)
         ev = tk.StringVar(value=end)
         pv = tk.StringVar(value=str(pause))
-        kv = tk.StringVar(value=kategorie)
+        kv = tk.StringVar(value=category_to_display(kategorie))
         # Basis = die Werte, mit denen die Zeile angelegt wurde. Wählt man für
         # eine NEUE Zeile eine Kategorie, überschreibt das ein Feld NUR, solange
         # es noch der Basis entspricht (= nicht manuell geändert), und zieht die
@@ -115,13 +158,13 @@ def open_entry_dialog(parent, date_str, storage, settings, on_change,
         tk.Label(row, text="–", font=FONT, bg=BG, fg=TEXT_MUTED).pack(side=tk.LEFT)
         dark_combo(row, ev, TIME_VALUES, width=6).pack(side=tk.LEFT, padx=2)
         dark_combo(row, pv, PAUSE_VALUES, width=4).pack(side=tk.LEFT, padx=2)
-        cat_combo = dark_combo_editable(row, kv, categories, width=14)
+        cat_combo = dark_combo(row, kv, category_choices(categories), width=18)
         cat_combo.pack(side=tk.LEFT, padx=2)
         record = {"frame": row, "start": sv, "end": ev, "pause": pv, "kategorie": kv}
 
         def on_cat_change(*_a):
             t_start, t_end, t_pause = resolve_slot_defaults(
-                category_times, kv.get().strip(), weekday_key,
+                category_times, category_from_display(kv.get()), weekday_key,
                 default_start, default_end, default_pause,
             )
             t_pause = str(t_pause)
@@ -152,6 +195,7 @@ def open_entry_dialog(parent, date_str, storage, settings, on_change,
             # beim nächsten "+ Slot" wieder auf).
             if not ist_rows:
                 ist_rows_frame.configure(height=1)
+            refresh_ist_save_state()
 
         # Bereits gespeicherte Slots tragen kein ×: Löschen läuft ausschließlich
         # über den Rechtsklick im Kalender (Design-Entscheidung — der Dialog
@@ -160,6 +204,7 @@ def open_entry_dialog(parent, date_str, storage, settings, on_change,
         if removable:
             secondary_button(row, "×", remove, padx=8, pady=0).pack(side=tk.LEFT, padx=2)
         ist_rows.append(record)
+        refresh_ist_save_state()
 
     # Vorbelegung: vorhandene Ist-Slots → bestehende Reservierung (erste Slot-
     # Zeit). Gibt es weder Ist-Zeit noch Reservierung, bleibt der Block leer —
@@ -182,20 +227,22 @@ def open_entry_dialog(parent, date_str, storage, settings, on_change,
     ).pack(side=tk.LEFT, padx=2)
 
     def save_ist():
+        # Ohne Slot deaktiviert; während Cooldown/Speichern geblockt.
+        if not ist_rows or ist_save_locked["value"]:
+            return
+        ist_save_locked["value"] = True
+        refresh_ist_save_state()  # sofort sperren gegen Doppelklick
         slots = [{
             "start": r["start"].get(),
             "end": r["end"].get(),
             "pause": int(r["pause"].get() or 0),
-            "kategorie": r["kategorie"].get().strip(),
+            "kategorie": category_from_display(r["kategorie"].get()),
         } for r in ist_rows]
-        if not slots:
-            storage.delete(date_str)
-            dialog.destroy()
-            on_change()
-            return
         ok, msg = validate_slots(slots, with_pause=True)
         if not ok:
             themed_showinfo(dialog, "Hinweis", msg)
+            ist_save_locked["value"] = False
+            refresh_ist_save_state()  # Fehler → wieder freigeben
             return
         storage.save(date_str, slots)
         dialog.destroy()
@@ -203,7 +250,10 @@ def open_entry_dialog(parent, date_str, storage, settings, on_change,
 
     ist_save = tk.Frame(outer, bg=BG)
     ist_save.pack(fill="x")
-    primary_button(ist_save, "Speichern", save_ist).pack(side=tk.LEFT, padx=2)
+    ist_save_btn = primary_button(ist_save, "Speichern", save_ist)
+    ist_save_btn.pack(side=tk.LEFT, padx=2)
+    refresh_ist_save_state()  # startet gesperrt (Cooldown)
+    dialog.after(int(STRAY_CLICK_GUARD_S * 1000), unlock_ist_save)
 
     # ---------- Reservierung ----------
     if show_reservation:
@@ -213,25 +263,37 @@ def open_entry_dialog(parent, date_str, storage, settings, on_change,
         res_rows_frame = tk.Frame(outer, bg=BG)
         res_rows_frame.pack(fill="x")
         res_rows = []  # Liste von {frame, start, end, kategorie}
+        res_save_btn = None  # wird nach dem Button-Bau gesetzt (s. unten)
+        res_save_locked = {"value": True}  # Cooldown + Speicher-Sperre (s. ist_save_locked)
+
+        def refresh_res_save_state():
+            if res_save_btn is not None:
+                set_primary_button_enabled(
+                    res_save_btn, bool(res_rows) and not res_save_locked["value"])
+
+        def unlock_res_save():
+            if dialog.winfo_exists():
+                res_save_locked["value"] = False
+                refresh_res_save_state()
 
         def add_res_row(start, end, kategorie, removable=True):
             row = tk.Frame(res_rows_frame, bg=BG)
             row.pack(fill="x", pady=2)
             sv = tk.StringVar(value=start)
             ev = tk.StringVar(value=end)
-            kv = tk.StringVar(value=kategorie)
+            kv = tk.StringVar(value=category_to_display(kategorie))
             base = {"start": start, "end": end}
             dark_combo(row, sv, TIME_VALUES, width=6).pack(side=tk.LEFT, padx=2)
             tk.Label(row, text="–", font=FONT, bg=BG, fg=TEXT_MUTED).pack(side=tk.LEFT)
             dark_combo(row, ev, TIME_VALUES, width=6).pack(side=tk.LEFT, padx=2)
-            cat_combo = dark_combo_editable(row, kv, categories, width=14)
+            cat_combo = dark_combo(row, kv, category_choices(categories), width=18)
             cat_combo.pack(side=tk.LEFT, padx=2)
             record = {"frame": row, "start": sv, "end": ev, "kategorie": kv}
 
             def on_cat_change(*_a):
                 # Reservierungen haben keine Pause → nur Start/Ende anwenden.
                 t_start, t_end, _ = resolve_slot_defaults(
-                    category_times, kv.get().strip(), weekday_key,
+                    category_times, category_from_display(kv.get()), weekday_key,
                     default_start, default_end, default_pause,
                 )
                 if sv.get() == base["start"]:
@@ -250,6 +312,7 @@ def open_entry_dialog(parent, date_str, storage, settings, on_change,
                 res_rows.remove(record)
                 if not res_rows:
                     res_rows_frame.configure(height=1)
+                refresh_res_save_state()
 
             # Gespeicherte Reservierungs-Slots tragen kein × (Löschen per
             # Rechtsklick im Kalender); nur neue, ungespeicherte Zeilen.
@@ -257,6 +320,7 @@ def open_entry_dialog(parent, date_str, storage, settings, on_change,
                 secondary_button(row, "×", remove, padx=8, pady=0).pack(
                     side=tk.LEFT, padx=2)
             res_rows.append(record)
+            refresh_res_save_state()
 
         # Bestehende Reservierung → Zeilen. Sonst leer: nur der „+ Slot"-Button
         # (an der Stelle, wo sonst die Default-Zeile stünde), keine Vorbelegung.
@@ -273,21 +337,21 @@ def open_entry_dialog(parent, date_str, storage, settings, on_change,
         ).pack(side=tk.LEFT, padx=2)
 
         def save_reservation():
+            # Ohne Slot deaktiviert; während Cooldown/Speichern geblockt.
+            if not res_rows or res_save_locked["value"]:
+                return
+            res_save_locked["value"] = True
+            refresh_res_save_state()  # sofort sperren gegen Doppelklick
             slots = [{
                 "start": r["start"].get(),
                 "end": r["end"].get(),
-                "kategorie": r["kategorie"].get().strip(),
+                "kategorie": category_from_display(r["kategorie"].get()),
             } for r in res_rows]
-            if not slots:
-                reservation_store.delete(date_str)
-                dialog.destroy()
-                on_change()
-                if trigger_reconcile is not None:
-                    trigger_reconcile()
-                return
             ok, msg = validate_slots(slots, with_pause=False)
             if not ok:
                 themed_showinfo(dialog, "Hinweis", msg)
+                res_save_locked["value"] = False
+                refresh_res_save_state()  # Fehler → wieder freigeben
                 return
             reservation_store.save(date_str, slots)
             dialog.destroy()
@@ -297,7 +361,10 @@ def open_entry_dialog(parent, date_str, storage, settings, on_change,
 
         res_save = tk.Frame(outer, bg=BG)
         res_save.pack(fill="x")
-        primary_button(res_save, "Reservierung speichern",
-                       save_reservation).pack(side=tk.LEFT, padx=2)
+        res_save_btn = primary_button(res_save, "Reservierung speichern",
+                                      save_reservation)
+        res_save_btn.pack(side=tk.LEFT, padx=2)
+        refresh_res_save_state()  # startet gesperrt (Cooldown)
+        dialog.after(int(STRAY_CLICK_GUARD_S * 1000), unlock_res_save)
 
     center_dialog_on_parent(dialog, parent)

--- a/src/time_utils.py
+++ b/src/time_utils.py
@@ -1,6 +1,10 @@
 import datetime
 
 DAYS_DE = ["Mo", "Di", "Mi", "Do", "Fr", "Sa", "So"]
+WEEKDAYS_DE_FULL = [
+    "Montag", "Dienstag", "Mittwoch", "Donnerstag",
+    "Freitag", "Samstag", "Sonntag",
+]
 MONTHS_DE = [
     "", "Januar", "Februar", "März", "April", "Mai", "Juni",
     "Juli", "August", "September", "Oktober", "November", "Dezember",
@@ -92,6 +96,20 @@ def format_iso_date(iso, fallback="—"):
         return datetime.date.fromisoformat(iso[:10]).strftime("%d.%m.%Y")
     except ValueError:
         return iso[:10]
+
+
+def format_iso_weekday_date(iso, fallback="—"):
+    """ISO-Datum oder -Zeitstempel → 'Wochentag - TT.MM.JJJJ' für die Anzeige
+    (z.B. 'Montag - 13.07.2026'). Leere oder unparsbare Werte liefern denselben
+    Fallback-Weg wie format_iso_date (fallback bzw. roher 10-Zeichen-Prefix).
+    """
+    if not iso or len(iso) < 10:
+        return fallback
+    try:
+        day = datetime.date.fromisoformat(iso[:10])
+    except ValueError:
+        return iso[:10]
+    return f"{WEEKDAYS_DE_FULL[day.weekday()]} - {day.strftime('%d.%m.%Y')}"
 
 
 def format_iso_datetime(iso, fallback="—"):

--- a/tests/test_entry_dialog.py
+++ b/tests/test_entry_dialog.py
@@ -1,6 +1,9 @@
 import datetime
 
-from src.dialogs.entry_dialog import reservation_block_visible
+from src.dialogs.entry_dialog import (
+    NO_CATEGORY_LABEL, category_choices, category_from_display,
+    category_to_display, reservation_block_visible,
+)
 
 
 TODAY = datetime.date(2026, 6, 26)
@@ -20,3 +23,22 @@ def test_reservation_block_visible_today():
 
 def test_reservation_block_visible_future():
     assert reservation_block_visible(datetime.date(2026, 6, 27), TODAY) is True
+
+
+def test_category_empty_maps_to_no_category_label_and_back():
+    # "" (keine Kategorie) ↔ Anzeige-Label, damit der Platzhalter nie als echte
+    # Kategorie gespeichert wird.
+    assert category_to_display("") == NO_CATEGORY_LABEL
+    assert category_from_display(NO_CATEGORY_LABEL) == ""
+
+
+def test_category_real_value_round_trips_unchanged():
+    assert category_to_display("Office") == "Office"
+    assert category_from_display("Office") == "Office"
+
+
+def test_category_choices_puts_no_category_first():
+    assert category_choices(["Office", "Homeoffice"]) == [
+        NO_CATEGORY_LABEL, "Office", "Homeoffice"]
+    # Keine Kategorien in den Einstellungen → nur der Platzhalter.
+    assert category_choices([]) == [NO_CATEGORY_LABEL]

--- a/tests/test_time_utils.py
+++ b/tests/test_time_utils.py
@@ -1,4 +1,6 @@
-from src.time_utils import format_iso_date, format_iso_datetime
+from src.time_utils import (
+    format_iso_date, format_iso_datetime, format_iso_weekday_date,
+)
 
 
 def test_format_iso_date_from_timestamp():
@@ -37,3 +39,22 @@ def test_format_iso_datetime_date_only_no_time():
 
 def test_format_iso_datetime_empty_uses_fallback():
     assert format_iso_datetime("", fallback="") == ""
+
+
+def test_format_iso_weekday_date_monday():
+    # 13.07.2026 ist ein Montag.
+    assert format_iso_weekday_date("2026-07-13") == "Montag - 13.07.2026"
+
+
+def test_format_iso_weekday_date_sunday_from_timestamp():
+    # 05.07.2026 ist ein Sonntag; Zeitstempel-Prefix wird akzeptiert.
+    assert format_iso_weekday_date("2026-07-05T09:00:00Z") == "Sonntag - 05.07.2026"
+
+
+def test_format_iso_weekday_date_empty_uses_fallback():
+    assert format_iso_weekday_date("", fallback="—") == "—"
+    assert format_iso_weekday_date(None, fallback="—") == "—"
+
+
+def test_format_iso_weekday_date_unparsable_falls_back_to_raw_prefix():
+    assert format_iso_weekday_date("2026-13-99") == "2026-13-99"


### PR DESCRIPTION
## Überblick
Branch bündelt die **#84**-Arbeit (tageweise Kategorie-Standardzeiten) und mehrere Entry-Dialog-UX-Fixes. **Kein Release** — kein Versionsbump/CHANGELOG/`release:*`-Label; Release läuft separat.

> Hinweis: Master enthält bislang keinen der #84-Commits, daher fährt die komplette #84-Feature-Arbeit in diesem PR mit. Die Entry-Dialog-Fixes bauen darauf auf und lassen sich nicht isoliert nach master bringen.

## #84 — Tageweise Kategorie-Standardzeiten (bestehende Commits)
- `resolve_slot_defaults` mit Wochentag + `per_day`-Zweig, Per-Feld-Fallback auf globale Defaults.
- Kategorien-Dialog mit Modus-Toggle (Allgemein / Per-Tag) + einklappbarem Per-Tag-Grid.
- `SCHEMA_VERSION` 3→4 als Forward-Compat-Guard + Sync-Idempotenz-Test.

## Entry-Dialog-UX (dieser Commit)
- **Titel mit Wochentag:** `Montag - 13.07.2026` über neuen Helfer `time_utils.format_iso_weekday_date`.
- **Speicher-Buttons:** deaktiviert, solange der jeweilige Block keinen Slot hat; zusätzlich kurzer Cooldown direkt nach dem Öffnen, damit ein Doppelklick auf die Kalenderzelle nicht sofort speichert (`set_primary_button_enabled` + Lock-Flag, da `label_button` keine `-state`-Option hat).
- **Kategorie readonly:** kein Freitext mehr — Kategorien werden in den Einstellungen gepflegt. `""` (keine Kategorie) wird als `(ohne Kategorie)` gezeigt und beim Speichern wieder auf `""` abgebildet; Dropdown verbreitert (`width=18`).

## Tests / Verify
- `pytest` → **649 passed, 2 skipped**. `ruff check` → clean.
- Neue Tests: `format_iso_weekday_date` (`test_time_utils`) + Kategorie-Round-Trip `"" ↔ "(ohne Kategorie)"` (`test_entry_dialog`).

## Hinweis
- `theme.py::dark_combo_editable` ist nach dem readonly-Umbau ohne Aufrufer (pre-existing, bewusst nicht gelöscht).

🤖 Generated with [Claude Code](https://claude.com/claude-code)