### PR TITLE
feat(release): Pre-Releases als plattformübergreifende Test-Builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches: [master]
   workflow_dispatch:
+    inputs:
+      prerelease:
+        description: "Pre-Release bauen (plattformübergreifender Test-Build, kein echtes Release)"
+        type: boolean
+        default: false
 
 jobs:
   pre-check:
@@ -14,6 +19,10 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
       should_release: ${{ steps.gate.outputs.should_release }}
+      is_prerelease: ${{ steps.gate.outputs.is_prerelease }}
+      tag: ${{ steps.tag.outputs.tag }}
+      title: ${{ steps.tag.outputs.title }}
+      notes_start: ${{ steps.tag.outputs.notes_start }}
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -30,18 +39,26 @@ jobs:
         shell: bash
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "Manueller Lauf → Release."
+            echo "Manueller Lauf → Release (prerelease=${{ inputs.prerelease }})."
             echo "should_release=true" >> "$GITHUB_OUTPUT"
+            if [ "${{ inputs.prerelease }}" = "true" ]; then
+              echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
+            fi
             exit 0
           fi
+          # Push-Events sind nie Pre-Release; Gate über das release:*-Label des PR.
           labels=$(gh api "repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" \
             --jq '.[].labels[].name' 2>/dev/null || true)
           echo "Labels des zugehörigen PR: ${labels:-<keine>}"
           if echo "$labels" | grep -qE '^release:(major|minor|patch)$'; then
             echo "should_release=true" >> "$GITHUB_OUTPUT"
+            echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
           else
             echo "Kein release:*-Label → übersprungen."
             echo "should_release=false" >> "$GITHUB_OUTPUT"
+            echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Read version
@@ -53,15 +70,46 @@ jobs:
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "Releasing v${VERSION}"
 
-      - name: Fail if tag already exists
+      - name: Compute tag, title and notes-start
+        id: tag
         if: steps.gate.outputs.should_release == 'true'
         shell: bash
         run: |
+          VERSION="${{ steps.version.outputs.version }}"
           git fetch --tags
-          if git rev-parse "v${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
-            echo "::error::Tag v${{ steps.version.outputs.version }} already exists. Bump src/version.py vor dem Merge."
-            exit 1
+          if [ "${{ steps.gate.outputs.is_prerelease }}" = "true" ]; then
+            # Fortlaufende Nummer je Zielversion: höchstes vorhandenes
+            # v<VERSION>-pre.N + 1 (Start bei 1). Kein Existenz-Abbruch — der
+            # Pre-Release-Tag darf mehrfach je Version entstehen.
+            max=0
+            for t in $(git tag -l "v${VERSION}-pre.*"); do
+              n="${t##*.}"
+              if echo "$n" | grep -qE '^[0-9]+$' && [ "$n" -gt "$max" ]; then
+                max="$n"
+              fi
+            done
+            N=$((max + 1))
+            TAG="v${VERSION}-pre.${N}"
+            TITLE="Zeiterfassung v${VERSION} - Pre-Release ${N}"
+          else
+            # Echtes Release: Tag darf noch nicht existieren (erzwingt Version-Bump).
+            TAG="v${VERSION}"
+            TITLE="Zeiterfassung v${VERSION}"
+            if git rev-parse "$TAG" >/dev/null 2>&1; then
+              echo "::error::Tag ${TAG} already exists. Bump src/version.py vor dem Merge."
+              exit 1
+            fi
           fi
+          # Release-Notes ab dem letzten ECHTEN Release (ohne -pre-Suffix): so
+          # bleiben Voll-Release-Notes vollständig (unbeeinflusst von zwischen-
+          # zeitlichen Pre-Releases) und Pre-Release-Notes kumulativ = alle PRs
+          # seit dem letzten Release. Leer beim allerersten Release → gh nutzt
+          # dann seine Auto-Erkennung.
+          NOTES_START=$(git tag -l 'v*' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1)
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "title=${TITLE}" >> "$GITHUB_OUTPUT"
+          echo "notes_start=${NOTES_START}" >> "$GITHUB_OUTPUT"
+          echo "→ tag=${TAG} title='${TITLE}' notes_start='${NOTES_START:-<auto>}'"
 
   build-windows:
     needs: pre-check
@@ -80,6 +128,7 @@ jobs:
       - name: Build
         env:
           ZEIT_RELEASE: "1"
+          ZEIT_PRERELEASE: ${{ needs.pre-check.outputs.is_prerelease == 'true' && '1' || '' }}
         run: python build.py
       - uses: actions/upload-artifact@v7
         with:
@@ -102,6 +151,7 @@ jobs:
       - name: Build
         env:
           ZEIT_RELEASE: "1"
+          ZEIT_PRERELEASE: ${{ needs.pre-check.outputs.is_prerelease == 'true' && '1' || '' }}
         run: python build.py
       - uses: actions/upload-artifact@v7
         with:
@@ -131,6 +181,7 @@ jobs:
       - name: Build
         env:
           ZEIT_RELEASE: "1"
+          ZEIT_PRERELEASE: ${{ needs.pre-check.outputs.is_prerelease == 'true' && '1' || '' }}
         run: python build.py
       - uses: actions/upload-artifact@v7
         with:
@@ -176,14 +227,28 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           VERSION="${{ needs.pre-check.outputs.version }}"
+          TAG="${{ needs.pre-check.outputs.tag }}"
+          TITLE="${{ needs.pre-check.outputs.title }}"
+          NOTES_START="${{ needs.pre-check.outputs.notes_start }}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag "v${VERSION}"
-          git push origin "v${VERSION}"
-          gh release create "v${VERSION}" \
-            dist/Zeiterfassung_Setup.exe \
-            dist/Zeiterfassung-${VERSION}-arm64.dmg \
-            dist/Zeiterfassung-${VERSION}-x86_64.AppImage \
-            dist/SHA256SUMS \
-            --title "Zeiterfassung v${VERSION}" \
+          git tag "$TAG"
+          git push origin "$TAG"
+          # Artefaktnamen tragen die reine VERSION (build.py benennt sie unabhängig
+          # vom Pre-Release-Status) — der Tag/Titel kennzeichnet die Vorabversion.
+          args=(
+            "$TAG"
+            dist/Zeiterfassung_Setup.exe
+            "dist/Zeiterfassung-${VERSION}-arm64.dmg"
+            "dist/Zeiterfassung-${VERSION}-x86_64.AppImage"
+            dist/SHA256SUMS
+            --title "$TITLE"
             --generate-notes
+          )
+          if [ -n "$NOTES_START" ]; then
+            args+=(--notes-start-tag "$NOTES_START")
+          fi
+          if [ "${{ needs.pre-check.outputs.is_prerelease }}" = "true" ]; then
+            args+=(--prerelease)
+          fi
+          gh release create "${args[@]}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,26 @@ Ablauf vor dem Merge:
 
 Der Workflow pusht **nichts** nach `master`. Versionsbump gehört in den PR.
 
+### Pre-Releases (plattformübergreifende Test-Builds)
+
+Für plattformübergreifendes Testen vor einem echten Release gibt es Pre-Releases:
+Actions → Workflow **Release** → „Run workflow" mit gesetztem Häkchen
+**prerelease** (Branch egal, gebaut wird der gewählte Ref). Ablauf:
+
+- Baut dieselben drei Artefakte (Windows/macOS-arm/Linux) wie ein echtes Release,
+  aber gestempelt mit `CHANNEL=prerelease` → In-App-Titel zeigt `X.Y.Z-pre`.
+- Tag ist **fortlaufend** `vX.Y.Z-pre.N` (N automatisch hochgezählt je Zielversion,
+  aus `src/version.py`) — kollidiert nie mit dem späteren echten Tag `vX.Y.Z`.
+- GitHub-Release wird als **Pre-Release** markiert (`--prerelease`): der Auto-Updater
+  liest `/releases/latest` und **ignoriert** Pre-Releases → normale Nutzer bekommen
+  sie nicht als Update angeboten.
+- **Kein Versionsbump, kein CHANGELOG, kein Label** nötig. Die Release-Notes werden
+  wie beim echten Release automatisch aus den PRs generiert (`--generate-notes`),
+  kumulativ seit dem letzten **echten** Release.
+
+Manuelles „Run workflow" **ohne** das prerelease-Häkchen baut wie bisher ein echtes
+Voll-Release (Tag `vX.Y.Z`).
+
 ## Recovery bei teilweise fehlgeschlagenem Release
 
 Wenn der `publish`-Job nach dem Tag-Push fehlschlägt (z.B. `gh release create` Netzwerkproblem), blockiert der Pre-Check beim Re-Run die erneute Ausführung wegen "tag already exists". Ablauf:

--- a/build.py
+++ b/build.py
@@ -230,11 +230,17 @@ def generate_build_info():
     Build erzeugt (gitignored) und von PyInstaller mitgebündelt — daher VOR dem
     eigentlichen Build aufrufen.
 
-    Nur der Release-Workflow setzt ZEIT_RELEASE=1 → CHANNEL='release'. Lokales
-    `python build.py` ohne Flag → 'dev' + Commit-Hash. Der Release-Tag vX.Y.Z
-    entsteht erst nach dem Build, taugt daher nicht zur Kanal-Erkennung — daher
-    das explizite Flag."""
-    channel = "release" if os.environ.get("ZEIT_RELEASE") == "1" else "dev"
+    Der Release-Workflow setzt ZEIT_RELEASE=1 → CHANNEL='release'; für einen
+    Pre-Release-Lauf zusätzlich ZEIT_PRERELEASE=1 → CHANNEL='prerelease' (Vorrang
+    vor 'release'). Lokales `python build.py` ohne Flag → 'dev' + Commit-Hash.
+    Der Release-Tag vX.Y.Z entsteht erst nach dem Build, taugt daher nicht zur
+    Kanal-Erkennung — daher die expliziten Flags."""
+    if os.environ.get("ZEIT_PRERELEASE") == "1":
+        channel = "prerelease"
+    elif os.environ.get("ZEIT_RELEASE") == "1":
+        channel = "release"
+    else:
+        channel = "dev"
 
     def _git(args):
         try:

--- a/src/version.py
+++ b/src/version.py
@@ -11,10 +11,13 @@ except ImportError:
 
 
 def _format_version_label(version, channel, sha):
-    """Anzeige-Label für den Fenstertitel. Release → reine Version; jeder andere
+    """Anzeige-Label für den Fenstertitel. Release → reine Version; Pre-Release
+    (plattformübergreifender Test-Build) → '-pre'-Marker ohne SHA; jeder andere
     Kanal (dev/source) → '-dev'-Suffix, mit Kurz-SHA in Klammern falls vorhanden."""
     if channel == "release":
         return version
+    if channel == "prerelease":
+        return f"{version}-pre"
     if sha:
         return f"{version}-dev ({sha})"
     return f"{version}-dev"

--- a/tests/test_version_label.py
+++ b/tests/test_version_label.py
@@ -23,3 +23,10 @@ def test_dev_without_sha_shows_only_dev():
 def test_source_channel_shows_dev_without_sha():
     # Start aus dem Quellcode (kein build_info) → 'source', kein SHA.
     assert _format_version_label("1.14.1", "source", "") == "1.14.1-dev"
+
+
+def test_prerelease_channel_shows_pre_marker():
+    # Pre-Release (plattformübergreifender Test-Build): eigener '-pre'-Marker,
+    # SHA wird wie beim Release nicht angehängt.
+    assert _format_version_label("1.16.1", "prerelease", "abc1234") == "1.16.1-pre"
+    assert _format_version_label("1.16.1", "prerelease", "") == "1.16.1-pre"


### PR DESCRIPTION
## Ziel
Manuell auslösbare **Pre-Releases** für plattformübergreifendes Testen vor einem echten Release. Kein Versionsbump/CHANGELOG/`release:*`-Label nötig; Release-Notes werden wie bei echten Releases automatisch aus den PRs generiert.

## Verhalten
- **Trigger:** Actions → *Release* → „Run workflow" mit Häkchen **prerelease**. Ohne Häkchen = echtes Voll-Release wie bisher; Push-mit-`release:*`-Label = echtes Release wie bisher (nie Pre-Release).
- **Tag:** fortlaufend `vX.Y.Z-pre.N` (N je Zielversion aus `src/version.py` hochgezählt) — kollidiert nie mit dem späteren echten `vX.Y.Z`.
- **GitHub-Release:** als `--prerelease` markiert. Der Auto-Updater liest `/releases/latest`, das Pre-Releases ausschließt → **normale Nutzer bekommen sie nicht** als Update angeboten (verifiziert in `updater.py`).
- **Release-Notes:** `--generate-notes`, kumulativ ab dem letzten **echten** Release (`--notes-start-tag`), damit Voll-Release-Notes von zwischenzeitlichen Pre-Releases unberührt bleiben.
- **In-App:** `build.py` stempelt `CHANNEL="prerelease"` (via `ZEIT_PRERELEASE=1`) → Fenstertitel zeigt `X.Y.Z-pre`.

## Bewusste Design-Entscheidungen (bitte gegenlesen)
- Release-**Titel** enthält N: „Zeiterfassung vX.Y.Z - Pre-Release N" (unterscheidet mehrere Pre-Releases in der Liste).
- `--notes-start-tag = letztes echtes Release` gilt für **alle** Releases. Ohne Pre-Releases identisch zur bisherigen gh-Auto-Erkennung; verhindert nur unvollständige Voll-Release-Notes nach Pre-Releases.
- Artefakt-Dateinamen tragen die reine Version (`Zeiterfassung-1.16.1-arm64.dmg`); Tag/Titel/Markierung kennzeichnen die Vorabversion.

## Tests / Verify
- `pytest tests/test_version_label.py` → 5 passed (neuer `prerelease`-Kanal-Test). `ruff` → clean. `release.yml` parst als YAML.
- **Nicht lokal ausführbar:** der echte GitHub-Actions-Lauf. Die Bash-Logik (N-Hochzählen, `notes_start`, `--prerelease`) ist per Review geprüft; erster Pre-Release-Lauf ist der eigentliche Beweis.

## Hinweis (operativ)
Der „prerelease"-Schalter erscheint im Actions-UI erst, wenn diese `release.yml` **auf master** liegt (GitHub zeigt `workflow_dispatch` nur vom Default-Branch). Nach dem Merge lässt sich per Ref-Auswahl auch ein Feature-Branch als Pre-Release bauen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)