### PR TITLE
fix(sync): Datenschicht threadsicher machen — geteilter Store-Lock + Sync-Guard (Audit H1/H2/M1)

### DIFF
--- a/docs/superpowers/plans/2026-07-04-datenschicht-threadsicherheit.md
+++ b/docs/superpowers/plans/2026-07-04-datenschicht-threadsicherheit.md
@@ -1,0 +1,1656 @@
+# Datenschicht-Threadsicherheit (Audit H1/H2/M1) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Die vier JSON-Stores threadsicher machen und alle Drive-Sync-Läufe serialisieren, damit weder parallele Writes JSON korrumpieren (H2) noch UI-Saves im Sync-Fenster verloren gehen (H1) noch verwaiste Timeout-Worker parallel schreiben (M1).
+
+**Architecture:** Ein geteilter `threading.RLock` (`data_lock`) wird in alle vier Stores injiziert und klammert in den Sync-Flows den Block Snapshot→Merge→Apply (nie über Netzwerk). Ein separater plain `threading.Lock` (`sync_guard`) serialisiert alle Sync-Einstiege; acquired UND released wird er im innersten Worker-Thread (`finally`, nach der letzten Store-Mutation) — nie in UI-Callbacks, nie beim Join-Timeout. Spec: `docs/superpowers/specs/2026-07-04-datenschicht-threadsicherheit-design.md`.
+
+**Tech Stack:** Python 3.10+ stdlib (`threading`, `contextlib`), Tkinter, pytest. Keine neuen Dependencies.
+
+## Global Constraints
+
+- **Guard-Invariante:** `sync_guard` ist ein plain `threading.Lock` (NIE `RLock` — `Lock.release()` ist cross-thread erlaubt, `RLock` erzwingt Owner-Release). Release ausschließlich im `finally` des Threads, der die Store-Mutationen ausführt.
+- **Daten-Lock-Invariante:** `data_lock` (`RLock`) wird NIE über einen Netzwerk-Call (`drive.get_drive_service`/`download`/`upload`, gcal-Calls) gehalten.
+- Alle neuen Parameter sind Keyword-Parameter mit Default `None` — bestehende Aufrufer/Tests bleiben unverändert lauffähig.
+- Tests: keine `sleep`s, keine Timing-Asserts — nur `threading.Event`/`start`/`join`/Probe-Threads. Alle bestehenden Tests (717 passed, 3 skipped) müssen grün bleiben.
+- Kommentare/Docstrings auf Deutsch, Stil der umliegenden Dateien.
+- Shell ist PowerShell 5.1: **kein `&&`** — Befehle einzeln oder mit `;` verketten.
+- Test-Kommando aus dem Repo-Root: `python -m pytest -q` (Gesamtlauf) bzw. `python -m pytest <datei>::<test> -v`.
+- Commit-Messages deutsch mit Conventional-Prefix; jede Commit-Message endet mit `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>` (als zweites `-m`).
+
+---
+
+### Task 0: Branch anlegen, Baseline prüfen, Docs committen
+
+**Files:**
+- Commit: `docs/superpowers/specs/2026-07-04-datenschicht-threadsicherheit-design.md`, `docs/superpowers/plans/2026-07-04-datenschicht-threadsicherheit.md`
+
+**Interfaces:**
+- Produces: Branch `fix/datenschicht-threadsicherheit` (ab `master`), grüne Baseline.
+
+- [ ] **Step 1: Branch von master abzweigen**
+
+```powershell
+git checkout master
+git pull
+git checkout -b fix/datenschicht-threadsicherheit
+```
+
+Hinweis: Repo-Setup ist Fork→Upstream (origin = Fork, PRs gegen `margenheld/Zeiterfassung`). Falls `master` hinter upstream hängt: `git fetch upstream ; git merge upstream/master` vor dem Abzweigen. Die untracked Dateien (`AUDIT-2026-07-04.md`, docs) wandern automatisch mit.
+
+- [ ] **Step 2: Baseline-Tests laufen lassen**
+
+Run: `python -m pytest -q`
+Expected: `717 passed, 3 skipped` (Anzahl kann leicht abweichen, aber 0 failed).
+
+- [ ] **Step 3: Spec + Plan committen (NICHT das Audit — bleibt Arbeitsdokument)**
+
+```powershell
+git add docs/superpowers/specs/2026-07-04-datenschicht-threadsicherheit-design.md docs/superpowers/plans/2026-07-04-datenschicht-threadsicherheit.md
+git commit -m "docs: Spec + Plan Datenschicht-Threadsicherheit (Audit H1/H2/M1)" -m "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 1: Geteilter RLock in allen vier Stores
+
+**Files:**
+- Modify: `src/storage.py`, `src/settings.py`, `src/conflicts_store.py`, `src/reservations.py`
+- Test: `tests/test_store_locking.py` (neu)
+
+**Interfaces:**
+- Produces: `Storage(filepath, device_id="", lock=None)`, `Settings(filepath, lock=None)`, `ConflictsStore(filepath, lock=None)`, `ReservationStore(filepath, lock=None)`. Bei `lock=None` legt jeder Store einen eigenen `threading.RLock` an; injizierter Lock wird geteilt. Alle öffentlichen Lese-/Schreibmethoden laufen unter `with self._lock:`.
+- Consumes: nichts (Basis-Task).
+
+- [ ] **Step 1: Failing Tests schreiben**
+
+Neue Datei `tests/test_store_locking.py`:
+
+```python
+"""Threadsicherheit der vier Stores: geteilter injizierter RLock (Audit H1/H2).
+
+Kein Sleep/Timing — Lock-Besitz wird über einen Probe-Thread geprüft
+(non-blocking acquire aus fremdem Thread), Robustheit über einen Stresstest,
+dessen Erfolgskriterium "keine Exception + valides JSON" ist.
+"""
+
+import json
+import threading
+
+from src.conflicts_store import ConflictsStore
+from src.reservations import ReservationStore
+from src.settings import Settings
+from src.storage import Storage
+
+
+def _other_thread_can_acquire(lock):
+    """True, wenn ein ANDERER Thread den Lock nehmen kann (= Lock frei).
+    Deterministisch: nur start/join, kein Sleep. RLock ist reentrant pro
+    Thread — deshalb MUSS die Probe aus einem fremden Thread kommen."""
+    out = []
+
+    def probe():
+        got = lock.acquire(blocking=False)
+        out.append(got)
+        if got:
+            lock.release()
+
+    t = threading.Thread(target=probe)
+    t.start()
+    t.join()
+    return out[0]
+
+
+def _slot(start="08:00", end="16:00", pause=0):
+    return {"start": start, "end": end, "pause": pause, "kategorie": ""}
+
+
+def _assert_disk_write_locked(store, lock, mutate):
+    """Spy auf _save_to_disk: während des Disk-Writes muss der Lock gehalten
+    sein (Probe aus fremdem Thread darf ihn NICHT bekommen)."""
+    held = []
+    orig = store._save_to_disk
+
+    def spy():
+        held.append(not _other_thread_can_acquire(lock))
+        orig()
+
+    store._save_to_disk = spy
+    mutate()
+    assert held == [True]
+
+
+def test_all_stores_accept_shared_lock(tmp_path):
+    lock = threading.RLock()
+    Storage(str(tmp_path / "z.json"), device_id="A", lock=lock)
+    Settings(str(tmp_path / "s.json"), lock=lock)
+    ConflictsStore(str(tmp_path / "c.json"), lock=lock)
+    ReservationStore(str(tmp_path / "r.json"), lock=lock)
+
+
+def test_storage_save_holds_lock_during_disk_write(tmp_path):
+    lock = threading.RLock()
+    storage = Storage(str(tmp_path / "z.json"), device_id="A", lock=lock)
+    _assert_disk_write_locked(
+        storage, lock, lambda: storage.save("2026-01-01", [_slot()]))
+
+
+def test_storage_apply_merge_holds_lock_during_disk_write(tmp_path):
+    lock = threading.RLock()
+    storage = Storage(str(tmp_path / "z.json"), device_id="A", lock=lock)
+    entry = {"slots": [_slot()], "modified_at": "2026-01-01T10:00:00Z",
+             "device_id": "A", "deleted": False}
+    _assert_disk_write_locked(
+        storage, lock, lambda: storage.apply_merge({"2026-01-01": entry}))
+
+
+def test_settings_set_holds_lock_during_disk_write(tmp_path):
+    lock = threading.RLock()
+    settings = Settings(str(tmp_path / "s.json"), lock=lock)
+    _assert_disk_write_locked(
+        settings, lock, lambda: settings.set("recipient", "x@example.com"))
+
+
+def test_conflicts_save_all_holds_lock_during_disk_write(tmp_path):
+    lock = threading.RLock()
+    conflicts = ConflictsStore(str(tmp_path / "c.json"), lock=lock)
+    _assert_disk_write_locked(
+        conflicts, lock, lambda: conflicts.save_all([{"id": "1", "resolved": False}]))
+
+
+def test_reservations_save_holds_lock_during_disk_write(tmp_path):
+    lock = threading.RLock()
+    store = ReservationStore(str(tmp_path / "r.json"), lock=lock)
+    _assert_disk_write_locked(
+        store, lock,
+        lambda: store.save("2026-01-01", [{"start": "08:00", "end": "12:00"}]))
+
+
+def test_default_lock_created_when_not_injected(tmp_path):
+    """Ohne Injektion legt der Store einen eigenen RLock an — Alt-Aufrufer
+    (bestehende Tests) bleiben unverändert und trotzdem intern threadsicher."""
+    storage = Storage(str(tmp_path / "z.json"), device_id="A")
+    _assert_disk_write_locked(
+        storage, storage._lock, lambda: storage.save("2026-01-01", [_slot()]))
+
+
+def test_parallel_writes_keep_file_valid_json(tmp_path):
+    """Stresstest (Robustheitsnetz, kein Timing-Assert): parallele
+    save/delete/apply_merge/get_all dürfen weder werfen noch die Datei
+    korrumpieren."""
+    lock = threading.RLock()
+    path = tmp_path / "z.json"
+    storage = Storage(str(path), device_id="A", lock=lock)
+    errors = []
+
+    def writer(i):
+        try:
+            for n in range(30):
+                date = f"2026-01-{(n % 28) + 1:02d}"
+                storage.save(date, [_slot()])
+                if n % 7 == 0:
+                    storage.delete(date)
+                if n % 11 == 0:
+                    storage.apply_merge(storage.get_all_raw())
+                storage.get_all()
+        except Exception as e:  # noqa: BLE001 — Fehler ins Hauptthread-Assert tragen
+            errors.append(e)
+
+    threads = [threading.Thread(target=writer, args=(i,)) for i in range(6)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert errors == []
+    json.loads(path.read_text(encoding="utf-8"))  # Datei ist valides JSON
+```
+
+- [ ] **Step 2: Tests laufen lassen — müssen fehlschlagen**
+
+Run: `python -m pytest tests/test_store_locking.py -v`
+Expected: FAIL, alle Tests mit `TypeError: __init__() got an unexpected keyword argument 'lock'`.
+
+- [ ] **Step 3: `src/storage.py` umbauen**
+
+Import ergänzen (nach `import json`):
+
+```python
+import threading
+```
+
+Konstruktor:
+
+```python
+    def __init__(self, filepath="zeiterfassung.json", device_id="", lock=None):
+        self.filepath = filepath
+        self.device_id = device_id
+        # Geteilter Daten-Lock (Audit H1/H2): main() injiziert EINEN RLock in
+        # alle vier Stores; ohne Injektion (Tests, Alt-Aufrufer) eigener Lock.
+        # _load()/Migration laufen vor dem Teilen (single-threaded Boot) —
+        # bewusst ungelockt.
+        self._lock = lock if lock is not None else threading.RLock()
+        self._data = {}
+        self._load()
+```
+
+Alle öffentlichen Methoden bekommen `with self._lock:` um den kompletten Body (Einrückung +1). Vollständig:
+
+```python
+    def get_all(self):
+        """Liefert {date: {slots: [...]}} ohne Tombstones."""
+        with self._lock:
+            return {
+                date: self._user_shape(entry)
+                for date, entry in self._data.items()
+                if not entry.get("deleted")
+            }
+
+    def get_all_raw(self):
+        """Liefert die kompletten Eintragsobjekte inkl. Metadaten und Tombstones.
+        Nur für den Sync-Pfad."""
+        with self._lock:
+            return dict(self._data)
+
+    def get(self, date_str):
+        with self._lock:
+            entry = self._data.get(date_str)
+            if entry is None or entry.get("deleted"):
+                return None
+            return self._user_shape(entry)
+
+    def save(self, date_str, slots):
+        with self._lock:
+            self._data[date_str] = {
+                "slots": [_normalize_slot(s) for s in slots],
+                "modified_at": _utc_now_iso(),
+                "device_id": self.device_id,
+                "deleted": False,
+            }
+            self._save_to_disk()
+
+    def delete(self, date_str):
+        with self._lock:
+            if date_str not in self._data:
+                return
+            # Tombstone: behält die Zeile mit deleted=true, damit der Sync ein
+            # Delete gegen ein veraltetes Save eines anderen Geräts durchsetzen kann.
+            self._data[date_str] = {
+                "slots": [],
+                "modified_at": _utc_now_iso(),
+                "device_id": self.device_id,
+                "deleted": True,
+            }
+            self._save_to_disk()
+
+    def apply_merge(self, merged_entries):
+        """Ersetzt den kompletten Storage-Stand durch das Merge-Ergebnis.
+        merged_entries: {date: {slots, modified_at, device_id, deleted}}.
+        Wirft ValueError, wenn ein Eintrag Pflichtfelder vermissen lässt."""
+        with self._lock:
+            for date, entry in merged_entries.items():
+                missing = _REQUIRED_ENTRY_KEYS - entry.keys()
+                if missing:
+                    raise ValueError(
+                        f"apply_merge: entry {date!r} missing keys {sorted(missing)}"
+                    )
+            self._data = dict(merged_entries)
+            self._save_to_disk()
+
+    def save_many(self, updates):
+        """Mehrere Einträge in einem einzigen Disk-Write speichern.
+
+        updates: {date_str: {"slots": [...]}}. Jeder Eintrag bekommt
+        frische modified_at/device_id/deleted=False. Existierende Tombstones
+        am selben Datum werden überschrieben.
+
+        Leeres Dict ist No-op (kein Disk-Roundtrip).
+        """
+        if not updates:
+            return
+        with self._lock:
+            now = _utc_now_iso()
+            for date_str, payload in updates.items():
+                self._data[date_str] = {
+                    "slots": [_normalize_slot(s) for s in payload.get("slots", [])],
+                    "modified_at": now,
+                    "device_id": self.device_id,
+                    "deleted": False,
+                }
+            self._save_to_disk()
+```
+
+(`_load`, `_migrate_legacy_entries`, `_save_to_disk`, `_user_shape` bleiben unverändert — `_save_to_disk` wird nur innerhalb gelockter Methoden gerufen.)
+
+- [ ] **Step 4: `src/settings.py` umbauen**
+
+Import ergänzen (nach `import os`): `import threading`
+
+Konstruktor:
+
+```python
+    def __init__(self, filepath="settings.json", lock=None):
+        self.filepath = filepath
+        # Geteilter Daten-Lock (Audit H1/H2) — siehe storage.py.
+        self._lock = lock if lock is not None else threading.RLock()
+        self._data = dict(DEFAULTS)
+        self._synced_meta = {}   # {key: {"modified_at": ..., "device_id": ...}}
+        self.device_id_for_sync = ""  # wird von main.py auf settings.device_id gesetzt
+        self._load()
+```
+
+Methoden (RLock ist reentrant — `set` → `set_many` und `apply_updates` → `set_synced`/`set_many` bleiben korrekt):
+
+```python
+    def get(self, key):
+        with self._lock:
+            return self._data.get(key, DEFAULTS.get(key))
+
+    def set_many(self, updates):
+        """Mehrere Werte setzen, einmal auf Platte schreiben.
+
+        Leeres Dict ist No-op (kein Disk-Roundtrip).
+        """
+        if not updates:
+            return
+        with self._lock:
+            self._data.update(updates)
+            self._save_to_disk()
+
+    def set_synced(self, key, value):
+        """Setzt einen whitelisted Sync-Key und stempelt Per-Field-Metadaten.
+        Außerhalb der Whitelist verhält sich wie ein normales set()."""
+        if key not in SYNCED_SETTING_KEYS:
+            self.set(key, value)
+            return
+        with self._lock:
+            self._data[key] = value
+            self._synced_meta[key] = {
+                "modified_at": _utc_now_iso(),
+                "device_id": self.device_id_for_sync,
+            }
+            self._save_to_disk()
+
+    def get_synced_doc(self):
+        """{key: {value, modified_at, device_id}} — Eingabe für den Sync-Merge.
+        Nur Keys mit vorhandener Metadaten-Spur werden zurückgegeben."""
+        with self._lock:
+            doc = {}
+            for key in SYNCED_SETTING_KEYS:
+                meta = self._synced_meta.get(key)
+                if meta is None:
+                    continue
+                doc[key] = {
+                    "value": self._data.get(key, DEFAULTS.get(key)),
+                    "modified_at": meta["modified_at"],
+                    "device_id": meta["device_id"],
+                }
+            return doc
+
+    def apply_synced(self, synced_doc):
+        """Übernimmt das Merge-Ergebnis: schreibt value in _data und Meta in
+        _synced_meta. Schreibt einmal auf Platte."""
+        if not synced_doc:
+            return
+        with self._lock:
+            for key, payload in synced_doc.items():
+                if key not in SYNCED_SETTING_KEYS:
+                    continue
+                if not isinstance(payload, dict) or "value" not in payload:
+                    continue
+                self._data[key] = payload["value"]
+                self._synced_meta[key] = {
+                    "modified_at": str(payload.get("modified_at", "")),
+                    "device_id": str(payload.get("device_id", "")),
+                }
+            self._save_to_disk()
+```
+
+(`set` und `apply_updates` delegieren an gelockte Methoden — unverändert lassen.)
+
+- [ ] **Step 5: `src/conflicts_store.py` umbauen**
+
+Import ergänzen: `import threading`
+
+```python
+    def __init__(self, filepath="conflicts.json", lock=None):
+        self.filepath = filepath
+        # Geteilter Daten-Lock (Audit H1/H2) — siehe storage.py.
+        self._lock = lock if lock is not None else threading.RLock()
+        self._conflicts = []
+        self._load()
+
+    def get_all(self):
+        with self._lock:
+            return list(self._conflicts)
+
+    def save_all(self, conflicts):
+        with self._lock:
+            self._conflicts = list(conflicts)
+            self._save_to_disk()
+
+    def count_unresolved(self):
+        with self._lock:
+            return sum(1 for c in self._conflicts if not c.get("resolved"))
+```
+
+- [ ] **Step 6: `src/reservations.py` umbauen**
+
+Import ergänzen: `import threading`
+
+```python
+    def __init__(self, filepath="reservations.json", lock=None):
+        self.filepath = filepath
+        # Geteilter Daten-Lock (Audit H1/H2) — siehe storage.py.
+        self._lock = lock if lock is not None else threading.RLock()
+        self._data = {}
+        self._load()
+```
+
+`get_all`, `get_all_raw`, `get`, `save`, `delete`, `apply_reconciled` analog zu Storage komplett in `with self._lock:` einrücken (Bodies unverändert, nur eingerückt; bei `save` gehört die komplette Positions-Übernahme-Logik inkl. `_save_to_disk()` in den Block, bei `delete` auch der Early-Return `if date_str not in self._data: return`).
+
+- [ ] **Step 7: Tests laufen lassen — müssen bestehen**
+
+Run: `python -m pytest tests/test_store_locking.py -v`
+Expected: alle PASS.
+
+- [ ] **Step 8: Gesamtsuite + Lint**
+
+Run: `python -m pytest -q ; ruff check .`
+Expected: 0 failed, ruff „All checks passed".
+
+- [ ] **Step 9: Commit**
+
+```powershell
+git add src/storage.py src/settings.py src/conflicts_store.py src/reservations.py tests/test_store_locking.py
+git commit -m "fix(stores): geteilten RLock in alle vier Stores injizieren (Audit H2)" -m "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Pull-Flow — Daten-Lock-Block + Sync-Guard
+
+**Files:**
+- Modify: `src/main.py` (`_run_pull_in_background`, neuer Helfer `_lock_ctx`)
+- Test: `tests/test_sync_threading.py` (neu)
+
+**Interfaces:**
+- Consumes: Stores mit `lock=`-Param (Task 1).
+- Produces: `_lock_ctx(lock)` (Context-Manager-Shim, `None` → `contextlib.nullcontext()`); `_run_pull_in_background(storage, settings, conflicts_store, base, ui_callback, data_lock=None, sync_guard=None)`. Skip-Semantik: bei gehaltenem Guard kehrt der Pull zurück, OHNE `ui_callback` zu rufen.
+
+- [ ] **Step 1: Failing Tests schreiben**
+
+Neue Datei `tests/test_sync_threading.py`:
+
+```python
+"""Threading-Verhalten der Sync-Flows: Sync-Guard (Re-Entrancy, Audit H2) und
+Daten-Lock-Klammer um Snapshot→Merge→Apply (Audit H1). Deterministisch über
+Probe-Threads — kein Sleep, keine Timing-Asserts."""
+
+import threading
+
+from src.conflicts_store import ConflictsStore
+from src.settings import Settings
+from src.storage import Storage
+
+
+def _other_thread_can_acquire(lock):
+    """True, wenn ein ANDERER Thread den Lock nehmen kann (= Lock frei)."""
+    out = []
+
+    def probe():
+        got = lock.acquire(blocking=False)
+        out.append(got)
+        if got:
+            lock.release()
+
+    t = threading.Thread(target=probe)
+    t.start()
+    t.join()
+    return out[0]
+
+
+def _stores(tmp_path, lock):
+    storage = Storage(str(tmp_path / "z.json"), device_id="A", lock=lock)
+    settings = Settings(str(tmp_path / "s.json"), lock=lock)
+    settings.device_id_for_sync = "A"
+    conflicts = ConflictsStore(str(tmp_path / "c.json"), lock=lock)
+    return storage, settings, conflicts
+
+
+def _mock_drive_empty(monkeypatch):
+    """Drive-Fassade: kein Remote-File (Pfad ohne Download), Upload gemockt."""
+    from src import drive
+    monkeypatch.setattr(drive, "get_drive_service", lambda *a, **k: object())
+    monkeypatch.setattr(drive, "find_sync_file", lambda service: None)
+    monkeypatch.setattr(
+        drive, "upload",
+        lambda service, content, file_id=None, expected_etag=None: ("file-1", "etag-1"))
+    return drive
+
+
+def test_pull_skipped_when_guard_held(tmp_path):
+    """Läuft bereits ein Sync (Guard gehalten), wird der Pull still
+    übersprungen: kein ui_callback, kein Drive-Zugriff."""
+    import src.main as main
+    lock = threading.RLock()
+    storage, settings, conflicts = _stores(tmp_path, lock)
+    guard = threading.Lock()
+    calls = []
+    assert guard.acquire(blocking=False)
+    try:
+        main._run_pull_in_background(
+            storage, settings, conflicts, str(tmp_path),
+            lambda **kw: calls.append(kw), data_lock=lock, sync_guard=guard)
+    finally:
+        guard.release()
+    assert calls == []
+
+
+def test_pull_holds_data_lock_during_apply_and_releases_guard(tmp_path, monkeypatch):
+    """Während apply_merged_doc muss der Daten-Lock gehalten sein (kein
+    UI-Save kann interleaven, H1); danach ist der Guard wieder frei."""
+    import src.main as main
+    from src import sync
+    lock = threading.RLock()
+    storage, settings, conflicts = _stores(tmp_path, lock)
+    guard = threading.Lock()
+    _mock_drive_empty(monkeypatch)
+    held = []
+    orig = sync.apply_merged_doc
+
+    def spy(merged, storage_, settings_, conflicts_):
+        held.append(not _other_thread_can_acquire(lock))
+        return orig(merged, storage_, settings_, conflicts_)
+
+    monkeypatch.setattr(sync, "apply_merged_doc", spy)
+    calls = []
+    main._run_pull_in_background(
+        storage, settings, conflicts, str(tmp_path),
+        lambda **kw: calls.append(kw), data_lock=lock, sync_guard=guard)
+    assert held == [True]                    # Apply lief unter dem Daten-Lock
+    assert calls and calls[0]["ok"] is True
+    assert guard.acquire(blocking=False)     # Guard wieder frei (finally)
+    guard.release()
+
+
+def test_pull_without_lock_and_guard_still_works(tmp_path, monkeypatch):
+    """Alt-Aufrufer-Kompatibilität: ohne data_lock/sync_guard läuft der Pull
+    wie bisher (bestehende Tests in test_sync.py decken die Semantik ab)."""
+    import src.main as main
+    lock = threading.RLock()
+    storage, settings, conflicts = _stores(tmp_path, lock)
+    _mock_drive_empty(monkeypatch)
+    calls = []
+    main._run_pull_in_background(
+        storage, settings, conflicts, str(tmp_path),
+        lambda **kw: calls.append(kw))
+    assert calls and calls[0]["ok"] is True
+```
+
+- [ ] **Step 2: Tests laufen lassen — müssen fehlschlagen**
+
+Run: `python -m pytest tests/test_sync_threading.py -v`
+Expected: FAIL mit `TypeError: _run_pull_in_background() got an unexpected keyword argument 'data_lock'` (die ersten zwei Tests); der dritte PASS (unveränderte Signatur-Nutzung).
+
+- [ ] **Step 3: `_lock_ctx`-Helfer + Pull-Umbau in `src/main.py`**
+
+Import ergänzen (nach `import logging`): `import contextlib`
+
+Helfer direkt vor `_run_pull_in_background` einfügen:
+
+```python
+def _lock_ctx(lock):
+    """Context-Manager-Shim für den optionalen Daten-Lock: `with _lock_ctx(l)`
+    lockt, wenn ein Lock übergeben wurde, und ist sonst ein No-op (Tests,
+    Alt-Aufrufer). Hält den Sync-Apply-Block atomar gegen UI-Saves (Audit H1)."""
+    return lock if lock is not None else contextlib.nullcontext()
+```
+
+`_run_pull_in_background` komplett ersetzen:
+
+```python
+def _run_pull_in_background(storage, settings, conflicts_store, base, ui_callback,
+                            data_lock=None, sync_guard=None):
+    """Pull läuft in einem Thread; UI-Update über ui_callback (root.after).
+
+    sync_guard (plain Lock, Re-Entrancy-Guard, Audit H2): läuft bereits ein
+    anderer Sync, wird der Pull still übersprungen — ohne ui_callback; der
+    laufende Sync meldet sein Ergebnis selbst. Release im finally DIESES
+    Threads (nach der letzten Store-Mutation), nie in UI-Callbacks.
+    data_lock (geteilter Store-RLock, Audit H1): klammert
+    Snapshot→Merge→Apply atomar gegen parallele UI-Saves. Wird NICHT über
+    den Download gehalten."""
+    from src import drive, sync
+    if sync_guard is not None and not sync_guard.acquire(blocking=False):
+        return
+    try:
+        try:
+            service = drive.get_drive_service(
+                os.path.join(base, "credentials.json"),
+                os.path.join(base, "token.json"),
+                gcal_enabled=settings.get("gcal_enabled"),
+            )
+            file_id = drive.find_sync_file(service)
+            if file_id is None:
+                remote_doc = {"schema_version": 1, "entries": {}, "settings": {}, "conflicts": []}
+                etag = ""
+            else:
+                content, etag = drive.download(service, file_id)
+                def _quarantine(fid):
+                    import datetime
+                    stamp = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
+                    try:
+                        service.files().update(
+                            fileId=fid,
+                            body={"name": f"zeiterfassung-sync.corrupt-{stamp}.json"},
+                        ).execute()
+                    except Exception:
+                        logging.getLogger(__name__).warning(
+                            "Quarantine rename failed for %s", fid, exc_info=True)
+                remote_doc = _parse_remote_or_quarantine(content, file_id, _quarantine)
+            if sync._remote_is_newer(remote_doc):
+                # Neueres (zukünftiges) Schema: NICHT mergen/pushen — Pull sauber
+                # abbrechen, last_pull_at/etag unverändert lassen.
+                ui_callback(ok=False, error=sync.NEWER_REMOTE_VERSION_MSG, tb="")
+                return
+            # Älteres Remote (v1/v2) wird aufs aktuelle Schema migriert und normal
+            # gemergt (absorb-and-upgrade). Dass ältere Geräte ein hochgezogenes
+            # v4-Doc nicht überschreiben, sichert deren Push-Guard (ab v1.15.2).
+            remote_doc = sync.migrate_doc_to_current(remote_doc)
+            # Snapshot→Merge→Apply atomar: kein UI-Save kann zwischen
+            # build_local_doc und apply_merged_doc interleaven (Audit H1).
+            with _lock_ctx(data_lock):
+                local_doc = sync.build_local_doc(storage, settings, conflicts_store)
+                merged = sync.merge(local_doc, remote_doc, settings.get("last_pull_at") or "")
+                sync.apply_merged_doc(merged, storage, settings, conflicts_store)
+                settings.set_many({
+                    "last_pull_at": sync._utc_now_iso(),
+                    "drive_etag": etag,
+                })
+            ui_callback(ok=True, error=None, tb="")
+        except Exception as e:
+            tb = traceback.format_exc()
+            logging.getLogger(__name__).exception("Sync pull failed")
+            ui_callback(ok=False, error=e, tb=tb)
+    finally:
+        if sync_guard is not None:
+            sync_guard.release()
+```
+
+- [ ] **Step 4: Tests laufen lassen — müssen bestehen**
+
+Run: `python -m pytest tests/test_sync_threading.py tests/test_sync.py -v`
+Expected: alle PASS (auch die bestehenden Pull-Tests, da neue Params Defaults haben).
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add src/main.py tests/test_sync_threading.py
+git commit -m "fix(sync): Pull — Daten-Lock um Snapshot/Merge/Apply + Re-Entrancy-Guard (Audit H1/H2)" -m "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Push + Kompaktierung — Guard im inneren Worker, Lock-Block ohne Netz
+
+**Files:**
+- Modify: `src/main.py` (`_run_push_blocking`, `_run_compaction_blocking`)
+- Test: `tests/test_sync_threading.py` (erweitern)
+
+**Interfaces:**
+- Consumes: `_lock_ctx` (Task 2), Stores mit Lock (Task 1).
+- Produces: `_run_push_blocking(storage, settings, conflicts_store, base, timeout_seconds=5, data_lock=None, sync_guard=None, guard_timeout=0)` und `_run_compaction_blocking(storage, settings, conflicts_store, base, timeout_seconds=20, data_lock=None, sync_guard=None)`. Skip-Result: `{"ok": False, "skipped": True}`. `guard_timeout>0` → blockierend warten (Quit-Semantik), sonst non-blocking-skip. Guard-Release im `finally` des **inneren** `_do`-Threads.
+
+- [ ] **Step 1: Failing Tests an `tests/test_sync_threading.py` anhängen**
+
+```python
+def test_push_skipped_when_guard_held(tmp_path):
+    import src.main as main
+    lock = threading.RLock()
+    storage, settings, conflicts = _stores(tmp_path, lock)
+    guard = threading.Lock()
+    assert guard.acquire(blocking=False)
+    try:
+        res = main._run_push_blocking(
+            storage, settings, conflicts, str(tmp_path),
+            data_lock=lock, sync_guard=guard)
+    finally:
+        guard.release()
+    assert res == {"ok": False, "skipped": True}
+
+
+def test_push_holds_data_lock_during_apply(tmp_path, monkeypatch):
+    import src.main as main
+    from src import sync
+    lock = threading.RLock()
+    storage, settings, conflicts = _stores(tmp_path, lock)
+    _mock_drive_empty(monkeypatch)
+    held = []
+    orig = sync.apply_merged_doc
+
+    def spy(merged, storage_, settings_, conflicts_):
+        held.append(not _other_thread_can_acquire(lock))
+        return orig(merged, storage_, settings_, conflicts_)
+
+    monkeypatch.setattr(sync, "apply_merged_doc", spy)
+    res = main._run_push_blocking(
+        storage, settings, conflicts, str(tmp_path),
+        data_lock=lock, sync_guard=None)
+    assert res.get("ok") is True
+    assert held == [True]
+
+
+def test_push_uploads_without_holding_data_lock(tmp_path, monkeypatch):
+    """Spec-Invariante: der Daten-Lock wird NIE über den Netzwerk-Upload
+    gehalten — während drive.upload muss er aus fremdem Thread nehmbar sein."""
+    import src.main as main
+    from src import drive
+    lock = threading.RLock()
+    storage, settings, conflicts = _stores(tmp_path, lock)
+    monkeypatch.setattr(drive, "get_drive_service", lambda *a, **k: object())
+    monkeypatch.setattr(drive, "find_sync_file", lambda service: None)
+    lock_free = []
+
+    def fake_upload(service, content, file_id=None, expected_etag=None):
+        lock_free.append(_other_thread_can_acquire(lock))
+        return ("file-1", "etag-1")
+
+    monkeypatch.setattr(drive, "upload", fake_upload)
+    res = main._run_push_blocking(
+        storage, settings, conflicts, str(tmp_path),
+        data_lock=lock, sync_guard=None)
+    assert res.get("ok") is True
+    assert lock_free == [True]
+
+
+def test_push_guard_released_after_run(tmp_path, monkeypatch):
+    import src.main as main
+    lock = threading.RLock()
+    storage, settings, conflicts = _stores(tmp_path, lock)
+    _mock_drive_empty(monkeypatch)
+    guard = threading.Lock()
+    res = main._run_push_blocking(
+        storage, settings, conflicts, str(tmp_path),
+        data_lock=lock, sync_guard=guard)
+    assert res.get("ok") is True
+    assert guard.acquire(blocking=False)   # Guard nach dem Lauf wieder frei
+    guard.release()
+
+
+def test_push_guard_timeout_waits_for_running_sync(tmp_path, monkeypatch):
+    """Quit-Semantik: guard_timeout>0 wartet auf den laufenden Sync statt zu
+    skippen. Deterministischer Ausgang (großzügige Timeouts begrenzen nur die
+    Dauer im Fehlerfall, sie werden nicht asserted)."""
+    import src.main as main
+    lock = threading.RLock()
+    storage, settings, conflicts = _stores(tmp_path, lock)
+    _mock_drive_empty(monkeypatch)
+    guard = threading.Lock()
+    guard.acquire()   # "laufender Sync"
+    out = {}
+
+    def run_push():
+        out["res"] = main._run_push_blocking(
+            storage, settings, conflicts, str(tmp_path),
+            timeout_seconds=30, data_lock=lock, sync_guard=guard,
+            guard_timeout=30)
+
+    t = threading.Thread(target=run_push)
+    t.start()
+    guard.release()   # der "laufende Sync" endet — der wartende Push übernimmt
+    t.join()
+    assert out["res"].get("ok") is True
+
+
+def test_compaction_skipped_when_guard_held(tmp_path):
+    import src.main as main
+    lock = threading.RLock()
+    storage, settings, conflicts = _stores(tmp_path, lock)
+    guard = threading.Lock()
+    assert guard.acquire(blocking=False)
+    try:
+        res = main._run_compaction_blocking(
+            storage, settings, conflicts, str(tmp_path),
+            data_lock=lock, sync_guard=guard)
+    finally:
+        guard.release()
+    assert res == {"ok": False, "skipped": True}
+
+
+def test_compaction_holds_data_lock_during_compact(tmp_path, monkeypatch):
+    import src.main as main
+    from src import sync
+    lock = threading.RLock()
+    storage, settings, conflicts = _stores(tmp_path, lock)
+    _mock_drive_empty(monkeypatch)
+    held = []
+    orig = sync.compact_local
+
+    def spy(storage_, settings_, conflicts_, now):
+        held.append(not _other_thread_can_acquire(lock))
+        return orig(storage_, settings_, conflicts_, now)
+
+    monkeypatch.setattr(sync, "compact_local", spy)
+    res = main._run_compaction_blocking(
+        storage, settings, conflicts, str(tmp_path),
+        data_lock=lock, sync_guard=None)
+    assert res.get("ok") is True
+    assert held == [True]
+```
+
+- [ ] **Step 2: Tests laufen lassen — müssen fehlschlagen**
+
+Run: `python -m pytest tests/test_sync_threading.py -v`
+Expected: die neuen Tests FAIL mit `TypeError: ... unexpected keyword argument 'data_lock'`; Task-2-Tests PASS.
+
+- [ ] **Step 3: `_run_push_blocking` komplett ersetzen**
+
+```python
+def _run_push_blocking(storage, settings, conflicts_store, base, timeout_seconds=5,
+                       data_lock=None, sync_guard=None, guard_timeout=0):
+    """Synchroner Push mit Timeout. Fehler werden geloggt, nicht angezeigt
+    (App schließt gerade).
+
+    sync_guard/guard_timeout (Audit H2/M1): Re-Entrancy-Guard. guard_timeout=0
+    → non-blocking (zweiter Klick/Tray-Sync liefert {"skipped": True});
+    guard_timeout>0 → blockierend warten (Quit-Push wartet auf einen laufenden
+    Sync). Der Guard wird im INNEREN _do-Thread acquired UND im finally
+    released — erst nach der letzten Store-Mutation. Ein per Join-Timeout
+    „verwaister" Worker hält ihn dadurch bis zum echten Ende: er IST dann der
+    laufende Sync, statt parallel zu einem neuen zu schreiben.
+    data_lock (Audit H1): klammert Snapshot→Merge→Apply→Upload-Snapshot
+    atomar; der Upload selbst läuft OHNE Daten-Lock (nie Lock über Netz)."""
+    import json
+    from src import drive, sync
+
+    result = {}
+
+    def _do():
+        if sync_guard is not None:
+            got = (sync_guard.acquire(timeout=guard_timeout) if guard_timeout > 0
+                   else sync_guard.acquire(blocking=False))
+            if not got:
+                result["ok"] = False
+                result["skipped"] = True
+                return
+        try:
+            try:
+                service = drive.get_drive_service(
+                    os.path.join(base, "credentials.json"),
+                    os.path.join(base, "token.json"),
+                    gcal_enabled=settings.get("gcal_enabled"),
+                )
+                file_id = drive.find_sync_file(service)
+                # Push = download -> Guard -> Merge -> upload. drive.upload kennt
+                # kein File-level If-Match (ignoriert expected_etag), daher MUSS hier
+                # das frische Remote-Doc gelesen und gemergt werden — sonst
+                # überschreibt der Push fremde oder neuere Stände blind (Datenverlust
+                # bzw. Clobber eines neueren Schemas während eines Rollouts).
+                if file_id is not None:
+                    remote_bytes, _etag = drive.download(service, file_id)
+                    try:
+                        remote_doc = json.loads(remote_bytes)
+                    except (json.JSONDecodeError, ValueError):
+                        remote_doc = {"schema_version": 1, "entries": {}, "settings": {}, "conflicts": []}
+                    if sync._remote_is_newer(remote_doc):
+                        # Neueres Gerät hat das Remote-Doc fortgeschrieben: nicht
+                        # mergen/überschreiben — Push abbrechen, neuere Daten bleiben.
+                        result["ok"] = False
+                        result["error"] = sync.NEWER_REMOTE_VERSION_MSG
+                        result["tb"] = ""
+                        return
+                else:
+                    remote_doc = {"schema_version": 1, "entries": {}, "settings": {}, "conflicts": []}
+                # Älteres Remote (v1/v2) absorbieren: aufs aktuelle Schema migrieren,
+                # dann mergen — sonst gingen v2-only-Stände beim Upload verloren.
+                remote_doc = sync.migrate_doc_to_current(remote_doc)
+                # Snapshot→Merge→Apply→Upload-Snapshot atomar (Audit H1);
+                # der Upload danach läuft bewusst ungelockt.
+                with _lock_ctx(data_lock):
+                    local_doc = sync.build_local_doc(storage, settings, conflicts_store)
+                    merged = sync.merge(local_doc, remote_doc, settings.get("last_pull_at") or "")
+                    sync.apply_merged_doc(merged, storage, settings, conflicts_store)
+                    doc = sync.build_local_doc(storage, settings, conflicts_store)
+                    content = json.dumps(doc, ensure_ascii=False).encode("utf-8")
+                new_id, new_etag = drive.upload(service, content, file_id, expected_etag="")
+                settings.set_many({
+                    "last_pull_at": sync._utc_now_iso(),
+                    "drive_etag": new_etag,
+                })
+                result["ok"] = True
+            except Exception as e:
+                logging.getLogger(__name__).exception("Sync push failed: %s", e)
+                result["ok"] = False
+                result["error"] = str(e)
+                result["tb"] = traceback.format_exc()
+        finally:
+            if sync_guard is not None:
+                sync_guard.release()
+
+    t = threading.Thread(target=_do, daemon=True)
+    t.start()
+    t.join(timeout=timeout_seconds)
+    if not result:
+        result = {"ok": False, "error": "Timeout", "tb": ""}
+    return result
+```
+
+- [ ] **Step 4: `_run_compaction_blocking` komplett ersetzen**
+
+```python
+def _run_compaction_blocking(storage, settings, conflicts_store, base, timeout_seconds=20,
+                             data_lock=None, sync_guard=None):
+    """User-ausgelöste Kompaktierung: frischer Pull → Alt-Client-Guard → Merge →
+    Watermark setzen + lokal strippen → Push. Liefert
+    {"ok": bool, "reason": str, "error": ..., "tb": ...}.
+
+    reason == "newer_version": ein neueres Gerät hat ein Schema geschrieben, das
+    diese Version nicht versteht — Kompaktierung abgebrochen, kein Merge/Upload
+    (sonst würde das neuere Doc überschrieben). Ältere Remote-Docs (v1/v2) werden
+    wie bei Pull/Push aufs aktuelle Schema migriert.
+
+    sync_guard: non-blocking — läuft ein Sync, kommt {"skipped": True} zurück
+    (der Settings-Dialog zeigt dann einen Hinweis). Release im finally des
+    inneren _do-Threads. data_lock: klammert Merge/Apply/Kompaktierung atomar;
+    der Upload läuft ungelockt (Invarianten wie _run_push_blocking)."""
+    import json
+    from src import drive, sync
+
+    result = {}
+
+    def _do():
+        if sync_guard is not None and not sync_guard.acquire(blocking=False):
+            result["ok"] = False
+            result["skipped"] = True
+            return
+        try:
+            try:
+                service = drive.get_drive_service(
+                    os.path.join(base, "credentials.json"),
+                    os.path.join(base, "token.json"),
+                    gcal_enabled=settings.get("gcal_enabled"),
+                )
+                file_id = drive.find_sync_file(service)
+                if file_id is not None:
+                    content, _etag = drive.download(service, file_id)
+                    try:
+                        remote_doc = json.loads(content)
+                    except (json.JSONDecodeError, ValueError):
+                        remote_doc = {"schema_version": 1}
+                    # Neueres Schema (>v3) auf dem FRISCH gepullten Doc: nicht
+                    # mergen/überschreiben — Kompaktierung abbrechen.
+                    if sync._remote_is_newer(remote_doc):
+                        result.update({"ok": False, "reason": "newer_version"})
+                        return
+                else:
+                    remote_doc = {"schema_version": 2, "entries": {}, "settings": {},
+                                  "conflicts": [], "meta": {"gc_watermark": ""}}
+
+                # Älteres Remote (v1/v2) absorbieren: aufs aktuelle Schema migrieren.
+                remote_doc = sync.migrate_doc_to_current(remote_doc)
+                now = sync._utc_now_iso()
+                # Merge + Apply + Watermark/Strippung + Upload-Snapshot atomar
+                # (Audit H1); der Upload danach läuft bewusst ungelockt.
+                with _lock_ctx(data_lock):
+                    # 1) normaler Merge des frischen Remote-Stands
+                    local_doc = sync.build_local_doc(storage, settings, conflicts_store)
+                    merged = sync.merge(local_doc, remote_doc, settings.get("last_pull_at") or "")
+                    sync.apply_merged_doc(merged, storage, settings, conflicts_store)
+                    settings.set("last_pull_at", now)
+                    # 2) Watermark setzen + lokal strippen
+                    sync.compact_local(storage, settings, conflicts_store, now)
+                    # 3) kompaktiertes Doc für den Upload snapshotten
+                    doc = sync.build_local_doc(storage, settings, conflicts_store)
+                    payload = json.dumps(doc, ensure_ascii=False).encode("utf-8")
+                new_id, new_etag = drive.upload(service, payload, file_id, expected_etag="")
+                settings.set("drive_etag", new_etag)
+                result.update({"ok": True})
+            except Exception as e:
+                logging.getLogger(__name__).exception("Kompaktierung fehlgeschlagen")
+                result.update({"ok": False, "error": str(e), "tb": traceback.format_exc()})
+        finally:
+            if sync_guard is not None:
+                sync_guard.release()
+
+    t = threading.Thread(target=_do, daemon=True)
+    t.start()
+    t.join(timeout=timeout_seconds)
+    if not result:
+        result = {"ok": False, "error": "Timeout", "tb": ""}
+    return result
+```
+
+- [ ] **Step 5: Tests laufen lassen — müssen bestehen**
+
+Run: `python -m pytest tests/test_sync_threading.py tests/test_sync.py -v`
+Expected: alle PASS.
+
+- [ ] **Step 6: Commit**
+
+```powershell
+git add src/main.py tests/test_sync_threading.py
+git commit -m "fix(sync): Push/Kompaktierung — Guard im inneren Worker, Lock nie über Netz (Audit H1/H2/M1)" -m "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: SyncOrchestrator — Verdrahtung, Button-Disable, skipped-Handling, Quit
+
+**Files:**
+- Modify: `src/sync_orchestrator.py`
+- Test: `tests/test_sync_orchestrator.py` (erweitern + eine bestehende Fixture anpassen)
+
+**Interfaces:**
+- Consumes: `_run_push_blocking(..., data_lock=, sync_guard=, guard_timeout=)` (Task 3).
+- Produces: `SyncOrchestrator(root, storage, settings, conflicts_store, base_path, runner, on_refresh, get_tray, data_lock=None, sync_guard=None)`; `_push(guard_timeout=0, timeout_seconds=15)`; `on_sync_clicked` deaktiviert den Button, `_on_manual_done` reaktiviert ihn und behandelt `skipped`; `_on_tray_done` skippt Toast bei `skipped`; `push_on_quit` nutzt `guard_timeout=5, timeout_seconds=10` und loggt bei `skipped` statt Dialog.
+
+- [ ] **Step 1: Failing Tests schreiben (und Fixture erweitern)**
+
+In `tests/test_sync_orchestrator.py` die Klasse `_FakeLabel` um eine `_FakeButton`-Klasse ergänzen und `_orch` um `data_lock`/`sync_guard` erweitern:
+
+```python
+class _FakeButton:
+    """Fake für den Sync-Button: config(state=...) + winfo_ismapped für
+    update_status_label (meldet sich als bereits gepackt)."""
+    def __init__(self):
+        self.state = None
+
+    def config(self, state=None):
+        if state is not None:
+            self.state = state
+
+    def winfo_ismapped(self):
+        return True
+```
+
+`_orch` ersetzen durch:
+
+```python
+def _orch(sync_enabled=True, execute_runner=False, get_tray=lambda: None,
+          conflicts=0, on_refresh=None, data_lock=None, sync_guard=None):
+    _vals = {"sync_enabled": sync_enabled, "last_pull_at": None}
+    settings = MagicMock(get=lambda k, d=None: _vals.get(k, d))
+    conflicts_store = MagicMock(count_unresolved=lambda: conflicts)
+    runner = _FakeRunner(execute=execute_runner)
+    orch = SyncOrchestrator(
+        root=object(), storage=object(), settings=settings,
+        conflicts_store=conflicts_store, base_path=".", runner=runner,
+        on_refresh=on_refresh or (lambda: None), get_tray=get_tray,
+        data_lock=data_lock, sync_guard=sync_guard,
+    )
+    return orch, runner
+```
+
+Im bestehenden Test `test_on_sync_clicked_enabled_sets_label_and_runs` das `sync_button=object()` durch `sync_button=_FakeButton()` ersetzen (der Klick konfiguriert den Button-State jetzt).
+
+Neue Tests anhängen:
+
+```python
+def test_on_sync_clicked_disables_button():
+    orch, runner = _orch(sync_enabled=True, execute_runner=False)
+    label, button = _FakeLabel(), _FakeButton()
+    orch.attach_widgets(sync_button=button, status_label=label,
+                        next_button=object())
+    orch.on_sync_clicked()
+    assert button.state == "disabled"
+
+
+def test_on_manual_done_reenables_button():
+    orch, _ = _orch(sync_enabled=True)
+    label, button = _FakeLabel(), _FakeButton()
+    orch.attach_widgets(sync_button=button, status_label=label,
+                        next_button=object())
+    orch._on_manual_done({"ok": True})
+    assert button.state == "normal"
+
+
+def test_on_manual_done_skipped_shows_no_error(monkeypatch):
+    import src.sync_orchestrator as so
+    errors = []
+    monkeypatch.setattr(so, "_show_sync_error", lambda *a, **k: errors.append(a))
+    refreshed = []
+    orch, _ = _orch(sync_enabled=True, on_refresh=lambda: refreshed.append(1))
+    label, button = _FakeLabel(), _FakeButton()
+    orch.attach_widgets(sync_button=button, status_label=label,
+                        next_button=object())
+    orch._on_manual_done({"ok": False, "skipped": True})
+    assert errors == []          # kein Fehlerdialog — anderer Sync läuft nur
+    assert refreshed == []       # kein Refresh nötig, nichts hat sich geändert
+    assert button.state == "normal"
+
+
+def test_on_tray_done_skipped_no_toast():
+    tray = MagicMock()
+    orch, _ = _orch(get_tray=lambda: tray)
+    orch._on_tray_done({"ok": False, "skipped": True})
+    tray.notify.assert_not_called()
+
+
+def test_push_passes_lock_guard_and_timeouts(monkeypatch):
+    captured = {}
+
+    def fake(storage, settings, conflicts_store, base, timeout_seconds=5, **kw):
+        captured.update(kw)
+        captured["timeout_seconds"] = timeout_seconds
+        return {"ok": True}
+
+    monkeypatch.setattr("src.main._run_push_blocking", fake)
+    lock, guard = object(), object()
+    orch, _ = _orch(sync_enabled=True, data_lock=lock, sync_guard=guard)
+    orch._push()
+    assert captured["data_lock"] is lock
+    assert captured["sync_guard"] is guard
+    assert captured["guard_timeout"] == 0
+    assert captured["timeout_seconds"] == 15
+
+
+def test_push_on_quit_uses_guard_timeout(monkeypatch):
+    captured = {}
+
+    def fake(storage, settings, conflicts_store, base, timeout_seconds=5, **kw):
+        captured.update(kw)
+        captured["timeout_seconds"] = timeout_seconds
+        return {"ok": True}
+
+    monkeypatch.setattr("src.main._run_push_blocking", fake)
+    orch, _ = _orch(sync_enabled=True)
+    orch.push_on_quit()
+    assert captured["guard_timeout"] == 5
+    assert captured["timeout_seconds"] == 10
+
+
+def test_push_on_quit_skipped_logs_no_dialog(monkeypatch):
+    import src.sync_orchestrator as so
+    errors = []
+    monkeypatch.setattr(so, "_show_sync_error", lambda *a, **k: errors.append(a))
+    monkeypatch.setattr("src.main._run_push_blocking",
+                        lambda *a, **k: {"ok": False, "skipped": True})
+    orch, _ = _orch(sync_enabled=True)
+    orch.push_on_quit()
+    assert errors == []
+```
+
+- [ ] **Step 2: Tests laufen lassen — müssen fehlschlagen**
+
+Run: `python -m pytest tests/test_sync_orchestrator.py -v`
+Expected: FAIL — `_orch` scheitert mit `TypeError: __init__() got an unexpected keyword argument 'data_lock'`.
+
+- [ ] **Step 3: `src/sync_orchestrator.py` umbauen**
+
+Import ergänzen (nach `import tkinter as tk`): `import logging`
+
+`__init__` ersetzen:
+
+```python
+    def __init__(self, root, storage, settings, conflicts_store, base_path,
+                 runner, on_refresh, get_tray, data_lock=None, sync_guard=None):
+        self._root = root
+        self._storage = storage
+        self._settings = settings
+        self._conflicts_store = conflicts_store
+        self._base_path = base_path
+        self._runner = runner          # App._bg, hat .run(fn, on_done)
+        self._on_refresh = on_refresh    # App._refresh
+        self._get_tray = get_tray        # lambda: App._tray
+        self._data_lock = data_lock      # geteilter Store-RLock (Audit H1)
+        self._sync_guard = sync_guard    # Sync-Re-Entrancy-Guard (Audit H2)
+        self._sync_button = None
+        self._status_label = None
+        self._next_button = None
+```
+
+`_push` ersetzen:
+
+```python
+    def _push(self, guard_timeout=0, timeout_seconds=15):
+        from src.main import _run_push_blocking
+        return _run_push_blocking(
+            self._storage, self._settings, self._conflicts_store,
+            self._base_path, timeout_seconds=timeout_seconds,
+            data_lock=self._data_lock, sync_guard=self._sync_guard,
+            guard_timeout=guard_timeout,
+        )
+```
+
+`on_sync_clicked` — nach der `_status_label`-Zeile den Button deaktivieren:
+
+```python
+    def on_sync_clicked(self):
+        if not self._settings.get("sync_enabled"):
+            themed_showinfo(
+                self._root,
+                "Synchronisation",
+                "Synchronisation ist deaktiviert. In den Einstellungen aktivierbar.")
+            return
+        self._status_label.config(text="Synchronisiere…")
+        if self._sync_button is not None:
+            self._sync_button.config(state=tk.DISABLED)
+        self._runner.run(self._push, self._on_manual_done)
+```
+
+`_on_manual_done` ersetzen:
+
+```python
+    def _on_manual_done(self, result):
+        if self._sync_button is not None:
+            self._sync_button.config(state=tk.NORMAL)
+        if result.get("skipped"):
+            # Anderer Sync läuft bereits — dessen Callback aktualisiert die UI.
+            self.update_status_label()
+            return
+        if not result.get("ok"):
+            _show_sync_error(self._root, result.get("error", "?"),
+                             result.get("tb", ""))
+        self._on_refresh()
+        self.update_status_label()
+```
+
+`_on_tray_done` — skipped-Early-Return an den Anfang:
+
+```python
+    def _on_tray_done(self, result):
+        if result.get("skipped"):
+            return  # anderer Sync läuft — kein Toast, nichts hat sich geändert
+        self._on_refresh()
+        self.update_status_label()
+        tray = self._get_tray()
+        if tray is None:
+            return
+        tray.notify(
+            _tray_toast(result.get("ok"), self._conflict_count(),
+                       result.get("error", "?")),
+            title="",
+        )
+```
+
+`push_on_quit` ersetzen (nutzt jetzt `self._push` statt Duplikat — DRY):
+
+```python
+    def push_on_quit(self):
+        """Blockierender Push beim Beenden. Wartet per guard_timeout bis 5 s
+        auf einen laufenden Sync (Worst Case gesamt ~10 s mit Push-Timeout).
+        Kein tray.stop() (bleibt App-Lifecycle)."""
+        if not self._settings.get("sync_enabled"):
+            return
+        try:
+            result = self._push(guard_timeout=5, timeout_seconds=10)
+        except Exception as e:
+            result = {"ok": False, "error": e, "tb": traceback.format_exc()}
+        if result.get("skipped"):
+            logging.getLogger(__name__).warning(
+                "Quit-Push übersprungen — ein anderer Sync läuft noch; "
+                "lokale Daten syncen beim nächsten Start.")
+            return
+        if not result.get("ok"):
+            _show_sync_error(
+                self._root, result.get("error", "?"), result.get("tb", ""),
+                suffix="Lokale Daten bleiben erhalten und werden beim "
+                       "nächsten Start synchronisiert.",
+            )
+```
+
+- [ ] **Step 4: Tests laufen lassen — müssen bestehen**
+
+Run: `python -m pytest tests/test_sync_orchestrator.py -v`
+Expected: alle PASS (inkl. der angepassten Bestands-Tests).
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add src/sync_orchestrator.py tests/test_sync_orchestrator.py
+git commit -m "fix(sync): Orchestrator — Guard/Lock-Verdrahtung, Button-Disable, skipped-Handling, Quit-Wartefenster" -m "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Reconcile-Pfad — Rebase+Apply unter dem Daten-Lock (angrenzend)
+
+**Files:**
+- Modify: `src/reservations_sync.py` (`reconcile_reservations`), `src/main.py` (`run_calendar_reconcile`), `src/background_tasks.py` (`BackgroundTaskRunner`)
+- Test: `tests/test_sync_threading.py` (erweitern)
+
+**Interfaces:**
+- Consumes: `ReservationStore(..., lock=)` (Task 1).
+- Produces: `reconcile_reservations(service, calendar_id, store, settings, data_lock=None)`; `run_calendar_reconcile(reservation_store, settings, base, storage, data_lock=None)`; `BackgroundTaskRunner(marshal, settings, base_path, reservation_store, reservations_active, storage=None, data_lock=None)`.
+
+- [ ] **Step 1: Failing Test an `tests/test_sync_threading.py` anhängen**
+
+```python
+def test_reconcile_holds_data_lock_during_rebase_and_apply(tmp_path, monkeypatch):
+    """Der Reconcile-Rebase+Replace (reservations_sync) läuft unter dem
+    geteilten Daten-Lock — kein UI-Save kann zwischen Rebase-Read und
+    apply_reconciled interleaven."""
+    from src.reservations import ReservationStore
+    from src import gcal
+    from src.reservations_sync import reconcile_reservations
+    lock = threading.RLock()
+    store = ReservationStore(str(tmp_path / "r.json"), lock=lock)
+    settings = Settings(str(tmp_path / "s.json"), lock=lock)
+    monkeypatch.setattr(gcal, "list_app_events", lambda service, cal: [])
+    held = []
+    orig = store.apply_reconciled
+
+    def spy(reconciled):
+        held.append(not _other_thread_can_acquire(lock))
+        return orig(reconciled)
+
+    store.apply_reconciled = spy
+    reconcile_reservations(object(), "cal-1", store, settings, data_lock=lock)
+    assert held == [True]
+```
+
+- [ ] **Step 2: Test laufen lassen — muss fehlschlagen**
+
+Run: `python -m pytest tests/test_sync_threading.py::test_reconcile_holds_data_lock_during_rebase_and_apply -v`
+Expected: FAIL mit `TypeError: reconcile_reservations() got an unexpected keyword argument 'data_lock'`.
+
+- [ ] **Step 3: `src/reservations_sync.py` umbauen**
+
+Import ergänzen (bei den Modul-Imports): `import contextlib`
+
+Signatur + Schlussteil von `reconcile_reservations` ändern (Docstring-Ergänzung + Lock-Klammer um Rebase/Apply/Watermark; der gcal-Netzwerkteil davor bleibt ungelockt):
+
+```python
+def reconcile_reservations(service, calendar_id, store, settings, data_lock=None):
+```
+
+Docstring um diesen Absatz ergänzen:
+
+```python
+    data_lock: optionaler geteilter Store-Lock (Audit H1/H2, angrenzend) —
+    klammert Rebase → apply_reconciled → Watermark atomar gegen parallele
+    UI-Saves. Die gcal-Netzwerk-Calls davor laufen bewusst ungelockt.
+```
+
+Den Schlussblock (ab dem Rebase-Kommentar) ersetzen:
+
+```python
+    # Rebase: Reservierungen, die seit dem Snapshot lokal gespeichert/geändert
+    # wurden (paralleler Reconcile / User-Save während des Netzwerkteils),
+    # dürfen nicht durch den apply_reconciled-Replace verloren gehen.
+    # Rebase + Replace + Watermark laufen atomar unter dem Daten-Lock —
+    # zwischen Rebase-Read und Replace kann so kein weiterer Save landen.
+    with (data_lock if data_lock is not None else contextlib.nullcontext()):
+        for date, entry in store.get_all_raw().items():
+            snap = local_snapshot.get(date)
+            if snap is None or entry.get("modified_at", "") > snap.get("modified_at", ""):
+                merged[date] = entry
+
+        store.apply_reconciled(merged)
+        settings.set("last_calendar_sync_at", _utc_now_iso())
+    return {"imported_dates": imported_dates}
+```
+
+(Bewusst KEIN Import von `src.main._lock_ctx` — der wäre ein Zyklus `reservations_sync → main → ui → …`; der Inline-`contextlib`-Ausdruck ist der Preis dafür.)
+
+- [ ] **Step 4: `run_calendar_reconcile` in `src/main.py` durchreichen**
+
+Signatur: `def run_calendar_reconcile(reservation_store, settings, base, storage, data_lock=None):`
+
+Docstring-Ergänzung (ein Satz): `data_lock wird an reconcile_reservations durchgereicht (Rebase+Apply atomar, Audit H1).`
+
+Aufruf ersetzen:
+
+```python
+        result = reconcile_reservations(service, calendar_id, reservation_store,
+                                        settings, data_lock=data_lock)
+```
+
+- [ ] **Step 5: `src/background_tasks.py` durchreichen**
+
+`__init__` ersetzen:
+
+```python
+    def __init__(self, marshal, settings, base_path, reservation_store,
+                 reservations_active, storage=None, data_lock=None):
+        self._marshal = marshal                          # App._marshal_to_ui
+        self._settings = settings
+        self._base_path = base_path
+        self._reservation_store = reservation_store
+        self._reservations_active = reservations_active  # callable -> bool
+        self._storage = storage
+        self._data_lock = data_lock                      # geteilter Store-RLock
+```
+
+In `reconcile_on_start` UND `trigger_reconcile` den `run_calendar_reconcile`-Aufruf ersetzen:
+
+```python
+            return run_calendar_reconcile(
+                self._reservation_store, self._settings, self._base_path,
+                self._storage, data_lock=self._data_lock)
+```
+
+- [ ] **Step 6: Tests laufen lassen — müssen bestehen**
+
+Run: `python -m pytest tests/test_sync_threading.py -v ; python -m pytest -q`
+Expected: neuer Test PASS, Gesamtsuite 0 failed.
+
+- [ ] **Step 7: Commit**
+
+```powershell
+git add src/reservations_sync.py src/main.py src/background_tasks.py tests/test_sync_threading.py
+git commit -m "fix(reservations): Reconcile-Rebase+Apply unter dem geteilten Daten-Lock" -m "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Settings-Dialog — Kompaktierung mit Guard + Hinweis bei laufendem Sync
+
+**Files:**
+- Modify: `src/dialogs/settings_dialog.py` (Signatur + Kompaktierungs-Closure, Z. ~505-551)
+
+**Interfaces:**
+- Consumes: `_run_compaction_blocking(..., data_lock=, sync_guard=)` (Task 3).
+- Produces: `open_settings_dialog(parent, settings, base_path, on_change, *, conflicts_store=None, storage=None, reservation_store=None, on_request_restart=None, data_lock=None, sync_guard=None)`.
+
+Hinweis: `settings_dialog` ist Tk-gebunden und in dieser Suite bewusst nicht headless getestet (Audit M16) — die Kompaktierungs-Semantik selbst ist über die Task-3-Tests abgedeckt; hier nur Durchreichung + Hinweis-Zweig. Verifikation über Gesamtsuite + manuellen Smoke in Task 7.
+
+- [ ] **Step 1: Signatur erweitern**
+
+```python
+def open_settings_dialog(parent, settings, base_path, on_change, *,
+                         conflicts_store=None, storage=None,
+                         reservation_store=None, on_request_restart=None,
+                         data_lock=None, sync_guard=None):
+```
+
+Docstring um einen Satz ergänzen: `data_lock/sync_guard: geteilter Store-Lock + Sync-Guard für die Kompaktierung (Audit H1/H2) — von App durchgereicht.`
+
+- [ ] **Step 2: `_show`-Closure — skipped-Zweig VOR den reason-Checks einfügen**
+
+In der Funktion `_show(res)` (aktuell Z. ~517) direkt nach dem `winfo_exists`-Guard:
+
+```python
+            def _show(res):
+                if not dialog.winfo_exists():
+                    return
+                if res.get("skipped"):
+                    themed_showinfo(
+                        dialog,
+                        "Kompaktierung",
+                        "Eine Synchronisation läuft gerade — bitte kurz "
+                        "warten und erneut versuchen.",
+                    )
+                    return
+                if res.get("reason") == "old_version":
+                    ...
+```
+
+(Restliche Zweige unverändert.)
+
+- [ ] **Step 3: `_do`-Closure — Lock + Guard durchreichen**
+
+```python
+            def _do():
+                from src.main import _run_compaction_blocking
+                res = _run_compaction_blocking(
+                    storage, settings, conflicts_store, base_path,
+                    data_lock=data_lock, sync_guard=sync_guard)
+                dialog.after(0, lambda: _show(res))
+```
+
+- [ ] **Step 4: Gesamtsuite + Lint**
+
+Run: `python -m pytest -q ; ruff check .`
+Expected: 0 failed, ruff sauber.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add src/dialogs/settings_dialog.py
+git commit -m "fix(settings): Kompaktierung — Sync-Guard durchreichen, Hinweis bei laufendem Sync" -m "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: End-Verdrahtung main()/App + Architektur-Doku + Gesamtverifikation
+
+**Files:**
+- Modify: `src/main.py` (`main()`), `src/ui.py` (`App.__init__`, `_open_settings`-Aufruf), `src/CLAUDE.md` (Threading-Modell)
+
+**Interfaces:**
+- Consumes: alles aus Tasks 1–6.
+- Produces: laufende App mit einem geteilten `data_lock` (RLock) über alle vier Stores und einem `sync_guard` (plain Lock) über alle fünf Sync-Einstiege.
+
+- [ ] **Step 1: `main()` verdrahten**
+
+In `src/main.py::main()` direkt vor der `Settings`-Instanzierung:
+
+```python
+    # Geteilter Daten-Lock über alle vier Stores (Audit H1/H2) + Sync-Guard.
+    # data_lock: RLock (reentrant — der Sync-Apply-Block ruft gelockte
+    # Store-Methoden). sync_guard: bewusst plain Lock, NIE RLock — er wird
+    # thread-übergreifend acquired/released (Lock erlaubt das, RLock nicht).
+    data_lock = threading.RLock()
+    sync_guard = threading.Lock()
+
+    settings = Settings(os.path.join(base, "settings.json"), lock=data_lock)
+    device_id = _ensure_device_id(settings)
+    settings.device_id_for_sync = device_id
+
+    storage = Storage(os.path.join(base, "zeiterfassung.json"),
+                      device_id=device_id, lock=data_lock)
+
+    conflicts_store = ConflictsStore(os.path.join(base, "conflicts.json"),
+                                     lock=data_lock)
+
+    reservation_store = ReservationStore(os.path.join(base, "reservations.json"),
+                                         lock=data_lock)
+```
+
+App-Konstruktion ersetzen:
+
+```python
+    app = App(root, storage, settings, base_path=base, conflicts_store=conflicts_store,
+              reservation_store=reservation_store, single_instance=guard,
+              data_lock=data_lock, sync_guard=sync_guard)
+```
+
+Startup-Pull-Thread ersetzen:
+
+```python
+        threading.Thread(
+            target=_run_pull_in_background,
+            args=(storage, settings, conflicts_store, base, _on_sync_done),
+            kwargs={"data_lock": data_lock, "sync_guard": sync_guard},
+            daemon=True,
+        ).start()
+```
+
+- [ ] **Step 2: `App.__init__` in `src/ui.py` verdrahten**
+
+Signatur (Z. 56-57) ersetzen:
+
+```python
+    def __init__(self, root, storage, settings, base_path=".", conflicts_store=None,
+                 reservation_store=None, single_instance=None,
+                 data_lock=None, sync_guard=None):
+```
+
+Nach `self.reservation_store = reservation_store` (Z. 64) einfügen:
+
+```python
+        self._data_lock = data_lock      # geteilter Store-RLock (Audit H1)
+        self._sync_guard = sync_guard    # Sync-Re-Entrancy-Guard (Audit H2)
+```
+
+`BackgroundTaskRunner`-Konstruktion (Z. 119-122) ersetzen:
+
+```python
+        self._bg = BackgroundTaskRunner(
+            self._marshal_to_ui, self.settings, self.base_path,
+            self.reservation_store, self._reservations_active, self.storage,
+            data_lock=data_lock,
+        )
+```
+
+`SyncOrchestrator`-Konstruktion (Z. 123-126) ersetzen:
+
+```python
+        self._sync = SyncOrchestrator(
+            self.root, self.storage, self.settings, self.conflicts_store,
+            self.base_path, self._bg, self._refresh, lambda: self._tray,
+            data_lock=data_lock, sync_guard=sync_guard,
+        )
+```
+
+Im `open_settings_dialog`-Aufruf (Z. ~351-358) die zwei Kwargs anhängen:
+
+```python
+        open_settings_dialog(
+            self.root, self.settings, self.base_path,
+            on_change=_on_change,
+            conflicts_store=self.conflicts_store,
+            storage=self.storage,
+            reservation_store=self.reservation_store,
+            on_request_restart=self.restart_for_scaling,
+            data_lock=self._data_lock,
+            sync_guard=self._sync_guard,
+        )
+```
+
+- [ ] **Step 3: `src/CLAUDE.md` — Threading-Modell ergänzen**
+
+Im Abschnitt „## Threading-Modell" nach dem bestehenden Absatz anfügen:
+
+```markdown
+**Datenschicht-Locking (Audit H1/H2/M1):** Alle vier Stores
+(`storage`/`settings`/`conflicts_store`/`reservations`) teilen sich einen in
+`main()` erzeugten `RLock` (Konstruktor-Param `lock=`; ohne Injektion legt
+jeder Store einen eigenen an — Tests bleiben unverändert). Die Sync-Flows
+(`_run_pull_in_background`/`_run_push_blocking`/`_run_compaction_blocking`/
+`reconcile_reservations`) klammern Snapshot→Merge→Apply mit diesem `data_lock`
+— **nie über Netzwerk-Calls**. Ein separater plain `threading.Lock`
+(`sync_guard`) serialisiert alle Drive-Sync-Einstiege (Startup-Pull, Manual-,
+Tray-, Quit-Push, Kompaktierung): non-blocking-skip mit
+`{"skipped": True}`-Result, nur der Quit-Push wartet (`guard_timeout=5`).
+Acquired UND released wird der Guard im innersten Worker-Thread (`finally`,
+nach der letzten Store-Mutation) — nie in UI-Callbacks, nie beim Join-Timeout;
+er MUSS plain `Lock` bleiben (cross-thread release). Neue Sync-Einstiege
+müssen beide Locks respektieren. Design:
+`docs/superpowers/specs/2026-07-04-datenschicht-threadsicherheit-design.md`.
+```
+
+- [ ] **Step 4: Gesamtsuite + Lint**
+
+Run: `python -m pytest -q ; ruff check .`
+Expected: 0 failed (Baseline + ~20 neue Tests), ruff „All checks passed".
+
+- [ ] **Step 5: Manueller Smoke-Test (Windows-Dev-Maschine)**
+
+Run: `python -m src.main`
+Prüfen: App startet; ein Eintrag lässt sich anlegen/löschen; App über X beenden (kein Hänger > ein paar Sekunden). Bei aktiviertem Sync zusätzlich: Sync-Button klicken → Button kurz deaktiviert, danach wieder aktiv. (Lokale Python-Umgebung braucht ggf. Deps — `holidays` ist installiert, Rest siehe Memory `run-app-needs-deps`.)
+
+- [ ] **Step 6: Commit**
+
+```powershell
+git add src/main.py src/ui.py src/CLAUDE.md
+git commit -m "feat(main): Daten-Lock + Sync-Guard app-weit verdrahten (Audit H1/H2/M1)" -m "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Abschluss
+
+Nach Task 7: `superpowers:finishing-a-development-branch` — Branch nach `origin` (Fork) pushen, PR gegen `margenheld/Zeiterfassung` öffnen (siehe Memory `pr-workflow-upstream`). PR-Beschreibung: Audit-Findings H1/H2/M1 referenzieren, Spec verlinken, explizit erwähnen, dass M6 (Cross-Store-Transaktionalität) bewusst out of scope bleibt. Kein `release:*`-Label (kein Release-PR).

--- a/docs/superpowers/specs/2026-07-04-datenschicht-threadsicherheit-design.md
+++ b/docs/superpowers/specs/2026-07-04-datenschicht-threadsicherheit-design.md
@@ -1,0 +1,261 @@
+# Design: Threadsicherheit der Datenschicht (Audit H1/H2/M1)
+
+> Stand 2026-07-04 · Branch `fix/dialog-accent-bar` · Ansatz A aus dem
+> Brainstorming zum Audit `AUDIT-2026-07-04.md`.
+
+## Problem
+
+Die vier Stores (`storage.py`, `settings.py`, `conflicts_store.py`,
+`reservations.py`) werden aus mehreren Threads konkurrierend gelesen und
+geschrieben, besitzen aber **kein einziges Lock** (das einzige `threading.Lock`
+in `src/` liegt in `single_instance.py:33`). Beteiligte Threads:
+
+- **UI-Thread:** Dialog-Saves/Deletes (`storage.save/delete/save_many`,
+  `settings.set*`, `conflicts_store.save_all`).
+- **Startup-Pull-Daemon** (`main.py:353` → `_run_pull_in_background`):
+  `build_local_doc` → `merge` → `apply_merged_doc`.
+- **Sync-Worker** (`_run_push_blocking`/`_run_compaction_blocking`, jeweils über
+  `BackgroundTaskRunner.run` **plus** einen inneren Timeout-Thread).
+- **Reconcile-Worker** (`reservations_sync.reconcile_reservations`) auf
+  `ReservationStore`.
+
+Daraus die drei Audit-Findings:
+
+- **H1 — Lost Update:** `build_local_doc` (Snapshot) → `merge` →
+  `apply_merge` (`storage.py:157`: `self._data = dict(merged_entries)`, kompletter
+  Replace). Ein UI-Save zwischen Snapshot und Replace wird überschrieben. Fenster
+  ist beim Drive-Sync **klein** (Snapshot liegt bereits *nach* dem Download,
+  Pull `main.py:99`/Push `:152`), aber ohne Lock real.
+- **H2 — keine Re-Entrancy + geteilte `.tmp`:** `on_sync_clicked`
+  (`sync_orchestrator.py:167`) hat keinen „läuft bereits"-Guard; Startup-Pull,
+  Tray-Sync und Manual-Sync können parallel laufen. Alle Stores schreiben in
+  denselben festen `self.filepath + ".tmp"` → zwei parallele `_save_to_disk`
+  schreiben interleaved → `os.replace` aktiviert korruptes JSON (Datenverlust
+  via Quarantäne beim nächsten Start).
+- **M1 — verwaister Timeout-Worker:** `_run_push_blocking` (`main.py:169-174`)
+  joint mit Timeout; der Daemon-Thread läuft danach weiter und kann später noch
+  `apply_merged_doc`/`set_many` ausführen — parallel zur UI oder im Shutdown.
+
+## Ziele / Nicht-Ziele
+
+**Ziele:** H1, H2 und M1 an der Wurzel schließen; Konsistenz mit vorhandenen
+Mustern; deterministisch testbar; minimale Signatur-/API-Störung; keine
+UI-Freezes.
+
+**Nicht-Ziele (bewusst außerhalb dieses Durchgangs):**
+- **M6** store-übergreifende Transaktionalität (Crash *zwischen* den vier
+  Apply-Writes bleibt möglich — der Lock serialisiert, macht aber nicht
+  transaktional).
+- **N1** `fsync` vor `os.replace`.
+- **H5** `settings_dialog`-Thread-Vertrag (eigener Befund; der neue Settings-Lock
+  macht dessen konkurrierende Writes immerhin *atomar*, behebt aber die
+  `TclError`-Verlustproblematik nicht).
+- **M2/M3** Drive Optimistic-Locking / Split-Brain.
+
+## Ansatz A — Ein geteilter RLock + atomarer Apply + Sync-Guard
+
+### Teil 1 — Geteilter RLock in allen vier Stores (→ H2b, Dict-Races)
+
+Ein einziger `threading.RLock`, in `main.py` erzeugt und in alle vier
+Store-Konstruktoren injiziert. Jede öffentliche Lese- **und** Schreibmethode
+kapselt ihren Body in `with self._lock:`.
+
+- Konstruktor-Signatur additiv: `__init__(..., lock=None)`. Bei `lock=None`
+  legt der Store einen **eigenen** `RLock` an → bestehende Tests, die Stores
+  direkt instanziieren, bleiben unverändert und trotzdem intern sicher.
+- **`RLock`** (nicht `Lock`), weil (a) `settings.set` → `set_many` reentrant ist
+  und (b) der atomare Apply-Block (Teil 2) den Lock hält, während er
+  Store-Methoden aufruft, die ihn erneut nehmen.
+- Zu kapselnde Methoden:
+  - `Storage`: `get_all`, `get_all_raw`, `get`, `save`, `delete`, `save_many`,
+    `apply_merge`.
+  - `Settings`: `get`, `set_many`, `set_synced`, `apply_synced`,
+    `get_synced_doc`.
+  - `ConflictsStore`: `get_all`, `save_all`, `count_unresolved`.
+  - `ReservationStore`: `get_all`, `get_all_raw`, `get`, `save`, `delete`,
+    `apply_reconciled`.
+  - Iterierende/kopierende Reads (`get_all`, `get_all_raw`) **müssen** gelockt
+    sein: der echte Hazard ist ein In-Place-Write (`self._data[k] = …` in
+    `save`) während ein anderer Thread in `dict()`/`json.dump` iteriert →
+    `RuntimeError: dictionary changed size during iteration`. (Ein kompletter
+    Replace wie in `apply_merge` mutiert das alte Dict dagegen nicht.)
+  - `__init__`/`_load`/`_migrate_*` laufen vor dem Teilen des Locks
+    (single-threaded beim Boot) — kein Lock nötig, aber unschädlich.
+- Der **feste `.tmp`-Pfad bleibt** — mit serialisierten Writes ist er sicher;
+  eindeutige Temp-Namen wären mit Lock redundant (YAGNI). Zweite Prozesse sind
+  durch `single_instance` ausgeschlossen.
+
+### Teil 2 — Atomarer Sync-Apply unter dem geteilten Lock (→ H1)
+
+In den drei Flow-Funktionen in `main.py` wird der Block
+`build_local_doc → merge → apply_merged_doc → last_pull_at/etag setzen` in
+`with data_lock:` geklammert. Da der lokale Snapshot **innerhalb** des Locks
+unmittelbar vor dem Apply gelesen wird, kann kein UI-Save interleaven → H1 zu.
+Kein separater Rebase-Nachbau nötig (anders als `reservations_sync`, das *vor*
+dem Netzwerk snapshotet).
+
+- **Der Daten-Lock wird NIE über Netzwerk gehalten.** Die Block-Grenzen sind
+  pro Flow verschieden, weil Push/Kompaktierung nach dem Apply noch uploaden:
+  - **Pull** (`_run_pull_in_background`): Download ungelockt →
+    `with data_lock:` { `build_local_doc` → `merge` → `apply_merged_doc` →
+    `set_many(last_pull_at, drive_etag)` }. (Kein Netz nach dem Apply — ein
+    Block reicht.)
+  - **Push** (`_run_push_blocking`): Download ungelockt → `with data_lock:`
+    { `build_local_doc` → `merge` → `apply_merged_doc` → zweites
+    `build_local_doc` (Upload-Doc) → `json.dumps` } → **Upload ungelockt** →
+    `set_many(last_pull_at, drive_etag)` danach (Store-Methode lockt selbst,
+    kein äußerer Block nötig). Ein UI-Save zwischen Upload-Snapshot und
+    `set_many` bleibt korrekt: LWW über `modified_at` gewinnt beim nächsten
+    Merge (bestehende Semantik, nicht verschlechtert).
+  - **Kompaktierung** (`_run_compaction_blocking`): Download ungelockt →
+    `with data_lock:` { `build_local_doc` → `merge` → `apply_merged_doc` →
+    `set(last_pull_at)` → `compact_local` → `build_local_doc` (Upload-Doc) →
+    `json.dumps` } → Upload ungelockt → `set(drive_etag)` danach.
+- Gehalten wird der Lock nur über `merge()`/`compact_local` (pure CPU, sub-ms
+  bei Personal-App-Datenmengen) + die lokalen Disk-Writes → vernachlässigbarer
+  UI-Stall.
+- Verdrahtung des `data_lock`: in `main.py` erzeugt, an die vier Stores **und**
+  an `App` übergeben; `App` reicht ihn an `SyncOrchestrator` (für
+  `_run_push_blocking`/`push_on_quit`) und an den Startup-Pull-Thread weiter.
+  Die Flow-Funktionen bekommen ihn als expliziten Parameter (kein Zugriff auf
+  `storage._lock`).
+
+### Teil 3 — Sync-Re-Entrancy-Guard (→ H2a, M1 benign)
+
+Ein separater **plain `threading.Lock`** (der **Sync-Guard**, nicht der
+Daten-Lock), ebenfalls in `main.py` erzeugt und an `App`/`SyncOrchestrator` +
+Startup-Pull + Settings-Dialog (Kompaktierung) verteilt.
+
+**Hartes Constraint — Guard-Lifecycle lebt im Worker, nie im UI-Done-Callback:**
+
+- `App._marshal_to_ui` verwirft Callbacks still, wenn das Fenster geschlossen
+  ist (`ui.py:451-455`) — ein Release im Done-Callback kann leaken.
+- Entscheidender: `push_on_quit` blockiert den **UI-Thread** in
+  `guard.acquire(timeout=…)`. Solange der UI-Thread blockiert, verarbeitet die
+  Mainloop keine `after(0)`-Callbacks — ein Release im Done-Callback könnte
+  also **nie** feuern, während der Quit darauf wartet. Jeder Quit während
+  eines laufenden Syncs würde deterministisch in den Timeout laufen und den
+  Abschluss-Push überspringen.
+- Daher die Invariante: **Released wird der Guard im `finally` des Threads,
+  der die Store-Mutationen ausführt** — beim Push/der Kompaktierung ist das der
+  *innere* `_do`-Thread von `_run_push_blocking`/`_run_compaction_blocking`,
+  NICHT der äußere `_push`-Worker (der released sonst beim Join-Timeout,
+  während der innere Thread noch schreibt — der Verwaiste liefe wieder
+  ungeguarded). Acquire am Sync-Einstieg:
+  `if not guard.acquire(blocking=False): return {"ok": False, "skipped": True}`.
+  Ob Acquire im Einstiegs-Thread + Release im inneren Thread (cross-thread,
+  für plain `Lock` legal) oder beides in den inneren Thread wandert, entscheidet
+  der Implementierungsplan — die Invariante (Release erst nach der letzten
+  Store-Mutation, nie im UI-Callback, nie beim Join-Timeout) ist fix.
+- Der Guard **muss** ein plain `Lock` bleiben (nie `RLock`): `Lock.release()`
+  ist aus jedem Thread erlaubt, `RLock` erzwingt Owner-Release (`RuntimeError`)
+  — relevant, da Quit-Acquire (UI-Thread) und Worker-Release (Daemon-Thread)
+  denselben Guard mischen ([threading-Doku](https://docs.python.org/3/library/threading.html)).
+
+Die Sync-Einstiege:
+
+- **Startup-Pull** (`main.py`): Guard-Wrapper um den Thread-Target-Body
+  (non-blocking-skip).
+- **Manual-Sync** (`on_sync_clicked`): Guard-Acquire im `_push`-Worker
+  (Release gemäß Invariante im innersten Thread);
+  zusätzlich **Sync-Button deaktivieren** im UI-Thread vor `runner.run`
+  (sichtbares Feedback), Re-Enable im Done-Callback. `skipped`-Result im
+  Done-Callback: kein Fehlerdialog, nur `update_status_label()`.
+- **Tray-Sync** (`tray_sync`): Guard im Worker; `skipped` → kein Toast.
+- **Quit-Push** (`push_on_quit`): `guard.acquire(timeout=5)` auf dem UI-Thread
+  ist mit Worker-Release korrekt: läuft ein Sync, wird der Guard frei, sobald
+  dessen Upload endet; danach eigener Push (+ Release im `finally`). Schlägt
+  das Acquire fehl → skip + Log; lokale Daten bleiben erhalten und syncen beim
+  nächsten Start (bestehende Failure-Semantik der Suffix-Meldung).
+  **Worst-Case-Quit-Dauer: 5 s Guard + 5 s Push-Timeout ≈ 10 s** (heute 5 s) —
+  bewusster Trade-off, dokumentieren.
+- **Kompaktierung** (Aufrufer ist `settings_dialog.py:546`!): Guard im Worker;
+  `skipped`-Result → themed Hinweis „Synchronisation läuft gerade — bitte kurz
+  warten" (user-getriggerte Aktion braucht Feedback, kein stiller Skip).
+
+Verhalten sonst: **überspringen, kein Queueing**.
+
+**M1 wird benign, nicht eliminiert:** Da der Guard im Worker-`finally` liegt,
+hält der innere Timeout-Thread von `_run_push_blocking` ihn nach dem
+Join-Timeout einfach weiter, bis er wirklich fertig ist — ein „verwaister"
+Worker blockiert damit nur weitere Syncs (korrekt: er *ist* der laufende Sync),
+statt parallel zu ihnen zu schreiben. Sein *später* Apply ist (a) atomar über
+den Daten-Lock und (b) liest den lokalen Stand frisch innerhalb des Locks → er
+kann **nicht korrumpieren**. Rest-Kaveat: Nach `root.destroy()` + Ende von
+`main()` beendet der Interpreter-Shutdown Daemon-Threads **hart** (Kill beim
+nächsten GIL-Take) — der Worker kann also mitten in der 4-Store-Apply-Sequenz
+sterben. Jede *Einzeldatei* bleibt dank tmp+`os.replace` intakt; eine
+Cross-Store-Inkonsistenz (z. B. Watermark hinkt) ist genau **M6** und bleibt
+als solches außerhalb dieses Durchgangs. Das strukturelle Entfernen des
+inneren Timeout-Threads wäre ein größerer Umbau und ist ebenfalls **nicht Teil
+dieses Durchgangs**.
+
+### Reservations (angrenzend, mitgenommen)
+
+`ReservationStore` erhält denselben Lock (Write-Atomizität Reconcile-Thread vs.
+UI-Save). Der bestehende Rebase+Apply in `reservations_sync.py:199-205` wird
+**inklusive** `settings.set("last_calendar_sync_at", …)` in `with data_lock:`
+geklammert — billig und konsistent, damit nicht ein Store-Sync ungelockt
+bleibt. Klar gekennzeichnet als „angrenzend", nicht Kern-H1/H2.
+
+## Lock-Ordnung / Deadlock-Analyse
+
+- Zwei Locks: **Sync-Guard** (außen) und **Daten-Lock** (innen, im Apply-Block).
+  Immer in dieser Schachtelung → kein Zyklus. Der Guard wird bewusst über den
+  Netzwerkteil gehalten (er *soll* Syncs serialisieren); der Daten-Lock nie.
+- Nur der Sync-Apply-Pfad hält den Daten-Lock über mehrere Store-Aufrufe; die
+  verschachtelten Store-Methoden re-akquirieren denselben `RLock` reentrant.
+- Kein anderer Pfad hält zwei Store-Locks gleichzeitig (es ist ohnehin ein
+  geteilter Lock) → keine Ordnungsprobleme zwischen Stores.
+
+## Teststrategie (deterministisch, keine Timing-Asserts)
+
+Wegen fehlendem Windows-CI (M15) und bekannter Flakiness der einen Socket-Test-
+Stelle (N23) ausschließlich `threading.Event`-Barrieren statt `sleep`:
+
+1. **Guard-Skip (deterministisch):** Fake-`_push`, das auf ein `Event` blockiert;
+   zweiter Sync-Aufruf während des ersten → wird übersprungen, `_push` genau
+   einmal ausgeführt.
+2. **Atomarer Apply / kein Lost Update (deterministisch):** Sync-Thread hält den
+   geteilten Lock, simuliert langsamen Merge (wartet auf Test-`Event`); ein
+   UI-Thread ruft `storage.save(dateX, …)` und blockiert nachweislich am Lock;
+   nach Freigabe landet der Save **nach** dem `apply_merge`-Replace und
+   überlebt deshalb (Ordering durch Serialisierung — NICHT über
+   `modified_at`-Vergleich, der bei Sekundenauflösung im Test identisch wäre,
+   vgl. Audit N2). Beweist die Serialisierung des Interleaves.
+3. **Stress-Robustheit (stochastisch, ohne Timing-Assert):** N Threads mit
+   gemischten `save`/`delete`/`apply_merge` auf einem Store mit geteiltem Lock +
+   Temp-Datei; nach `join` ist die Datei stets valides JSON und keine Exception
+   geflogen. Moderate Iterationszahl.
+
+Bestehende Store-/Sync-Tests bleiben grün (Konstruktor `lock=None`-Default).
+
+## Betroffene Dateien (Überblick)
+
+- `src/storage.py`, `src/settings.py`, `src/conflicts_store.py`,
+  `src/reservations.py` — `lock=None`-Param + `with self._lock:` in den Methoden.
+- `src/main.py` — Lock + Guard erzeugen, an Stores/App/Pull-Thread verdrahten;
+  Apply-Block in `_run_pull_in_background`/`_run_push_blocking`/
+  `_run_compaction_blocking` klammern; Startup-Pull-Guard.
+- `src/ui.py` (`App`) — `data_lock`/`sync_guard` durchreichen.
+- `src/sync_orchestrator.py` — Guard-Wrapper im `_push`-Worker;
+  `push_on_quit`-Acquire; Button-Disable/Re-Enable; `skipped`-Handling in den
+  Done-Callbacks; Lock/Guard an `_run_push_blocking` weiter.
+- `src/dialogs/settings_dialog.py` — Kompaktierungs-Aufruf (Z. 546) bekommt
+  Guard + Daten-Lock durchgereicht; `skipped` → themed Hinweis.
+- `src/reservations_sync.py` — Rebase+Apply-Block klammern (angrenzend).
+- `tests/` — neue Tests 1–3; ggf. `src/CLAUDE.md` „Threading-Modell" ergänzen.
+
+## Risiken
+
+- **UI-Stall:** Daten-Lock über Disk-Writes → kurzer Stall bei langsamer Platte.
+  Für Ein-Nutzer-App mit seltenen Writes akzeptiert.
+- **Contention:** Ein globaler Lock serialisiert auch unabhängige Stores.
+  Bei Personal-App praktisch null.
+- **Quit-Dauer:** Worst Case ~10 s (5 s Guard-Wait + 5 s Push-Timeout) statt
+  heute 5 s, wenn beim Beenden gerade ein Sync läuft. Akzeptierter Trade-off
+  gegen den parallelen Doppel-Push.
+- **Backward-Compat:** `lock=None`-Default hält bestehende Tests unverändert.
+- **M1-Rest:** dokumentiert-benignes Restverhalten (redundanter, atomarer
+  Disk-Write; Interpreter-Shutdown-Kill mitten in der Sequenz = M6, out of
+  scope).

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -91,6 +91,22 @@ State-/Widget-Mutation aus einem Worker läuft über `App._marshal_to_ui` (`root
 gegen `TclError` abgesichert, falls das Fenster zwischenzeitlich zu ist). Keine direkten
 `threading.Thread`-Aufrufe in `ui.py` mehr.
 
+**Datenschicht-Locking (Audit H1/H2/M1):** Alle vier Stores
+(`storage`/`settings`/`conflicts_store`/`reservations`) teilen sich einen in
+`main()` erzeugten `RLock` (Konstruktor-Param `lock=`; ohne Injektion legt
+jeder Store einen eigenen an — Tests bleiben unverändert). Die Sync-Flows
+(`_run_pull_in_background`/`_run_push_blocking`/`_run_compaction_blocking`/
+`reconcile_reservations`) klammern Snapshot→Merge→Apply mit diesem `data_lock`
+— **nie über Netzwerk-Calls**. Ein separater plain `threading.Lock`
+(`sync_guard`) serialisiert alle Drive-Sync-Einstiege (Startup-Pull, Manual-,
+Tray-, Quit-Push, Kompaktierung): non-blocking-skip mit
+`{"skipped": True}`-Result, nur der Quit-Push wartet (`guard_timeout=5`).
+Acquired UND released wird der Guard im innersten Worker-Thread (`finally`,
+nach der letzten Store-Mutation) — nie in UI-Callbacks, nie beim Join-Timeout;
+er MUSS plain `Lock` bleiben (cross-thread release). Neue Sync-Einstiege
+müssen beide Locks respektieren. Design:
+`docs/superpowers/specs/2026-07-04-datenschicht-threadsicherheit-design.md`.
+
 ## Daten- & Persistenz-Schicht
 
 - `storage.py` — Ist-Zeiten (JSON, Schlüssel = ISO-Datum). `reservations.py` — Reservierungen

--- a/src/background_tasks.py
+++ b/src/background_tasks.py
@@ -21,13 +21,14 @@ log = logging.getLogger(__name__)
 
 class BackgroundTaskRunner:
     def __init__(self, marshal, settings, base_path, reservation_store,
-                 reservations_active, storage=None):
+                 reservations_active, storage=None, data_lock=None):
         self._marshal = marshal                          # App._marshal_to_ui
         self._settings = settings
         self._base_path = base_path
         self._reservation_store = reservation_store
         self._reservations_active = reservations_active  # callable -> bool
         self._storage = storage
+        self._data_lock = data_lock                      # geteilter Store-RLock
 
     def run(self, fn, on_done=None):
         """Fuehrt fn() in einem Daemon-Thread aus und liefert dessen Rueckgabe
@@ -135,7 +136,8 @@ class BackgroundTaskRunner:
         def fn():
             from src.main import run_calendar_reconcile  # lazy: Circular-Import-Schutz
             return run_calendar_reconcile(
-                self._reservation_store, self._settings, self._base_path, self._storage)
+                self._reservation_store, self._settings, self._base_path,
+                self._storage, data_lock=self._data_lock)
 
         def on_done(result):
             if result.get("ok"):
@@ -153,6 +155,7 @@ class BackgroundTaskRunner:
         def fn():
             from src.main import run_calendar_reconcile  # lazy: Circular-Import-Schutz
             return run_calendar_reconcile(
-                self._reservation_store, self._settings, self._base_path, self._storage)
+                self._reservation_store, self._settings, self._base_path,
+                self._storage, data_lock=self._data_lock)
 
         self.run(fn, on_done)

--- a/src/conflicts_store.py
+++ b/src/conflicts_store.py
@@ -1,14 +1,17 @@
 import datetime
 import json
 import os
+import threading
 
 
 class ConflictsStore:
     """JSON-Persistenz für die lokale Konflikt-Liste. Spiegelt die conflicts-Liste
     aus dem Sync-File, damit der ConflictsDialog ohne Netz funktioniert."""
 
-    def __init__(self, filepath="conflicts.json"):
+    def __init__(self, filepath="conflicts.json", lock=None):
         self.filepath = filepath
+        # Geteilter Daten-Lock (Audit H1/H2) — siehe storage.py.
+        self._lock = lock if lock is not None else threading.RLock()
         self._conflicts = []
         self._load()
 
@@ -37,11 +40,14 @@ class ConflictsStore:
             raise
 
     def get_all(self):
-        return list(self._conflicts)
+        with self._lock:
+            return list(self._conflicts)
 
     def save_all(self, conflicts):
-        self._conflicts = list(conflicts)
-        self._save_to_disk()
+        with self._lock:
+            self._conflicts = list(conflicts)
+            self._save_to_disk()
 
     def count_unresolved(self):
-        return sum(1 for c in self._conflicts if not c.get("resolved"))
+        with self._lock:
+            return sum(1 for c in self._conflicts if not c.get("resolved"))

--- a/src/dialogs/conflicts_dialog.py
+++ b/src/dialogs/conflicts_dialog.py
@@ -33,11 +33,14 @@ def _fmt_setting_candidate(cand):
 
 
 class ConflictsDialog:
-    def __init__(self, parent, storage, settings, conflicts_store):
+    def __init__(self, parent, storage, settings, conflicts_store, data_lock=None):
         self.parent = parent
         self.storage = storage
         self.settings = settings
         self.conflicts_store = conflicts_store
+        # Geteilter Store-RLock (Review-Finding), durchgereicht bis zu
+        # sync.resolve_conflict — siehe dort für die Begründung.
+        self._data_lock = data_lock
         self._selected = None
 
         self.top = tk.Toplevel(parent)
@@ -113,7 +116,8 @@ class ConflictsDialog:
         device_id = self.settings.get("device_id") or ""
         try:
             sync.resolve_conflict(c["id"], chosen, self.conflicts_store,
-                                  self.storage, self.settings, device_id)
+                                  self.storage, self.settings, device_id,
+                                  data_lock=self._data_lock)
         except Exception as e:
             themed_showerror(self.top, "Konflikt-Resolution fehlgeschlagen", str(e))
             return

--- a/src/dialogs/settings_dialog.py
+++ b/src/dialogs/settings_dialog.py
@@ -33,13 +33,16 @@ from src.weekly_limit import format_limit_warnings, period_scan_needed, scan_per
 
 def open_settings_dialog(parent, settings, base_path, on_change, *,
                          conflicts_store=None, storage=None,
-                         reservation_store=None, on_request_restart=None):
+                         reservation_store=None, on_request_restart=None,
+                         data_lock=None, sync_guard=None):
     """Modaler Dialog zum Bearbeiten der App-Einstellungen, aufgeteilt auf vier
     Tabs (Arbeitszeit / Bericht & Mail / Google / App).
 
     on_change wird nach erfolgreichem Speichern aufgerufen, damit der Kalender
     sich aktualisiert. conflicts_store und storage sind optional; sind sie
     gesetzt, erscheint im Google-Tab der Sync-Block mit Konflikte-Button.
+    data_lock/sync_guard: geteilter Store-Lock + Sync-Guard für die Kompaktierung
+    (Audit H1/H2) — von App durchgereicht.
     """
     dialog = tk.Toplevel(parent)
     dialog.title("Einstellungen")
@@ -517,6 +520,14 @@ def open_settings_dialog(parent, settings, base_path, on_change, *,
             def _show(res):
                 if not dialog.winfo_exists():
                     return
+                if res.get("skipped"):
+                    themed_showinfo(
+                        dialog,
+                        "Kompaktierung",
+                        "Eine Synchronisation läuft gerade — bitte kurz "
+                        "warten und erneut versuchen.",
+                    )
+                    return
                 if res.get("reason") == "old_version":
                     themed_showwarning(
                         dialog,
@@ -545,7 +556,8 @@ def open_settings_dialog(parent, settings, base_path, on_change, *,
             def _do():
                 from src.main import _run_compaction_blocking
                 res = _run_compaction_blocking(
-                    storage, settings, conflicts_store, base_path)
+                    storage, settings, conflicts_store, base_path,
+                    data_lock=data_lock, sync_guard=sync_guard)
                 dialog.after(0, lambda: _show(res))
 
             threading.Thread(target=_do, daemon=True).start()

--- a/src/dialogs/settings_dialog.py
+++ b/src/dialogs/settings_dialog.py
@@ -422,7 +422,9 @@ def open_settings_dialog(parent, settings, base_path, on_change, *,
     if unresolved > 0:
         def _open_conflicts_dialog():
             from src.dialogs.conflicts_dialog import ConflictsDialog
-            ConflictsDialog(dialog, storage, settings, conflicts_store)
+            # data_lock durchgereicht bis zu sync.resolve_conflict
+            # (Review-Finding: RMW-Spanne muss atomar gegen Hintergrund-Sync sein).
+            ConflictsDialog(dialog, storage, settings, conflicts_store, data_lock=data_lock)
 
         secondary_button(
             tab_google,

--- a/src/main.py
+++ b/src/main.py
@@ -383,20 +383,31 @@ def main():
             "Single-Instance-Guard-Fehler — Start ohne Guard", exc_info=True)
         guard = None
 
-    settings = Settings(os.path.join(base, "settings.json"))
+    # Geteilter Daten-Lock über alle vier Stores (Audit H1/H2) + Sync-Guard.
+    # data_lock: RLock (reentrant — der Sync-Apply-Block ruft gelockte
+    # Store-Methoden). sync_guard: bewusst plain Lock, NIE RLock — er wird
+    # thread-übergreifend acquired/released (Lock erlaubt das, RLock nicht).
+    data_lock = threading.RLock()
+    sync_guard = threading.Lock()
+
+    settings = Settings(os.path.join(base, "settings.json"), lock=data_lock)
     device_id = _ensure_device_id(settings)
     settings.device_id_for_sync = device_id
 
-    storage = Storage(os.path.join(base, "zeiterfassung.json"), device_id=device_id)
+    storage = Storage(os.path.join(base, "zeiterfassung.json"),
+                      device_id=device_id, lock=data_lock)
 
-    conflicts_store = ConflictsStore(os.path.join(base, "conflicts.json"))
+    conflicts_store = ConflictsStore(os.path.join(base, "conflicts.json"),
+                                     lock=data_lock)
 
-    reservation_store = ReservationStore(os.path.join(base, "reservations.json"))
+    reservation_store = ReservationStore(os.path.join(base, "reservations.json"),
+                                         lock=data_lock)
 
     root = tk.Tk()
     _apply_ui_scaling(root, settings.get("ui_scale"))
     app = App(root, storage, settings, base_path=base, conflicts_store=conflicts_store,
-              reservation_store=reservation_store, single_instance=guard)
+              reservation_store=reservation_store, single_instance=guard,
+              data_lock=data_lock, sync_guard=sync_guard)
 
     if "--minimized" in sys.argv:
         root.iconify()
@@ -424,6 +435,7 @@ def main():
         threading.Thread(
             target=_run_pull_in_background,
             args=(storage, settings, conflicts_store, base, _on_sync_done),
+            kwargs={"data_lock": data_lock, "sync_guard": sync_guard},
             daemon=True,
         ).start()
 

--- a/src/main.py
+++ b/src/main.py
@@ -307,12 +307,14 @@ def _run_compaction_blocking(storage, settings, conflicts_store, base, timeout_s
     return result
 
 
-def run_calendar_reconcile(reservation_store, settings, base, storage):
+def run_calendar_reconcile(reservation_store, settings, base, storage, data_lock=None):
     """Baut den Calendar-Service und fährt einen Reservierungs-Reconcile.
 
     Liefert {"ok": bool, "error": str, "tb": str, "limit_warnings": [...]}.
     Wirft NICHT — der Caller (UI-Thread) wertet das Dict aus. No-op, wenn
     gcal deaktiviert oder kein Kalender gewählt ist.
+
+    data_lock wird an reconcile_reservations durchgereicht (Rebase+Apply atomar, Audit H1).
 
     limit_warnings (#98): Werkstudenten-Wochenlimit-Ergebnis (siehe
     weekly_limit.py) für die ISO-Wochen frisch importierter Reservierungs-
@@ -335,7 +337,8 @@ def run_calendar_reconcile(reservation_store, settings, base, storage):
             os.path.join(base, "token.json"),
             sync_enabled=settings.get("sync_enabled"),
         )
-        result = reconcile_reservations(service, calendar_id, reservation_store, settings)
+        result = reconcile_reservations(service, calendar_id, reservation_store,
+                                        settings, data_lock=data_lock)
         limit_warnings = check_dates_for_warnings(
             settings, storage.get_all(), result["imported_dates"])
         return {"ok": True, "error": "", "tb": "", "limit_warnings": limit_warnings}

--- a/src/main.py
+++ b/src/main.py
@@ -1,4 +1,5 @@
 # src/main.py
+import contextlib
 import logging
 import os
 import sys
@@ -60,54 +61,79 @@ def _parse_remote_or_quarantine(content_bytes, file_id, on_corrupt):
         return {"schema_version": 1, "entries": {}, "settings": {}, "conflicts": []}
 
 
-def _run_pull_in_background(storage, settings, conflicts_store, base, ui_callback):
-    """Pull läuft in einem Thread; UI-Update über ui_callback (root.after)."""
+def _lock_ctx(lock):
+    """Context-Manager-Shim für den optionalen Daten-Lock: `with _lock_ctx(l)`
+    lockt, wenn ein Lock übergeben wurde, und ist sonst ein No-op (Tests,
+    Alt-Aufrufer). Hält den Sync-Apply-Block atomar gegen UI-Saves (Audit H1)."""
+    return lock if lock is not None else contextlib.nullcontext()
+
+
+def _run_pull_in_background(storage, settings, conflicts_store, base, ui_callback,
+                            data_lock=None, sync_guard=None):
+    """Pull läuft in einem Thread; UI-Update über ui_callback (root.after).
+
+    sync_guard (plain Lock, Re-Entrancy-Guard, Audit H2): läuft bereits ein
+    anderer Sync, wird der Pull still übersprungen — ohne ui_callback; der
+    laufende Sync meldet sein Ergebnis selbst. Release im finally DIESES
+    Threads (nach der letzten Store-Mutation), nie in UI-Callbacks.
+    data_lock (geteilter Store-RLock, Audit H1): klammert
+    Snapshot→Merge→Apply atomar gegen parallele UI-Saves. Wird NICHT über
+    den Download gehalten."""
     from src import drive, sync
+    if sync_guard is not None and not sync_guard.acquire(blocking=False):
+        return
     try:
-        service = drive.get_drive_service(
-            os.path.join(base, "credentials.json"),
-            os.path.join(base, "token.json"),
-            gcal_enabled=settings.get("gcal_enabled"),
-        )
-        file_id = drive.find_sync_file(service)
-        if file_id is None:
-            remote_doc = {"schema_version": 1, "entries": {}, "settings": {}, "conflicts": []}
-            etag = ""
-        else:
-            content, etag = drive.download(service, file_id)
-            def _quarantine(fid):
-                import datetime
-                stamp = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
-                try:
-                    service.files().update(
-                        fileId=fid,
-                        body={"name": f"zeiterfassung-sync.corrupt-{stamp}.json"},
-                    ).execute()
-                except Exception:
-                    logging.getLogger(__name__).warning(
-                        "Quarantine rename failed for %s", fid, exc_info=True)
-            remote_doc = _parse_remote_or_quarantine(content, file_id, _quarantine)
-        if sync._remote_is_newer(remote_doc):
-            # Neueres (zukünftiges) Schema: NICHT mergen/pushen — Pull sauber
-            # abbrechen, last_pull_at/etag unverändert lassen.
-            ui_callback(ok=False, error=sync.NEWER_REMOTE_VERSION_MSG, tb="")
-            return
-        # Älteres Remote (v1/v2) wird aufs aktuelle Schema migriert und normal
-        # gemergt (absorb-and-upgrade). Dass ältere Geräte ein hochgezogenes
-        # v4-Doc nicht überschreiben, sichert deren Push-Guard (ab v1.15.2).
-        remote_doc = sync.migrate_doc_to_current(remote_doc)
-        local_doc = sync.build_local_doc(storage, settings, conflicts_store)
-        merged = sync.merge(local_doc, remote_doc, settings.get("last_pull_at") or "")
-        sync.apply_merged_doc(merged, storage, settings, conflicts_store)
-        settings.set_many({
-            "last_pull_at": sync._utc_now_iso(),
-            "drive_etag": etag,
-        })
-        ui_callback(ok=True, error=None, tb="")
-    except Exception as e:
-        tb = traceback.format_exc()
-        logging.getLogger(__name__).exception("Sync pull failed")
-        ui_callback(ok=False, error=e, tb=tb)
+        try:
+            service = drive.get_drive_service(
+                os.path.join(base, "credentials.json"),
+                os.path.join(base, "token.json"),
+                gcal_enabled=settings.get("gcal_enabled"),
+            )
+            file_id = drive.find_sync_file(service)
+            if file_id is None:
+                remote_doc = {"schema_version": 1, "entries": {}, "settings": {}, "conflicts": []}
+                etag = ""
+            else:
+                content, etag = drive.download(service, file_id)
+                def _quarantine(fid):
+                    import datetime
+                    stamp = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
+                    try:
+                        service.files().update(
+                            fileId=fid,
+                            body={"name": f"zeiterfassung-sync.corrupt-{stamp}.json"},
+                        ).execute()
+                    except Exception:
+                        logging.getLogger(__name__).warning(
+                            "Quarantine rename failed for %s", fid, exc_info=True)
+                remote_doc = _parse_remote_or_quarantine(content, file_id, _quarantine)
+            if sync._remote_is_newer(remote_doc):
+                # Neueres (zukünftiges) Schema: NICHT mergen/pushen — Pull sauber
+                # abbrechen, last_pull_at/etag unverändert lassen.
+                ui_callback(ok=False, error=sync.NEWER_REMOTE_VERSION_MSG, tb="")
+                return
+            # Älteres Remote (v1/v2) wird aufs aktuelle Schema migriert und normal
+            # gemergt (absorb-and-upgrade). Dass ältere Geräte ein hochgezogenes
+            # v4-Doc nicht überschreiben, sichert deren Push-Guard (ab v1.15.2).
+            remote_doc = sync.migrate_doc_to_current(remote_doc)
+            # Snapshot→Merge→Apply atomar: kein UI-Save kann zwischen
+            # build_local_doc und apply_merged_doc interleaven (Audit H1).
+            with _lock_ctx(data_lock):
+                local_doc = sync.build_local_doc(storage, settings, conflicts_store)
+                merged = sync.merge(local_doc, remote_doc, settings.get("last_pull_at") or "")
+                sync.apply_merged_doc(merged, storage, settings, conflicts_store)
+                settings.set_many({
+                    "last_pull_at": sync._utc_now_iso(),
+                    "drive_etag": etag,
+                })
+            ui_callback(ok=True, error=None, tb="")
+        except Exception as e:
+            tb = traceback.format_exc()
+            logging.getLogger(__name__).exception("Sync pull failed")
+            ui_callback(ok=False, error=e, tb=tb)
+    finally:
+        if sync_guard is not None:
+            sync_guard.release()
 
 
 def _run_push_blocking(storage, settings, conflicts_store, base, timeout_seconds=5):

--- a/src/main.py
+++ b/src/main.py
@@ -136,61 +136,86 @@ def _run_pull_in_background(storage, settings, conflicts_store, base, ui_callbac
             sync_guard.release()
 
 
-def _run_push_blocking(storage, settings, conflicts_store, base, timeout_seconds=5):
+def _run_push_blocking(storage, settings, conflicts_store, base, timeout_seconds=5,
+                       data_lock=None, sync_guard=None, guard_timeout=0):
     """Synchroner Push mit Timeout. Fehler werden geloggt, nicht angezeigt
-    (App schließt gerade)."""
+    (App schließt gerade).
+
+    sync_guard/guard_timeout (Audit H2/M1): Re-Entrancy-Guard. guard_timeout=0
+    → non-blocking (zweiter Klick/Tray-Sync liefert {"skipped": True});
+    guard_timeout>0 → blockierend warten (Quit-Push wartet auf einen laufenden
+    Sync). Der Guard wird im INNEREN _do-Thread acquired UND im finally
+    released — erst nach der letzten Store-Mutation. Ein per Join-Timeout
+    „verwaister" Worker hält ihn dadurch bis zum echten Ende: er IST dann der
+    laufende Sync, statt parallel zu einem neuen zu schreiben.
+    data_lock (Audit H1): klammert Snapshot→Merge→Apply→Upload-Snapshot
+    atomar; der Upload selbst läuft OHNE Daten-Lock (nie Lock über Netz)."""
     import json
     from src import drive, sync
 
     result = {}
 
     def _do():
+        if sync_guard is not None:
+            got = (sync_guard.acquire(timeout=guard_timeout) if guard_timeout > 0
+                   else sync_guard.acquire(blocking=False))
+            if not got:
+                result["ok"] = False
+                result["skipped"] = True
+                return
         try:
-            service = drive.get_drive_service(
-                os.path.join(base, "credentials.json"),
-                os.path.join(base, "token.json"),
-                gcal_enabled=settings.get("gcal_enabled"),
-            )
-            file_id = drive.find_sync_file(service)
-            # Push = download -> Guard -> Merge -> upload. drive.upload kennt
-            # kein File-level If-Match (ignoriert expected_etag), daher MUSS hier
-            # das frische Remote-Doc gelesen und gemergt werden — sonst
-            # überschreibt der Push fremde oder neuere Stände blind (Datenverlust
-            # bzw. Clobber eines neueren Schemas während eines Rollouts).
-            if file_id is not None:
-                remote_bytes, _etag = drive.download(service, file_id)
-                try:
-                    remote_doc = json.loads(remote_bytes)
-                except (json.JSONDecodeError, ValueError):
+            try:
+                service = drive.get_drive_service(
+                    os.path.join(base, "credentials.json"),
+                    os.path.join(base, "token.json"),
+                    gcal_enabled=settings.get("gcal_enabled"),
+                )
+                file_id = drive.find_sync_file(service)
+                # Push = download -> Guard -> Merge -> upload. drive.upload kennt
+                # kein File-level If-Match (ignoriert expected_etag), daher MUSS hier
+                # das frische Remote-Doc gelesen und gemergt werden — sonst
+                # überschreibt der Push fremde oder neuere Stände blind (Datenverlust
+                # bzw. Clobber eines neueren Schemas während eines Rollouts).
+                if file_id is not None:
+                    remote_bytes, _etag = drive.download(service, file_id)
+                    try:
+                        remote_doc = json.loads(remote_bytes)
+                    except (json.JSONDecodeError, ValueError):
+                        remote_doc = {"schema_version": 1, "entries": {}, "settings": {}, "conflicts": []}
+                    if sync._remote_is_newer(remote_doc):
+                        # Neueres Gerät hat das Remote-Doc fortgeschrieben: nicht
+                        # mergen/überschreiben — Push abbrechen, neuere Daten bleiben.
+                        result["ok"] = False
+                        result["error"] = sync.NEWER_REMOTE_VERSION_MSG
+                        result["tb"] = ""
+                        return
+                else:
                     remote_doc = {"schema_version": 1, "entries": {}, "settings": {}, "conflicts": []}
-                if sync._remote_is_newer(remote_doc):
-                    # Neueres Gerät hat das Remote-Doc fortgeschrieben: nicht
-                    # mergen/überschreiben — Push abbrechen, neuere Daten bleiben.
-                    result["ok"] = False
-                    result["error"] = sync.NEWER_REMOTE_VERSION_MSG
-                    result["tb"] = ""
-                    return
-            else:
-                remote_doc = {"schema_version": 1, "entries": {}, "settings": {}, "conflicts": []}
-            # Älteres Remote (v1/v2) absorbieren: aufs aktuelle Schema migrieren,
-            # dann mergen — sonst gingen v2-only-Stände beim Upload verloren.
-            remote_doc = sync.migrate_doc_to_current(remote_doc)
-            local_doc = sync.build_local_doc(storage, settings, conflicts_store)
-            merged = sync.merge(local_doc, remote_doc, settings.get("last_pull_at") or "")
-            sync.apply_merged_doc(merged, storage, settings, conflicts_store)
-            doc = sync.build_local_doc(storage, settings, conflicts_store)
-            content = json.dumps(doc, ensure_ascii=False).encode("utf-8")
-            new_id, new_etag = drive.upload(service, content, file_id, expected_etag="")
-            settings.set_many({
-                "last_pull_at": sync._utc_now_iso(),
-                "drive_etag": new_etag,
-            })
-            result["ok"] = True
-        except Exception as e:
-            logging.getLogger(__name__).exception("Sync push failed: %s", e)
-            result["ok"] = False
-            result["error"] = str(e)
-            result["tb"] = traceback.format_exc()
+                # Älteres Remote (v1/v2) absorbieren: aufs aktuelle Schema migrieren,
+                # dann mergen — sonst gingen v2-only-Stände beim Upload verloren.
+                remote_doc = sync.migrate_doc_to_current(remote_doc)
+                # Snapshot→Merge→Apply→Upload-Snapshot atomar (Audit H1);
+                # der Upload danach läuft bewusst ungelockt.
+                with _lock_ctx(data_lock):
+                    local_doc = sync.build_local_doc(storage, settings, conflicts_store)
+                    merged = sync.merge(local_doc, remote_doc, settings.get("last_pull_at") or "")
+                    sync.apply_merged_doc(merged, storage, settings, conflicts_store)
+                    doc = sync.build_local_doc(storage, settings, conflicts_store)
+                    content = json.dumps(doc, ensure_ascii=False).encode("utf-8")
+                new_id, new_etag = drive.upload(service, content, file_id, expected_etag="")
+                settings.set_many({
+                    "last_pull_at": sync._utc_now_iso(),
+                    "drive_etag": new_etag,
+                })
+                result["ok"] = True
+            except Exception as e:
+                logging.getLogger(__name__).exception("Sync push failed: %s", e)
+                result["ok"] = False
+                result["error"] = str(e)
+                result["tb"] = traceback.format_exc()
+        finally:
+            if sync_guard is not None:
+                sync_guard.release()
 
     t = threading.Thread(target=_do, daemon=True)
     t.start()
@@ -200,7 +225,8 @@ def _run_push_blocking(storage, settings, conflicts_store, base, timeout_seconds
     return result
 
 
-def _run_compaction_blocking(storage, settings, conflicts_store, base, timeout_seconds=20):
+def _run_compaction_blocking(storage, settings, conflicts_store, base, timeout_seconds=20,
+                             data_lock=None, sync_guard=None):
     """User-ausgelöste Kompaktierung: frischer Pull → Alt-Client-Guard → Merge →
     Watermark setzen + lokal strippen → Push. Liefert
     {"ok": bool, "reason": str, "error": ..., "tb": ...}.
@@ -208,54 +234,70 @@ def _run_compaction_blocking(storage, settings, conflicts_store, base, timeout_s
     reason == "newer_version": ein neueres Gerät hat ein Schema geschrieben, das
     diese Version nicht versteht — Kompaktierung abgebrochen, kein Merge/Upload
     (sonst würde das neuere Doc überschrieben). Ältere Remote-Docs (v1/v2) werden
-    wie bei Pull/Push aufs aktuelle Schema migriert."""
+    wie bei Pull/Push aufs aktuelle Schema migriert.
+
+    sync_guard: non-blocking — läuft ein Sync, kommt {"skipped": True} zurück
+    (der Settings-Dialog zeigt dann einen Hinweis). Release im finally des
+    inneren _do-Threads. data_lock: klammert Merge/Apply/Kompaktierung atomar;
+    der Upload läuft ungelockt (Invarianten wie _run_push_blocking)."""
     import json
     from src import drive, sync
 
     result = {}
 
     def _do():
+        if sync_guard is not None and not sync_guard.acquire(blocking=False):
+            result["ok"] = False
+            result["skipped"] = True
+            return
         try:
-            service = drive.get_drive_service(
-                os.path.join(base, "credentials.json"),
-                os.path.join(base, "token.json"),
-                gcal_enabled=settings.get("gcal_enabled"),
-            )
-            file_id = drive.find_sync_file(service)
-            if file_id is not None:
-                content, _etag = drive.download(service, file_id)
-                try:
-                    remote_doc = json.loads(content)
-                except (json.JSONDecodeError, ValueError):
-                    remote_doc = {"schema_version": 1}
-                # Neueres Schema (>v3) auf dem FRISCH gepullten Doc: nicht
-                # mergen/überschreiben — Kompaktierung abbrechen.
-                if sync._remote_is_newer(remote_doc):
-                    result.update({"ok": False, "reason": "newer_version"})
-                    return
-            else:
-                remote_doc = {"schema_version": 2, "entries": {}, "settings": {},
-                              "conflicts": [], "meta": {"gc_watermark": ""}}
+            try:
+                service = drive.get_drive_service(
+                    os.path.join(base, "credentials.json"),
+                    os.path.join(base, "token.json"),
+                    gcal_enabled=settings.get("gcal_enabled"),
+                )
+                file_id = drive.find_sync_file(service)
+                if file_id is not None:
+                    content, _etag = drive.download(service, file_id)
+                    try:
+                        remote_doc = json.loads(content)
+                    except (json.JSONDecodeError, ValueError):
+                        remote_doc = {"schema_version": 1}
+                    # Neueres Schema (>v3) auf dem FRISCH gepullten Doc: nicht
+                    # mergen/überschreiben — Kompaktierung abbrechen.
+                    if sync._remote_is_newer(remote_doc):
+                        result.update({"ok": False, "reason": "newer_version"})
+                        return
+                else:
+                    remote_doc = {"schema_version": 2, "entries": {}, "settings": {},
+                                  "conflicts": [], "meta": {"gc_watermark": ""}}
 
-            # Älteres Remote (v1/v2) absorbieren: aufs aktuelle Schema migrieren.
-            remote_doc = sync.migrate_doc_to_current(remote_doc)
-            # 1) normaler Merge des frischen Remote-Stands
-            now = sync._utc_now_iso()
-            local_doc = sync.build_local_doc(storage, settings, conflicts_store)
-            merged = sync.merge(local_doc, remote_doc, settings.get("last_pull_at") or "")
-            sync.apply_merged_doc(merged, storage, settings, conflicts_store)
-            settings.set("last_pull_at", now)
-            # 2) Watermark setzen + lokal strippen
-            sync.compact_local(storage, settings, conflicts_store, now)
-            # 3) kompaktiertes Doc hochladen
-            doc = sync.build_local_doc(storage, settings, conflicts_store)
-            payload = json.dumps(doc, ensure_ascii=False).encode("utf-8")
-            new_id, new_etag = drive.upload(service, payload, file_id, expected_etag="")
-            settings.set("drive_etag", new_etag)
-            result.update({"ok": True})
-        except Exception as e:
-            logging.getLogger(__name__).exception("Kompaktierung fehlgeschlagen")
-            result.update({"ok": False, "error": str(e), "tb": traceback.format_exc()})
+                # Älteres Remote (v1/v2) absorbieren: aufs aktuelle Schema migrieren.
+                remote_doc = sync.migrate_doc_to_current(remote_doc)
+                now = sync._utc_now_iso()
+                # Merge + Apply + Watermark/Strippung + Upload-Snapshot atomar
+                # (Audit H1); der Upload danach läuft bewusst ungelockt.
+                with _lock_ctx(data_lock):
+                    # 1) normaler Merge des frischen Remote-Stands
+                    local_doc = sync.build_local_doc(storage, settings, conflicts_store)
+                    merged = sync.merge(local_doc, remote_doc, settings.get("last_pull_at") or "")
+                    sync.apply_merged_doc(merged, storage, settings, conflicts_store)
+                    settings.set("last_pull_at", now)
+                    # 2) Watermark setzen + lokal strippen
+                    sync.compact_local(storage, settings, conflicts_store, now)
+                    # 3) kompaktiertes Doc für den Upload snapshotten
+                    doc = sync.build_local_doc(storage, settings, conflicts_store)
+                    payload = json.dumps(doc, ensure_ascii=False).encode("utf-8")
+                new_id, new_etag = drive.upload(service, payload, file_id, expected_etag="")
+                settings.set("drive_etag", new_etag)
+                result.update({"ok": True})
+            except Exception as e:
+                logging.getLogger(__name__).exception("Kompaktierung fehlgeschlagen")
+                result.update({"ok": False, "error": str(e), "tb": traceback.format_exc()})
+        finally:
+            if sync_guard is not None:
+                sync_guard.release()
 
     t = threading.Thread(target=_do, daemon=True)
     t.start()

--- a/src/reservations.py
+++ b/src/reservations.py
@@ -15,6 +15,7 @@ erhalten, bis der Reconcile die zugehörigen Events entfernt hat.
 import datetime
 import json
 import os
+import threading
 
 
 def _utc_now_iso():
@@ -38,8 +39,10 @@ def _normalize_slot(slot):
 
 
 class ReservationStore:
-    def __init__(self, filepath="reservations.json"):
+    def __init__(self, filepath="reservations.json", lock=None):
         self.filepath = filepath
+        # Geteilter Daten-Lock (Audit H1/H2) — siehe storage.py.
+        self._lock = lock if lock is not None else threading.RLock()
         self._data = {}
         self._load()
 
@@ -112,22 +115,25 @@ class ReservationStore:
 
     def get_all(self):
         """{date: {slots: [...]}} ohne Tombstones — für die UI."""
-        return {
-            date: self._user_shape(entry)
-            for date, entry in self._data.items()
-            if not entry.get("deleted")
-        }
+        with self._lock:
+            return {
+                date: self._user_shape(entry)
+                for date, entry in self._data.items()
+                if not entry.get("deleted")
+            }
 
     def get_all_raw(self):
         """Komplette Objekte inkl. Metadaten, gcal_event_id und Tombstones —
         für den Reconcile."""
-        return dict(self._data)
+        with self._lock:
+            return dict(self._data)
 
     def get(self, date_str):
-        entry = self._data.get(date_str)
-        if entry is None or entry.get("deleted"):
-            return None
-        return self._user_shape(entry)
+        with self._lock:
+            entry = self._data.get(date_str)
+            if entry is None or entry.get("deleted"):
+                return None
+            return self._user_shape(entry)
 
     def save(self, date_str, slots):
         """Legt die Reservierungs-Slots eines Tages an oder überschreibt sie.
@@ -137,41 +143,44 @@ class ReservationStore:
         anzulegen, übernehmen wir bestehende event_ids positionsweise vom
         vorherigen Stand. Eine explizit mitgelieferte gcal_event_id hat Vorrang;
         Zeilen über den Altbestand hinaus bleiben ohne id (→ neues Event)."""
-        existing_slots = (self._data.get(date_str) or {}).get("slots", [])
-        new_slots = []
-        for i, s in enumerate(slots):
-            ns = _normalize_slot(s)
-            if ns["gcal_event_id"] is None and i < len(existing_slots):
-                ns["gcal_event_id"] = existing_slots[i].get("gcal_event_id")
-            new_slots.append(ns)
-        self._data[date_str] = {
-            "slots": new_slots,
-            "modified_at": _utc_now_iso(),
-            "deleted": False,
-        }
-        self._save_to_disk()
+        with self._lock:
+            existing_slots = (self._data.get(date_str) or {}).get("slots", [])
+            new_slots = []
+            for i, s in enumerate(slots):
+                ns = _normalize_slot(s)
+                if ns["gcal_event_id"] is None and i < len(existing_slots):
+                    ns["gcal_event_id"] = existing_slots[i].get("gcal_event_id")
+                new_slots.append(ns)
+            self._data[date_str] = {
+                "slots": new_slots,
+                "modified_at": _utc_now_iso(),
+                "deleted": False,
+            }
+            self._save_to_disk()
 
     def delete(self, date_str):
         """Tombstone schreiben (slots=[]). Der Reconcile entfernt die
         zugehörigen Kalender-Events über den vollständigen Event-Pull (AP7)."""
-        if date_str not in self._data:
-            return
-        self._data[date_str] = {
-            "slots": [],
-            "modified_at": _utc_now_iso(),
-            "deleted": True,
-        }
-        self._save_to_disk()
+        with self._lock:
+            if date_str not in self._data:
+                return
+            self._data[date_str] = {
+                "slots": [],
+                "modified_at": _utc_now_iso(),
+                "deleted": True,
+            }
+            self._save_to_disk()
 
     def apply_reconciled(self, reconciled):
         """Ersetzt den kompletten Stand durch das Reconcile-Ergebnis.
         Wirft ValueError, wenn ein Eintrag Pflichtfelder vermissen lässt —
         analog zu Storage.apply_merge."""
-        for date, entry in reconciled.items():
-            missing = _REQUIRED_RESERVATION_KEYS - entry.keys()
-            if missing:
-                raise ValueError(
-                    f"apply_reconciled: entry {date!r} missing keys {sorted(missing)}"
-                )
-        self._data = dict(reconciled)
-        self._save_to_disk()
+        with self._lock:
+            for date, entry in reconciled.items():
+                missing = _REQUIRED_RESERVATION_KEYS - entry.keys()
+                if missing:
+                    raise ValueError(
+                        f"apply_reconciled: entry {date!r} missing keys {sorted(missing)}"
+                    )
+            self._data = dict(reconciled)
+            self._save_to_disk()

--- a/src/reservations_sync.py
+++ b/src/reservations_sync.py
@@ -8,6 +8,7 @@ Slots oder die Remote-Events gewinnen. `reconcile_reservations()` orchestriert
 pull → merge → push und schreibt neue event_ids pro Slot zurück.
 """
 
+import contextlib
 import datetime
 
 
@@ -157,11 +158,15 @@ def merge_reservations(local_raw, remote_events, watermark):
     return {"merged": merged, "plan": plan, "imported_dates": sorted(imported_dates)}
 
 
-def reconcile_reservations(service, calendar_id, store, settings):
+def reconcile_reservations(service, calendar_id, store, settings, data_lock=None):
     """Voller Kalender-Abgleich: pull → merge → push.
 
     Mutiert store und settings. Wirft bei Netz-/API-Fehlern weiter — der Caller
     entscheidet, ob still geloggt oder als Messagebox gezeigt wird.
+
+    data_lock: optionaler geteilter Store-Lock (Audit H1/H2, angrenzend) —
+    klammert Rebase → apply_reconciled → Watermark atomar gegen parallele
+    UI-Saves. Die gcal-Netzwerk-Calls davor laufen bewusst ungelockt.
 
     Liefert {"imported_dates": [...]} — die Daten, an denen in diesem Lauf
     Reservierungs-Slots aus dem Kalender importiert wurden (siehe
@@ -196,11 +201,14 @@ def reconcile_reservations(service, calendar_id, store, settings):
     # Rebase: Reservierungen, die seit dem Snapshot lokal gespeichert/geändert
     # wurden (paralleler Reconcile / User-Save während des Netzwerkteils),
     # dürfen nicht durch den apply_reconciled-Replace verloren gehen.
-    for date, entry in store.get_all_raw().items():
-        snap = local_snapshot.get(date)
-        if snap is None or entry.get("modified_at", "") > snap.get("modified_at", ""):
-            merged[date] = entry
+    # Rebase + Replace + Watermark laufen atomar unter dem Daten-Lock —
+    # zwischen Rebase-Read und Replace kann so kein weiterer Save landen.
+    with (data_lock if data_lock is not None else contextlib.nullcontext()):
+        for date, entry in store.get_all_raw().items():
+            snap = local_snapshot.get(date)
+            if snap is None or entry.get("modified_at", "") > snap.get("modified_at", ""):
+                merged[date] = entry
 
-    store.apply_reconciled(merged)
-    settings.set("last_calendar_sync_at", _utc_now_iso())
+        store.apply_reconciled(merged)
+        settings.set("last_calendar_sync_at", _utc_now_iso())
     return {"imported_dates": imported_dates}

--- a/src/settings.py
+++ b/src/settings.py
@@ -2,6 +2,7 @@ import datetime
 import json
 import logging
 import os
+import threading
 
 WEEKDAY_KEYS = ("mon", "tue", "wed", "thu", "fri", "sat", "sun")  # Index = datetime.weekday()
 
@@ -183,8 +184,10 @@ def clamp_ui_scale(value):
 
 
 class Settings:
-    def __init__(self, filepath="settings.json"):
+    def __init__(self, filepath="settings.json", lock=None):
         self.filepath = filepath
+        # Geteilter Daten-Lock (Audit H1/H2) — siehe storage.py.
+        self._lock = lock if lock is not None else threading.RLock()
         self._data = dict(DEFAULTS)
         self._synced_meta = {}   # {key: {"modified_at": ..., "device_id": ...}}
         self.device_id_for_sync = ""  # wird von main.py auf settings.device_id gesetzt
@@ -256,7 +259,8 @@ class Settings:
             raise
 
     def get(self, key):
-        return self._data.get(key, DEFAULTS.get(key))
+        with self._lock:
+            return self._data.get(key, DEFAULTS.get(key))
 
     def set(self, key, value):
         self.set_many({key: value})
@@ -268,8 +272,9 @@ class Settings:
         """
         if not updates:
             return
-        self._data.update(updates)
-        self._save_to_disk()
+        with self._lock:
+            self._data.update(updates)
+            self._save_to_disk()
 
     def set_synced(self, key, value):
         """Setzt einen whitelisted Sync-Key und stempelt Per-Field-Metadaten.
@@ -277,12 +282,13 @@ class Settings:
         if key not in SYNCED_SETTING_KEYS:
             self.set(key, value)
             return
-        self._data[key] = value
-        self._synced_meta[key] = {
-            "modified_at": _utc_now_iso(),
-            "device_id": self.device_id_for_sync,
-        }
-        self._save_to_disk()
+        with self._lock:
+            self._data[key] = value
+            self._synced_meta[key] = {
+                "modified_at": _utc_now_iso(),
+                "device_id": self.device_id_for_sync,
+            }
+            self._save_to_disk()
 
     def apply_updates(self, updates):
         """Routet ein updates-Dict aus dem Settings-Dialog auf den korrekten
@@ -298,31 +304,33 @@ class Settings:
     def get_synced_doc(self):
         """{key: {value, modified_at, device_id}} — Eingabe für den Sync-Merge.
         Nur Keys mit vorhandener Metadaten-Spur werden zurückgegeben."""
-        doc = {}
-        for key in SYNCED_SETTING_KEYS:
-            meta = self._synced_meta.get(key)
-            if meta is None:
-                continue
-            doc[key] = {
-                "value": self._data.get(key, DEFAULTS.get(key)),
-                "modified_at": meta["modified_at"],
-                "device_id": meta["device_id"],
-            }
-        return doc
+        with self._lock:
+            doc = {}
+            for key in SYNCED_SETTING_KEYS:
+                meta = self._synced_meta.get(key)
+                if meta is None:
+                    continue
+                doc[key] = {
+                    "value": self._data.get(key, DEFAULTS.get(key)),
+                    "modified_at": meta["modified_at"],
+                    "device_id": meta["device_id"],
+                }
+            return doc
 
     def apply_synced(self, synced_doc):
         """Übernimmt das Merge-Ergebnis: schreibt value in _data und Meta in
         _synced_meta. Schreibt einmal auf Platte."""
         if not synced_doc:
             return
-        for key, payload in synced_doc.items():
-            if key not in SYNCED_SETTING_KEYS:
-                continue
-            if not isinstance(payload, dict) or "value" not in payload:
-                continue
-            self._data[key] = payload["value"]
-            self._synced_meta[key] = {
-                "modified_at": str(payload.get("modified_at", "")),
-                "device_id": str(payload.get("device_id", "")),
-            }
-        self._save_to_disk()
+        with self._lock:
+            for key, payload in synced_doc.items():
+                if key not in SYNCED_SETTING_KEYS:
+                    continue
+                if not isinstance(payload, dict) or "value" not in payload:
+                    continue
+                self._data[key] = payload["value"]
+                self._synced_meta[key] = {
+                    "modified_at": str(payload.get("modified_at", "")),
+                    "device_id": str(payload.get("device_id", "")),
+                }
+            self._save_to_disk()

--- a/src/storage.py
+++ b/src/storage.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 import os
+import threading
 
 
 def _utc_now_iso():
@@ -26,9 +27,14 @@ def _normalize_slot(slot):
 
 
 class Storage:
-    def __init__(self, filepath="zeiterfassung.json", device_id=""):
+    def __init__(self, filepath="zeiterfassung.json", device_id="", lock=None):
         self.filepath = filepath
         self.device_id = device_id
+        # Geteilter Daten-Lock (Audit H1/H2): main() injiziert EINEN RLock in
+        # alle vier Stores; ohne Injektion (Tests, Alt-Aufrufer) eigener Lock.
+        # _load()/Migration laufen vor dem Teilen (single-threaded Boot) —
+        # bewusst ungelockt.
+        self._lock = lock if lock is not None else threading.RLock()
         self._data = {}
         self._load()
 
@@ -105,57 +111,63 @@ class Storage:
 
     def get_all(self):
         """Liefert {date: {slots: [...]}} ohne Tombstones."""
-        return {
-            date: self._user_shape(entry)
-            for date, entry in self._data.items()
-            if not entry.get("deleted")
-        }
+        with self._lock:
+            return {
+                date: self._user_shape(entry)
+                for date, entry in self._data.items()
+                if not entry.get("deleted")
+            }
 
     def get_all_raw(self):
         """Liefert die kompletten Eintragsobjekte inkl. Metadaten und Tombstones.
         Nur für den Sync-Pfad."""
-        return dict(self._data)
+        with self._lock:
+            return dict(self._data)
 
     def get(self, date_str):
-        entry = self._data.get(date_str)
-        if entry is None or entry.get("deleted"):
-            return None
-        return self._user_shape(entry)
+        with self._lock:
+            entry = self._data.get(date_str)
+            if entry is None or entry.get("deleted"):
+                return None
+            return self._user_shape(entry)
 
     def save(self, date_str, slots):
-        self._data[date_str] = {
-            "slots": [_normalize_slot(s) for s in slots],
-            "modified_at": _utc_now_iso(),
-            "device_id": self.device_id,
-            "deleted": False,
-        }
-        self._save_to_disk()
+        with self._lock:
+            self._data[date_str] = {
+                "slots": [_normalize_slot(s) for s in slots],
+                "modified_at": _utc_now_iso(),
+                "device_id": self.device_id,
+                "deleted": False,
+            }
+            self._save_to_disk()
 
     def delete(self, date_str):
-        if date_str not in self._data:
-            return
-        # Tombstone: behält die Zeile mit deleted=true, damit der Sync ein
-        # Delete gegen ein veraltetes Save eines anderen Geräts durchsetzen kann.
-        self._data[date_str] = {
-            "slots": [],
-            "modified_at": _utc_now_iso(),
-            "device_id": self.device_id,
-            "deleted": True,
-        }
-        self._save_to_disk()
+        with self._lock:
+            if date_str not in self._data:
+                return
+            # Tombstone: behält die Zeile mit deleted=true, damit der Sync ein
+            # Delete gegen ein veraltetes Save eines anderen Geräts durchsetzen kann.
+            self._data[date_str] = {
+                "slots": [],
+                "modified_at": _utc_now_iso(),
+                "device_id": self.device_id,
+                "deleted": True,
+            }
+            self._save_to_disk()
 
     def apply_merge(self, merged_entries):
         """Ersetzt den kompletten Storage-Stand durch das Merge-Ergebnis.
         merged_entries: {date: {slots, modified_at, device_id, deleted}}.
         Wirft ValueError, wenn ein Eintrag Pflichtfelder vermissen lässt."""
-        for date, entry in merged_entries.items():
-            missing = _REQUIRED_ENTRY_KEYS - entry.keys()
-            if missing:
-                raise ValueError(
-                    f"apply_merge: entry {date!r} missing keys {sorted(missing)}"
-                )
-        self._data = dict(merged_entries)
-        self._save_to_disk()
+        with self._lock:
+            for date, entry in merged_entries.items():
+                missing = _REQUIRED_ENTRY_KEYS - entry.keys()
+                if missing:
+                    raise ValueError(
+                        f"apply_merge: entry {date!r} missing keys {sorted(missing)}"
+                    )
+            self._data = dict(merged_entries)
+            self._save_to_disk()
 
     def save_many(self, updates):
         """Mehrere Einträge in einem einzigen Disk-Write speichern.
@@ -168,12 +180,13 @@ class Storage:
         """
         if not updates:
             return
-        now = _utc_now_iso()
-        for date_str, payload in updates.items():
-            self._data[date_str] = {
-                "slots": [_normalize_slot(s) for s in payload.get("slots", [])],
-                "modified_at": now,
-                "device_id": self.device_id,
-                "deleted": False,
-            }
-        self._save_to_disk()
+        with self._lock:
+            now = _utc_now_iso()
+            for date_str, payload in updates.items():
+                self._data[date_str] = {
+                    "slots": [_normalize_slot(s) for s in payload.get("slots", [])],
+                    "modified_at": now,
+                    "device_id": self.device_id,
+                    "deleted": False,
+                }
+            self._save_to_disk()

--- a/src/sync.py
+++ b/src/sync.py
@@ -10,6 +10,7 @@ Doc-Struktur (Sync-File und Zwischenformate):
 }
 """
 
+import contextlib
 import datetime
 import uuid
 
@@ -332,29 +333,41 @@ def _remote_is_newer(remote_doc):
     return (remote_doc.get("schema_version") or 1) > SCHEMA_VERSION
 
 
-def resolve_conflict(conflict_id, chosen_value, conflicts_store, storage, settings, device_id):
+def resolve_conflict(conflict_id, chosen_value, conflicts_store, storage, settings, device_id,
+                      data_lock=None):
     """User hat einen Konflikt aufgelöst. chosen_value enthält den gewählten
     (oder manuell editierten) Wert. Für entries: {slots: [...]} (und
     optional deleted). Für settings: {value}.
     Schreibt den Wert in den entsprechenden Store und markiert den Konflikt
-    als resolved im ConflictsStore."""
-    all_conflicts = conflicts_store.get_all()
-    target = next((c for c in all_conflicts if c["id"] == conflict_id), None)
-    if target is None:
-        raise KeyError(f"Konflikt {conflict_id!r} nicht gefunden")
+    als resolved im ConflictsStore.
 
-    now = _utc_now_iso()
-    target["resolved"] = True
-    target["resolution"] = dict(chosen_value)
-    target["resolved_at"] = now
-    target["resolved_by"] = device_id
+    data_lock: geteilter Store-RLock (Whole-Branch-Review-Finding). Die
+    Read-Modify-Write-Spanne (get_all → mutieren → storage/settings-Write →
+    save_all) muss atomar gegen einen parallel laufenden Hintergrund-Sync
+    sein — dessen apply_merged_doc kann sonst zwischen dem Lesen und dem
+    Zurückschreiben in conflicts_store schreiben, wodurch der stale Snapshot
+    hier die frisch gemergte Änderung überschreibt/verliert. sync.py ist ein
+    pure Modul und darf nicht aus src.main importieren (Circular-Import) —
+    daher optionaler Parameter mit Default None + contextlib.nullcontext,
+    genau wie in reservations_sync.py."""
+    with (data_lock if data_lock is not None else contextlib.nullcontext()):
+        all_conflicts = conflicts_store.get_all()
+        target = next((c for c in all_conflicts if c["id"] == conflict_id), None)
+        if target is None:
+            raise KeyError(f"Konflikt {conflict_id!r} nicht gefunden")
 
-    if target["kind"] == "entry":
-        if chosen_value.get("deleted"):
-            storage.delete(target["key"])
-        else:
-            storage.save(target["key"], chosen_value.get("slots", []))
-    elif target["kind"] == "setting":
-        settings.set_synced(target["key"], chosen_value.get("value"))
+        now = _utc_now_iso()
+        target["resolved"] = True
+        target["resolution"] = dict(chosen_value)
+        target["resolved_at"] = now
+        target["resolved_by"] = device_id
 
-    conflicts_store.save_all(all_conflicts)
+        if target["kind"] == "entry":
+            if chosen_value.get("deleted"):
+                storage.delete(target["key"])
+            else:
+                storage.save(target["key"], chosen_value.get("slots", []))
+        elif target["kind"] == "setting":
+            settings.set_synced(target["key"], chosen_value.get("value"))
+
+        conflicts_store.save_all(all_conflicts)

--- a/src/sync_orchestrator.py
+++ b/src/sync_orchestrator.py
@@ -7,6 +7,7 @@ Display zum Import nötig). `_run_push_blocking` wird LAZY in den Methoden aus
 src.sync_orchestrator).
 """
 
+import logging
 import tkinter as tk
 import traceback
 from tkinter import messagebox
@@ -107,7 +108,7 @@ class SyncOrchestrator:
     lazy über get_tray gelesen (einzige Quelle bleibt App._tray)."""
 
     def __init__(self, root, storage, settings, conflicts_store, base_path,
-                 runner, on_refresh, get_tray):
+                 runner, on_refresh, get_tray, data_lock=None, sync_guard=None):
         self._root = root
         self._storage = storage
         self._settings = settings
@@ -116,6 +117,8 @@ class SyncOrchestrator:
         self._runner = runner          # App._bg, hat .run(fn, on_done)
         self._on_refresh = on_refresh    # App._refresh
         self._get_tray = get_tray        # lambda: App._tray
+        self._data_lock = data_lock      # geteilter Store-RLock (Audit H1)
+        self._sync_guard = sync_guard    # Sync-Re-Entrancy-Guard (Audit H2)
         self._sync_button = None
         self._status_label = None
         self._next_button = None
@@ -130,11 +133,13 @@ class SyncOrchestrator:
             return self._conflicts_store.count_unresolved()
         return 0
 
-    def _push(self):
+    def _push(self, guard_timeout=0, timeout_seconds=15):
         from src.main import _run_push_blocking
         return _run_push_blocking(
             self._storage, self._settings, self._conflicts_store,
-            self._base_path, timeout_seconds=15,
+            self._base_path, timeout_seconds=timeout_seconds,
+            data_lock=self._data_lock, sync_guard=self._sync_guard,
+            guard_timeout=guard_timeout,
         )
 
     def on_pull_success(self):
@@ -172,9 +177,17 @@ class SyncOrchestrator:
                 "Synchronisation ist deaktiviert. In den Einstellungen aktivierbar.")
             return
         self._status_label.config(text="Synchronisiere…")
+        if self._sync_button is not None:
+            self._sync_button.config(state=tk.DISABLED)
         self._runner.run(self._push, self._on_manual_done)
 
     def _on_manual_done(self, result):
+        if self._sync_button is not None:
+            self._sync_button.config(state=tk.NORMAL)
+        if result.get("skipped"):
+            # Anderer Sync läuft bereits — dessen Callback aktualisiert die UI.
+            self.update_status_label()
+            return
         if not result.get("ok"):
             _show_sync_error(self._root, result.get("error", "?"),
                              result.get("tb", ""))
@@ -187,6 +200,8 @@ class SyncOrchestrator:
         self._runner.run(self._push, self._on_tray_done)
 
     def _on_tray_done(self, result):
+        if result.get("skipped"):
+            return  # anderer Sync läuft — kein Toast, nichts hat sich geändert
         self._on_refresh()
         self.update_status_label()
         tray = self._get_tray()
@@ -199,18 +214,20 @@ class SyncOrchestrator:
         )
 
     def push_on_quit(self):
-        """Blockierender Push beim Beenden (kurzes Timeout). Kein tray.stop()
-        (bleibt App-Lifecycle)."""
+        """Blockierender Push beim Beenden. Wartet per guard_timeout bis 5 s
+        auf einen laufenden Sync (Worst Case gesamt ~10 s mit Push-Timeout).
+        Kein tray.stop() (bleibt App-Lifecycle)."""
         if not self._settings.get("sync_enabled"):
             return
-        from src.main import _run_push_blocking
         try:
-            result = _run_push_blocking(
-                self._storage, self._settings, self._conflicts_store,
-                self._base_path, timeout_seconds=5,
-            )
+            result = self._push(guard_timeout=5, timeout_seconds=10)
         except Exception as e:
             result = {"ok": False, "error": e, "tb": traceback.format_exc()}
+        if result.get("skipped"):
+            logging.getLogger(__name__).warning(
+                "Quit-Push übersprungen — ein anderer Sync läuft noch; "
+                "lokale Daten syncen beim nächsten Start.")
+            return
         if not result.get("ok"):
             _show_sync_error(
                 self._root, result.get("error", "?"), result.get("tb", ""),

--- a/src/sync_orchestrator.py
+++ b/src/sync_orchestrator.py
@@ -13,7 +13,7 @@ import traceback
 from tkinter import messagebox
 
 from src.drive import DriveAuthError, DriveNetworkError
-from src.theme import themed_showinfo
+from src.theme import set_icon_button_enabled, themed_showinfo
 from src.time_utils import format_iso_date
 
 
@@ -122,6 +122,12 @@ class SyncOrchestrator:
         self._sync_button = None
         self._status_label = None
         self._next_button = None
+        # Re-Entrancy-Flag für den manuellen Sync-Button: der icon_button ist
+        # nur OPTISCH deaktivierbar (set_icon_button_enabled, kein echtes
+        # -state), die Klick-Bindung bleibt aktiv. Dieses Flag trägt daher den
+        # No-op bei bereits laufendem Manual-Sync (der sync_guard schützt die
+        # Daten zusätzlich engineseitig; hier geht es um Doppelklick-UX).
+        self._sync_in_progress = False
 
     def attach_widgets(self, sync_button, status_label, next_button):
         self._sync_button = sync_button
@@ -176,14 +182,18 @@ class SyncOrchestrator:
                 "Synchronisation",
                 "Synchronisation ist deaktiviert. In den Einstellungen aktivierbar.")
             return
+        if self._sync_in_progress:
+            return  # läuft bereits — Button ist nur optisch gedimmt
+        self._sync_in_progress = True
         self._status_label.config(text="Synchronisiere…")
         if self._sync_button is not None:
-            self._sync_button.config(state=tk.DISABLED)
+            set_icon_button_enabled(self._sync_button, False)
         self._runner.run(self._push, self._on_manual_done)
 
     def _on_manual_done(self, result):
+        self._sync_in_progress = False
         if self._sync_button is not None:
-            self._sync_button.config(state=tk.NORMAL)
+            set_icon_button_enabled(self._sync_button, True)
         if result.get("skipped"):
             # Anderer Sync läuft bereits — dessen Callback aktualisiert die UI.
             self.update_status_label()

--- a/src/theme.py
+++ b/src/theme.py
@@ -1024,3 +1024,25 @@ def icon_button(parent, text, command, fg=ACCENT, hover_fg=None):
         font=FONT_BOLD,
         width=3,
     )
+
+
+def set_icon_button_enabled(btn, enabled, *, fg=ACCENT):
+    """Pendant zu set_primary_button_enabled für `icon_button` (Header-⟳):
+    deaktiviert = gedämpfte Schrift (TEXT_MUTED) + Pfeil-Cursor, kein
+    Hover-Wechsel; aktiviert zurück auf `fg` (Default ACCENT wie icon_button).
+
+    Ein `icon_button` ist ein `_LabelButton` (Frame) und kennt KEIN `-state` —
+    `btn.config(state=...)` wirft `TclError`. Darum diese Optik-only-Variante.
+    Wie bei set_primary_button_enabled bleibt die `command`/on_click-Bindung
+    aktiv, der Callback muss bei disabled also selbst ein No-op machen."""
+    cursor = "hand2" if enabled else "arrow"
+    c = (
+        {"bg": CELL_BG, "fg": fg,
+         "hover_bg": ENTRY_BG, "hover_fg": fg}
+        if enabled else
+        {"bg": CELL_BG, "fg": TEXT_MUTED,
+         "hover_bg": CELL_BG, "hover_fg": TEXT_MUTED}
+    )
+    btn._colors = c
+    btn.config(bg=c["bg"], cursor=cursor)
+    btn._label.config(bg=c["bg"], fg=c["fg"], cursor=cursor)

--- a/src/ui.py
+++ b/src/ui.py
@@ -54,7 +54,8 @@ def _delete_action(slots, selected, prefix):
 
 class App:
     def __init__(self, root, storage, settings, base_path=".", conflicts_store=None,
-                 reservation_store=None, single_instance=None):
+                 reservation_store=None, single_instance=None,
+                 data_lock=None, sync_guard=None):
         self.root = root
         self.storage = storage
         self.settings = settings
@@ -62,6 +63,8 @@ class App:
         self.base_path = base_path
         self.conflicts_store = conflicts_store
         self.reservation_store = reservation_store
+        self._data_lock = data_lock      # geteilter Store-RLock (Audit H1)
+        self._sync_guard = sync_guard    # Sync-Re-Entrancy-Guard (Audit H2)
         self.root.title(f"Zeiterfassung v{version_label()}")
         self.root.configure(bg=BG)
         apply_dark_titlebar(self.root)
@@ -119,10 +122,12 @@ class App:
         self._bg = BackgroundTaskRunner(
             self._marshal_to_ui, self.settings, self.base_path,
             self.reservation_store, self._reservations_active, self.storage,
+            data_lock=data_lock,
         )
         self._sync = SyncOrchestrator(
             self.root, self.storage, self.settings, self.conflicts_store,
             self.base_path, self._bg, self._refresh, lambda: self._tray,
+            data_lock=data_lock, sync_guard=sync_guard,
         )
         self._renderer = GridRenderer(
             self.root, self.storage, self.settings, self.reservation_store,
@@ -355,6 +360,8 @@ class App:
             storage=self.storage,
             reservation_store=self.reservation_store,
             on_request_restart=self.restart_for_scaling,
+            data_lock=self._data_lock,
+            sync_guard=self._sync_guard,
         )
 
     def _apply_always_on_top(self):

--- a/tests/test_background_tasks.py
+++ b/tests/test_background_tasks.py
@@ -89,7 +89,7 @@ def test_reconcile_on_start_passes_storage_and_result_to_on_ok(monkeypatch):
 
     captured = {}
 
-    def fake_reconcile(reservation_store, settings, base_path, storage):
+    def fake_reconcile(reservation_store, settings, base_path, storage, data_lock=None):
         captured["storage"] = storage
         return {"ok": True, "error": "", "tb": "", "limit_warnings": ["w"]}
 
@@ -111,7 +111,7 @@ def test_trigger_reconcile_passes_storage_through(monkeypatch):
 
     captured = {}
 
-    def fake_reconcile(reservation_store, settings, base_path, storage):
+    def fake_reconcile(reservation_store, settings, base_path, storage, data_lock=None):
         captured["storage"] = storage
         return {"ok": True, "error": "", "tb": "", "limit_warnings": []}
 

--- a/tests/test_store_locking.py
+++ b/tests/test_store_locking.py
@@ -1,0 +1,136 @@
+"""Threadsicherheit der vier Stores: geteilter injizierter RLock (Audit H1/H2).
+
+Kein Sleep/Timing — Lock-Besitz wird über einen Probe-Thread geprüft
+(non-blocking acquire aus fremdem Thread), Robustheit über einen Stresstest,
+dessen Erfolgskriterium "keine Exception + valides JSON" ist.
+"""
+
+import json
+import threading
+
+from src.conflicts_store import ConflictsStore
+from src.reservations import ReservationStore
+from src.settings import Settings
+from src.storage import Storage
+
+
+def _other_thread_can_acquire(lock):
+    """True, wenn ein ANDERER Thread den Lock nehmen kann (= Lock frei).
+    Deterministisch: nur start/join, kein Sleep. RLock ist reentrant pro
+    Thread — deshalb MUSS die Probe aus einem fremden Thread kommen."""
+    out = []
+
+    def probe():
+        got = lock.acquire(blocking=False)
+        out.append(got)
+        if got:
+            lock.release()
+
+    t = threading.Thread(target=probe)
+    t.start()
+    t.join()
+    return out[0]
+
+
+def _slot(start="08:00", end="16:00", pause=0):
+    return {"start": start, "end": end, "pause": pause, "kategorie": ""}
+
+
+def _assert_disk_write_locked(store, lock, mutate):
+    """Spy auf _save_to_disk: während des Disk-Writes muss der Lock gehalten
+    sein (Probe aus fremdem Thread darf ihn NICHT bekommen)."""
+    held = []
+    orig = store._save_to_disk
+
+    def spy():
+        held.append(not _other_thread_can_acquire(lock))
+        orig()
+
+    store._save_to_disk = spy
+    mutate()
+    assert held == [True]
+
+
+def test_all_stores_accept_shared_lock(tmp_path):
+    lock = threading.RLock()
+    Storage(str(tmp_path / "z.json"), device_id="A", lock=lock)
+    Settings(str(tmp_path / "s.json"), lock=lock)
+    ConflictsStore(str(tmp_path / "c.json"), lock=lock)
+    ReservationStore(str(tmp_path / "r.json"), lock=lock)
+
+
+def test_storage_save_holds_lock_during_disk_write(tmp_path):
+    lock = threading.RLock()
+    storage = Storage(str(tmp_path / "z.json"), device_id="A", lock=lock)
+    _assert_disk_write_locked(
+        storage, lock, lambda: storage.save("2026-01-01", [_slot()]))
+
+
+def test_storage_apply_merge_holds_lock_during_disk_write(tmp_path):
+    lock = threading.RLock()
+    storage = Storage(str(tmp_path / "z.json"), device_id="A", lock=lock)
+    entry = {"slots": [_slot()], "modified_at": "2026-01-01T10:00:00Z",
+             "device_id": "A", "deleted": False}
+    _assert_disk_write_locked(
+        storage, lock, lambda: storage.apply_merge({"2026-01-01": entry}))
+
+
+def test_settings_set_holds_lock_during_disk_write(tmp_path):
+    lock = threading.RLock()
+    settings = Settings(str(tmp_path / "s.json"), lock=lock)
+    _assert_disk_write_locked(
+        settings, lock, lambda: settings.set("recipient", "x@example.com"))
+
+
+def test_conflicts_save_all_holds_lock_during_disk_write(tmp_path):
+    lock = threading.RLock()
+    conflicts = ConflictsStore(str(tmp_path / "c.json"), lock=lock)
+    _assert_disk_write_locked(
+        conflicts, lock, lambda: conflicts.save_all([{"id": "1", "resolved": False}]))
+
+
+def test_reservations_save_holds_lock_during_disk_write(tmp_path):
+    lock = threading.RLock()
+    store = ReservationStore(str(tmp_path / "r.json"), lock=lock)
+    _assert_disk_write_locked(
+        store, lock,
+        lambda: store.save("2026-01-01", [{"start": "08:00", "end": "12:00"}]))
+
+
+def test_default_lock_created_when_not_injected(tmp_path):
+    """Ohne Injektion legt der Store einen eigenen RLock an — Alt-Aufrufer
+    (bestehende Tests) bleiben unverändert und trotzdem intern threadsicher."""
+    storage = Storage(str(tmp_path / "z.json"), device_id="A")
+    _assert_disk_write_locked(
+        storage, storage._lock, lambda: storage.save("2026-01-01", [_slot()]))
+
+
+def test_parallel_writes_keep_file_valid_json(tmp_path):
+    """Stresstest (Robustheitsnetz, kein Timing-Assert): parallele
+    save/delete/apply_merge/get_all dürfen weder werfen noch die Datei
+    korrumpieren."""
+    lock = threading.RLock()
+    path = tmp_path / "z.json"
+    storage = Storage(str(path), device_id="A", lock=lock)
+    errors = []
+
+    def writer(i):
+        try:
+            for n in range(30):
+                date = f"2026-01-{(n % 28) + 1:02d}"
+                storage.save(date, [_slot()])
+                if n % 7 == 0:
+                    storage.delete(date)
+                if n % 11 == 0:
+                    storage.apply_merge(storage.get_all_raw())
+                storage.get_all()
+        except Exception as e:  # noqa: BLE001 — Fehler ins Hauptthread-Assert tragen
+            errors.append(e)
+
+    threads = [threading.Thread(target=writer, args=(i,)) for i in range(6)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert errors == []
+    json.loads(path.read_text(encoding="utf-8"))  # Datei ist valides JSON

--- a/tests/test_sync_orchestrator.py
+++ b/tests/test_sync_orchestrator.py
@@ -63,17 +63,22 @@ class _FakeLabel:
 
 
 class _FakeButton:
-    """Fake für den Sync-Button: config(state=...) + winfo_ismapped für
-    update_status_label (meldet sich als bereits gepackt)."""
-    def __init__(self):
-        self.state = None
-
-    def config(self, state=None):
-        if state is not None:
-            self.state = state
-
+    """Fake für den Sync-Button: winfo_ismapped für update_status_label
+    (meldet sich als bereits gepackt). Das optische Enable/Disable läuft über
+    theme.set_icon_button_enabled, das die Tests im Orchestrator-Namespace
+    monkeypatchen (der echte icon_button ist ein _LabelButton mit `_label`)."""
     def winfo_ismapped(self):
         return True
+
+
+def _patch_dim(monkeypatch):
+    """Ersetzt set_icon_button_enabled im Orchestrator durch einen Rekorder und
+    gibt die Aufrufliste [(button, enabled), ...] zurück."""
+    import src.sync_orchestrator as so
+    calls = []
+    monkeypatch.setattr(so, "set_icon_button_enabled",
+                        lambda btn, enabled, **k: calls.append((btn, enabled)))
+    return calls
 
 
 def _orch(sync_enabled=True, execute_runner=False, get_tray=lambda: None,
@@ -102,7 +107,8 @@ def test_on_sync_clicked_disabled_does_not_run(monkeypatch):
     assert shown  # Hinweis-Dialog gezeigt
 
 
-def test_on_sync_clicked_enabled_sets_label_and_runs():
+def test_on_sync_clicked_enabled_sets_label_and_runs(monkeypatch):
+    _patch_dim(monkeypatch)
     orch, runner = _orch(sync_enabled=True, execute_runner=False)
     label = _FakeLabel()
     orch.attach_widgets(sync_button=_FakeButton(), status_label=label,
@@ -133,26 +139,45 @@ def test_push_on_quit_disabled_is_noop():
     orch.push_on_quit()
 
 
-def test_on_sync_clicked_disables_button():
+def test_on_sync_clicked_dims_button(monkeypatch):
+    calls = _patch_dim(monkeypatch)
     orch, runner = _orch(sync_enabled=True, execute_runner=False)
     label, button = _FakeLabel(), _FakeButton()
     orch.attach_widgets(sync_button=button, status_label=label,
                         next_button=object())
     orch.on_sync_clicked()
-    assert button.state == "disabled"
+    assert calls == [(button, False)]   # optisch deaktiviert (kein -state!)
+    assert orch._sync_in_progress is True
 
 
-def test_on_manual_done_reenables_button():
+def test_on_manual_done_reenables_button(monkeypatch):
+    calls = _patch_dim(monkeypatch)
     orch, _ = _orch(sync_enabled=True)
     label, button = _FakeLabel(), _FakeButton()
     orch.attach_widgets(sync_button=button, status_label=label,
                         next_button=object())
     orch._on_manual_done({"ok": True})
-    assert button.state == "normal"
+    assert calls == [(button, True)]    # optisch wieder aktiv
+    assert orch._sync_in_progress is False
+
+
+def test_on_sync_clicked_reentrant_is_noop(monkeypatch):
+    # Der icon_button ist nur optisch deaktivierbar; das _sync_in_progress-Flag
+    # trägt den No-op. Runner führt NICHT aus -> _on_manual_done setzt das Flag
+    # nicht zurück, der zweite Klick muss folgenlos bleiben.
+    _patch_dim(monkeypatch)
+    orch, runner = _orch(sync_enabled=True, execute_runner=False)
+    label, button = _FakeLabel(), _FakeButton()
+    orch.attach_widgets(sync_button=button, status_label=label,
+                        next_button=object())
+    orch.on_sync_clicked()
+    orch.on_sync_clicked()              # zweiter Klick während laufendem Sync
+    assert len(runner.calls) == 1       # war ein No-op
 
 
 def test_on_manual_done_skipped_shows_no_error(monkeypatch):
     import src.sync_orchestrator as so
+    _patch_dim(monkeypatch)
     errors = []
     monkeypatch.setattr(so, "_show_sync_error", lambda *a, **k: errors.append(a))
     refreshed = []
@@ -163,7 +188,7 @@ def test_on_manual_done_skipped_shows_no_error(monkeypatch):
     orch._on_manual_done({"ok": False, "skipped": True})
     assert errors == []          # kein Fehlerdialog — anderer Sync läuft nur
     assert refreshed == []       # kein Refresh nötig, nichts hat sich geändert
-    assert button.state == "normal"
+    assert orch._sync_in_progress is False
 
 
 def test_on_tray_done_skipped_no_toast():

--- a/tests/test_sync_orchestrator.py
+++ b/tests/test_sync_orchestrator.py
@@ -62,8 +62,22 @@ class _FakeLabel:
         self.text = text
 
 
+class _FakeButton:
+    """Fake für den Sync-Button: config(state=...) + winfo_ismapped für
+    update_status_label (meldet sich als bereits gepackt)."""
+    def __init__(self):
+        self.state = None
+
+    def config(self, state=None):
+        if state is not None:
+            self.state = state
+
+    def winfo_ismapped(self):
+        return True
+
+
 def _orch(sync_enabled=True, execute_runner=False, get_tray=lambda: None,
-          conflicts=0, on_refresh=None):
+          conflicts=0, on_refresh=None, data_lock=None, sync_guard=None):
     _vals = {"sync_enabled": sync_enabled, "last_pull_at": None}
     settings = MagicMock(get=lambda k, d=None: _vals.get(k, d))
     conflicts_store = MagicMock(count_unresolved=lambda: conflicts)
@@ -72,6 +86,7 @@ def _orch(sync_enabled=True, execute_runner=False, get_tray=lambda: None,
         root=object(), storage=object(), settings=settings,
         conflicts_store=conflicts_store, base_path=".", runner=runner,
         on_refresh=on_refresh or (lambda: None), get_tray=get_tray,
+        data_lock=data_lock, sync_guard=sync_guard,
     )
     return orch, runner
 
@@ -90,7 +105,7 @@ def test_on_sync_clicked_disabled_does_not_run(monkeypatch):
 def test_on_sync_clicked_enabled_sets_label_and_runs():
     orch, runner = _orch(sync_enabled=True, execute_runner=False)
     label = _FakeLabel()
-    orch.attach_widgets(sync_button=object(), status_label=label,
+    orch.attach_widgets(sync_button=_FakeButton(), status_label=label,
                         next_button=object())
     orch.on_sync_clicked()
     assert label.text == "Synchronisiere…"
@@ -116,3 +131,87 @@ def test_push_on_quit_disabled_is_noop():
     orch, _ = _orch(sync_enabled=False)
     # darf nicht werfen und nichts pushen (Guard greift vor dem Lazy-Import)
     orch.push_on_quit()
+
+
+def test_on_sync_clicked_disables_button():
+    orch, runner = _orch(sync_enabled=True, execute_runner=False)
+    label, button = _FakeLabel(), _FakeButton()
+    orch.attach_widgets(sync_button=button, status_label=label,
+                        next_button=object())
+    orch.on_sync_clicked()
+    assert button.state == "disabled"
+
+
+def test_on_manual_done_reenables_button():
+    orch, _ = _orch(sync_enabled=True)
+    label, button = _FakeLabel(), _FakeButton()
+    orch.attach_widgets(sync_button=button, status_label=label,
+                        next_button=object())
+    orch._on_manual_done({"ok": True})
+    assert button.state == "normal"
+
+
+def test_on_manual_done_skipped_shows_no_error(monkeypatch):
+    import src.sync_orchestrator as so
+    errors = []
+    monkeypatch.setattr(so, "_show_sync_error", lambda *a, **k: errors.append(a))
+    refreshed = []
+    orch, _ = _orch(sync_enabled=True, on_refresh=lambda: refreshed.append(1))
+    label, button = _FakeLabel(), _FakeButton()
+    orch.attach_widgets(sync_button=button, status_label=label,
+                        next_button=object())
+    orch._on_manual_done({"ok": False, "skipped": True})
+    assert errors == []          # kein Fehlerdialog — anderer Sync läuft nur
+    assert refreshed == []       # kein Refresh nötig, nichts hat sich geändert
+    assert button.state == "normal"
+
+
+def test_on_tray_done_skipped_no_toast():
+    tray = MagicMock()
+    orch, _ = _orch(get_tray=lambda: tray)
+    orch._on_tray_done({"ok": False, "skipped": True})
+    tray.notify.assert_not_called()
+
+
+def test_push_passes_lock_guard_and_timeouts(monkeypatch):
+    captured = {}
+
+    def fake(storage, settings, conflicts_store, base, timeout_seconds=5, **kw):
+        captured.update(kw)
+        captured["timeout_seconds"] = timeout_seconds
+        return {"ok": True}
+
+    monkeypatch.setattr("src.main._run_push_blocking", fake)
+    lock, guard = object(), object()
+    orch, _ = _orch(sync_enabled=True, data_lock=lock, sync_guard=guard)
+    orch._push()
+    assert captured["data_lock"] is lock
+    assert captured["sync_guard"] is guard
+    assert captured["guard_timeout"] == 0
+    assert captured["timeout_seconds"] == 15
+
+
+def test_push_on_quit_uses_guard_timeout(monkeypatch):
+    captured = {}
+
+    def fake(storage, settings, conflicts_store, base, timeout_seconds=5, **kw):
+        captured.update(kw)
+        captured["timeout_seconds"] = timeout_seconds
+        return {"ok": True}
+
+    monkeypatch.setattr("src.main._run_push_blocking", fake)
+    orch, _ = _orch(sync_enabled=True)
+    orch.push_on_quit()
+    assert captured["guard_timeout"] == 5
+    assert captured["timeout_seconds"] == 10
+
+
+def test_push_on_quit_skipped_logs_no_dialog(monkeypatch):
+    import src.sync_orchestrator as so
+    errors = []
+    monkeypatch.setattr(so, "_show_sync_error", lambda *a, **k: errors.append(a))
+    monkeypatch.setattr("src.main._run_push_blocking",
+                        lambda *a, **k: {"ok": False, "skipped": True})
+    orch, _ = _orch(sync_enabled=True)
+    orch.push_on_quit()
+    assert errors == []

--- a/tests/test_sync_threading.py
+++ b/tests/test_sync_threading.py
@@ -1,0 +1,103 @@
+"""Threading-Verhalten der Sync-Flows: Sync-Guard (Re-Entrancy, Audit H2) und
+Daten-Lock-Klammer um Snapshot→Merge→Apply (Audit H1). Deterministisch über
+Probe-Threads — kein Sleep, keine Timing-Asserts."""
+
+import threading
+
+from src.conflicts_store import ConflictsStore
+from src.settings import Settings
+from src.storage import Storage
+
+
+def _other_thread_can_acquire(lock):
+    """True, wenn ein ANDERER Thread den Lock nehmen kann (= Lock frei)."""
+    out = []
+
+    def probe():
+        got = lock.acquire(blocking=False)
+        out.append(got)
+        if got:
+            lock.release()
+
+    t = threading.Thread(target=probe)
+    t.start()
+    t.join()
+    return out[0]
+
+
+def _stores(tmp_path, lock):
+    storage = Storage(str(tmp_path / "z.json"), device_id="A", lock=lock)
+    settings = Settings(str(tmp_path / "s.json"), lock=lock)
+    settings.device_id_for_sync = "A"
+    conflicts = ConflictsStore(str(tmp_path / "c.json"), lock=lock)
+    return storage, settings, conflicts
+
+
+def _mock_drive_empty(monkeypatch):
+    """Drive-Fassade: kein Remote-File (Pfad ohne Download), Upload gemockt."""
+    from src import drive
+    monkeypatch.setattr(drive, "get_drive_service", lambda *a, **k: object())
+    monkeypatch.setattr(drive, "find_sync_file", lambda service: None)
+    monkeypatch.setattr(
+        drive, "upload",
+        lambda service, content, file_id=None, expected_etag=None: ("file-1", "etag-1"))
+    return drive
+
+
+def test_pull_skipped_when_guard_held(tmp_path):
+    """Läuft bereits ein Sync (Guard gehalten), wird der Pull still
+    übersprungen: kein ui_callback, kein Drive-Zugriff."""
+    import src.main as main
+    lock = threading.RLock()
+    storage, settings, conflicts = _stores(tmp_path, lock)
+    guard = threading.Lock()
+    calls = []
+    assert guard.acquire(blocking=False)
+    try:
+        main._run_pull_in_background(
+            storage, settings, conflicts, str(tmp_path),
+            lambda **kw: calls.append(kw), data_lock=lock, sync_guard=guard)
+    finally:
+        guard.release()
+    assert calls == []
+
+
+def test_pull_holds_data_lock_during_apply_and_releases_guard(tmp_path, monkeypatch):
+    """Während apply_merged_doc muss der Daten-Lock gehalten sein (kein
+    UI-Save kann interleaven, H1); danach ist der Guard wieder frei."""
+    import src.main as main
+    from src import sync
+    lock = threading.RLock()
+    storage, settings, conflicts = _stores(tmp_path, lock)
+    guard = threading.Lock()
+    _mock_drive_empty(monkeypatch)
+    held = []
+    orig = sync.apply_merged_doc
+
+    def spy(merged, storage_, settings_, conflicts_):
+        held.append(not _other_thread_can_acquire(lock))
+        return orig(merged, storage_, settings_, conflicts_)
+
+    monkeypatch.setattr(sync, "apply_merged_doc", spy)
+    calls = []
+    main._run_pull_in_background(
+        storage, settings, conflicts, str(tmp_path),
+        lambda **kw: calls.append(kw), data_lock=lock, sync_guard=guard)
+    assert held == [True]                    # Apply lief unter dem Daten-Lock
+    assert calls and calls[0]["ok"] is True
+    assert guard.acquire(blocking=False)     # Guard wieder frei (finally)
+    guard.release()
+
+
+def test_pull_without_lock_and_guard_still_works(tmp_path, monkeypatch):
+    """Alt-Aufrufer-Kompatibilität: ohne data_lock/sync_guard läuft der Pull
+    wie bisher (bestehende Tests in test_sync.py decken die Semantik ab)."""
+    import src.main as main
+    lock = threading.RLock()
+    storage, settings, conflicts = _stores(tmp_path, lock)
+    _mock_drive_empty(monkeypatch)
+    calls = []
+    main._run_pull_in_background(
+        storage, settings, conflicts, str(tmp_path),
+        lambda **kw: calls.append(kw))
+    assert calls and calls[0]["ok"] is True

--- a/tests/test_sync_threading.py
+++ b/tests/test_sync_threading.py
@@ -101,3 +101,137 @@ def test_pull_without_lock_and_guard_still_works(tmp_path, monkeypatch):
         storage, settings, conflicts, str(tmp_path),
         lambda **kw: calls.append(kw))
     assert calls and calls[0]["ok"] is True
+
+
+def test_push_skipped_when_guard_held(tmp_path):
+    import src.main as main
+    lock = threading.RLock()
+    storage, settings, conflicts = _stores(tmp_path, lock)
+    guard = threading.Lock()
+    assert guard.acquire(blocking=False)
+    try:
+        res = main._run_push_blocking(
+            storage, settings, conflicts, str(tmp_path),
+            data_lock=lock, sync_guard=guard)
+    finally:
+        guard.release()
+    assert res == {"ok": False, "skipped": True}
+
+
+def test_push_holds_data_lock_during_apply(tmp_path, monkeypatch):
+    import src.main as main
+    from src import sync
+    lock = threading.RLock()
+    storage, settings, conflicts = _stores(tmp_path, lock)
+    _mock_drive_empty(monkeypatch)
+    held = []
+    orig = sync.apply_merged_doc
+
+    def spy(merged, storage_, settings_, conflicts_):
+        held.append(not _other_thread_can_acquire(lock))
+        return orig(merged, storage_, settings_, conflicts_)
+
+    monkeypatch.setattr(sync, "apply_merged_doc", spy)
+    res = main._run_push_blocking(
+        storage, settings, conflicts, str(tmp_path),
+        data_lock=lock, sync_guard=None)
+    assert res.get("ok") is True
+    assert held == [True]
+
+
+def test_push_uploads_without_holding_data_lock(tmp_path, monkeypatch):
+    """Spec-Invariante: der Daten-Lock wird NIE über den Netzwerk-Upload
+    gehalten — während drive.upload muss er aus fremdem Thread nehmbar sein."""
+    import src.main as main
+    from src import drive
+    lock = threading.RLock()
+    storage, settings, conflicts = _stores(tmp_path, lock)
+    monkeypatch.setattr(drive, "get_drive_service", lambda *a, **k: object())
+    monkeypatch.setattr(drive, "find_sync_file", lambda service: None)
+    lock_free = []
+
+    def fake_upload(service, content, file_id=None, expected_etag=None):
+        lock_free.append(_other_thread_can_acquire(lock))
+        return ("file-1", "etag-1")
+
+    monkeypatch.setattr(drive, "upload", fake_upload)
+    res = main._run_push_blocking(
+        storage, settings, conflicts, str(tmp_path),
+        data_lock=lock, sync_guard=None)
+    assert res.get("ok") is True
+    assert lock_free == [True]
+
+
+def test_push_guard_released_after_run(tmp_path, monkeypatch):
+    import src.main as main
+    lock = threading.RLock()
+    storage, settings, conflicts = _stores(tmp_path, lock)
+    _mock_drive_empty(monkeypatch)
+    guard = threading.Lock()
+    res = main._run_push_blocking(
+        storage, settings, conflicts, str(tmp_path),
+        data_lock=lock, sync_guard=guard)
+    assert res.get("ok") is True
+    assert guard.acquire(blocking=False)   # Guard nach dem Lauf wieder frei
+    guard.release()
+
+
+def test_push_guard_timeout_waits_for_running_sync(tmp_path, monkeypatch):
+    """Quit-Semantik: guard_timeout>0 wartet auf den laufenden Sync statt zu
+    skippen. Deterministischer Ausgang (großzügige Timeouts begrenzen nur die
+    Dauer im Fehlerfall, sie werden nicht asserted)."""
+    import src.main as main
+    lock = threading.RLock()
+    storage, settings, conflicts = _stores(tmp_path, lock)
+    _mock_drive_empty(monkeypatch)
+    guard = threading.Lock()
+    guard.acquire()   # "laufender Sync"
+    out = {}
+
+    def run_push():
+        out["res"] = main._run_push_blocking(
+            storage, settings, conflicts, str(tmp_path),
+            timeout_seconds=30, data_lock=lock, sync_guard=guard,
+            guard_timeout=30)
+
+    t = threading.Thread(target=run_push)
+    t.start()
+    guard.release()   # der "laufende Sync" endet — der wartende Push übernimmt
+    t.join()
+    assert out["res"].get("ok") is True
+
+
+def test_compaction_skipped_when_guard_held(tmp_path):
+    import src.main as main
+    lock = threading.RLock()
+    storage, settings, conflicts = _stores(tmp_path, lock)
+    guard = threading.Lock()
+    assert guard.acquire(blocking=False)
+    try:
+        res = main._run_compaction_blocking(
+            storage, settings, conflicts, str(tmp_path),
+            data_lock=lock, sync_guard=guard)
+    finally:
+        guard.release()
+    assert res == {"ok": False, "skipped": True}
+
+
+def test_compaction_holds_data_lock_during_compact(tmp_path, monkeypatch):
+    import src.main as main
+    from src import sync
+    lock = threading.RLock()
+    storage, settings, conflicts = _stores(tmp_path, lock)
+    _mock_drive_empty(monkeypatch)
+    held = []
+    orig = sync.compact_local
+
+    def spy(storage_, settings_, conflicts_, now):
+        held.append(not _other_thread_can_acquire(lock))
+        return orig(storage_, settings_, conflicts_, now)
+
+    monkeypatch.setattr(sync, "compact_local", spy)
+    res = main._run_compaction_blocking(
+        storage, settings, conflicts, str(tmp_path),
+        data_lock=lock, sync_guard=None)
+    assert res.get("ok") is True
+    assert held == [True]

--- a/tests/test_sync_threading.py
+++ b/tests/test_sync_threading.py
@@ -235,3 +235,26 @@ def test_compaction_holds_data_lock_during_compact(tmp_path, monkeypatch):
         data_lock=lock, sync_guard=None)
     assert res.get("ok") is True
     assert held == [True]
+
+
+def test_reconcile_holds_data_lock_during_rebase_and_apply(tmp_path, monkeypatch):
+    """Der Reconcile-Rebase+Replace (reservations_sync) läuft unter dem
+    geteilten Daten-Lock — kein UI-Save kann zwischen Rebase-Read und
+    apply_reconciled interleaven."""
+    from src.reservations import ReservationStore
+    from src import gcal
+    from src.reservations_sync import reconcile_reservations
+    lock = threading.RLock()
+    store = ReservationStore(str(tmp_path / "r.json"), lock=lock)
+    settings = Settings(str(tmp_path / "s.json"), lock=lock)
+    monkeypatch.setattr(gcal, "list_app_events", lambda service, cal: [])
+    held = []
+    orig = store.apply_reconciled
+
+    def spy(reconciled):
+        held.append(not _other_thread_can_acquire(lock))
+        return orig(reconciled)
+
+    store.apply_reconciled = spy
+    reconcile_reservations(object(), "cal-1", store, settings, data_lock=lock)
+    assert held == [True]

--- a/tests/test_sync_threading.py
+++ b/tests/test_sync_threading.py
@@ -237,6 +237,36 @@ def test_compaction_holds_data_lock_during_compact(tmp_path, monkeypatch):
     assert held == [True]
 
 
+def test_resolve_conflict_holds_data_lock_during_save_all(tmp_path):
+    """Whole-Branch-Review-Finding: resolve_conflict liest conflicts_store,
+    mutiert die Liste und schreibt sie zurück (save_all) — diese RMW-Spanne
+    muss unter dem geteilten Daten-Lock laufen, sonst kann ein Hintergrund-
+    Sync (apply_merged_doc) dazwischen schreiben und die frisch gemergte
+    Änderung verlieren."""
+    from src import sync
+    lock = threading.RLock()
+    storage, settings, conflicts = _stores(tmp_path, lock)
+    conflicts.save_all([{
+        "id": "c1", "kind": "entry", "key": "2026-01-01",
+        "candidates": [], "detected_at": "", "resolved": False,
+        "resolution": None, "resolved_at": None, "resolved_by": None,
+    }])
+    held = []
+    orig = conflicts.save_all
+
+    def spy(all_conflicts):
+        held.append(not _other_thread_can_acquire(lock))
+        return orig(all_conflicts)
+
+    conflicts.save_all = spy
+    chosen = {"slots": [{"start": "08:00", "end": "16:00", "pause": 0, "kategorie": ""}]}
+    sync.resolve_conflict("c1", chosen, conflicts, storage, settings,
+                           device_id="A", data_lock=lock)
+    assert held == [True]
+    assert storage.get("2026-01-01") == {"slots": chosen["slots"]}
+    assert conflicts.get_all()[0]["resolved"] is True
+
+
 def test_reconcile_holds_data_lock_during_rebase_and_apply(tmp_path, monkeypatch):
     """Der Reconcile-Rebase+Replace (reservations_sync) läuft unter dem
     geteilten Daten-Lock — kein UI-Save kann zwischen Rebase-Read und


### PR DESCRIPTION
## ℹ️ Teil der Audit-Serie (2026-07-04)

Reihenfolge der zusammengehörigen PRs: **#119 → #121 → #122 → #123 → #124**.
Dieser PR (#121) ist unabhängig von #119 (beide gegen `master`), sollte aber vor
#122/#123/#124 gemergt werden — die bauen darauf auf.

## Zusammenfassung

Behebt die drei gravierendsten Findings aus dem Code-Audit vom 2026-07-04 — die Datenschicht war nicht threadsicher, wurde aber aus UI-Thread, Startup-Pull-Thread und Sync-Workern konkurrierend beschrieben:

- **H1 — Lost-Update-Fenster:** `build_local_doc` (Snapshot) → `merge` → `apply_merge` ersetzte den kompletten Store-Stand; ein UI-Save zwischen Snapshot und Replace ging verloren.
- **H2 — Keine Re-Entrancy + geteilte `.tmp`:** Zweiter Sync-Klick / Tray-Sync / Startup-Pull konnten parallel laufen; alle Stores schrieben interleaved in denselben festen Temp-Pfad → `os.replace` konnte korruptes JSON aktivieren (Datenverlust via Quarantäne).
- **M1 — Verwaister Timeout-Worker:** Nach dem Join-Timeout von `_run_push_blocking` schrieb der Daemon-Thread später noch parallel zur UI bzw. mitten im Shutdown.

## Design

Zwei Locks, klare Invarianten (Details: `docs/superpowers/specs/2026-07-04-datenschicht-threadsicherheit-design.md`):

- **`data_lock` (ein geteilter `RLock`):** in alle vier Stores injiziert (`lock=`-Konstruktor-Param, Default: eigener Lock → bestehende Tests unverändert); jede öffentliche Store-Methode lockt. Die Sync-Flows (Pull/Push/Kompaktierung/Kalender-Reconcile) klammern Snapshot→Merge→Apply atomar — **nie über Netzwerk-Calls** (per Test abgesichert: Probe-Thread bestätigt, dass der Lock während `drive.upload` frei ist).
- **`sync_guard` (plain `Lock`):** serialisiert alle fünf Drive-Sync-Einstiege (Startup-Pull, Manual, Tray, Quit-Push, Kompaktierung). Acquired **und** released im innersten Worker-Thread (`finally`, nach der letzten Store-Mutation) — nie in UI-Callbacks, nie beim Join-Timeout. Ein verwaister Worker hält den Guard bis zum echten Ende und *ist* damit der laufende Sync, statt parallel zu schreiben (M1 → benign). Zweitklick/Tray skippen still (`{"skipped": true}`, Sync-Button ist währenddessen deaktiviert); nur der Quit-Push wartet bis 5 s auf einen laufenden Sync (Quit-Worst-Case ~10 s statt 5 s — bewusster Trade-off gegen den Doppel-Push).
- **Konflikt-Auflösung:** `sync.resolve_conflict` (UI-Thread) macht sein Read-Modify-Write auf der Konfliktliste jetzt ebenfalls unter dem `data_lock` (Finding aus dem Whole-Branch-Review).

**Bewusst außerhalb des Scopes** (im Spec dokumentiert): M6 (Cross-Store-Transaktionalität — Crash *zwischen* den vier Apply-Writes bleibt möglich, der Lock serialisiert nur), N1 (`fsync`), H5 (`settings_dialog`-Thread-Vertrag), M2/M3 (Drive Optimistic-Locking / Split-Brain).

## Nachtrag: Folgefix Sync-Button (Commit `0c1ed90`)

Nach dem ersten Push kam ein Folgefix dazu, der zum `sync_guard` oben gehört:
Der Sync-Button ist ein themed `icon_button` (ein `_LabelButton`/`Frame`, **ohne**
`-state`-Option). Der ursprüngliche Deaktivierungs-Versuch per `.config(state=…)`
warf beim Klick `TclError: unknown option "-state"`. Ersetzt durch den
Optik-only-Helfer `set_icon_button_enabled` (dimmt `fg`, kein `-state`) plus ein
`_sync_in_progress`-Guard-Flag im Orchestrator (re-entranter Klick ist still
No-op). Enthält drei zusätzliche Tests (`test_sync_orchestrator.py`:
`…_dims_button`, `…_reenables_button`, `…_reentrant_is_noop`).

## Tests

- **+27 neue Tests** (`test_store_locking.py`, `test_sync_threading.py`, Orchestrator-Erweiterungen): deterministisch über Probe-Threads/Events — keine sleeps, keine Timing-Asserts. Abgedeckt: Lock während Disk-Write/Apply/Kompaktierung gehalten, Lock während Upload frei, Guard-Skip, Guard-Release nach Lauf, Quit-Wartefenster, skipped-Handling in der UI, Stresstest (parallele Writes → Datei bleibt valides JSON).
- Gesamtsuite: **744 passed, 3 skipped**, ruff clean.
- Manueller Smoke (Windows): App-Start `v1.17.0`, Eintrag anlegen, Beenden ohne Hänger.

Architektur-Doku (`src/CLAUDE.md` → Threading-Modell) ist im PR mitgepflegt. Kein `release:*`-Label — reiner Fix-PR, Release folgt separat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016pPmbLT2BQqZx9qhfTXWFD

