### PR TITLE
fix(theme): Akzentbalken bei Warn-/Fehler-Dialogen entfernt

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,6 +171,19 @@ Windows/Linux ist Löschen ausschließlich der Rechtsklick.
 Neue Lösch-/Rechtsklick-Stellen müssen dieses Modell einhalten (kein zweiter
 Lösch-Pfad im Linksklick-Dialog auf Win/Linux).
 
+## Dialog-Styling: ein gemeinsames Theme
+
+Alle Dialoge (modal wie nicht-modal) teilen sich dasselbe Dark-Theme aus
+`src/theme.py` — Drop-ins für die `tkinter.messagebox`-Familie
+(`themed_showinfo`/`themed_showwarning`/`themed_showerror`,
+`themed_askyesno`, `themed_ask_delete_choice`) sowie die Fenster-Chrome-
+Helfer (`apply_dark_titlebar`, `disable_min_max`, `apply_app_icon`,
+`center_dialog_on_parent`). Neue Dialoge nutzen diese Helfer statt
+`tkinter.messagebox`/eigenem Ad-hoc-Styling, und bekommen **keine**
+dialogspezifischen Stil-Extras (Farbakzente, abweichende Fonts o.ä.) ohne
+Rücksprache — das Theme bleibt bewusst einheitlich über alle Dialoge hinweg,
+nicht pro Dialog individualisiert.
+
 ## Tests / CI
 
 `.github/workflows/test.yml` installiert gezielt nur die Pakete, die die Tests brauchen (`pytest`, `holidays==0.99`, `google-api-python-client`, `google-auth`, `google-auth-oauthlib`), **nicht** `requirements.txt`. Grund: `pycairo` (transitive Dep von `xhtml2pdf`) braucht Cairo-Systemheader auf Ubuntu und bricht sonst den CI-Build. Der Import von `xhtml2pdf` in `src/report.py::generate_pdf` ist lazy, daher laufen die Report-Tests ohne die Lib. `holidays` und die Google-Libs sind pure Python ohne C-Deps und problemlos installierbar — letztere sind nötig, weil Tests `src.ui` importieren (z.B. `tests/test_ui_delete.py`), dessen Importkette die Google-Wrapper zieht. Ein zweiter Job läuft `ruff check .` (Lint).

--- a/src/theme.py
+++ b/src/theme.py
@@ -26,9 +26,6 @@ ACCENT_HOVER = "#c73550"
 # "nicht klickbar" erkennbar, behält aber den Rot-Charakter des Löschen-Buttons.
 ACCENT_DISABLED = "#5c2a37"
 STATUS_OK = "#4ade80"
-# Amber für Warn-Dialoge (dezenter Akzentbalken) — hebt Warnung von neutralem
-# Info ab, ohne den roten Fehler-/Lösch-Akzent (ACCENT) zu verwenden.
-WARNING = "#e8a13a"
 TEXT = "#e0e0e0"
 TEXT_MUTED = "#888888"
 ENTRY_BG = "#1a3a5c"
@@ -958,13 +955,11 @@ def themed_ask_delete_choice(parent, title: str, message: str, options, lock_ms:
     return result["value"]
 
 
-def _themed_ok_dialog(parent, title: str, message: str, accent=None) -> None:
+def _themed_ok_dialog(parent, title: str, message: str) -> None:
     """Modaler OK-Dialog im App-Theme — Basis für info/warning/error.
 
     Eigener Toplevel mit Dark-Theme-Farben und gebrandeter Titelleiste
     (`tkinter.messagebox.*` ist eine Black-Box ohne Customization-Hooks).
-    `accent`: optionale Farbe für einen dezenten Balken am oberen Rand, der
-    Warnung (amber) bzw. Fehler (rot) vom neutralen Info-Dialog abhebt.
     """
     dialog = tk.Toplevel(parent)
     dialog.title(title)
@@ -974,11 +969,6 @@ def _themed_ok_dialog(parent, title: str, message: str, accent=None) -> None:
     disable_min_max(dialog)
     apply_app_icon(dialog)
     dialog.focus_set()
-
-    if accent is not None:
-        bar = tk.Frame(dialog, bg=accent, height=4)
-        bar.pack(fill=tk.X)
-        bar.pack_propagate(False)
 
     tk.Label(
         dialog, text=message, font=FONT, bg=BG, fg=TEXT,
@@ -1005,12 +995,12 @@ def themed_showinfo(parent, title: str, message: str) -> None:
 
 def themed_showwarning(parent, title: str, message: str) -> None:
     """Modaler Warn-Dialog im App-Theme. Drop-in für `messagebox.showwarning`."""
-    _themed_ok_dialog(parent, title, message, accent=WARNING)
+    _themed_ok_dialog(parent, title, message)
 
 
 def themed_showerror(parent, title: str, message: str) -> None:
     """Modaler Fehler-Dialog im App-Theme. Drop-in für `messagebox.showerror`."""
-    _themed_ok_dialog(parent, title, message, accent=ACCENT)
+    _themed_ok_dialog(parent, title, message)
 
 
 def icon_button(parent, text, command, fg=ACCENT, hover_fg=None):


### PR DESCRIPTION
## Summary
- Entfernt den 4px-Farbbalken am oberen Rand von `themed_showwarning`/`themed_showerror` (`_themed_ok_dialog`, `src/theme.py`) — passte optisch nicht ins Design-Schema.
- `_themed_ok_dialog` verliert den `accent`-Parameter; die jetzt ungenutzte `WARNING`-Farbkonstante entfällt mit.
- Dokumentiert als Konvention in `CLAUDE.md`: alle Dialoge teilen sich dasselbe Theme aus `theme.py`, keine dialogspezifischen Stil-Extras ohne Rücksprache.

## Test plan
- [x] `pytest` (717 passed, 3 skipped)
- [x] `ruff check .`
- [x] `pyright` sauber
- [x] Manuell verifiziert (Dialog live angezeigt, Balken weg, restliches Layout unverändert)

🤖 Generated with [Claude Code](https://claude.com/claude-code)