### PR TITLE
chore(release): v1.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,69 @@
 # Changelog
 
+## 1.17.0 — 2026-07-03
+
+### Hinzugefügt
+- **PDF-Export**: Der Bericht für einen frei gewählten Zeitraum lässt sich jetzt
+  direkt als PDF lokal speichern — über den neuen „Export"-Eintrag im Footer und
+  im Tray-Menü, ohne Mail-Versand.
+- **Reservierungs-Erinnerungen**: Optionale Benachrichtigung (Toast), wenn ein für
+  heute reservierter Slot fällig wird und dafür noch keine Ist-Zeit erfasst ist —
+  mit einstellbarer Vorlaufzeit in Minuten. Das Infobereich-Icon läuft dafür auch
+  dann, wenn nur die Erinnerungen aktiv sind (nicht „in den Infobereich
+  minimieren").
+- **Wochenstunden-Limit** (Werkstudenten): In den Einstellungen lässt sich ein
+  maximales Wochenstunden-Kontingent für einen konfigurierbaren Zeitraum
+  hinterlegen. Beim Speichern einer Ist-Zeit und nach einem Google-Kalender-Abgleich
+  warnt die App, wenn eine Woche das Limit überschreitet (gezählt werden nur
+  Ist-Zeiten, keine Reservierungen).
+- **UI-Skalierung**: Ein Schieberegler in den Einstellungen skaliert die gesamte
+  Oberfläche stufenweise; die Änderung greift nach einem kurzen Neustart und wirkt
+  auf allen Plattformen (inklusive macOS). Der Faktor ist gerätelokal und wird
+  nicht synchronisiert.
+- **Kategorie-Standardzeiten pro Wochentag**: Die Standard-Start/-Endzeit einer
+  Kategorie lässt sich jetzt optional pro Wochentag (Mo–So) hinterlegen, umschaltbar
+  über einen Modus-Toggle im Kategorien-Dialog. Der Eintrags-Dialog zieht beim
+  Anlegen automatisch die passende Zeit für den jeweiligen Wochentag.
+- **Kategorie-Aufschlüsselung im Bericht optional**: Die „Summe je Kategorie" im
+  Bericht lässt sich beim Senden und Exportieren an- und abschalten; liegen nur
+  unkategorisierte Slots vor, entfällt die Tabelle automatisch.
+
+### Geändert
+- **Einstellungen in Reitern**: Der Einstellungen-Dialog ist in vier Tabs gegliedert
+  (Arbeitszeit / Bericht & Mail / Google / App) — statt einer einzigen langen Liste.
+- **Autostart & Einzelinstanz** (Windows): Der Autostart läuft jetzt über einen
+  Registry-Eintrag, den App und Installer gemeinsam nutzen — dadurch kann kein
+  doppelter Autostart-Eintrag mehr entstehen, der beim Hochfahren zwei Instanzen
+  parallel startete. Die Autostart-Checkbox in den Einstellungen zeigt jetzt den
+  tatsächlichen Zustand an, auch wenn er über den Installer gesetzt wurde. Eine
+  bestehende Alt-Verknüpfung im Autostart-Ordner wird beim ersten Start automatisch
+  übernommen. Zusätzlich läuft die App jetzt immer nur einmal: Ein zweiter Start
+  holt das vorhandene Fenster nach vorn, statt eine zweite Instanz zu öffnen.
+- **Arbeitszeit-Tooltip**: Der Hover-Tooltip im Kalender zeigt die erfasste
+  Arbeitszeit schon ab einem einzelnen Slot (vorher erst bei mehreren).
+
+### Behoben
+- Reservierungen lassen sich per Linksklick nicht mehr für bereits vergangene Tage
+  anlegen.
+- Bericht-PDF: Die Stundentabelle kollabiert die linken Spalten nicht mehr.
+- Update-Banner: Das Fenster wächst jetzt um die Banner-Höhe, sodass der Footer
+  sichtbar bleibt (vorher konnte er abgeschnitten werden).
+- Kleinere Dialog-Interaktionen: Die Löschen-Rückfrage ist auch bei nur einer
+  betroffenen Einheit einen kurzen Moment gesperrt (gegen versehentliches
+  Sofort-Bestätigen), und ein Zellen-Tooltip schließt jetzt zuverlässig, sobald
+  sich ein modaler Dialog darüber öffnet.
+
+### Intern
+- Natives macOS-Infobereich-Icon (NSStatusItem) als Backend vorbereitet — vorerst
+  ruhend und nur per Opt-in (`ZEIT_MACOS_TRAY=1`) aktivierbar, bis das macOS-Gate
+  durchlaufen ist; ein Main-Thread-Absturz des macOS-Trays wurde behoben.
+- Pre-Release-Builds: Der Release-Workflow kann jetzt plattformübergreifende
+  Test-Builds erzeugen (fortlaufender `-pre.N`-Tag, als Pre-Release markiert und vom
+  Auto-Updater ignoriert), um Änderungen vor einem echten Release auf allen
+  Plattformen zu testen.
+- `SYNCED_SETTING_KEYS` als Single Source of Truth in `settings.py`; die
+  Save-Pfad-Logik des Einstellungen-Dialogs ist headless testbar extrahiert.
+
 ## 1.16.1 — 2026-06-25
 
 ### Behoben

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,7 +205,8 @@ Lokal: `pytest` aus dem Repo-Root. Alle Tests müssen vor dem PR-Merge grün sei
 - `src/time_utils.py` — Stundenberechnung, KW-Labels
 - `src/holidays_de.py` — Feiertags-Lookup (über `holidays`-Lib)
 - `src/paths.py` — `get_base_path()` dispatched über `platform.system()` und Frozen- vs. Repo-Modus
-- `src/autostart.py` — plattformabhängiger Autostart (Windows-Shortcut / macOS-LaunchAgent / Linux `.desktop`)
+- `src/autostart.py` — plattformabhängiger Autostart (Windows-**Registry** HKCU Run, gleicher Wertname `Zeiterfassung` wie `installer.iss` → strukturell ein Eintrag; macOS-LaunchAgent / Linux `.desktop`). `is_autostart_enabled()` liest den echten Zustand, `migrate_legacy_autostart()` überführt Alt-Startup-Shortcuts frozen-gated in die Registry
+- `src/single_instance.py` — Tk-freier Single-Instance-Guard (pro-Nutzer-Localhost-Port, `acquire`/`serve`/`release`); verhindert parallele Instanzen und holt bei manuellem Zweitstart das vorhandene Fenster nach vorn (SHOW), beim Autostart-Doppelfeuer ohne Fenster-Pop (PING)
 - `src/updater.py` — GitHub-Releases-Check (stdlib-only, gedrosselt 1×/Tag)
 - `src/platform_open.py` — `os.startfile`/`open`/`xdg-open`-Wrapper
 - `src/logging_setup.py` — File-Logging + globaler Excepthook (Setup-Fehler sind **nicht-fatal**, siehe `main.py`)

--- a/README.md
+++ b/README.md
@@ -12,9 +12,14 @@ Desktop-App zur Erfassung von Arbeitszeiten mit Kalenderansicht, PDF-Report und 
 - **Multi-Device-Sync** — Optionale Synchronisation von Zeiteinträgen und Mail-Vorlagen über Google Drive (`appDataFolder`), inklusive manueller Konflikt-Auflösung wenn dasselbe Datum offline auf mehreren Geräten bearbeitet wurde
 - **Teilen & Importieren** — Eigene Arbeitszeiten als JSON-Anhang per Mail an eine zweite Person teilen; der Empfänger importiert sie mit Zeitraum-Filter und drei Konflikt-Modi (alles importieren / alles lokal / pro Tag entscheiden)
 - **Reservierungen & Google-Kalender** — Zukünftige Arbeitszeiten pro Tag reservieren (eigenes Konzept neben den Ist-Zeiten, im Kalender als violetter Eck-Punkt markiert); optionaler Abgleich mit einem wählbaren Google Kalender
+- **Reservierungs-Erinnerungen** — Optionale Toast-Benachrichtigung, wenn ein für heute reservierter Slot fällig wird und noch keine Ist-Zeit erfasst ist (konfigurierbare Vorlaufzeit)
+- **PDF-Export** — Bericht für einen frei gewählten Zeitraum direkt als PDF lokal speichern (ohne Mail-Versand)
+- **Wochenstunden-Limit** — Optionales Werkstudenten-Limit über einen konfigurierbaren Zeitraum mit Warnung beim Überschreiten
+- **Kategorien** — Mehrere Zeitblöcke pro Tag mit eigenen Kategorien; Standard-Start/-Ende pro Kategorie, optional pro Wochentag; Kategorie-Aufschlüsselung im Bericht optional
+- **UI-Skalierung** — Stufenloser Skalierungsfaktor für die Oberfläche (gerätelokal)
 - **Zeitraumwahl** — Flexibler Datumsbereich für Reports
-- **Einstellungen** — E-Mail-Vorlagen mit Platzhaltern, Standardpause, Empfänger
-- **Autostart** — Optionaler minimierter Start bei Anmeldung (Windows, macOS, Linux)
+- **Einstellungen** — In Tabs gegliedert (Arbeitszeit / Bericht & Mail / Google / App); E-Mail-Vorlagen mit Platzhaltern, Standardpause, Empfänger
+- **Autostart & Einzelinstanz** — Optionaler minimierter Start bei Anmeldung (Windows, macOS, Linux); es läuft immer nur eine Instanz — ein zweiter Start holt das vorhandene Fenster nach vorn
 - **Update-Check** — Prüft beim Start einmal pro Tag auf neuere Releases und zeigt einen unaufdringlichen Banner mit Direkt-Download
 - **Dark Mode UI** — Modernes dunkles Design
 - **Cross-Platform-Installer** — Per PyInstaller gebaut, als Setup-Exe (Windows), DMG (macOS) und AppImage (Linux) paketierbar
@@ -30,7 +35,7 @@ Zeiterfassung/
 │   ├── background_tasks.py # Hintergrund-Worker + Thread-Mechanik (Token-Refresh, Update-Check, Reconcile)
 │   ├── sync_orchestrator.py # Drive-Sync-Steuerung (manuell/Tray/Pull/Quit, Fehler-Aufbereitung)
 │   ├── update_banner.py   # GitHub-Release-Hinweis-Banner
-│   ├── dialogs/           # Modal-Dialoge (entry, send, settings, share, import, conflicts, category)
+│   ├── dialogs/           # Modal-Dialoge (entry, send, export, settings, share, import, conflicts, category) + geteilter period_picker
 │   ├── storage.py         # JSON-Persistenz der Zeiteinträge
 │   ├── settings.py        # Einstellungen mit Standardwerten
 │   ├── category_defaults.py # Default-Kategorien für Zeit-Slots
@@ -42,10 +47,15 @@ Zeiterfassung/
 │   ├── share.py           # Export/Import von Arbeitszeiten als Share-JSON
 │   ├── reservations.py    # Reservierungen (zukünftige Soll-Zeiten)
 │   ├── reservations_sync.py # Abgleich der Reservierungen mit Google Kalender
+│   ├── reminders.py       # Fälligkeits-Logik für Reservierungs-Erinnerungen (Tk-frei)
+│   ├── reminder_scheduler.py # Periodischer Reminder-Poll → Toast über Tray
+│   ├── weekly_limit.py    # Wochenstunden-Limit (Werkstudenten-Privileg), pure Logik
 │   ├── gcal.py            # Google-Calendar-API-Wrapper
 │   ├── oauth_utils.py     # Gemeinsame OAuth-Token-Boilerplate (Persistenz, Scope-Upgrade) für mail/drive/gcal
-│   ├── tray.py            # Infobereich-Icon (Minimize-to-Tray)
-│   ├── autostart.py       # Plattformabhängiger Autostart (Windows/macOS/Linux)
+│   ├── tray.py            # Infobereich-Icon (Minimize-to-Tray); Plattform-Fassade
+│   ├── tray_mac.py        # Natives macOS-Tray-Backend (NSStatusItem, dormant/opt-in)
+│   ├── autostart.py       # Plattformabhängiger Autostart (Windows-Registry/macOS/Linux)
+│   ├── single_instance.py # Single-Instance-Guard (verhindert parallele Instanzen)
 │   ├── updater.py         # GitHub-Releases-Check (stdlib-only, gedrosselt 1×/Tag)
 │   ├── holidays_de.py     # Feiertags-Lookup (python-holidays)
 │   ├── time_utils.py      # Zeitberechnung und Validierung
@@ -339,7 +349,7 @@ Die App läuft auf **Windows, macOS und Linux**. Plattformspezifische Features w
 | Einstellungen & Vorlagen | ✓ | ✓ | ✓ |
 | Taskbar-Icon (AppUserModelID) | ✓ | — (nicht nötig) | — (nicht nötig) |
 | Window-Icon | ✓ (`.ico`) | ✓ (`.png` Fallback) | ✓ (`.png` Fallback) |
-| Autostart bei Anmeldung | ✓ (VBScript-Shortcut) | ✓ (LaunchAgent plist) | ✓ (`.desktop`-Datei) |
+| Autostart bei Anmeldung | ✓ (Registry HKCU Run) | ✓ (LaunchAgent plist) | ✓ (`.desktop`-Datei) |
 | Standalone-Binary (PyInstaller) | ✓ (`.exe`) | ✓ (`.app` Bundle) | ✓ (AppImage) |
 
 ## Tests

--- a/src/version.py
+++ b/src/version.py
@@ -1,4 +1,4 @@
-VERSION = "1.16.1"
+VERSION = "1.17.0"
 
 # build_info wird beim Build von build.py generiert (gitignored) und von
 # PyInstaller mitgebündelt. Beim Start aus dem Quellcode existiert es nicht —


### PR DESCRIPTION
Release-PR für **v1.17.0** (Minor). Bündelt die seit v1.16.1 auf `master` gemergte Feature-Arbeit.

## Was dieser PR macht
- `src/version.py`: `1.16.1` → `1.17.0`
- `CHANGELOG.md`: 1.17.0-Eintrag
- Docs aktualisiert: Root-`CLAUDE.md` (`single_instance.py` ergänzt, `autostart.py` Registry statt Shortcut), `README.md` (Feature-Liste, Struktur-Baum, Plattform-Tabelle)
- Label `release:minor` → Merge triggert `release.yml` (liest Version aus `version.py`, taggt `v1.17.0`, baut Installer, veröffentlicht)

## Enthalten in 1.17.0 (seit v1.16.1)

**Neu:** PDF-Export (Bericht lokal speichern), Reservierungs-Erinnerungen (Toast), Werkstudenten-Wochenlimit, UI-Skalierung, Kategorie-Standardzeiten pro Wochentag, optionale Kategorie-Aufschlüsselung im Bericht.

**Geändert:** Einstellungen in vier Tabs; Autostart-Vereinheitlichung (Windows-Registry, App+Installer teilen den Eintrag → keine doppelten Autostart-Einträge/zwei Instanzen mehr) + Einzelinstanz-Guard (zweiter Start holt vorhandenes Fenster nach vorn); Arbeitszeit-Tooltip ab einem Slot.

**Behoben:** keine Reservierung für vergangene Tage per Linksklick; PDF-Stundentabelle-Spalten; Update-Banner-Geometrie (Footer bleibt sichtbar); Dialog-Interaktionen (Löschen-Rückfrage-Sperre, Tooltip über Modal).

**Intern:** natives macOS-Tray (dormant/opt-in) + Main-Thread-Crash-Fix; Pre-Release-Build-Infrastruktur; `SYNCED_SETTING_KEYS` Single Source of Truth.

Fixes, die zu einem in dieser Version neu eingeführten Feature gehören (z. B. macOS-Skalierungs-Fix, Slider-Akzent, Autostart-Checkbox/recv-Timeout), sind bewusst in die jeweilige Feature-Beschreibung gefaltet statt separat unter „Behoben" gelistet.

## Verifikation
`pytest` 717 passed / 3 skipped, `ruff check .` clean. Autostart-Unification zusätzlich manuell am echten Frozen-Build verifiziert (siehe #114).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
