### PR TITLE
fix: Autostart-Vereinheitlichung (Registry) + Single-Instance-Guard

### DIFF
--- a/docs/superpowers/plans/2026-07-03-autostart-unification.md
+++ b/docs/superpowers/plans/2026-07-03-autostart-unification.md
@@ -1,0 +1,851 @@
+# Autostart-Vereinheitlichung + Single-Instance-Guard — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Auf Windows kann nur noch **ein** Autostart-Eintrag existieren (App und Installer teilen denselben Registry-Run-Key); die Autostart-Checkbox zeigt den echten Zustand; Bestandsnutzer werden absichtserhaltend migriert; ein plattformübergreifender Single-Instance-Guard verhindert parallele Instanzen.
+
+**Architecture:** Windows-Autostart wechselt von einem Startup-Shortcut auf den HKCU-Run-Registry-Wert `Zeiterfassung` (gleicher Wertname wie im Installer → strukturell ein Eintrag). Eine frozen-gegatete Migration überführt Alt-Shortcuts absichtserhaltend in die Registry. Ein neues Tk-freies Modul `single_instance.py` bindet beim Start einen pro-Nutzer abgeleiteten Localhost-Port; nur die Erstinstanz gewinnt den Bind (atomar), Folge­instanzen melden sich per Socket und beenden sich.
+
+**Tech Stack:** Python stdlib (`winreg`, `socket`, `zlib`, `threading`), Tkinter (bestehend), pytest.
+
+## Global Constraints
+
+- **`import winreg` immer LAZY** (in der Funktion, nie auf Modulebene): CI läuft auf Ubuntu und importiert `autostart.py` über `tests → ui → settings_dialog → autostart`; ein Modul-Level-Import bräche jeden CI-Lauf. Gleiche Regel wie die Lazy-Google-Imports in `drive.py`/`gcal.py`.
+- **Registry-Wertformat exakt wie der Installer:** Wertname `Zeiterfassung`, Daten `"<target>" --minimized` (Exe-Pfad in Anführungszeichen, Space, Argumente; ohne Argumente nur `"<target>"`). `installer.iss` bleibt unverändert.
+- **Migration nur im Frozen-Build** (`sys.frozen`) und nur auf Windows — sonst Selbstbeschädigung im Repo-Modus.
+- **Datum intern ISO / UI deutsch, UTF-8-Mail-Pipeline, Klick-Modell** — hier nicht berührt, gelten aber projektweit.
+- **`autostart` bleibt device-lokal**, nicht in `SYNCED_SETTING_KEYS` aufnehmen.
+- **Guard darf den Start nie blockieren**: jeder Fehlerpfad (belegter Fremd-Port, Bind-Fehler, Exception) endet im normalen (ggf. ungeschützten) Start.
+- **Socket-Option plattformabhängig:** Windows `SO_EXCLUSIVEADDRUSE` (vor `bind`), POSIX `SO_REUSEADDR`. `SO_REUSEADDR` auf Windows würde den zweiten Bind gelingen lassen → Guard wirkungslos.
+- Commit-Typ englisch (`feat:`/`fix:`/`docs:`/`test:`), Body/Beschreibung Deutsch ok. Kein `git push` (kein Trigger).
+
+---
+
+## Dateien-Überblick
+
+| Datei | Verantwortung |
+|-------|---------------|
+| `src/autostart.py` | Windows-Backend Registry statt Shortcut; `is_autostart_enabled()`; `migrate_legacy_autostart()` |
+| `src/single_instance.py` | **neu** — Tk-freier Guard: Port-Ableitung, plattform-Socket-Option, Protokoll, `acquire`/`serve`/`release` |
+| `src/main.py` | Migration + Guard-`acquire` vor Tk-Bau; Guard an `App`; `serve()` nach Bau |
+| `src/ui.py` | `App` hält Guard; `release()` vor Skalierungs-Relaunch und bei Quit |
+| `src/dialogs/settings_dialog.py` | Checkbox-Init + `old_autostart` aus `is_autostart_enabled()` |
+| `tests/test_autostart.py` | Windows-Klasse auf Registry umbauen; `is_autostart_enabled`, `migrate_legacy_autostart` |
+| `tests/test_single_instance.py` | **neu** |
+| `src/CLAUDE.md` | Guard-Modul + Registry-Vertrag dokumentieren |
+
+---
+
+### Task 1: Windows-Autostart von Shortcut auf Registry umstellen + `is_autostart_enabled()`
+
+**Files:**
+- Modify: `src/autostart.py` (`_enable_windows`, `_disable_windows`; neu: Registry-Helfer, `is_autostart_enabled`)
+- Test: `tests/test_autostart.py` (Windows-Klasse `TestWindowsAutostart` umbauen; neue Klasse `TestIsAutostartEnabled`)
+
+**Interfaces:**
+- Consumes: `resolve_autostart_target(base_path)` (bestehend), `_get_shortcut_path()` (bestehend).
+- Produces:
+  - `is_autostart_enabled() -> bool` — plattform-dispatched Statusabfrage.
+  - Modul-Konstanten `_RUN_KEY_SUBKEY: str`, `_RUN_VALUE_NAME: str` (test-patchbar).
+  - `_windows_run_command(target: str, arguments: str) -> str` — baut den Registry-Datenstring.
+  - Interne Helfer `_windows_registry_enabled() -> bool`, `_remove_legacy_shortcut() -> None`.
+  - `enable_autostart(target, arguments)` / `disable_autostart()` behalten Signatur & Verhalten (nur Windows-Backend wechselt).
+
+- [ ] **Step 1: Failing test — Registry-Datenstring-Format**
+
+In `tests/test_autostart.py`, oben ergänzen:
+```python
+from src.autostart import is_autostart_enabled, _windows_run_command
+```
+Neuen Test hinzufügen (plattformunabhängig, reine String-Logik):
+```python
+def test_windows_run_command_matches_installer_format():
+    cmd = _windows_run_command(r"C:\app\Zeiterfassung.exe", "--minimized")
+    assert cmd == r'"C:\app\Zeiterfassung.exe" --minimized'
+
+
+def test_windows_run_command_without_arguments():
+    cmd = _windows_run_command(r"C:\app\Zeiterfassung.exe", "")
+    assert cmd == r'"C:\app\Zeiterfassung.exe"'
+```
+
+- [ ] **Step 2: Run → verläuft fehlerhaft (ImportError)**
+
+Run: `pytest tests/test_autostart.py::test_windows_run_command_matches_installer_format -v`
+Expected: FAIL — `ImportError: cannot import name '_windows_run_command'`.
+
+- [ ] **Step 3: Registry-Helfer + Konstanten implementieren**
+
+In `src/autostart.py` unter die bestehenden Konstanten (`SHORTCUT_NAME`, `MACOS_LABEL`):
+```python
+_RUN_KEY_SUBKEY = r"Software\Microsoft\Windows\CurrentVersion\Run"
+_RUN_VALUE_NAME = "Zeiterfassung"
+
+
+def _windows_run_command(target, arguments):
+    """Baut den HKCU-Run-Datenstring — identisch zum Installer-Format:
+    Exe in Anführungszeichen, dann (falls vorhanden) die Argumente."""
+    if arguments:
+        return f'"{target}" {arguments}'
+    return f'"{target}"'
+
+
+def _remove_legacy_shortcut():
+    """Entfernt den Alt-Startup-Shortcut, falls vorhanden (tolerant)."""
+    try:
+        os.remove(_get_shortcut_path())
+    except FileNotFoundError:
+        pass
+
+
+def _windows_registry_enabled():
+    import winreg
+    try:
+        with winreg.OpenKey(winreg.HKEY_CURRENT_USER, _RUN_KEY_SUBKEY) as key:
+            winreg.QueryValueEx(key, _RUN_VALUE_NAME)
+        return True
+    except FileNotFoundError:
+        return False
+```
+
+- [ ] **Step 4: `_enable_windows` / `_disable_windows` auf Registry umstellen**
+
+In `src/autostart.py` den **kompletten** bestehenden `_enable_windows`-Body (VBS/cscript) und `_disable_windows`-Body ersetzen durch:
+```python
+def _enable_windows(target, arguments):
+    import winreg
+    command = _windows_run_command(target, arguments)
+    with winreg.CreateKey(winreg.HKEY_CURRENT_USER, _RUN_KEY_SUBKEY) as key:
+        winreg.SetValueEx(key, _RUN_VALUE_NAME, 0, winreg.REG_SZ, command)
+    _remove_legacy_shortcut()
+
+
+def _disable_windows():
+    import winreg
+    try:
+        with winreg.OpenKey(
+            winreg.HKEY_CURRENT_USER, _RUN_KEY_SUBKEY, 0, winreg.KEY_SET_VALUE
+        ) as key:
+            winreg.DeleteValue(key, _RUN_VALUE_NAME)
+    except FileNotFoundError:
+        pass
+    _remove_legacy_shortcut()
+```
+`import tempfile` (oben in `autostart.py`) wird danach **unbenutzt** (nur der alte VBS-Pfad nutzte `mkstemp`) → entfernen, sonst meldet `ruff` F401. `subprocess`/`plistlib` bleiben (macOS-Backend nutzt sie).
+
+- [ ] **Step 5: `is_autostart_enabled()` implementieren**
+
+In `src/autostart.py` nach `disable_autostart()` einfügen:
+```python
+def is_autostart_enabled():
+    """Echter Autostart-Zustand (nicht das gespeicherte Setting).
+
+    Windows: Registry-Run-Wert ODER Alt-Shortcut vorhanden (Shortcut-Fallback,
+    falls die Migration einmal fehlschlägt). macOS/Linux: Plist- bzw.
+    .desktop-Datei vorhanden."""
+    system = platform.system()
+    if system == "Windows":
+        return _windows_registry_enabled() or os.path.exists(_get_shortcut_path())
+    if system == "Darwin":
+        return os.path.exists(_macos_plist_path())
+    if system == "Linux":
+        return os.path.exists(_linux_desktop_path())
+    return False
+```
+
+- [ ] **Step 6: `_windows_run_command`-Tests grün**
+
+Run: `pytest tests/test_autostart.py::test_windows_run_command_matches_installer_format tests/test_autostart.py::test_windows_run_command_without_arguments -v`
+Expected: PASS (2 passed).
+
+- [ ] **Step 7: Windows-Registry-Tests schreiben (real winreg gegen Temp-Subkey)**
+
+In `tests/test_autostart.py` die Klasse `TestWindowsAutostart` **komplett ersetzen** (die alten cscript/VBS-Tests entfallen). Nutzt echten `winreg` gegen einen throwaway HKCU-Subkey — schreibt **nie** in den echten Run-Key:
+```python
+@pytest.mark.skipif(platform.system() != "Windows", reason="Windows only")
+class TestWindowsAutostart:
+    @pytest.fixture
+    def temp_run_key(self, monkeypatch):
+        import winreg
+        subkey = r"Software\ZeiterfassungTest\Run"
+        monkeypatch.setattr("src.autostart._RUN_KEY_SUBKEY", subkey)
+        yield subkey
+        try:
+            winreg.DeleteKey(winreg.HKEY_CURRENT_USER, subkey)
+        except FileNotFoundError:
+            pass
+
+    def test_enable_writes_registry_value(self, temp_run_key, fake_startup):
+        import winreg
+        enable_autostart(r"C:\app\Zeiterfassung.exe", "--minimized")
+        with winreg.OpenKey(winreg.HKEY_CURRENT_USER, temp_run_key) as key:
+            value, _typ = winreg.QueryValueEx(key, "Zeiterfassung")
+        assert value == r'"C:\app\Zeiterfassung.exe" --minimized'
+
+    def test_disable_removes_registry_value(self, temp_run_key, fake_startup):
+        import winreg
+        enable_autostart(r"C:\app\Zeiterfassung.exe", "--minimized")
+        disable_autostart()
+        with winreg.OpenKey(winreg.HKEY_CURRENT_USER, temp_run_key) as key:
+            with pytest.raises(FileNotFoundError):
+                winreg.QueryValueEx(key, "Zeiterfassung")
+
+    def test_disable_without_value_no_error(self, temp_run_key, fake_startup):
+        disable_autostart()  # kein Wert vorhanden → kein Fehler
+
+    def test_enable_removes_legacy_shortcut(self, temp_run_key, fake_startup):
+        shortcut = fake_startup / "Zeiterfassung.lnk"
+        shortcut.write_text("fake")
+        enable_autostart(r"C:\app\Zeiterfassung.exe", "--minimized")
+        assert not shortcut.exists()
+```
+
+- [ ] **Step 8: `is_autostart_enabled`-Tests (alle Plattformen)**
+
+In `tests/test_autostart.py` neue Klasse anfügen. macOS/Linux nutzen die vorhandenen `fake_home`-Muster; Windows den Temp-Key:
+```python
+class TestIsAutostartEnabled:
+    def test_linux_true_when_desktop_exists(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setattr("src.autostart.platform.system", lambda: "Linux")
+        assert is_autostart_enabled() is False
+        enable_autostart("/opt/Zeiterfassung.AppImage", "--minimized")
+        assert is_autostart_enabled() is True
+
+    @pytest.mark.skipif(platform.system() != "Darwin", reason="macOS only")
+    def test_macos_true_when_plist_exists(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setattr("src.autostart.platform.system", lambda: "Darwin")
+        (tmp_path / "Library" / "LaunchAgents").mkdir(parents=True)
+        assert is_autostart_enabled() is False
+
+    @pytest.mark.skipif(platform.system() != "Windows", reason="Windows only")
+    def test_windows_true_when_registry_value_exists(self, monkeypatch, tmp_path):
+        import winreg
+        subkey = r"Software\ZeiterfassungTest\Run2"
+        monkeypatch.setattr("src.autostart._RUN_KEY_SUBKEY", subkey)
+        monkeypatch.setattr("src.autostart._get_startup_folder", lambda: str(tmp_path))
+        assert is_autostart_enabled() is False
+        enable_autostart(r"C:\app\Zeiterfassung.exe", "--minimized")
+        try:
+            assert is_autostart_enabled() is True
+        finally:
+            winreg.DeleteKey(winreg.HKEY_CURRENT_USER, subkey)
+```
+Hinweis: Der Linux-Test läuft auch in der Ubuntu-CI (kein skipif) — deckt `is_autostart_enabled` + `enable`/`disable` real ab.
+
+- [ ] **Step 9: Volle Autostart-Tests grün**
+
+Run: `pytest tests/test_autostart.py -v`
+Expected: PASS (macOS/Linux-Klassen unverändert grün; Windows-Klassen laufen bzw. sind auf Nicht-Windows geskippt).
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/autostart.py tests/test_autostart.py
+git commit -m "feat(autostart): Windows-Autostart auf HKCU-Run-Registry + is_autostart_enabled"
+```
+
+---
+
+### Task 2: `migrate_legacy_autostart()` — Alt-Shortcut absichtserhaltend in die Registry überführen
+
+**Files:**
+- Modify: `src/autostart.py` (neu: `migrate_legacy_autostart`)
+- Test: `tests/test_autostart.py` (neue Klasse `TestMigrateLegacyAutostart`)
+
+**Interfaces:**
+- Consumes: `resolve_autostart_target`, `_windows_registry_enabled`, `_enable_windows`, `_remove_legacy_shortcut`, `_get_shortcut_path`.
+- Produces: `migrate_legacy_autostart(base_path: str) -> None` — no-op außer im Frozen-Windows-Build mit vorhandenem Alt-Shortcut.
+
+- [ ] **Step 1: Failing tests — die vier Zustände**
+
+In `tests/test_autostart.py` ergänzen (`from src.autostart import migrate_legacy_autostart` oben hinzufügen):
+```python
+@pytest.mark.skipif(platform.system() != "Windows", reason="Windows only")
+class TestMigrateLegacyAutostart:
+    @pytest.fixture
+    def frozen_win(self, monkeypatch, tmp_path):
+        import winreg
+        subkey = r"Software\ZeiterfassungTest\RunMig"
+        monkeypatch.setattr("src.autostart._RUN_KEY_SUBKEY", subkey)
+        monkeypatch.setattr("src.autostart._get_startup_folder", lambda: str(tmp_path))
+        monkeypatch.setattr("src.autostart.sys.frozen", True, raising=False)
+        monkeypatch.setattr("src.autostart.sys.executable",
+                            str(tmp_path / "Zeiterfassung.exe"), raising=False)
+        yield tmp_path
+        try:
+            winreg.DeleteKey(winreg.HKEY_CURRENT_USER, subkey)
+        except FileNotFoundError:
+            pass
+
+    def test_state2_shortcut_only_writes_registry(self, frozen_win):
+        (frozen_win / "Zeiterfassung.lnk").write_text("fake")
+        migrate_legacy_autostart(str(frozen_win))
+        from src.autostart import _windows_registry_enabled
+        assert _windows_registry_enabled() is True
+        assert not (frozen_win / "Zeiterfassung.lnk").exists()
+
+    def test_state3_both_keeps_registry_drops_shortcut(self, frozen_win):
+        enable_autostart(str(frozen_win / "Zeiterfassung.exe"), "--minimized")
+        (frozen_win / "Zeiterfassung.lnk").write_text("fake")
+        migrate_legacy_autostart(str(frozen_win))
+        from src.autostart import _windows_registry_enabled
+        assert _windows_registry_enabled() is True
+        assert not (frozen_win / "Zeiterfassung.lnk").exists()
+
+    def test_state4_nothing_stays_nothing(self, frozen_win):
+        migrate_legacy_autostart(str(frozen_win))
+        from src.autostart import _windows_registry_enabled
+        assert _windows_registry_enabled() is False
+
+    def test_idempotent_second_run_noop(self, frozen_win):
+        (frozen_win / "Zeiterfassung.lnk").write_text("fake")
+        migrate_legacy_autostart(str(frozen_win))
+        migrate_legacy_autostart(str(frozen_win))  # kein Fehler, kein Shortcut mehr
+        assert not (frozen_win / "Zeiterfassung.lnk").exists()
+
+    def test_not_frozen_is_noop(self, frozen_win, monkeypatch):
+        monkeypatch.setattr("src.autostart.sys.frozen", False, raising=False)
+        (frozen_win / "Zeiterfassung.lnk").write_text("fake")
+        migrate_legacy_autostart(str(frozen_win))
+        from src.autostart import _windows_registry_enabled
+        assert _windows_registry_enabled() is False          # nichts geschrieben
+        assert (frozen_win / "Zeiterfassung.lnk").exists()   # Shortcut unangetastet
+```
+
+- [ ] **Step 2: Run → FAIL (ImportError)**
+
+Run: `pytest tests/test_autostart.py::TestMigrateLegacyAutostart -v`
+Expected: FAIL — `cannot import name 'migrate_legacy_autostart'`.
+
+- [ ] **Step 3: `migrate_legacy_autostart` implementieren**
+
+In `src/autostart.py` nach `is_autostart_enabled()` einfügen:
+```python
+def migrate_legacy_autostart(base_path):
+    """Überführt einen Alt-Startup-Shortcut in den Registry-Run-Key —
+    absichtserhaltend. Nur im Frozen-Windows-Build; sonst No-op (im Repo-Modus
+    würde der Registry-Wert auf python.exe+Repo zeigen und den installierten
+    Shortcut löschen — Selbstbeschädigung). Idempotent: ist der Shortcut weg,
+    tut jeder weitere Lauf nichts."""
+    if not getattr(sys, "frozen", False):
+        return
+    if platform.system() != "Windows":
+        return
+    if not os.path.exists(_get_shortcut_path()):
+        return
+    if not _windows_registry_enabled():
+        target, arguments = resolve_autostart_target(base_path)
+        _enable_windows(target, arguments)  # schreibt Registry + entfernt Shortcut
+        return
+    _remove_legacy_shortcut()
+```
+
+- [ ] **Step 4: Run → PASS**
+
+Run: `pytest tests/test_autostart.py::TestMigrateLegacyAutostart -v`
+Expected: PASS (auf Nicht-Windows geskippt).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/autostart.py tests/test_autostart.py
+git commit -m "feat(autostart): migrate_legacy_autostart — Alt-Shortcut absichtserhaltend in Registry"
+```
+
+---
+
+### Task 3: Settings-Dialog-Checkbox liest den echten Zustand
+
+**Files:**
+- Modify: `src/dialogs/settings_dialog.py` (Import; Zeile ~713 Checkbox-Init; Zeile ~866 `old_autostart`)
+
+**Interfaces:**
+- Consumes: `is_autostart_enabled()` (Task 1).
+- Produces: — (reine Wiring-Änderung; kein neuer Unit-Test, weil Tk-gebunden. Das Verhalten „Checkbox = echter Zustand" ist über `is_autostart_enabled()` in Task 1 getestet.)
+
+- [ ] **Step 1: Import ergänzen**
+
+In `src/dialogs/settings_dialog.py` die bestehende Import-Zeile
+```python
+from src.autostart import disable_autostart, enable_autostart, resolve_autostart_target
+```
+erweitern zu:
+```python
+from src.autostart import disable_autostart, enable_autostart, is_autostart_enabled, resolve_autostart_target
+```
+
+- [ ] **Step 2: Checkbox-Init aus dem echten Zustand**
+
+In `src/dialogs/settings_dialog.py` (~Zeile 713) ersetzen:
+```python
+    autostart_var = tk.BooleanVar(value=settings.get("autostart"))
+```
+durch:
+```python
+    autostart_var = tk.BooleanVar(value=is_autostart_enabled())
+```
+
+- [ ] **Step 3: `old_autostart` aus dem echten Zustand**
+
+In `src/dialogs/settings_dialog.py` (~Zeile 866) ersetzen:
+```python
+        old_autostart = settings.get("autostart")
+```
+durch:
+```python
+        old_autostart = is_autostart_enabled()
+```
+(So ist „unverändert gelassen" ein echtes No-op; der `updates`-Dict-Eintrag `"autostart": new_autostart` bleibt für Abwärtskompatibilität bestehen.)
+
+- [ ] **Step 4: Verify — Suite grün + Lint**
+
+Run: `pytest -q && ruff check .`
+Expected: PASS (keine neuen Failures; die Wiring-Änderung bricht keine bestehenden Tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/dialogs/settings_dialog.py
+git commit -m "fix(settings-ui): Autostart-Checkbox liest echten Zustand statt gespeichertem Flag"
+```
+
+---
+
+### Task 4: `single_instance.py` — Tk-freier Single-Instance-Guard
+
+**Files:**
+- Create: `src/single_instance.py`
+- Test: `tests/test_single_instance.py`
+
+**Interfaces:**
+- Consumes: — (stdlib only).
+- Produces:
+  - `acquire(base_path: str, show_requested: bool) -> _Guard | None` — `None` ⇒ ein Geschwister läuft, Aufrufer soll sich beenden; `_Guard` ⇒ Primär (ggf. degradiert-ungebunden).
+  - `_derive_port(base_path: str) -> int` — deterministischer Port 20000–31999.
+  - `class _Guard` mit `bound: bool`, `serve(show_fn: Callable[[], None]) -> None`, `release() -> None`.
+  - Protokoll-Konstanten `_MAGIC_SHOW`, `_MAGIC_PING`, `_MAGIC_OK` (bytes).
+
+- [ ] **Step 1: Failing test — Port-Ableitung**
+
+Create `tests/test_single_instance.py`:
+```python
+# tests/test_single_instance.py
+import socket
+import sys
+import threading
+
+import pytest
+
+from src.single_instance import _derive_port, acquire
+
+
+def test_derive_port_deterministic_and_in_range():
+    p1 = _derive_port(r"C:\Users\a\Zeiterfassung")
+    p2 = _derive_port(r"C:\Users\a\Zeiterfassung")
+    assert p1 == p2
+    assert 20000 <= p1 < 32000
+
+
+def test_derive_port_differs_per_path():
+    assert _derive_port("/home/a") != _derive_port("/home/b")
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="normcase ist nur auf Windows case-/separator-normalisierend")
+def test_derive_port_normalizes_case_and_separators():
+    a = _derive_port(r"C:\Users\A\Zeiterfassung")
+    b = _derive_port(r"c:/users/a/zeiterfassung")
+    assert a == b
+```
+
+- [ ] **Step 2: Run → FAIL (ModuleNotFoundError)**
+
+Run: `pytest tests/test_single_instance.py::test_derive_port_deterministic_and_in_range -v`
+Expected: FAIL — `No module named 'src.single_instance'`.
+
+- [ ] **Step 3: Modul-Grundgerüst + `_derive_port`**
+
+Create `src/single_instance.py`:
+```python
+# src/single_instance.py
+"""Single-Instance-Guard (Tk-frei). Erstinstanz bindet einen pro-Nutzer
+abgeleiteten Localhost-Port; Folgeinstanzen melden sich per Socket und beenden
+sich. Blockiert den Start nie — jeder Fehlerpfad endet im (ggf. ungeschützten)
+Weiterlauf."""
+import logging
+import os
+import socket
+import sys
+import threading
+import zlib
+
+_MAGIC_SHOW = b"ZEIT-SHOW"
+_MAGIC_PING = b"ZEIT-PING"
+_MAGIC_OK = b"ZEIT-OK"
+_ACK_TIMEOUT = 2.0          # großzügig gegen Boot-Last
+_PORT_BASE = 20000
+_PORT_SPAN = 12000          # Range 20000–31999, unter allen Ephemeral-Ranges
+
+_log = logging.getLogger(__name__)
+
+
+def _derive_port(base_path):
+    norm = os.path.normcase(os.path.normpath(base_path))
+    return _PORT_BASE + (zlib.crc32(norm.encode("utf-8")) % _PORT_SPAN)
+```
+
+- [ ] **Step 4: Run → PASS (Port-Tests)**
+
+Run: `pytest tests/test_single_instance.py -k derive_port -v`
+Expected: PASS (3 passed).
+
+- [ ] **Step 5: Failing test — Primär/Zweit-Erkennung + SHOW/PING**
+
+In `tests/test_single_instance.py` ergänzen:
+```python
+def test_first_acquire_is_primary_second_exits(tmp_path):
+    base = str(tmp_path)
+    g1 = acquire(base, show_requested=True)
+    try:
+        assert g1 is not None and g1.bound is True
+        g2 = acquire(base, show_requested=True)
+        assert g2 is None            # Geschwister erkannt → Aufrufer beendet sich
+    finally:
+        g1.release()
+
+
+def test_show_fires_callback_ping_does_not(tmp_path):
+    base = str(tmp_path)
+    g1 = acquire(base, show_requested=True)
+    fired = threading.Event()
+    g1.serve(lambda: fired.set())
+    try:
+        # SHOW → Callback feuert
+        assert acquire(base, show_requested=True) is None
+        assert fired.wait(timeout=3.0) is True
+
+        # PING → Callback feuert NICHT
+        fired.clear()
+        assert acquire(base, show_requested=False) is None
+        assert fired.wait(timeout=1.0) is False
+    finally:
+        g1.release()
+
+
+def test_pending_show_before_serve_fires_on_serve(tmp_path):
+    base = str(tmp_path)
+    g1 = acquire(base, show_requested=True)
+    try:
+        assert acquire(base, show_requested=True) is None   # SHOW vor serve()
+        fired = threading.Event()
+        g1.serve(lambda: fired.set())                        # gepuffertes SHOW feuert nach
+        assert fired.wait(timeout=3.0) is True
+    finally:
+        g1.release()
+
+
+def test_foreign_occupant_yields_degraded_primary(tmp_path):
+    base = str(tmp_path)
+    port = _derive_port(base)
+    squatter = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    squatter.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    squatter.bind(("127.0.0.1", port))
+    squatter.listen(1)
+    try:
+        g = acquire(base, show_requested=True)   # Port belegt, kein ZEIT-OK
+        assert g is not None and g.bound is False  # degradiert, aber Start läuft
+    finally:
+        squatter.close()
+```
+Hinweis: `test_foreign_occupant` bindet den Port selbst; auf Windows würde ein zweiter `acquire`-Bind wegen `SO_EXCLUSIVEADDRUSE` scheitern, auf POSIX wegen belegtem Port — in beiden Fällen fällt `acquire` in den Notify-Pfad, bekommt kein `ZEIT-OK` und liefert den degradierten Guard.
+
+- [ ] **Step 6: Run → FAIL (kein `acquire`)**
+
+Run: `pytest tests/test_single_instance.py::test_first_acquire_is_primary_second_exits -v`
+Expected: FAIL — `AttributeError: module 'src.single_instance' has no attribute 'acquire'`.
+
+- [ ] **Step 7: `_Guard`, `_notify_primary`, `acquire` implementieren**
+
+In `src/single_instance.py` anfügen:
+```python
+class _Guard:
+    def __init__(self, port):
+        self.port = port
+        self.bound = False
+        self._sock = None
+        self._lock = threading.Lock()
+        self._show_fn = None
+        self._pending_show = False
+        self._stop = False
+
+    def _try_bind(self):
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        if sys.platform == "win32":
+            # Windows: verhindert, dass ein zweiter Prozess denselben Port bindet.
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_EXCLUSIVEADDRUSE, 1)
+        else:
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        try:
+            sock.bind(("127.0.0.1", self.port))
+            sock.listen(5)
+        except OSError:
+            sock.close()
+            return False
+        sock.settimeout(0.5)
+        self._sock = sock
+        self.bound = True
+        threading.Thread(target=self._accept_loop, daemon=True).start()
+        return True
+
+    def _accept_loop(self):
+        while not self._stop:
+            sock = self._sock
+            if sock is None:            # release() lief parallel → sauber raus
+                break
+            try:
+                conn, _addr = sock.accept()
+            except socket.timeout:
+                continue
+            except OSError:
+                break
+            with conn:
+                try:
+                    data = conn.recv(32)
+                    if data.startswith(_MAGIC_SHOW):
+                        conn.sendall(_MAGIC_OK)
+                        self._fire_show()
+                    elif data.startswith(_MAGIC_PING):
+                        conn.sendall(_MAGIC_OK)
+                except OSError:
+                    pass
+
+    def _fire_show(self):
+        with self._lock:
+            fn = self._show_fn
+            if fn is None:
+                self._pending_show = True
+                return
+        fn()
+
+    def serve(self, show_fn):
+        """Registriert den Fenster-Holen-Callback. Ein vor serve() eingetroffenes
+        SHOW feuert jetzt nach."""
+        with self._lock:
+            self._show_fn = show_fn
+            pending = self._pending_show
+            self._pending_show = False
+        if pending:
+            show_fn()
+
+    def release(self):
+        """Listener stoppen und Port freigeben (No-op wenn nie gebunden)."""
+        self._stop = True
+        if self._sock is not None:
+            try:
+                self._sock.close()
+            except OSError:
+                pass
+            self._sock = None
+        self.bound = False
+
+
+def _notify_primary(port, show_requested):
+    """Meldet sich bei der laufenden Instanz. True nur, wenn sie sich per
+    ZEIT-OK als unsere App bestätigt."""
+    msg = _MAGIC_SHOW if show_requested else _MAGIC_PING
+    try:
+        with socket.create_connection(("127.0.0.1", port), timeout=_ACK_TIMEOUT) as sock:
+            sock.sendall(msg)
+            sock.settimeout(_ACK_TIMEOUT)
+            return sock.recv(len(_MAGIC_OK)) == _MAGIC_OK
+    except OSError:
+        return False
+
+
+def acquire(base_path, show_requested):
+    """Erstinstanz → gebundener _Guard. Läuft schon eine (bestätigt per ZEIT-OK)
+    → None (Aufrufer beendet sich). Port von Fremd-Software belegt → degradierter
+    (ungebundener) _Guard, damit der Start nie blockiert."""
+    port = _derive_port(base_path)
+    guard = _Guard(port)
+    if guard._try_bind():
+        return guard
+    if _notify_primary(port, show_requested):
+        return None
+    _log.warning("Single-Instance-Port %d belegt, kein ZEIT-OK — Start ohne Guard", port)
+    return guard
+```
+
+- [ ] **Step 8: Run → alle Guard-Tests grün**
+
+Run: `pytest tests/test_single_instance.py -v`
+Expected: PASS (alle). Bei vereinzelt langsamem CI kann `test_show_fires_callback...` an Timing liegen — Timeouts sind großzügig (3 s) gewählt.
+
+- [ ] **Step 9: Lint**
+
+Run: `ruff check src/single_instance.py tests/test_single_instance.py`
+Expected: keine Findings (ungenutzte Imports vermeiden: `time`/`monkeypatch` nur nutzen, wo importiert — ggf. unbenutzte Test-Imports entfernen).
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/single_instance.py tests/test_single_instance.py
+git commit -m "feat(single-instance): Tk-freier Guard (pro-Nutzer-Port, SHOW/PING-Protokoll)"
+```
+
+---
+
+### Task 5: Verdrahtung in `main.py` + `ui.py` (Migration, Guard-acquire/serve/release)
+
+**Files:**
+- Modify: `src/main.py` (`main()`: Migration + `acquire` vor Tk-Bau; Guard an `App`; `serve()` nach Bau)
+- Modify: `src/ui.py` (`App.__init__` neuer Param `single_instance`; `restart_for_scaling` + `_quit_with_sync_push` rufen `release()`)
+
+**Interfaces:**
+- Consumes: `single_instance.acquire` / `_Guard.serve` / `_Guard.release` (Task 4); `autostart.migrate_legacy_autostart` (Task 2); `App._restore_from_tray` + `App._marshal_to_ui` (bestehend, `ui.py:444`/`:450`).
+- Produces: `App.__init__(..., single_instance=None)` — speichert `self._single_instance`.
+
+Reines Wiring (Tk-/Prozess-gebunden) → kein neuer Unit-Test; verifiziert per Suite-grün, Lint und manuellem End-to-End-Test (Doppelstart).
+
+- [ ] **Step 1: `App.__init__` nimmt den Guard entgegen**
+
+In `src/ui.py` die Signatur von `App.__init__` (Zeile ~56) erweitern:
+```python
+    def __init__(self, root, storage, settings, base_path=".", conflicts_store=None,
+                 reservation_store=None, single_instance=None):
+```
+Direkt im Rumpf (bei den anderen `self.…`-Zuweisungen, nach `self.settings = settings`) ergänzen:
+```python
+        self._single_instance = single_instance
+```
+
+- [ ] **Step 2: `release()` vor dem Skalierungs-Relaunch**
+
+In `src/ui.py::restart_for_scaling` (Zeile ~619) **vor** `subprocess.Popen(cmd)` einfügen:
+```python
+        if self._single_instance is not None:
+            self._single_instance.release()
+```
+Begründung (als Kommentar mit aufnehmen):
+```python
+        # Port VOR dem Spawn freigeben, sonst fände die neue Instanz ihn noch
+        # belegt, schickte SHOW und beendete sich — die App verschwände beim
+        # bloßen Skalierungswechsel.
+```
+So steht es unmittelbar über dem `try:`/`Popen`. Fail-safety bleibt: schlägt `Popen` fehl, läuft die alte App weiter (dann kurz ungeschützt — akzeptabel).
+
+- [ ] **Step 3: `release()` beim Quit**
+
+In `src/ui.py::_quit_with_sync_push` (Zeile ~600) vor `self.root.destroy()` ergänzen:
+```python
+        if self._single_instance is not None:
+            self._single_instance.release()
+```
+
+- [ ] **Step 4: `main.py` — Migration + `acquire` vor dem Tk-Aufbau**
+
+In `src/main.py::main()` direkt **nach** dem `setup_logging`-Block und **vor** `settings = Settings(...)` einfügen:
+```python
+    from src import single_instance
+    from src.autostart import migrate_legacy_autostart
+
+    try:
+        migrate_legacy_autostart(base)
+    except Exception:
+        logging.getLogger(__name__).warning(
+            "Autostart-Migration fehlgeschlagen", exc_info=True)
+
+    guard = None
+    try:
+        guard = single_instance.acquire(base, show_requested="--minimized" not in sys.argv)
+        if guard is None:
+            return  # Eine Instanz läuft bereits; sie hat SHOW/PING erhalten.
+    except Exception:
+        logging.getLogger(__name__).warning(
+            "Single-Instance-Guard-Fehler — Start ohne Guard", exc_info=True)
+        guard = None
+```
+
+- [ ] **Step 5: `main.py` — Guard an `App` reichen**
+
+In `src/main.py` den `App(...)`-Aufruf (Zeile ~308) erweitern:
+```python
+    app = App(root, storage, settings, base_path=base, conflicts_store=conflicts_store,
+              reservation_store=reservation_store, single_instance=guard)
+```
+
+- [ ] **Step 6: `main.py` — Listener nach dem App-Bau bedienen**
+
+In `src/main.py` nach dem `App(...)`-Aufruf und nach `if "--minimized" in sys.argv: root.iconify()` einfügen (vor dem Sync-Block):
+```python
+    if guard is not None:
+        guard.serve(lambda: app._marshal_to_ui(app._restore_from_tray))
+```
+
+- [ ] **Step 7: Verify — Suite grün + Lint**
+
+Run: `pytest -q && ruff check .`
+Expected: PASS (keine neuen Failures; `main.py`/`ui.py` importieren sauber).
+
+- [ ] **Step 8: Manueller End-to-End-Test (Doppelstart)**
+
+Aus dem Repo (zwei Terminals bzw. nacheinander):
+```
+python -m src.main
+```
+Dann **zweites** `python -m src.main` starten.
+Erwartung: die zweite Instanz beendet sich sofort; das Fenster der ersten kommt nach vorn (SHOW, da ohne `--minimized`). Mit `python -m src.main --minimized` als zweiter Start: zweite Instanz beendet sich, **kein** Fenster-Pop (PING).
+Evidenz (Log): `Single-Instance…` erscheint nur bei belegtem Fremd-Port; im Normalfall keine Warnung.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/main.py src/ui.py
+git commit -m "feat(app): Single-Instance-Guard + Autostart-Migration verdrahten"
+```
+
+---
+
+### Task 6: Architektur-Referenz aktualisieren
+
+**Files:**
+- Modify: `src/CLAUDE.md` (Modul-Liste + Verträge)
+
+**Interfaces:** — (Doku, kein Test.)
+
+- [ ] **Step 1: Guard-Modul + Registry-Vertrag dokumentieren**
+
+In `src/CLAUDE.md` im Abschnitt „Berichte & Plattform/Infra" (bei `autostart.py`) ergänzen:
+- `autostart.py`: Windows-Backend nutzt den **HKCU-Run-Registry-Wert** `Zeiterfassung` (gleicher Wertname wie `installer.iss` → strukturell ein Eintrag); `import winreg` lazy (CI-Ubuntu). `is_autostart_enabled()` liest den echten Zustand (Registry **oder** Alt-Shortcut). `migrate_legacy_autostart()` überführt Alt-Shortcuts frozen-gegatet in die Registry.
+- Neuer Eintrag `single_instance.py`: Tk-freier Single-Instance-Guard (pro-Nutzer-Port aus `get_base_path()`, `SO_EXCLUSIVEADDRUSE`/`SO_REUSEADDR`, SHOW/PING-Protokoll). `main.py` ruft `acquire()` vor dem Tk-Bau, `serve()` danach; `App.restart_for_scaling`/`_quit_with_sync_push` rufen `release()`.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/CLAUDE.md
+git commit -m "docs(src): Autostart-Registry-Vertrag + single_instance-Modul dokumentieren"
+```
+
+---
+
+## Verifikation vor Abschluss (gesamt)
+
+- [ ] `pytest -q` — alle Tests grün (Evidenz: Zusammenfassungszeile zeigen).
+- [ ] `ruff check .` — keine Findings.
+- [ ] Manueller Doppelstart-Test aus Task 5 Step 8 durchgeführt (Evidenz: Verhalten beschrieben).
+
+## Übergabe
+
+**VERHALTEN:** Windows-Autostart läuft künftig ausschließlich über den HKCU-Run-Registry-Wert `Zeiterfassung`; App-Checkbox und Installer schreiben denselben Wert → nie mehr zwei Autostart-Trigger. Die Checkbox zeigt den echten Zustand. Bestandsnutzer werden beim ersten Start des neuen (frozen) Builds absichtserhaltend migriert. Ein Guard verhindert parallele Instanzen und holt bei manuellem Zweitstart das vorhandene Fenster nach vorn.
+
+**RISIKO:**
+- *Registry-Format-Drift:* Weicht der App-Wert vom Installer-Wert ab (Wertname!), entstünden wieder zwei Einträge. Abgesichert durch `test_windows_run_command_matches_installer_format` + identischen Wertnamen; `installer.iss` bleibt bewusst unverändert.
+- *Guard bei Fremd-Port:* Belegt Software den abgeleiteten Port, startet die App ungeschützt weiter (kein Block) — akzeptierter Degraded-Fall, geloggt.
+- *Skalierungs-Relaunch:* Ohne `release()` vor `Popen` verschwände die App — durch Task 5 Step 2 abgedeckt.
+- Migration ist frozen-only; im Repo-Modus passiert nichts (bewusst).
+
+**TEST (manuell, QA/Prod-Pfad):**
+1. *Doppelstart:* App starten, zweites Mal starten → zweite Instanz beendet sich, Fenster der ersten kommt nach vorn. (Task 5 Step 8)
+2. *Autostart-Checkbox-Wahrheit (installiert):* Mit Installer-Häkchen „Mit Windows starten" installieren → App öffnen → Einstellungen: Checkbox ist **an** (nicht mehr fälschlich aus). Abhaken → Neustart des Rechners → App startet **nicht** automatisch (Registry-Wert weg).
+3. *Migration (Bestandsnutzer-Simulation):* Vor Update Zustand 3 herstellen (Registry-Wert + Startup-Shortcut) → neuen Build starten → nur noch der Registry-Wert existiert, Shortcut ist weg, genau **eine** Instanz beim nächsten Boot.

--- a/docs/superpowers/specs/2026-07-03-autostart-unification-design.md
+++ b/docs/superpowers/specs/2026-07-03-autostart-unification-design.md
@@ -1,0 +1,267 @@
+# Autostart-Vereinheitlichung + Single-Instance-Guard
+
+**Datum:** 2026-07-03
+**Status:** Design freigegeben, bereit für Implementierungsplan
+**Plattformen:** Windows / macOS / Linux
+
+## Problem
+
+Bei einem Nutzer starten beim Hochfahren des Rechners **zwei Instanzen** der App
+parallel (Autostart + Tray aktiv, Windows). Ursache ist ein Logikfehler: es gibt
+zwei voneinander unabhängige Autostart-Mechanismen, die sich gegenseitig nicht
+kennen.
+
+1. **Installer** (`installer.iss`): der Setup-Task „Mit Windows starten (minimiert)"
+   schreibt einen Registry-Wert
+   `HKCU\Software\Microsoft\Windows\CurrentVersion\Run\Zeiterfassung` =
+   `"<app>\Zeiterfassung.exe" --minimized`.
+2. **App-Setting** (`settings_dialog.py` → `autostart.py`): die Checkbox „Autostart
+   (minimiert bei Anmeldung)" legt einen Shortcut `Zeiterfassung.lnk` im
+   Startup-Ordner an.
+
+Die Checkbox liest `settings.get("autostart")` (Default `False`) und weiß nichts
+vom Installer-Registry-Key. Sie zeigt also **aus**, obwohl Autostart längst läuft.
+Hakt der Nutzer sie an, entsteht ein **zweiter** Autostart-Eintrag (Shortcut
+zusätzlich zur Registry) → beim nächsten Boot feuern beide → zwei Instanzen.
+
+Verschärfend:
+- `disable_autostart()` löscht nur den Shortcut, nie den Registry-Key — der
+  Installer-Autostart ist aus der App heraus gar nicht abschaltbar.
+- Es gibt **keinen Single-Instance-Guard**: beide Instanzen laufen voll durch und
+  schreiben auf dieselben JSON-Dateien (Last-write-wins, potenzieller Datenverlust;
+  mit aktivem Sync zusätzlich Push-Races). Das Tray macht es unsichtbar-persistent
+  (beide hängen minimiert im Infobereich statt als zwei offensichtliche Fenster).
+
+## Ziel
+
+- Auf Windows kann strukturell nur **ein** Autostart-Eintrag existieren.
+- Die Autostart-Checkbox zeigt den **echten** Zustand, plattformübergreifend.
+- Bestandsnutzer werden beim Update automatisch und **absichtserhaltend** migriert.
+- Ein Single-Instance-Guard fängt jeden verbleibenden Doppelstart ab (auch
+  manuellen Doppelklick), plattformübergreifend, ohne den Nutzer je am Start zu
+  hindern.
+
+Nicht im Scope: Umbau des `settings.json`-Schemas, Änderungen an den
+macOS-/Linux-Autostart-Backends (nur die neue Statusabfrage kommt dort dazu).
+
+## Ansatz
+
+Gewählt: **Ansatz A** — der Registry-Run-Key wird die einzige Windows-Quelle; App
+und Installer beschreiben denselben Wertnamen. Verworfen: Ansatz B (Shortcut als
+einzige Quelle — VBS-Hack bliebe, Migration schiefer) und Ansatz C (App verwaltet
+defensiv beide Orte, Installer unangetastet — heilt Bestandsnutzer nur bei
+Toggle, Checkbox lügt weiter).
+
+---
+
+## Abschnitt 1 — Autostart-Vereinheitlichung (Windows)
+
+Die App schreibt statt eines Startup-Shortcuts denselben Registry-Wert, den der
+Installer nutzt.
+
+- `_enable_windows` / `_disable_windows` in `autostart.py` arbeiten über `winreg`
+  (stdlib) auf `HKCU\Software\Microsoft\Windows\CurrentVersion\Run`, Wertname
+  `Zeiterfassung`, Datenformat **exakt** wie der Installer: `"<target>" --minimized`
+  (Exe-Pfad in Anführungszeichen, Space, Argumente).
+- Weil App und Installer denselben **Wertnamen** beschreiben, ist es strukturell
+  **ein** Eintrag — egal in welcher Reihenfolge Installer-Häkchen und
+  App-Checkbox gesetzt werden. Zwei Autostart-Trigger sind unmöglich.
+- Der VBS/cscript-Hack (Temp-Skript zum Shortcut-Anlegen) entfällt ersatzlos.
+- **macOS/Linux bleiben unverändert** (Plist bzw. `.desktop`).
+
+Der öffentliche Vertrag `enable_autostart(target, arguments)` /
+`disable_autostart()` bleibt gleich — nur das Windows-Backend wechselt von
+Shortcut zu Registry.
+
+### Registry-Wertformat (Vertrag mit dem Installer)
+
+Der Installer schreibt (`installer.iss`):
+```
+ValueName: "Zeiterfassung"
+ValueData: """{app}\Zeiterfassung.exe"" --minimized"
+```
+→ tatsächliche Daten: `"C:\...\Zeiterfassung.exe" --minimized`.
+
+Die App baut denselben String: `f'"{target}" {arguments}'` (bzw. nur `f'"{target}"'`
+wenn `arguments` leer). In Frozen-Windows ist `target = sys.executable =
+{app}\Zeiterfassung.exe` → exakter Match, ein Eintrag.
+
+---
+
+## Abschnitt 2 — Migration der Bestandsnutzer (Windows)
+
+Vier mögliche Zustände beim Update. Blindes Löschen des Shortcuts würde Zustand 2
+kaputtmachen, daher **absichtserhaltende** Migration statt bloßem Aufräumen.
+
+| Zustand vor Update      | Registry-Key | Shortcut | gewünscht nach Migration          |
+|-------------------------|--------------|----------|-----------------------------------|
+| 1 — nur Installer-Häkchen | ✓          | —        | Registry bleibt (autostart an)    |
+| 2 — nur App-Checkbox    | —            | ✓        | Registry **schreiben**, Shortcut weg (autostart bleibt an) |
+| 3 — beides (der Bug)    | ✓            | ✓        | Shortcut weg, Registry bleibt (single) |
+| 4 — nichts              | —            | —        | nichts                            |
+
+Neue Funktion `migrate_legacy_autostart(base_path)` in `autostart.py`, aufgerufen
+beim App-Start in `main.py` (Windows-only, in `try/except` — nicht-fatal wie das
+übrige Startup-Setup):
+
+```
+wenn Legacy-Shortcut existiert:
+    wenn Registry-Key fehlt:
+        Registry-Key schreiben  (Absicht aus Zustand 2 retten)
+    Legacy-Shortcut löschen
+```
+
+- **Idempotent über Shortcut-Präsenz**: nach dem ersten Lauf ist der Shortcut weg
+  → jeder weitere Start ist ein No-op. Kein „migrated"-Flag nötig.
+- **Selbstheilend**: der Registry-Wert wird aus `resolve_autostart_target(base)`
+  (= aktuelle Exe) gebaut, nicht aus dem alten Shortcut-Ziel → zeigt garantiert auf
+  den aktuellen Installationspfad.
+- Der Installer braucht **kein** `[InstallDelete]` — die App räumt beim ersten
+  Start selbst auf und erhält dabei die Absicht (was der Installer nicht könnte).
+
+---
+
+## Abschnitt 3 — Checkbox zeigt die Wahrheit
+
+Neue Funktion `is_autostart_enabled()` in `autostart.py`, plattform-dispatched,
+liest den **echten** Zustand:
+- Windows: Registry-Wert `Zeiterfassung` unter dem Run-Key vorhanden?
+- macOS: Plist-Datei vorhanden?
+- Linux: `.desktop`-Datei vorhanden?
+
+Im Settings-Dialog (`settings_dialog.py`):
+- Die Checkbox wird aus `is_autostart_enabled()` initialisiert statt aus dem
+  Setting.
+- `old_autostart` in der Save-Logik liest ebenfalls den echten Zustand → „unverändert
+  gelassen" ist ein echtes No-op, togglen ruft sauber `enable`/`disable`.
+- Weil die Migration (Abschnitt 2) beim Start läuft, ist zum Zeitpunkt des
+  Dialog-Öffnens der Shortcut bereits in die Registry überführt → kohärenter
+  Zustand.
+
+Das Setting `autostart` bleibt in den DEFAULTS (kein `settings.json`-Umbau) und
+wird beim Speichern weiter mitgeschrieben, ist aber **nicht mehr die
+Anzeigequelle**. `autostart` ist device-lokal und **nicht** in
+`SYNCED_SETTING_KEYS` — bleibt so (Autostart darf nicht zwischen Geräten
+synchronisiert werden).
+
+---
+
+## Abschnitt 4 — Single-Instance-Guard
+
+Defense-in-depth: fängt jeden verbleibenden Doppelstart ab (manueller Doppelklick;
+Boot-Doppelfeuer bei noch nicht migrierten Bestandsnutzern). Neues **Tk-freies**
+Modul `src/single_instance.py`, testbar wie `reminders.py`.
+
+### Primitiv: TCP-Socket auf 127.0.0.1, pro Nutzer fester Port
+
+- Port `P = 20000 + (crc32(base_path) % 20000)`, abgeleitet aus dem
+  per-Nutzer-Datenverzeichnis (`get_base_path()`). Zwei Instanzen desselben
+  Nutzers → selber Port; verschiedene Windows-Nutzer → verschiedene `LOCALAPPDATA`
+  → verschiedene Ports (keine Kollision bei Fast User Switching). Reines
+  `socket`/`zlib`-stdlib, **auf allen drei Plattformen identisch** — kein
+  `fcntl`/`msvcrt`-Plattformzweig.
+- **Atomare Primar-Entscheidung durch den OS-Bind**: nur einer kann `P` binden.
+  Das löst genau die Race, die den Bug ausmacht (zwei Autostart-Trigger feuern beim
+  Boot quasi gleichzeitig).
+
+### Ablauf in `main.py`, *vor* dem Tk-Aufbau
+
+1. `bind()` auf `P` (mit `SO_REUSEADDR`):
+   - **Erfolg → Primärinstanz.** `listen()` + Accept-Thread sofort starten (daemon).
+     Normal weiterstarten.
+   - **Fehlschlag (Port belegt) → Zweitinstanz.** Verbinden, Nachricht senden, dann
+     `sys.exit(0)`:
+     - Start **ohne** `--minimized` (manueller Doppelklick) → `SHOW` →
+       Primärinstanz holt ihr Fenster nach vorn.
+     - Start **mit** `--minimized` (Autostart-Doppelfeuer) → `PING` →
+       Primärinstanz tut nichts (keine Fenster-Überraschung beim Boot).
+   - **Belegt, aber Gegenstelle antwortet nicht wie erwartet** (fremde Software auf
+     dem Port) → warnen, loggen, **normal weiterstarten**. Der Guard blockiert den
+     Nutzer nie.
+
+### Fenster-Holen
+
+- Der Accept-Thread ackt **sofort** — auch während die Primärinstanz noch die UI
+  baut (gepufferter Callback), damit die Zweitinstanz nicht in einen Timeout läuft
+  und fälschlich selbst startet.
+- `SHOW` ruft `App._restore_from_tray()` (`ui.py`: deiconify + lift + focus) via
+  `_marshal_to_ui` auf den Tk-Thread. Kein neuer Fenster-Code — der vorhandene
+  Tray-Restore-Pfad wird wiederverwendet.
+
+### Verdrahtung
+
+- `acquire_single_instance(base)` früh in `main()`: die Zweitinstanz beendet sich,
+  bevor Tk gebaut wird (schneller, sauberer Exit).
+- Nach dem App-Bau `guard.serve(show_fn)`: ersetzt den Puffer-Callback; ein während
+  des Baus eingetroffenes `SHOW` feuert dann nach.
+- Der gebundene Socket wird beim App-Quit geschlossen (Port freigeben);
+  `SO_REUSEADDR` vermeidet TIME_WAIT-Probleme beim Rebind.
+
+### Protokoll
+
+- Magic-Nachrichten (ASCII, feste Präfixe), z. B. `ZEIT-SHOW`, `ZEIT-PING`;
+  Primärinstanz ackt mit `ZEIT-OK`.
+- Zweitinstanz sendet best-effort und beendet sich in **jedem** Fall, sobald der
+  Bind fehlschlug (der belegte Port ist der Beweis, dass eine Instanz läuft) — außer
+  der Occupant identifiziert sich nicht als unsere App (kein `ZEIT-OK`), dann
+  degradierter Weiterstart.
+
+---
+
+## Abschnitt 5 — Fehlerbehandlung & Tests
+
+### Fehlerbehandlung (Prinzip: der Nutzer wird nie am Start gehindert)
+
+- Migration (`migrate_legacy_autostart`) und Guard-`acquire` laufen in `main.py` in
+  `try/except`, nicht-fatal — wie `setup_logging`. Wirft `winreg` oder der Socket,
+  wird geloggt und normal weitergestartet.
+- `winreg`-Delete auf fehlenden Wert wird toleriert (analog „disable ohne Shortcut
+  ist kein Fehler").
+- Guard: belegter Port ohne erwartete Antwort → degradierter Start (unguarded),
+  geloggt.
+
+### Tests (Test-zuerst, rot→grün)
+
+**`test_autostart.py`** (Windows-Klasse umbauen, macOS/Linux-Klassen unberührt):
+- Registry statt Shortcut: `enable` schreibt Wertname `Zeiterfassung` mit Daten
+  `"<target>" --minimized`; `disable` entfernt ihn; `disable` ohne Wert wirft
+  nicht. Über gepatchte `winreg`-Fake bzw. Temp-Key.
+- Wertformat matcht exakt den Installer-String.
+- `is_autostart_enabled()`: True wenn Wert/Datei existiert, sonst False — je
+  Plattform (Win Registry / macOS Plist / Linux `.desktop`).
+- `migrate_legacy_autostart`: die vier Zustände aus Abschnitt 2 (v. a. Zustand 2 →
+  Registry geschrieben; Zustand 3 → Shortcut weg, Registry bleibt; idempotent bei
+  erneutem Lauf).
+
+**`test_single_instance.py`** (neu, reine Socket-Logik):
+- Port-Ableitung deterministisch je `base_path`; verschiedene Pfade → verschiedene
+  Ports.
+- Erster `acquire` = primär; zweiter `acquire` mit gleichem `base` = erkennt Primär,
+  liefert „secondary".
+- `SHOW` triggert den Callback; `PING` triggert ihn **nicht**.
+- Belegter Port durch Fremd-Socket (kein gültiges Ack) → `acquire` degradiert,
+  blockiert nicht.
+
+### Verifikation vor Abschluss
+
+Voller `pytest`-Lauf grün + `ruff check .` (Evidenz zeigen, nicht „fertig"
+behaupten). Windows-Registry- und Guard-Pfade sind auf der Windows-Dev-Maschine
+real ausführbar; macOS/Linux-Zweige bleiben unangetastet → hier kein
+Pre-Release-Gate nötig (anders als bei plattformspezifischen Änderungen).
+
+---
+
+## Betroffene Dateien
+
+| Datei | Änderung |
+|-------|----------|
+| `src/autostart.py` | Windows-Backend Shortcut→Registry (`winreg`); neu `is_autostart_enabled()`, `migrate_legacy_autostart()` |
+| `src/single_instance.py` | **neu** — Tk-freier Guard (Socket, Port-Ableitung, Protokoll) |
+| `src/main.py` | Guard-`acquire` vor Tk-Bau; `migrate_legacy_autostart` beim Start; `guard.serve(show_fn)` nach App-Bau; Socket-Close bei Quit |
+| `src/dialogs/settings_dialog.py` | Checkbox init + `old_autostart` aus `is_autostart_enabled()` |
+| `tests/test_autostart.py` | Windows-Klasse auf Registry umbauen; Tests für `is_autostart_enabled`, `migrate_legacy_autostart` |
+| `tests/test_single_instance.py` | **neu** |
+| `src/CLAUDE.md` | Guard-Modul + Autostart-Registry-Vertrag dokumentieren |
+
+`installer.iss` bleibt **unverändert** (Registry-Task schreibt schon den richtigen
+Wertnamen; App gleicht sich an, nicht umgekehrt).

--- a/docs/superpowers/specs/2026-07-03-autostart-unification-design.md
+++ b/docs/superpowers/specs/2026-07-03-autostart-unification-design.md
@@ -86,6 +86,16 @@ Die App baut denselben String: `f'"{target}" {arguments}'` (bzw. nur `f'"{target
 wenn `arguments` leer). In Frozen-Windows ist `target = sys.executable =
 {app}\Zeiterfassung.exe` → exakter Match, ein Eintrag.
 
+### Constraint: `import winreg` MUSS lazy sein
+
+`winreg` existiert nur auf Windows. Die CI läuft auf **Ubuntu** und importiert
+`autostart.py` über die Kette `tests → ui → settings_dialog → autostart`. Ein
+Modul-Level-`import winreg` würde damit **jeden** CI-Lauf rot machen (nicht nur die
+Autostart-Tests). Der Import muss daher **lazy in den Windows-Funktionen** stehen
+(`_enable_windows`, `_disable_windows`, `is_autostart_enabled`,
+`migrate_legacy_autostart`) — dieselbe Regel wie die bereits etablierten
+Lazy-Google-Imports (`drive.py`/`gcal.py`) für CI ohne `requirements.txt`.
+
 ---
 
 ## Abschnitt 2 — Migration der Bestandsnutzer (Windows)
@@ -101,15 +111,24 @@ kaputtmachen, daher **absichtserhaltende** Migration statt bloßem Aufräumen.
 | 4 — nichts              | —            | —        | nichts                            |
 
 Neue Funktion `migrate_legacy_autostart(base_path)` in `autostart.py`, aufgerufen
-beim App-Start in `main.py` (Windows-only, in `try/except` — nicht-fatal wie das
-übrige Startup-Setup):
+beim App-Start in `main.py` (Windows-only **und nur im Frozen-Build**, in
+`try/except` — nicht-fatal wie das übrige Startup-Setup):
 
 ```
+wenn nicht sys.frozen:  return          # Dev-Modus nie migrieren, s.u.
 wenn Legacy-Shortcut existiert:
     wenn Registry-Key fehlt:
         Registry-Key schreiben  (Absicht aus Zustand 2 retten)
     Legacy-Shortcut löschen
 ```
+
+**Warum `sys.frozen`-Gate (nicht nur das Shortcut-Gate):** Zeigt der Legacy-Shortcut
+auf die **installierte** Exe und man startet das **Repo** (`python -m src.main`),
+würde die Migration den Registry-Wert aus `resolve_autostart_target(repo)`
+schreiben — Autostart zeigte danach auf `python.exe + Repo` und der Shortcut zur
+installierten App wäre gelöscht. Die „Selbstheilung" würde auf der Dev-Maschine zur
+Selbstbeschädigung. Das `sys.frozen`-Gate schließt das aus; im echten
+Installationsbetrieb (frozen) greift die Migration wie gewollt.
 
 - **Idempotent über Shortcut-Präsenz**: nach dem ersten Lauf ist der Shortcut weg
   → jeder weitere Start ist ein No-op. Kein „migrated"-Flag nötig.
@@ -125,7 +144,10 @@ wenn Legacy-Shortcut existiert:
 
 Neue Funktion `is_autostart_enabled()` in `autostart.py`, plattform-dispatched,
 liest den **echten** Zustand:
-- Windows: Registry-Wert `Zeiterfassung` unter dem Run-Key vorhanden?
+- Windows: Registry-Wert `Zeiterfassung` unter dem Run-Key **oder** Legacy-Shortcut
+  vorhanden. Der Shortcut-Fallback ist die Absicherung für den Fall, dass die
+  Migration (Abschnitt 2) einmal excepted — sonst zeigte die Checkbox „aus", obwohl
+  der Shortcut noch autostartet (der ursprüngliche Lügen-Bug).
 - macOS: Plist-Datei vorhanden?
 - Linux: `.desktop`-Datei vorhanden?
 
@@ -144,6 +166,11 @@ Anzeigequelle**. `autostart` ist device-lokal und **nicht** in
 `SYNCED_SETTING_KEYS` — bleibt so (Autostart darf nicht zwischen Geräten
 synchronisiert werden).
 
+**Bekannter Zustand:** damit wird `settings["autostart"]` faktisch *write-only* —
+niemand liest es mehr (die Anzeige kommt aus `is_autostart_enabled()`). Bewusst so
+gewählt, um einen `settings.json`-Schema-Umbau zu vermeiden; das Feld bleibt als
+harmloser Altbestand stehen.
+
 ---
 
 ## Abschnitt 4 — Single-Instance-Guard
@@ -154,19 +181,45 @@ Modul `src/single_instance.py`, testbar wie `reminders.py`.
 
 ### Primitiv: TCP-Socket auf 127.0.0.1, pro Nutzer fester Port
 
-- Port `P = 20000 + (crc32(base_path) % 20000)`, abgeleitet aus dem
-  per-Nutzer-Datenverzeichnis (`get_base_path()`). Zwei Instanzen desselben
-  Nutzers → selber Port; verschiedene Windows-Nutzer → verschiedene `LOCALAPPDATA`
-  → verschiedene Ports (keine Kollision bei Fast User Switching). Reines
-  `socket`/`zlib`-stdlib, **auf allen drei Plattformen identisch** — kein
+- Port `P = 20000 + (crc32(norm(base_path)) % 12000)` → Range **20000–31999**,
+  abgeleitet aus dem per-Nutzer-Datenverzeichnis (`get_base_path()`). Zwei Instanzen
+  desselben Nutzers → selber Port; verschiedene Windows-Nutzer → verschiedene
+  `LOCALAPPDATA` → verschiedene Ports (keine Kollision bei Fast User Switching).
+  Reines `socket`/`zlib`-stdlib, **auf allen drei Plattformen identisch** — kein
   `fcntl`/`msvcrt`-Plattformzweig.
+  - **Range unter allen Ephemeral-Ports** (Finding): Linux vergibt ephemere
+    Client-Ports ab 32768; `20000–31999` liegt darunter, damit eine zufällige
+    ausgehende Verbindung nicht unseren Guard-Port belegt (was sonst zum
+    Degraded-Start führte).
+  - **`norm(base_path)` = `os.path.normcase(os.path.normpath(...))`** vor dem Hashen:
+    sonst ergäben Groß-/Kleinschreibungs- oder Trenner-Varianten desselben
+    Windows-Pfads verschiedene Ports und der Guard griffe nicht.
 - **Atomare Primar-Entscheidung durch den OS-Bind**: nur einer kann `P` binden.
   Das löst genau die Race, die den Bug ausmacht (zwei Autostart-Trigger feuern beim
-  Boot quasi gleichzeitig).
+  Boot quasi gleichzeitig). Diese Atomarität steht und fällt mit der richtigen
+  Socket-Option (s. u.) — auf Windows wäre sie mit `SO_REUSEADDR` **kaputt**.
+
+### Socket-Option (plattformabhängig — kritisch für die Atomarität)
+
+- **Windows: `SO_EXCLUSIVEADDRUSE`** (vor `bind` gesetzt). `SO_REUSEADDR` ist auf
+  Windows **falsch**: es erlaubt einem zweiten Socket, denselben Port zu binden — der
+  zweite Bind gelingt und das Verhalten aller Sockets auf dem Port ist danach
+  „indeterminate" (MS-Doku). Beim Boot-Doppelfeuer hielten sich dann **beide**
+  Instanzen für primär → der Guard wäre ausgerechnet auf der Zielplattform
+  wirkungslos. `SO_EXCLUSIVEADDRUSE` lässt den zweiten Bind mit `WSAEADDRINUSE`
+  fehlschlagen — genau die gewünschte atomare Entscheidung.
+- **POSIX (macOS/Linux): `SO_REUSEADDR`** — verhindert, dass ein Rebind kurz nach
+  einem Quit an TIME_WAIT-Resten scheitert. Auf POSIX ist die Semantik anders als auf
+  Windows und für Server üblich.
+- Der Windows-Nachteil (Bind kann nach sehr schnellem Quit+Restart an TIME_WAIT
+  scheitern) wird vom Degraded-Fallback aufgefangen: Bind scheitert → Connect findet
+  keinen Listener → kein `ZEIT-OK` → unguarded weiterstarten. Nutzer nie blockiert.
+- Quelle: [Using SO_REUSEADDR and SO_EXCLUSIVEADDRUSE](https://learn.microsoft.com/en-us/windows/win32/winsock/using-so-reuseaddr-and-so-exclusiveaddruse)
+  (MS Learn) — die Option muss **vor** `bind` gesetzt werden.
 
 ### Ablauf in `main.py`, *vor* dem Tk-Aufbau
 
-1. `bind()` auf `P` (mit `SO_REUSEADDR`):
+1. `bind()` auf `P` (Socket-Option je Plattform, s. o.):
    - **Erfolg → Primärinstanz.** `listen()` + Accept-Thread sofort starten (daemon).
      Normal weiterstarten.
    - **Fehlschlag (Port belegt) → Zweitinstanz.** Verbinden, Nachricht senden, dann
@@ -194,17 +247,41 @@ Modul `src/single_instance.py`, testbar wie `reminders.py`.
   bevor Tk gebaut wird (schneller, sauberer Exit).
 - Nach dem App-Bau `guard.serve(show_fn)`: ersetzt den Puffer-Callback; ein während
   des Baus eingetroffenes `SHOW` feuert dann nach.
-- Der gebundene Socket wird beim App-Quit geschlossen (Port freigeben);
-  `SO_REUSEADDR` vermeidet TIME_WAIT-Probleme beim Rebind.
+- Der gebundene Socket wird beim App-Quit geschlossen (Port freigeben; auf POSIX
+  hält `SO_REUSEADDR` den Rebind TIME_WAIT-frei).
+
+### Kritisch: Port-Freigabe beim UI-Skalierungs-Neustart (Finding)
+
+`App.restart_for_scaling()` (`ui.py`) spawnt **bewusst zuerst** den neuen Prozess und
+destroyt erst danach das alte Fenster (Fail-safe: schlägt `Popen` fehl, läuft die
+alte App intakt weiter). Ohne Gegenmaßnahme bräche der Guard diesen Pfad: die neue
+Instanz fände den Port noch vom sterbenden Alt-Prozess belegt → sendet `SHOW`
+(Relaunch läuft **ohne** `--minimized`) → beendet sich sofort; die alte Instanz
+destroyt sich Millisekunden später → **die App ist komplett weg**, obwohl der Nutzer
+nur die Skalierung ändern wollte.
+
+**Fix:** Der Guard bekommt eine öffentliche Methode `release()` (Listener stoppen +
+Socket schließen). `restart_for_scaling` ruft `guard.release()` **vor** `Popen` auf,
+sodass die neue Instanz sauber primär wird. Fail-safety bleibt erhalten: schlägt
+`Popen` fehl, läuft die alte App weiter — dann nur kurz unguarded (akzeptabel, der
+Guard ist Defense-in-depth, kein Sicherheitsmechanismus). Der Guard-Handle muss dazu
+von `main()` bis in die App reichbar sein (z. B. an `App` übergeben, analog zu
+`storage`/`settings`).
 
 ### Protokoll
 
 - Magic-Nachrichten (ASCII, feste Präfixe), z. B. `ZEIT-SHOW`, `ZEIT-PING`;
   Primärinstanz ackt mit `ZEIT-OK`.
-- Zweitinstanz sendet best-effort und beendet sich in **jedem** Fall, sobald der
-  Bind fehlschlug (der belegte Port ist der Beweis, dass eine Instanz läuft) — außer
-  der Occupant identifiziert sich nicht als unsere App (kein `ZEIT-OK`), dann
-  degradierter Weiterstart.
+- Verhalten der Zweitinstanz nach fehlgeschlagenem Bind, präzise nach Ack:
+  - **`ZEIT-OK` empfangen** (Occupant ist unsere App) → Zweitinstanz beendet sich
+    (`sys.exit(0)`); die Primärinstanz hat `SHOW`/`PING` bereits verarbeitet.
+  - **Kein/falsches Ack innerhalb des Timeouts** (Occupant ist fremde Software oder
+    ein wedged Prozess) → **degradierter Weiterstart** (unguarded), geloggt.
+- **Ack-Timeout großzügig (~2 s)**: Boot-Last kann die Accept-Verarbeitung der
+  Primärinstanz kurz verzögern. Weil der Accept-Thread schon vor dem UI-Bau ackt
+  (gepufferter Callback, s. „Fenster-Holen"), reichen 2 s auch unter Last
+  komfortabel — verhindert, dass die Zweitinstanz fälschlich in den Degraded-Pfad
+  fällt und doch startet.
 
 ---
 
@@ -255,11 +332,12 @@ Pre-Release-Gate nötig (anders als bei plattformspezifischen Änderungen).
 
 | Datei | Änderung |
 |-------|----------|
-| `src/autostart.py` | Windows-Backend Shortcut→Registry (`winreg`); neu `is_autostart_enabled()`, `migrate_legacy_autostart()` |
-| `src/single_instance.py` | **neu** — Tk-freier Guard (Socket, Port-Ableitung, Protokoll) |
-| `src/main.py` | Guard-`acquire` vor Tk-Bau; `migrate_legacy_autostart` beim Start; `guard.serve(show_fn)` nach App-Bau; Socket-Close bei Quit |
+| `src/autostart.py` | Windows-Backend Shortcut→Registry (`winreg` **lazy**, s. Abschnitt 1); neu `is_autostart_enabled()` (Registry **oder** Legacy-Shortcut), `migrate_legacy_autostart()` (frozen-only) |
+| `src/single_instance.py` | **neu** — Tk-freier Guard: Port-Ableitung (`norm(base)`, Range 20000–31999), plattformabhängige Socket-Option (`SO_EXCLUSIVEADDRUSE`/`SO_REUSEADDR`), Protokoll, `serve()`, `release()` |
+| `src/main.py` | Guard-`acquire` vor Tk-Bau; `migrate_legacy_autostart` beim Start; `guard.serve(show_fn)` nach App-Bau; Guard-Handle an `App` reichen; Socket-Close bei Quit |
+| `src/ui.py` | `restart_for_scaling`: `guard.release()` **vor** `Popen` (Finding 2); Guard-Handle in `App` aufnehmen |
 | `src/dialogs/settings_dialog.py` | Checkbox init + `old_autostart` aus `is_autostart_enabled()` |
-| `tests/test_autostart.py` | Windows-Klasse auf Registry umbauen; Tests für `is_autostart_enabled`, `migrate_legacy_autostart` |
+| `tests/test_autostart.py` | Windows-Klasse auf Registry umbauen; Tests für `is_autostart_enabled`, `migrate_legacy_autostart` (4 Zustände, frozen-Gate) |
 | `tests/test_single_instance.py` | **neu** |
 | `src/CLAUDE.md` | Guard-Modul + Autostart-Registry-Vertrag dokumentieren |
 

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -114,10 +114,23 @@ denselben OAuth-Token; Scope-Upgrade erzwingt frischen Consent.
 - `report.py` — HTML-Mail + PDF (xhtml2pdf **lazy**), gruppiert pro ISO-KW.
 - `theme.py`/`tooltip.py` — UI-Hilfen (Farben/Fonts/themed Dialoge, `_hover`-Overlays).
 - `time_utils.py` — Stunden, KW-Labels, `format_iso_date`/`format_iso_datetime`.
-- `holidays_de.py`, `paths.py` (`get_base_path` Frozen-vs-Repo), `autostart.py`, `updater.py`
+- `holidays_de.py`, `paths.py` (`get_base_path` Frozen-vs-Repo), `updater.py`
   (GitHub-Releases, stdlib-only, 1×/Tag), `platform_open.py`, `logging_setup.py`,
-  `tray.py` (Fassade) + `tray_mac.py` (natives macOS-NSStatusItem-Backend, #88),
   `version.py` (einzige Versions-Quelle).
+- `autostart.py` — plattformabhängig (Windows-Registry HKCU Run / macOS-LaunchAgent / Linux-.desktop).
+  Windows-Backend nutzt den **Registry-Wert `Zeiterfassung`** (Wertname = `installer.iss` → strukturell
+  ein Eintrag); `import winreg` lazy (CI-Ubuntu). `is_autostart_enabled()` liest den echten Zustand
+  (Registry-Wert **oder** Alt-Startup-Shortcut als Fallback, falls Migration scheitert).
+  `migrate_legacy_autostart()` überführt Alt-Shortcuts in den Registry-Key, ist aber frozen-gated
+  (Repo-Modus: No-op, würde andernfalls python.exe+Repo ins Register schreiben und bestehende
+  Shortcuts beschädigen).
+- `single_instance.py` — Tk-freier Single-Instance-Guard. Erste Instanz leitet einen Port aus
+  `get_base_path()` ab und bindet einen Listener (`SO_EXCLUSIVEADDRUSE` Windows, `SO_REUSEADDR` Unix).
+  Folgeinstanzen melden sich per SHOW/PING-Protokoll und beenden sich. `main.py` ruft `acquire()`
+  vor dem Tk-Aufbau, `serve(show_fn)` danach. `App.restart_for_scaling` und `_quit_with_sync_push`
+  rufen `release()`. Blockiert den Start nie — ist der Port von Fremd-Software belegt (keine ZEIT-OK),
+  läuft die App ungeschützt weiter (geloggt, akzeptierter Degraded-Fall).
+- `tray.py` (Fassade) + `tray_mac.py` (natives macOS-NSStatusItem-Backend, #88).
 
 Das Tray-Icon läuft, sobald `minimize_to_tray` **oder** `reminders_enabled` aktiv ist (`ui.py::_apply_tray_setting`); bei nur `reminders_enabled` dient es ausschließlich als Toast-Kanal.
 

--- a/src/autostart.py
+++ b/src/autostart.py
@@ -126,6 +126,25 @@ def is_autostart_enabled():
     return False
 
 
+def migrate_legacy_autostart(base_path):
+    """Überführt einen Alt-Startup-Shortcut in den Registry-Run-Key —
+    absichtserhaltend. Nur im Frozen-Windows-Build; sonst No-op (im Repo-Modus
+    würde der Registry-Wert auf python.exe+Repo zeigen und den installierten
+    Shortcut löschen — Selbstbeschädigung). Idempotent: ist der Shortcut weg,
+    tut jeder weitere Lauf nichts."""
+    if not getattr(sys, "frozen", False):
+        return
+    if platform.system() != "Windows":
+        return
+    if not os.path.exists(_get_shortcut_path()):
+        return
+    if not _windows_registry_enabled():
+        target, arguments = resolve_autostart_target(base_path)
+        _enable_windows(target, arguments)  # schreibt Registry + entfernt Shortcut
+        return
+    _remove_legacy_shortcut()
+
+
 def _enable_windows(target, arguments):
     import winreg
     command = _windows_run_command(target, arguments)

--- a/src/autostart.py
+++ b/src/autostart.py
@@ -4,11 +4,39 @@ import platform
 import plistlib
 import subprocess
 import sys
-import tempfile
 
 
 SHORTCUT_NAME = "Zeiterfassung.lnk"
 MACOS_LABEL = "com.margenheld.zeiterfassung"
+
+_RUN_KEY_SUBKEY = r"Software\Microsoft\Windows\CurrentVersion\Run"
+_RUN_VALUE_NAME = "Zeiterfassung"
+
+
+def _windows_run_command(target, arguments):
+    """Baut den HKCU-Run-Datenstring — identisch zum Installer-Format:
+    Exe in Anführungszeichen, dann (falls vorhanden) die Argumente."""
+    if arguments:
+        return f'"{target}" {arguments}'
+    return f'"{target}"'
+
+
+def _remove_legacy_shortcut():
+    """Entfernt den Alt-Startup-Shortcut, falls vorhanden (tolerant)."""
+    try:
+        os.remove(_get_shortcut_path())
+    except FileNotFoundError:
+        pass
+
+
+def _windows_registry_enabled():
+    import winreg
+    try:
+        with winreg.OpenKey(winreg.HKEY_CURRENT_USER, _RUN_KEY_SUBKEY) as key:
+            winreg.QueryValueEx(key, _RUN_VALUE_NAME)
+        return True
+    except FileNotFoundError:
+        return False
 
 
 def resolve_autostart_target(base_path):
@@ -82,32 +110,40 @@ def disable_autostart():
         raise RuntimeError(f"Autostart not supported on {system}")
 
 
+def is_autostart_enabled():
+    """Echter Autostart-Zustand (nicht das gespeicherte Setting).
+
+    Windows: Registry-Run-Wert ODER Alt-Shortcut vorhanden (Shortcut-Fallback,
+    falls die Migration einmal fehlschlägt). macOS/Linux: Plist- bzw.
+    .desktop-Datei vorhanden."""
+    system = platform.system()
+    if system == "Windows":
+        return _windows_registry_enabled() or os.path.exists(_get_shortcut_path())
+    if system == "Darwin":
+        return os.path.exists(_macos_plist_path())
+    if system == "Linux":
+        return os.path.exists(_linux_desktop_path())
+    return False
+
+
 def _enable_windows(target, arguments):
-    shortcut_path = _get_shortcut_path()
-    working_dir = os.path.dirname(target)
-
-    vbs_content = f'''Set ws = CreateObject("WScript.Shell")
-Set sc = ws.CreateShortcut("{shortcut_path}")
-sc.TargetPath = "{target}"
-sc.Arguments = "{arguments}"
-sc.WorkingDirectory = "{working_dir}"
-sc.Save
-'''
-
-    fd, vbs_path = tempfile.mkstemp(suffix=".vbs")
-    try:
-        with os.fdopen(fd, "w") as f:
-            f.write(vbs_content)
-        subprocess.run(["cscript", "//nologo", vbs_path], check=True)
-    finally:
-        if os.path.exists(vbs_path):
-            os.remove(vbs_path)
+    import winreg
+    command = _windows_run_command(target, arguments)
+    with winreg.CreateKey(winreg.HKEY_CURRENT_USER, _RUN_KEY_SUBKEY) as key:
+        winreg.SetValueEx(key, _RUN_VALUE_NAME, 0, winreg.REG_SZ, command)
+    _remove_legacy_shortcut()
 
 
 def _disable_windows():
-    shortcut_path = _get_shortcut_path()
-    if os.path.exists(shortcut_path):
-        os.remove(shortcut_path)
+    import winreg
+    try:
+        with winreg.OpenKey(
+            winreg.HKEY_CURRENT_USER, _RUN_KEY_SUBKEY, 0, winreg.KEY_SET_VALUE
+        ) as key:
+            winreg.DeleteValue(key, _RUN_VALUE_NAME)
+    except FileNotFoundError:
+        pass
+    _remove_legacy_shortcut()
 
 
 def _enable_macos(target, arguments):

--- a/src/dialogs/settings_dialog.py
+++ b/src/dialogs/settings_dialog.py
@@ -8,7 +8,7 @@ import traceback
 from tkinter import messagebox, ttk
 from typing import Any
 
-from src.autostart import disable_autostart, enable_autostart, resolve_autostart_target
+from src.autostart import disable_autostart, enable_autostart, is_autostart_enabled, resolve_autostart_target
 from src.platform_open import open_folder
 from src.theme import (
     ACCENT, BG, CELL_BG, FONT, FONT_BOLD, FONT_SMALL,
@@ -710,7 +710,7 @@ def open_settings_dialog(parent, settings, base_path, on_change, *,
         cursor="hand2",
     ).pack(anchor="w")
 
-    autostart_var = tk.BooleanVar(value=settings.get("autostart"))
+    autostart_var = tk.BooleanVar(value=is_autostart_enabled())
     tk.Checkbutton(
         app_frame, text="Autostart (minimiert bei Anmeldung)",
         variable=autostart_var, font=FONT,
@@ -863,7 +863,7 @@ def open_settings_dialog(parent, settings, base_path, on_change, *,
         old_wsl_end = settings.get("werkstudent_limit_end")
 
         new_autostart = autostart_var.get()
-        old_autostart = settings.get("autostart")
+        old_autostart = is_autostart_enabled()
 
         # Autostart-Toggle muss vor dem Settings-Write passieren, weil
         # er failen kann und dann nichts persistiert werden soll.

--- a/src/main.py
+++ b/src/main.py
@@ -293,6 +293,25 @@ def main():
     except Exception:
         pass
 
+    from src import single_instance
+    from src.autostart import migrate_legacy_autostart
+
+    try:
+        migrate_legacy_autostart(base)
+    except Exception:
+        logging.getLogger(__name__).warning(
+            "Autostart-Migration fehlgeschlagen", exc_info=True)
+
+    guard = None
+    try:
+        guard = single_instance.acquire(base, show_requested="--minimized" not in sys.argv)
+        if guard is None:
+            return  # Eine Instanz läuft bereits; sie hat SHOW/PING erhalten.
+    except Exception:
+        logging.getLogger(__name__).warning(
+            "Single-Instance-Guard-Fehler — Start ohne Guard", exc_info=True)
+        guard = None
+
     settings = Settings(os.path.join(base, "settings.json"))
     device_id = _ensure_device_id(settings)
     settings.device_id_for_sync = device_id
@@ -306,10 +325,13 @@ def main():
     root = tk.Tk()
     _apply_ui_scaling(root, settings.get("ui_scale"))
     app = App(root, storage, settings, base_path=base, conflicts_store=conflicts_store,
-              reservation_store=reservation_store)
+              reservation_store=reservation_store, single_instance=guard)
 
     if "--minimized" in sys.argv:
         root.iconify()
+
+    if guard is not None:
+        guard.serve(lambda: app._marshal_to_ui(app._restore_from_tray))
 
     if settings.get("sync_enabled"):
         def _on_sync_done(ok, error, tb=""):

--- a/src/single_instance.py
+++ b/src/single_instance.py
@@ -37,12 +37,12 @@ class _Guard:
 
     def _try_bind(self):
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        if sys.platform == "win32":
-            # Windows: verhindert, dass ein zweiter Prozess denselben Port bindet.
-            sock.setsockopt(socket.SOL_SOCKET, socket.SO_EXCLUSIVEADDRUSE, 1)
-        else:
-            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         try:
+            if sys.platform == "win32":
+                # Windows: verhindert, dass ein zweiter Prozess denselben Port bindet.
+                sock.setsockopt(socket.SOL_SOCKET, socket.SO_EXCLUSIVEADDRUSE, 1)
+            else:
+                sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             sock.bind(("127.0.0.1", self.port))
             sock.listen(5)
         except OSError:
@@ -65,6 +65,7 @@ class _Guard:
                 continue
             except OSError:
                 break
+            conn.settimeout(_ACK_TIMEOUT)
             with conn:
                 try:
                     data = conn.recv(32)

--- a/src/single_instance.py
+++ b/src/single_instance.py
@@ -1,0 +1,133 @@
+# src/single_instance.py
+"""Single-Instance-Guard (Tk-frei). Erstinstanz bindet einen pro-Nutzer
+abgeleiteten Localhost-Port; Folgeinstanzen melden sich per Socket und beenden
+sich. Blockiert den Start nie — jeder Fehlerpfad endet im (ggf. ungeschützten)
+Weiterlauf."""
+import logging
+import os
+import socket
+import sys
+import threading
+import zlib
+
+_MAGIC_SHOW = b"ZEIT-SHOW"
+_MAGIC_PING = b"ZEIT-PING"
+_MAGIC_OK = b"ZEIT-OK"
+_ACK_TIMEOUT = 2.0          # großzügig gegen Boot-Last
+_PORT_BASE = 20000
+_PORT_SPAN = 12000          # Range 20000–31999, unter allen Ephemeral-Ranges
+
+_log = logging.getLogger(__name__)
+
+
+def _derive_port(base_path):
+    norm = os.path.normcase(os.path.normpath(base_path))
+    return _PORT_BASE + (zlib.crc32(norm.encode("utf-8")) % _PORT_SPAN)
+
+
+class _Guard:
+    def __init__(self, port):
+        self.port = port
+        self.bound = False
+        self._sock = None
+        self._lock = threading.Lock()
+        self._show_fn = None
+        self._pending_show = False
+        self._stop = False
+
+    def _try_bind(self):
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        if sys.platform == "win32":
+            # Windows: verhindert, dass ein zweiter Prozess denselben Port bindet.
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_EXCLUSIVEADDRUSE, 1)
+        else:
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        try:
+            sock.bind(("127.0.0.1", self.port))
+            sock.listen(5)
+        except OSError:
+            sock.close()
+            return False
+        sock.settimeout(0.5)
+        self._sock = sock
+        self.bound = True
+        threading.Thread(target=self._accept_loop, daemon=True).start()
+        return True
+
+    def _accept_loop(self):
+        while not self._stop:
+            sock = self._sock
+            if sock is None:            # release() lief parallel → sauber raus
+                break
+            try:
+                conn, _addr = sock.accept()
+            except socket.timeout:
+                continue
+            except OSError:
+                break
+            with conn:
+                try:
+                    data = conn.recv(32)
+                    if data.startswith(_MAGIC_SHOW):
+                        conn.sendall(_MAGIC_OK)
+                        self._fire_show()
+                    elif data.startswith(_MAGIC_PING):
+                        conn.sendall(_MAGIC_OK)
+                except OSError:
+                    pass
+
+    def _fire_show(self):
+        with self._lock:
+            fn = self._show_fn
+            if fn is None:
+                self._pending_show = True
+                return
+        fn()
+
+    def serve(self, show_fn):
+        """Registriert den Fenster-Holen-Callback. Ein vor serve() eingetroffenes
+        SHOW feuert jetzt nach."""
+        with self._lock:
+            self._show_fn = show_fn
+            pending = self._pending_show
+            self._pending_show = False
+        if pending:
+            show_fn()
+
+    def release(self):
+        """Listener stoppen und Port freigeben (No-op wenn nie gebunden)."""
+        self._stop = True
+        if self._sock is not None:
+            try:
+                self._sock.close()
+            except OSError:
+                pass
+            self._sock = None
+        self.bound = False
+
+
+def _notify_primary(port, show_requested):
+    """Meldet sich bei der laufenden Instanz. True nur, wenn sie sich per
+    ZEIT-OK als unsere App bestätigt."""
+    msg = _MAGIC_SHOW if show_requested else _MAGIC_PING
+    try:
+        with socket.create_connection(("127.0.0.1", port), timeout=_ACK_TIMEOUT) as sock:
+            sock.sendall(msg)
+            sock.settimeout(_ACK_TIMEOUT)
+            return sock.recv(len(_MAGIC_OK)) == _MAGIC_OK
+    except OSError:
+        return False
+
+
+def acquire(base_path, show_requested):
+    """Erstinstanz → gebundener _Guard. Läuft schon eine (bestätigt per ZEIT-OK)
+    → None (Aufrufer beendet sich). Port von Fremd-Software belegt → degradierter
+    (ungebundener) _Guard, damit der Start nie blockiert."""
+    port = _derive_port(base_path)
+    guard = _Guard(port)
+    if guard._try_bind():
+        return guard
+    if _notify_primary(port, show_requested):
+        return None
+    _log.warning("Single-Instance-Port %d belegt, kein ZEIT-OK — Start ohne Guard", port)
+    return guard

--- a/src/ui.py
+++ b/src/ui.py
@@ -54,10 +54,11 @@ def _delete_action(slots, selected, prefix):
 
 class App:
     def __init__(self, root, storage, settings, base_path=".", conflicts_store=None,
-                 reservation_store=None):
+                 reservation_store=None, single_instance=None):
         self.root = root
         self.storage = storage
         self.settings = settings
+        self._single_instance = single_instance
         self.base_path = base_path
         self.conflicts_store = conflicts_store
         self.reservation_store = reservation_store
@@ -604,6 +605,8 @@ class App:
         if self._tray is not None:
             self._tray.stop()
         self._reminders.stop()
+        if self._single_instance is not None:
+            self._single_instance.release()
         self.root.destroy()
 
     def restart_for_scaling(self):
@@ -616,6 +619,11 @@ class App:
         from src.main import relaunch_command
         cmd = relaunch_command(
             sys.argv, sys.executable, getattr(sys, "frozen", False))
+        if self._single_instance is not None:
+            self._single_instance.release()
+        # Port VOR dem Spawn freigeben, sonst fände die neue Instanz ihn noch
+        # belegt, schickte SHOW und beendete sich — die App verschwände beim
+        # bloßen Skalierungswechsel.
         try:
             subprocess.Popen(cmd)
         except Exception:

--- a/tests/test_autostart.py
+++ b/tests/test_autostart.py
@@ -4,7 +4,7 @@ import platform
 import plistlib
 import pytest
 from unittest.mock import patch, MagicMock
-from src.autostart import enable_autostart, disable_autostart
+from src.autostart import enable_autostart, disable_autostart, migrate_legacy_autostart
 from src.autostart import (
     _macos_plist_path,
     _linux_desktop_path,
@@ -220,3 +220,55 @@ class TestIsAutostartEnabled:
             assert is_autostart_enabled() is True
         finally:
             winreg.DeleteKey(winreg.HKEY_CURRENT_USER, subkey)
+
+
+@pytest.mark.skipif(platform.system() != "Windows", reason="Windows only")
+class TestMigrateLegacyAutostart:
+    @pytest.fixture
+    def frozen_win(self, monkeypatch, tmp_path):
+        import winreg
+        subkey = r"Software\ZeiterfassungTest\RunMig"
+        monkeypatch.setattr("src.autostart._RUN_KEY_SUBKEY", subkey)
+        monkeypatch.setattr("src.autostart._get_startup_folder", lambda: str(tmp_path))
+        monkeypatch.setattr("src.autostart.sys.frozen", True, raising=False)
+        monkeypatch.setattr("src.autostart.sys.executable",
+                            str(tmp_path / "Zeiterfassung.exe"), raising=False)
+        yield tmp_path
+        try:
+            winreg.DeleteKey(winreg.HKEY_CURRENT_USER, subkey)
+        except FileNotFoundError:
+            pass
+
+    def test_state2_shortcut_only_writes_registry(self, frozen_win):
+        (frozen_win / "Zeiterfassung.lnk").write_text("fake")
+        migrate_legacy_autostart(str(frozen_win))
+        from src.autostart import _windows_registry_enabled
+        assert _windows_registry_enabled() is True
+        assert not (frozen_win / "Zeiterfassung.lnk").exists()
+
+    def test_state3_both_keeps_registry_drops_shortcut(self, frozen_win):
+        enable_autostart(str(frozen_win / "Zeiterfassung.exe"), "--minimized")
+        (frozen_win / "Zeiterfassung.lnk").write_text("fake")
+        migrate_legacy_autostart(str(frozen_win))
+        from src.autostart import _windows_registry_enabled
+        assert _windows_registry_enabled() is True
+        assert not (frozen_win / "Zeiterfassung.lnk").exists()
+
+    def test_state4_nothing_stays_nothing(self, frozen_win):
+        migrate_legacy_autostart(str(frozen_win))
+        from src.autostart import _windows_registry_enabled
+        assert _windows_registry_enabled() is False
+
+    def test_idempotent_second_run_noop(self, frozen_win):
+        (frozen_win / "Zeiterfassung.lnk").write_text("fake")
+        migrate_legacy_autostart(str(frozen_win))
+        migrate_legacy_autostart(str(frozen_win))  # kein Fehler, kein Shortcut mehr
+        assert not (frozen_win / "Zeiterfassung.lnk").exists()
+
+    def test_not_frozen_is_noop(self, frozen_win, monkeypatch):
+        monkeypatch.setattr("src.autostart.sys.frozen", False, raising=False)
+        (frozen_win / "Zeiterfassung.lnk").write_text("fake")
+        migrate_legacy_autostart(str(frozen_win))
+        from src.autostart import _windows_registry_enabled
+        assert _windows_registry_enabled() is False          # nichts geschrieben
+        assert (frozen_win / "Zeiterfassung.lnk").exists()   # Shortcut unangetastet

--- a/tests/test_autostart.py
+++ b/tests/test_autostart.py
@@ -4,11 +4,23 @@ import platform
 import plistlib
 import pytest
 from unittest.mock import patch, MagicMock
-from src.autostart import enable_autostart, disable_autostart, _get_startup_folder, _get_shortcut_path
+from src.autostart import enable_autostart, disable_autostart
 from src.autostart import (
     _macos_plist_path,
     _linux_desktop_path,
+    is_autostart_enabled,
+    _windows_run_command,
 )
+
+
+def test_windows_run_command_matches_installer_format():
+    cmd = _windows_run_command(r"C:\app\Zeiterfassung.exe", "--minimized")
+    assert cmd == r'"C:\app\Zeiterfassung.exe" --minimized'
+
+
+def test_windows_run_command_without_arguments():
+    cmd = _windows_run_command(r"C:\app\Zeiterfassung.exe", "")
+    assert cmd == r'"C:\app\Zeiterfassung.exe"'
 
 
 @pytest.fixture
@@ -20,41 +32,40 @@ def fake_startup(tmp_path, monkeypatch):
 
 @pytest.mark.skipif(platform.system() != "Windows", reason="Windows only")
 class TestWindowsAutostart:
+    @pytest.fixture
+    def temp_run_key(self, monkeypatch):
+        import winreg
+        subkey = r"Software\ZeiterfassungTest\Run"
+        monkeypatch.setattr("src.autostart._RUN_KEY_SUBKEY", subkey)
+        yield subkey
+        try:
+            winreg.DeleteKey(winreg.HKEY_CURRENT_USER, subkey)
+        except FileNotFoundError:
+            pass
 
-    def test_get_startup_folder_returns_existing_dir(self):
-        folder = _get_startup_folder()
-        assert os.path.isdir(folder)
+    def test_enable_writes_registry_value(self, temp_run_key, fake_startup):
+        import winreg
+        enable_autostart(r"C:\app\Zeiterfassung.exe", "--minimized")
+        with winreg.OpenKey(winreg.HKEY_CURRENT_USER, temp_run_key) as key:
+            value, _typ = winreg.QueryValueEx(key, "Zeiterfassung")
+        assert value == r'"C:\app\Zeiterfassung.exe" --minimized'
 
-    def test_get_shortcut_path(self, fake_startup):
-        path = _get_shortcut_path()
-        assert path == str(fake_startup / "Zeiterfassung.lnk")
+    def test_disable_removes_registry_value(self, temp_run_key, fake_startup):
+        import winreg
+        enable_autostart(r"C:\app\Zeiterfassung.exe", "--minimized")
+        disable_autostart()
+        with winreg.OpenKey(winreg.HKEY_CURRENT_USER, temp_run_key) as key:
+            with pytest.raises(FileNotFoundError):
+                winreg.QueryValueEx(key, "Zeiterfassung")
 
-    def test_enable_creates_shortcut(self, fake_startup):
-        with patch("src.autostart.subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(returncode=0)
-            enable_autostart(r"C:\app\Zeiterfassung.exe", "--minimized")
-            mock_run.assert_called_once()
-            args = mock_run.call_args[0][0]
-            assert args[0] == "cscript"
-            assert args[1] == "//nologo"
-            assert args[2].endswith(".vbs")
+    def test_disable_without_value_no_error(self, temp_run_key, fake_startup):
+        disable_autostart()  # kein Wert vorhanden → kein Fehler
 
-    def test_enable_cleans_up_vbs(self, fake_startup):
-        with patch("src.autostart.subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(returncode=0)
-            enable_autostart(r"C:\app\Zeiterfassung.exe", "--minimized")
-            vbs_path = mock_run.call_args[0][0][2]
-            assert not os.path.exists(vbs_path)
-
-    def test_disable_removes_shortcut(self, fake_startup):
+    def test_enable_removes_legacy_shortcut(self, temp_run_key, fake_startup):
         shortcut = fake_startup / "Zeiterfassung.lnk"
         shortcut.write_text("fake")
-        assert shortcut.exists()
-        disable_autostart()
+        enable_autostart(r"C:\app\Zeiterfassung.exe", "--minimized")
         assert not shortcut.exists()
-
-    def test_disable_no_shortcut_no_error(self, fake_startup):
-        disable_autostart()
 
 
 class TestMacOSAutostart:
@@ -174,3 +185,38 @@ class TestLinuxAutostart:
 
     def test_disable_tolerates_missing_file(self, fake_home):
         disable_autostart()
+
+
+class TestIsAutostartEnabled:
+    def test_linux_true_when_desktop_exists(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("USERPROFILE", str(tmp_path))
+        monkeypatch.delenv("HOMEDRIVE", raising=False)
+        monkeypatch.delenv("HOMEPATH", raising=False)
+        monkeypatch.setattr("src.autostart.platform.system", lambda: "Linux")
+        assert is_autostart_enabled() is False
+        enable_autostart("/opt/Zeiterfassung.AppImage", "--minimized")
+        assert is_autostart_enabled() is True
+
+    @pytest.mark.skipif(platform.system() != "Darwin", reason="macOS only")
+    def test_macos_true_when_plist_exists(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("USERPROFILE", str(tmp_path))
+        monkeypatch.delenv("HOMEDRIVE", raising=False)
+        monkeypatch.delenv("HOMEPATH", raising=False)
+        monkeypatch.setattr("src.autostart.platform.system", lambda: "Darwin")
+        (tmp_path / "Library" / "LaunchAgents").mkdir(parents=True)
+        assert is_autostart_enabled() is False
+
+    @pytest.mark.skipif(platform.system() != "Windows", reason="Windows only")
+    def test_windows_true_when_registry_value_exists(self, monkeypatch, tmp_path):
+        import winreg
+        subkey = r"Software\ZeiterfassungTest\Run2"
+        monkeypatch.setattr("src.autostart._RUN_KEY_SUBKEY", subkey)
+        monkeypatch.setattr("src.autostart._get_startup_folder", lambda: str(tmp_path))
+        assert is_autostart_enabled() is False
+        enable_autostart(r"C:\app\Zeiterfassung.exe", "--minimized")
+        try:
+            assert is_autostart_enabled() is True
+        finally:
+            winreg.DeleteKey(winreg.HKEY_CURRENT_USER, subkey)

--- a/tests/test_single_instance.py
+++ b/tests/test_single_instance.py
@@ -1,0 +1,81 @@
+# tests/test_single_instance.py
+import socket
+import sys
+import threading
+
+import pytest
+
+from src.single_instance import _derive_port, acquire
+
+
+def test_derive_port_deterministic_and_in_range():
+    p1 = _derive_port(r"C:\Users\a\Zeiterfassung")
+    p2 = _derive_port(r"C:\Users\a\Zeiterfassung")
+    assert p1 == p2
+    assert 20000 <= p1 < 32000
+
+
+def test_derive_port_differs_per_path():
+    assert _derive_port("/home/a") != _derive_port("/home/b")
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="normcase ist nur auf Windows case-/separator-normalisierend")
+def test_derive_port_normalizes_case_and_separators():
+    a = _derive_port(r"C:\Users\A\Zeiterfassung")
+    b = _derive_port(r"c:/users/a/zeiterfassung")
+    assert a == b
+
+
+def test_first_acquire_is_primary_second_exits(tmp_path):
+    base = str(tmp_path)
+    g1 = acquire(base, show_requested=True)
+    try:
+        assert g1 is not None and g1.bound is True
+        g2 = acquire(base, show_requested=True)
+        assert g2 is None            # Geschwister erkannt → Aufrufer beendet sich
+    finally:
+        g1.release()
+
+
+def test_show_fires_callback_ping_does_not(tmp_path):
+    base = str(tmp_path)
+    g1 = acquire(base, show_requested=True)
+    fired = threading.Event()
+    g1.serve(lambda: fired.set())
+    try:
+        # SHOW → Callback feuert
+        assert acquire(base, show_requested=True) is None
+        assert fired.wait(timeout=3.0) is True
+
+        # PING → Callback feuert NICHT
+        fired.clear()
+        assert acquire(base, show_requested=False) is None
+        assert fired.wait(timeout=1.0) is False
+    finally:
+        g1.release()
+
+
+def test_pending_show_before_serve_fires_on_serve(tmp_path):
+    base = str(tmp_path)
+    g1 = acquire(base, show_requested=True)
+    try:
+        assert acquire(base, show_requested=True) is None   # SHOW vor serve()
+        fired = threading.Event()
+        g1.serve(lambda: fired.set())                        # gepuffertes SHOW feuert nach
+        assert fired.wait(timeout=3.0) is True
+    finally:
+        g1.release()
+
+
+def test_foreign_occupant_yields_degraded_primary(tmp_path):
+    base = str(tmp_path)
+    port = _derive_port(base)
+    squatter = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    squatter.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    squatter.bind(("127.0.0.1", port))
+    squatter.listen(1)
+    try:
+        g = acquire(base, show_requested=True)   # Port belegt, kein ZEIT-OK
+        assert g is not None and g.bound is False  # degradiert, aber Start läuft
+    finally:
+        squatter.close()

--- a/tests/test_single_instance.py
+++ b/tests/test_single_instance.py
@@ -2,6 +2,7 @@
 import socket
 import sys
 import threading
+import time
 
 import pytest
 
@@ -63,6 +64,35 @@ def test_pending_show_before_serve_fires_on_serve(tmp_path):
         fired = threading.Event()
         g1.serve(lambda: fired.set())                        # gepuffertes SHOW feuert nach
         assert fired.wait(timeout=3.0) is True
+    finally:
+        g1.release()
+
+
+def test_silent_connection_does_not_wedge_listener(tmp_path):
+    base = str(tmp_path)
+    g1 = acquire(base, show_requested=True)
+    fired = threading.Event()
+    g1.serve(lambda: fired.set())
+    try:
+        # Ein Peer verbindet sich und hält die Verbindung offen, OHNE etwas zu senden.
+        port = _derive_port(base)
+        silent = socket.create_connection(("127.0.0.1", port), timeout=2.0)
+        try:
+            # Der Listener darf nicht dauerhaft wedgen: nach dem Timeout der stillen
+            # Verbindung muss ein echtes SHOW wieder bestätigt werden. Der erste
+            # Versuch überlappt zeitlich mit dem serverseitigen recv-Timeout-Fenster
+            # der stillen Verbindung (beide nutzen _ACK_TIMEOUT und starten praktisch
+            # gleichzeitig) und darf knapp scheitern — das ist ein Timing-Artefakt,
+            # kein Bug. Ohne Fix (Accept-Loop wedgt für immer) würde dagegen JEDER
+            # Versuch bis zum Ablauf des Deadline-Fensters scheitern.
+            deadline = time.monotonic() + 10.0
+            acked = False
+            while not acked and time.monotonic() < deadline:
+                acked = acquire(base, show_requested=True) is None
+            assert acked is True
+            assert fired.wait(timeout=3.0) is True
+        finally:
+            silent.close()
     finally:
         g1.release()
 


### PR DESCRIPTION
## Problem

Bei einem Nutzer (Autostart + Tray aktiv, Windows) starten beim Hochfahren **zwei Instanzen** parallel. Ursache: zwei voneinander unabhängige Autostart-Mechanismen, die sich gegenseitig nicht kennen.

- **Installer** (`installer.iss`): schreibt den HKCU-Run-Registry-Wert `Zeiterfassung`.
- **App-Checkbox** (`settings_dialog` → `autostart.py`): legt einen Startup-Shortcut an.

Die Checkbox las `settings.get("autostart")` (Default `False`) und wusste nichts vom Installer-Registry-Key → sie zeigte **aus**, obwohl Autostart lief. Anhaken erzeugte einen **zweiten** Eintrag → beim Boot feuerten beide → zwei Instanzen. Zusätzlich fehlte jeder Single-Instance-Schutz (beide schrieben auf dieselben JSON-Dateien, Last-write-wins).

## Lösung

**Vereinheitlichung (Windows):** Die App schreibt jetzt über `winreg` **denselben** Registry-Wertnamen `Zeiterfassung`, den der Installer nutzt (Datenformat exakt `"<exe>" --minimized`). Damit ist es strukturell **ein** Eintrag, egal in welcher Reihenfolge Installer-Häkchen und App-Checkbox gesetzt werden. Der alte VBS/cscript-Shortcut-Hack entfällt. `installer.iss` bleibt unverändert.

**Migration (Bestandsnutzer):** `migrate_legacy_autostart()` überführt beim Start (frozen-gegatet, Windows-only) einen Alt-Shortcut **absichtserhaltend** in die Registry und räumt ihn ab — auch der Fall „nur Shortcut, kein Registry-Key" verliert seinen Autostart nicht.

**Checkbox-Wahrheit:** `is_autostart_enabled()` liest den echten Zustand (Registry oder Shortcut auf Windows, Plist auf macOS, `.desktop` auf Linux). Die Checkbox spiegelt damit die Realität statt eines veralteten Flags.

**Single-Instance-Guard:** Neues Tk-freies Modul `single_instance.py`. Die Erstinstanz bindet einen pro-Nutzer aus dem Datenverzeichnis abgeleiteten Localhost-Port (atomar via `SO_EXCLUSIVEADDRUSE` auf Windows / `SO_REUSEADDR` auf POSIX). Eine Zweitinstanz meldet sich per Socket und beendet sich: bei manuellem Start (`SHOW`) holt die Erstinstanz ihr Fenster nach vorn, beim Autostart-Doppelfeuer (`--minimized` → `PING`) ohne Fenster-Pop. Jeder Fehlerpfad endet im normalen (ggf. ungeschützten) Start — der Guard blockiert nie.

## Verhalten / Risiko / Test

**VERHALTEN:** Windows-Autostart läuft ausschließlich über den Registry-Wert `Zeiterfassung`; App und Installer teilen ihn → nie mehr zwei Trigger. Checkbox zeigt echten Zustand. Guard verhindert parallele Instanzen.

**RISIKO:**
- *Registry-Format-Drift:* Ein abweichender Wertname/Format würde wieder zwei Einträge erzeugen — abgesichert durch Test (`test_windows_run_command_matches_installer_format`) und identischen Wertnamen; `installer.iss` bewusst unangetastet.
- *Guard bei Fremd-Port:* belegter Port ohne gültige Antwort → ungeschützter Weiterstart (kein Block), geloggt.
- *macOS/Linux:* Autostart-Backends unverändert; der Guard ist reiner stdlib-Socket-Code, lief automatisiert aber nur auf Windows.

**TEST (manuell, vor Merge):**
1. *Doppelstart:* App starten, zweites Mal starten → zweite Instanz beendet sich, Fenster der ersten kommt nach vorn. Mit `--minimized` als zweiter Start: kein Fenster-Pop.
2. *Checkbox (installiert):* mit Installer-Autostart installieren → Checkbox **an**; abhaken → Boot startet nicht mehr automatisch.
3. *Migration:* vor Update Registry-Wert **und** Startup-Shortcut anlegen → neuen Build starten → nur noch Registry, eine Instanz.

## Reviews

Jeder Task task-scoped reviewt; finales Whole-Branch-Review (Opus) fand einen echten Bug: `_accept_loop`'s `recv` hatte keinen Timeout (`accept()` liefert die Verbindung im Blocking-Mode), sodass eine still offengehaltene Verbindung die single-threaded Accept-Loop permanent hätte wedgen können → Guard stumm aus. Gefixt (`conn.settimeout(_ACK_TIMEOUT)` + Socket-Setup im try) mit Regressionstest; Fix re-reviewt.

**Verifikation:** `pytest` 717 passed / 3 skipped, `ruff check .` clean.

Design & Plan: `docs/superpowers/specs/2026-07-03-autostart-unification-design.md`, `docs/superpowers/plans/2026-07-03-autostart-unification.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
