### PR TITLE
fix(holidays): transiente FileNotFoundError bei gettext-Übersetzung abfangen

### DIFF
--- a/src/holidays_de.py
+++ b/src/holidays_de.py
@@ -1,3 +1,5 @@
+import logging
+import time
 from datetime import date
 from functools import lru_cache
 
@@ -34,8 +36,26 @@ def code_for_state_label(label: str) -> str:
 
 @lru_cache(maxsize=64)
 def _holidays_cached(state_code: str, year: int) -> dict[date, str]:
+    """Ruft holidays.Germany(..., language="de") auf. Im Onefile-Build kann die
+    de.mo-Übersetzungsdatei bei sehr schnell aufeinanderfolgenden Prozessstarts
+    (z.B. App-Neustart nach UI-Skalierungsänderung) transient noch nicht
+    sichtbar sein — gettext wirft dann FileNotFoundError statt still auf
+    Englisch zurückzufallen (Issue #116). Kurzer Retry deckt das ab; bleibt es
+    dabei, greift derselbe Silent-Empty-Fallback wie bei ungültigem
+    state_code, statt die App abstürzen zu lassen."""
     import holidays
-    return dict(holidays.Germany(subdiv=state_code, years=year, language="de"))
+    attempts = 3
+    for attempt in range(attempts):
+        try:
+            return dict(holidays.Germany(subdiv=state_code, years=year, language="de"))
+        except OSError:
+            if attempt == attempts - 1:
+                logging.getLogger(__name__).warning(
+                    "Feiertage für %s/%s nicht ladbar (Übersetzungsdatei "
+                    "transient nicht gefunden)", state_code, year, exc_info=True)
+                return {}
+            time.sleep(0.2)
+    return {}
 
 
 def get_holidays(state_code: str, year: int) -> dict[date, str]:

--- a/tests/test_holidays_de.py
+++ b/tests/test_holidays_de.py
@@ -1,6 +1,7 @@
+import time
 from datetime import date
 
-from src.holidays_de import STATES, get_holidays
+from src.holidays_de import STATES, _holidays_cached, get_holidays
 
 
 def test_states_list_starts_with_empty_option():
@@ -71,3 +72,46 @@ def test_code_for_state_label_empty_option_maps_to_empty_code():
 def test_code_for_state_label_unknown_label_is_empty():
     from src.holidays_de import code_for_state_label
     assert code_for_state_label("Atlantis") == ""
+
+
+# --- Resilienz gegen transiente FileNotFoundError (Issue #116, gettext-Race
+# im Onefile-Build beim Neustart für UI-Skalierung) ---
+
+
+def test_transient_failure_is_retried_and_succeeds(monkeypatch):
+    import holidays
+
+    _holidays_cached.cache_clear()
+    monkeypatch.setattr(time, "sleep", lambda s: None)
+
+    real_germany = holidays.Germany
+    calls = {"n": 0}
+
+    def flaky_germany(*args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise FileNotFoundError(
+                "No translation file found for domain: 'DE'")
+        return real_germany(*args, **kwargs)
+
+    monkeypatch.setattr(holidays, "Germany", flaky_germany)
+
+    h = get_holidays("BY", 2031)
+
+    assert calls["n"] == 3
+    assert date(2031, 10, 3) in h
+
+
+def test_persistent_failure_falls_back_to_empty_dict(monkeypatch):
+    import holidays
+
+    _holidays_cached.cache_clear()
+    monkeypatch.setattr(time, "sleep", lambda s: None)
+
+    def always_fails(*args, **kwargs):
+        raise FileNotFoundError(
+            "No translation file found for domain: 'DE'")
+
+    monkeypatch.setattr(holidays, "Germany", always_fails)
+
+    assert get_holidays("BY", 2032) == {}


### PR DESCRIPTION
## Summary
- Behebt #116: `holidays.Germany(..., language="de")` kann im Onefile-Build beim App-Neustart nach UI-Skalierungsänderung mit `FileNotFoundError` crashen, wenn die `de.mo`-Übersetzungsdatei durch zwei sehr schnell aufeinanderfolgende Prozessstarts transient noch nicht sichtbar ist.
- `_holidays_cached` versucht den Aufruf jetzt bis zu 3× mit kurzem Backoff; schlägt es dauerhaft fehl, greift derselbe Silent-Empty-Fallback wie bei ungültigem `state_code` (App crasht nie, verliert im Worst-Case nur für diesen Start die Feiertagsanzeige).
- Root-Cause-Verifikation im Detail: siehe Kommentar/Docstring in `src/holidays_de.py` sowie Analyse in #116.

## Test plan
- [x] Neue Tests (TDD, RED→GREEN verifiziert): transiente Fehlschläge werden erfolgreich retried, dauerhafte Fehlschläge fallen auf `{}` zurück
- [x] `pytest` (719 passed)
- [x] `ruff check .`
- [x] `pyright` sauber (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)