### PR TITLE
fix(scaling): UI-Skalierung auf macOS wirksam machen

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -20,6 +20,7 @@ from src.paths import get_base_path
 from src.reservations import ReservationStore
 from src.settings import Settings, clamp_ui_scale
 from src.storage import Storage
+from src.theme import init_fonts
 from src.ui import App
 from src.version import VERSION
 
@@ -269,13 +270,11 @@ def run_calendar_reconcile(reservation_store, settings, base):
 
 
 def _apply_ui_scaling(root, factor):
-    """Setzt tk-scaling einmalig auf System-DPI × Faktor. MUSS vor dem Aufbau
-    der App-Widgets laufen, damit measure_max_width die skalierten Fonts misst
-    und die Fenstergeometrie entsprechend pinnt. Bei Faktor 1.0 unverändert
-    (base × 1.0 == base)."""
-    f = clamp_ui_scale(factor)
-    base = float(root.tk.call("tk", "scaling"))
-    root.tk.call("tk", "scaling", base * f)
+    """Legt die per UI-Faktor skalierten App-Fonts an (ersetzt das frühere
+    `tk scaling`, das auf macOS/Aqua die Punkt-Fonts nicht skalierte → Slider dort
+    wirkungslos). MUSS vor dem Aufbau der App-Widgets laufen, damit
+    measure_max_width die skalierten Fonts misst und die Fenstergeometrie pinnt."""
+    init_fonts(root, clamp_ui_scale(factor))
 
 
 def main():

--- a/src/theme.py
+++ b/src/theme.py
@@ -2,8 +2,9 @@ import os
 import platform
 import time
 import tkinter as tk
+from tkinter import font as tkfont
 from tkinter import ttk
-from typing import TypedDict
+from typing import Literal, TypedDict
 
 from src.paths import get_base_path
 
@@ -34,13 +35,72 @@ ENTRY_BG = "#1a3a5c"
 WEEKEND_ENTRY_BG = "#1a3050"
 WEEKEND_FG = "#6c6c80"
 
-FONT = (FONT_FAMILY, 10)
-FONT_SMALL = (FONT_FAMILY, 8)
-FONT_TINY = (FONT_FAMILY, 7)
-FONT_BOLD = (FONT_FAMILY, 10, "bold")
-FONT_HEADER = (FONT_FAMILY, 16, "bold")
-FONT_HEADER_SMALL = (FONT_FAMILY, 12, "bold")
-FONT_FOOTER = (FONT_FAMILY, 12, "bold")
+# Fonts als Tk *named fonts*: Die FONT*-Konstanten sind die NAMEN der named
+# fonts (keine Größen-Tupel). Alle Widgets binden font=FONT usw. als String; die
+# tatsächliche, per UI-Faktor skalierte Größe steckt im named font, den init_fonts
+# nach der Root-Erzeugung anlegt. So skaliert die UI plattformübergreifend über
+# echte Punktgrößen statt über `tk scaling` — das skaliert auf macOS/Aqua die
+# Punkt-Fonts NICHT (Ursache des macOS-Skalierungs-Bugs).
+FONT = "AppFont"
+FONT_SMALL = "AppFontSmall"
+FONT_TINY = "AppFontTiny"
+FONT_BOLD = "AppFontBold"
+FONT_HEADER = "AppFontHeader"
+FONT_HEADER_SMALL = "AppFontHeaderSmall"
+FONT_FOOTER = "AppFontFooter"
+
+# name → (Basis-Punktgröße, weight); die Größe wird in init_fonts × Faktor gesetzt.
+_APP_FONTS: dict[str, tuple[int, Literal["normal", "bold"]]] = {
+    FONT: (10, "normal"),
+    FONT_SMALL: (8, "normal"),
+    FONT_TINY: (7, "normal"),
+    FONT_BOLD: (10, "bold"),
+    FONT_HEADER: (16, "bold"),
+    FONT_HEADER_SMALL: (12, "bold"),
+    FONT_FOOTER: (12, "bold"),
+}
+
+# Standard-Tk-Fonts werden mitskaliert, damit Widgets ohne explizites font=…
+# (Default-Font) ebenfalls mitziehen — Parität zum früheren `tk scaling`.
+_STANDARD_FONTS = (
+    "TkDefaultFont", "TkTextFont", "TkFixedFont", "TkMenuFont",
+    "TkHeadingFont", "TkCaptionFont", "TkSmallCaptionFont",
+    "TkIconFont", "TkTooltipFont",
+)
+
+
+def scaled_size(base, scale):
+    """Skalierte Font-Größe: round(base × scale). Betrag min. 1 (nie 0 =
+    unsichtbar), Vorzeichen erhalten — Standard-Tk-Fonts tragen je nach Plattform
+    negative (Pixel-)Größen."""
+    scaled = round(base * scale)
+    if scaled == 0:
+        return -1 if base < 0 else 1
+    return scaled
+
+
+# Hält die erzeugten Font-Objekte prozessweit am Leben. ZWINGEND: ohne Referenz
+# löscht der GC via tkinter.font.Font.__del__ den named font sofort wieder
+# (`font delete`), und font=FONT wäre in den Widgets ein unbekannter Name.
+_APP_FONT_OBJECTS = []
+
+
+def init_fonts(root, scale):
+    """Legt die App-named-fonts an (Basisgröße × scale) und skaliert die
+    Standard-Tk-Fonts mit. MUSS nach der Root-Erzeugung und VOR dem Aufbau der
+    App-Widgets laufen, damit measure_max_width die skalierten Fonts misst und die
+    Fenstergeometrie korrekt pinnt. Ersetzt das frühere `tk scaling`, das auf
+    macOS/Aqua wirkungslos war (skaliert dort die Punkt-Fonts nicht)."""
+    for name, (size, weight) in _APP_FONTS.items():
+        _APP_FONT_OBJECTS.append(
+            tkfont.Font(root=root, name=name, family=FONT_FAMILY,
+                        size=scaled_size(size, scale), weight=weight))
+    for name in _STANDARD_FONTS:
+        try:
+            f = tkfont.nametofont(name)
+        except tk.TclError:
+            continue  # nicht jede Plattform/Tk-Build kennt jeden Standard-Font
+        f.configure(size=scaled_size(f.cget("size"), scale))
 
 # Hover colors (slightly lighter variants)
 CELL_BG_HOVER = "#1e2d52"

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -1,4 +1,4 @@
-from src.theme import _click_keeps_focus
+from src.theme import _click_keeps_focus, scaled_size
 
 
 class _FakeWidget:
@@ -24,3 +24,20 @@ def test_click_keeps_focus_handles_destroyed_widget_path_string():
     # "×"-Schaltfläche einer Slot-Zeile) liefert event.widget als Pfad-String.
     # Darf NICHT crashen (AttributeError: 'str' has no 'winfo_class').
     assert _click_keeps_focus(".!toplevel.!frame.!label") is False
+
+
+def test_scaled_size_scales_and_rounds():
+    assert scaled_size(10, 1.5) == 15
+    assert scaled_size(8, 1.5) == 12
+    assert scaled_size(10, 1.0) == 10
+
+
+def test_scaled_size_never_zero():
+    # Sehr kleiner Faktor darf einen Font nicht auf 0 (unsichtbar) kollabieren.
+    assert scaled_size(1, 0.1) == 1
+
+
+def test_scaled_size_keeps_negative_sign():
+    # Standard-Tk-Fonts können negative (Pixel-)Größen tragen — Vorzeichen bleibt.
+    assert scaled_size(-10, 1.5) == -15
+    assert scaled_size(-2, 0.1) == -1


### PR DESCRIPTION
## Problem
Der Skalierungs-Slider (Einstellungen) war **auf macOS wirkungslos** — auf Win/Linux funktionierte er.

## Ursache
Die Skalierung lief allein über `tk scaling`. Das skaliert auf **macOS/Aqua die in Punkten definierten Fonts NICHT** (dokumentierter Tk-Unterschied: auf Aqua wirkt `tk scaling` nur auf Pixel-Fonts). Die App nutzt durchgehend Punkt-Fonts → auf dem Mac passiert nichts. Beleg: [Tk differences on Mac OS X](https://wiki.tcl-lang.org/page/Tk+differences+on+Mac+OS+X), Abschnitt *Font scaling*.

## Fix (Approach A — plattformunabhängig)
Skalierung über **echte Punktgrößen** statt `tk scaling`, umgesetzt via Tk *named fonts*:
- `theme.py`: Die `FONT*`-Konstanten sind jetzt **Namen** von named fonts (Strings) statt Größen-Tupel — **keine** `font=FONT`-Aufrufstelle ändert sich. `init_fonts(root, scale)` legt die named fonts mit `Basisgröße × Faktor` an und skaliert zusätzlich die Standard-Tk-Fonts mit (Parität zum früheren `tk scaling`). `tk scaling` wird nicht mehr angefasst (sonst Doppel-Skalierung auf Win/Linux).
- `main.py`: `_apply_ui_scaling` ruft `init_fonts` statt `tk.call("tk","scaling",…)`.
- Die Font-Objekte werden prozessweit gehalten (`_APP_FONT_OBJECTS`) — sonst löscht der GC via `Font.__del__` den named font sofort wieder (das hätte auch die echte App getroffen; von der Verifikation gefangen).
- `scaled_size` als reiner, getesteter Helfer (Rundung, min 1, Vorzeichen erhalten).

## Verify
- **Windows real geprüft:** Fonts skalieren 10→15→20 bei 100/150/200 % (App- **und** Standard-Fonts); Layout unverändert korrekt, keine Regression. Vom Nutzer auf Windows bestätigt.
- `pytest` → 653 passed, 2 skipped. `ruff check .` → clean.
- **macOS-Nachtest steht aus** (lokal nicht möglich): Build/Pre-Release starten, Skalierung 100 %→150 % → UI muss jetzt größer werden.

## Unberührt
Reports (eigene CSS-Größen), HiDPI (Tk-DPI-Default bleibt), Restart-on-change-Modell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)