### PR TITLE
fix(theme): conflicts_dialog ans Dialog-Theme + create_dialog-Helfer (Audit H3/M13)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,6 +184,12 @@ dialogspezifischen Stil-Extras (Farbakzente, abweichende Fonts o.ä.) ohne
 Rücksprache — das Theme bleibt bewusst einheitlich über alle Dialoge hinweg,
 nicht pro Dialog individualisiert.
 
+Neue Dialoge entstehen über `theme.create_dialog(parent, title, …)` —
+nicht über handgebaute `Toplevel`-Boilerplate; der Helfer setzt die
+komplette Fenster-Chrome (BG, dunkle Titelleiste, disable_min_max,
+App-Icon, modal/Escape) konventionskonform. `center_dialog_on_parent`
+nach dem Widget-Aufbau bleibt Aufgabe des Dialogs.
+
 ## Tests / CI
 
 `.github/workflows/test.yml` installiert gezielt nur die Pakete, die die Tests brauchen (`pytest`, `holidays==0.99`, `google-api-python-client`, `google-auth`, `google-auth-oauthlib`), **nicht** `requirements.txt`. Grund: `pycairo` (transitive Dep von `xhtml2pdf`) braucht Cairo-Systemheader auf Ubuntu und bricht sonst den CI-Build. Der Import von `xhtml2pdf` in `src/report.py::generate_pdf` ist lazy, daher laufen die Report-Tests ohne die Lib. `holidays` und die Google-Libs sind pure Python ohne C-Deps und problemlos installierbar — letztere sind nötig, weil Tests `src.ui` importieren (z.B. `tests/test_ui_delete.py`), dessen Importkette die Google-Wrapper zieht. Ein zweiter Job läuft `ruff check .` (Lint).

--- a/docs/superpowers/plans/2026-07-04-dialog-theme-helper.md
+++ b/docs/superpowers/plans/2026-07-04-dialog-theme-helper.md
@@ -1,0 +1,535 @@
+# Dialog-Theme-Helfer + conflicts_dialog (Audit H3/M13) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `conflicts_dialog` vollständig ans gemeinsame Dark-Dialog-Theme anschließen (H3) und die 12-fach duplizierte Chrome-Boilerplate durch einen `theme.create_dialog(...)`-Helfer ersetzen (M13), der die Konvention strukturell erzwingt.
+
+**Architecture:** Ein schlanker Chrome-Helfer in `theme.py` (title/resizable/grab/focus/bg/titlebar/minmax/icon/Escape); Content-Styles und `center_dialog_on_parent` bleiben Call-Site. Button-Disable folgt dem bestehenden Optik-only-Muster (`set_primary_button_enabled`) via neuem `set_secondary_button_enabled`. Migration strikt verhaltensgleich pro Stelle. Spec: `docs/superpowers/specs/2026-07-04-dialog-theme-helper-design.md`.
+
+**Tech Stack:** Python 3.10+ / Tkinter; Screenshots via Pillow `ImageGrab` (bereits Dependency); keine neuen Dependencies.
+
+## Global Constraints
+
+- **Gate:** Implementierung startet erst, wenn PR #119 UND PR #121 in `master` sind und `master` in diesen Branch gemergt wurde (Task 0). Alle Zeilennummern gelten „Stand nach Master-Merge — vor dem Edit verifizieren".
+- **Verhaltensgleichheit pro Migrationsstelle** ist das Review-Kriterium: settings und send:22 haben KEIN Escape-Bind; import:411 bleibt resizable und behält seine ungegatete `transient(parent)`-Zeile; theme-interne Dialoge grabben am ENDE (center → grab_set → wait_window) — nichts davon „reparieren".
+- `create_dialog` hat **keinen** transient-Param (transient setzt `center_dialog_on_parent`, gated auf sichtbaren Parent — Tray-Fall).
+- Button-Disable ist **Optik-only** (Muster `set_primary_button_enabled`): Callback muss bei disabled selbst No-op sein.
+- Keine neuen Farben/Fonts außerhalb der Palette (`BG`, `ENTRY_BG`, `CELL_BG`, `ACCENT`, `TEXT`, `TEXT_MUTED`, `FONT`, `FONT_BOLD`).
+- Keine neuen Headless-Tests (Dialog-Chrome ist Tk-gebunden); Verifikation = Gesamtsuite grün + `ruff check .` + Tk-Smoke-Skripte + Screenshots auf der Windows-Dev-Maschine. Smoke-/Screenshot-Skripte leben im Scratchpad, werden NICHT committet.
+- Kommentare/Docstrings deutsch, Stil der umliegenden Dateien.
+- Shell ist PowerShell 5.1: **kein `&&`** — `;` oder separate Befehle.
+- Commit-Messages deutsch mit Conventional-Prefix; jede endet mit `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>` (als zweites `-m`).
+
+---
+
+### Task 0: Gate prüfen, master mergen, Baseline
+
+**Files:** keine Quell-Änderungen (ggf. Merge-Commit).
+
+**Interfaces:**
+- Produces: Branch-Stand mit #119 (`_themed_ok_dialog` ohne accent-Param, `WARNING`-Konstante entfernt) und #121 (`conflicts_dialog` mit `data_lock`-Param) — die Basis aller Code-Zitate in Tasks 1–5.
+
+- [ ] **Step 1: Gate prüfen**
+
+Run: `gh pr view 119 --repo margenheld/Zeiterfassung --json state ; gh pr view 121 --repo margenheld/Zeiterfassung --json state`
+Expected: beide `"state": "MERGED"`. Wenn nicht: **STOPP** — Task nicht fortsetzen, Controller informieren (BLOCKED).
+
+- [ ] **Step 2: master in den Branch mergen**
+
+```powershell
+git checkout master ; git pull ; git checkout fix/dialog-theme-helper ; git merge master
+```
+Expected: Merge ohne Konflikte (Branch enthält bisher nur Docs).
+
+- [ ] **Step 3: Basis verifizieren**
+
+Run: `python -m pytest -q ; ruff check .`
+Expected: 0 failed (≥744 passed), „All checks passed".
+Zusätzlich prüfen (Read): `src/theme.py` enthält KEINE `WARNING`-Konstante mehr und `_themed_ok_dialog(parent, title, message)` hat keinen accent-Param (#119 da); `src/dialogs/conflicts_dialog.py::__init__` hat `data_lock=None` (#121 da).
+
+---
+
+### Task 1: `create_dialog` + `set_secondary_button_enabled` in theme.py
+
+**Files:**
+- Modify: `src/theme.py` (Helfer nach `set_primary_button_enabled` ~Z. 353-371 bzw. vor `themed_askyesno`)
+
+**Interfaces:**
+- Produces: `create_dialog(parent, title, *, resizable=False, modal=True, escape_closes=True) -> tk.Toplevel` und `set_secondary_button_enabled(btn, enabled) -> None`. Tasks 2–4 konsumieren beide.
+- Consumes: bestehende `apply_dark_titlebar`, `disable_min_max`, `apply_app_icon`, `BG`, `CELL_BG`, `ENTRY_BG`, `TEXT`, `TEXT_MUTED`.
+
+- [ ] **Step 1: `set_secondary_button_enabled` einfügen (direkt nach `set_primary_button_enabled`)**
+
+```python
+def set_secondary_button_enabled(btn, enabled):
+    """Pendant zu set_primary_button_enabled für `secondary_button`:
+    deaktiviert = gedämpfte Schrift (TEXT_MUTED) + Pfeil-Cursor, kein
+    Hover-Wechsel. Mutiert `_colors` (Enter/Leave lesen frisch daraus).
+    Wichtig: nur die OPTIK — die `command`/on_click-Bindung bleibt aktiv,
+    daher muss der Callback selbst bei disabled ein No-op machen."""
+    cursor = "hand2" if enabled else "arrow"
+    c = (
+        {"bg": CELL_BG, "fg": TEXT,
+         "hover_bg": ENTRY_BG, "hover_fg": TEXT}
+        if enabled else
+        {"bg": CELL_BG, "fg": TEXT_MUTED,
+         "hover_bg": CELL_BG, "hover_fg": TEXT_MUTED}
+    )
+    btn._colors = c
+    btn.config(bg=c["bg"], cursor=cursor)
+    btn._label.config(bg=c["bg"], fg=c["fg"], cursor=cursor)
+```
+
+- [ ] **Step 2: `create_dialog` einfügen (direkt vor `themed_askyesno`)**
+
+```python
+def create_dialog(parent, title, *, resizable=False, modal=True,
+                  escape_closes=True):
+    """Erzeugt einen konventionskonformen Dialog-Toplevel — DER Einstieg
+    für neue Dialoge (ersetzt die frühere 8-Zeilen-Chrome-Boilerplate).
+
+    Chrome in fester Reihenfolge: title → resizable(False, False) →
+    grab_set → focus_set → configure(bg=BG) → apply_dark_titlebar →
+    disable_min_max → apply_app_icon → <Escape>-Bind auf destroy.
+    focus_set() MUSS nach grab_set() laufen, sonst feuern Tastatur-
+    Bindungen (z.B. Escape) am Dialog nie.
+
+    resizable=True ruft resizable() bewusst NICHT auf (Tk-Default bleibt).
+    modal=False lässt grab_set() weg — für Dialoge, die wie die themed_*-
+    Familie am Ende selbst center→grab_set→wait_window fahren.
+    escape_closes=False lässt den Escape-Bind weg — für Dialoge ohne
+    Escape (Settings) oder mit eigener Escape-Semantik (themed_*).
+
+    KEIN transient-Param: transient setzt center_dialog_on_parent —
+    bewusst gated auf sichtbaren Parent (Tray-Fall, siehe dort).
+    Content-Styles (apply_combobox_style/apply_notebook_style/
+    attach_unfocus_on_click) und center_dialog_on_parent (braucht die
+    fertige Größe) bleiben beim Aufrufer."""
+    dialog = tk.Toplevel(parent)
+    dialog.title(title)
+    if not resizable:
+        dialog.resizable(False, False)
+    if modal:
+        dialog.grab_set()
+    dialog.focus_set()
+    dialog.configure(bg=BG)
+    apply_dark_titlebar(dialog)
+    disable_min_max(dialog)
+    apply_app_icon(dialog)
+    if escape_closes:
+        dialog.bind("<Escape>", lambda _e: dialog.destroy())
+    return dialog
+```
+
+- [ ] **Step 3: Tk-Smoke-Skript ausführen (Scratchpad, nicht committen)**
+
+Datei `<scratchpad>\smoke_create_dialog.py`:
+
+```python
+import sys
+sys.path.insert(0, r"D:\Programme (x86)\Zeiterfassung_Repo\Zeiterfassung")
+import tkinter as tk
+from src.theme import BG, create_dialog
+
+root = tk.Tk()
+root.withdraw()
+
+d1 = create_dialog(root, "Smoke-Default", modal=False)
+assert d1.title() == "Smoke-Default"
+assert d1.cget("bg") == BG
+assert "<Escape>" in d1.bind()
+d1.destroy()
+
+d2 = create_dialog(root, "Smoke-Var", modal=False, escape_closes=False,
+                   resizable=True)
+assert "<Escape>" not in d2.bind()
+d2.destroy()
+
+root.destroy()
+print("SMOKE OK")
+```
+
+Run: `python <scratchpad>\smoke_create_dialog.py`
+Expected: `SMOKE OK` (kein Traceback).
+
+- [ ] **Step 4: Suite + Lint**
+
+Run: `python -m pytest -q ; ruff check .`
+Expected: 0 failed, lint clean.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add src/theme.py
+git commit -m "feat(theme): create_dialog-Chrome-Helfer + set_secondary_button_enabled (Audit M13-Basis)" -m "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: conflicts_dialog ans Theme (H3)
+
+**Files:**
+- Modify: `src/dialogs/conflicts_dialog.py` (Imports, `__init__`, `_build`, `_on_select`, `_resolve_with_candidate`)
+
+**Interfaces:**
+- Consumes: `create_dialog`, `set_secondary_button_enabled`, `secondary_button`, `center_dialog_on_parent`, Palette (Task 1 / Bestand).
+- Produces: identische öffentliche API (`ConflictsDialog(parent, storage, settings, conflicts_store, data_lock=None)`); `data_lock`-Durchreichung aus #121 unangetastet.
+
+- [ ] **Step 1: Vorher-Screenshot (Scratchpad-Skript, wird in Step 4 wiederverwendet)**
+
+Datei `<scratchpad>\shot_conflicts_dialog.py`:
+
+```python
+import json, os, sys, tempfile
+sys.path.insert(0, r"D:\Programme (x86)\Zeiterfassung_Repo\Zeiterfassung")
+import tkinter as tk
+from src.storage import Storage
+from src.settings import Settings
+from src.conflicts_store import ConflictsStore
+from src.dialogs.conflicts_dialog import ConflictsDialog
+from src.theme import init_fonts
+
+OUT = sys.argv[1] if len(sys.argv) > 1 else "conflicts_dialog.png"
+
+tmp = tempfile.mkdtemp()
+conflict = {
+    "id": "c-demo", "kind": "entry", "key": "2026-07-01",
+    "candidates": [
+        {"slots": [{"start": "08:00", "end": "16:00", "pause": 30, "kategorie": ""}],
+         "modified_at": "2026-07-01T10:00:00Z", "device_id": "device-A", "deleted": False},
+        {"slots": [{"start": "09:00", "end": "17:30", "pause": 45, "kategorie": "Büro"}],
+         "modified_at": "2026-07-01T11:00:00Z", "device_id": "device-B", "deleted": False},
+    ],
+    "detected_at": "2026-07-01T12:00:00Z",
+    "resolved": False, "resolution": None, "resolved_at": None, "resolved_by": None,
+}
+with open(os.path.join(tmp, "conflicts.json"), "w", encoding="utf-8") as f:
+    json.dump([conflict], f)
+
+root = tk.Tk()
+root.withdraw()
+init_fonts(root, 1.0)
+dlg = ConflictsDialog(
+    root,
+    Storage(os.path.join(tmp, "z.json"), device_id="local"),
+    Settings(os.path.join(tmp, "s.json")),
+    ConflictsStore(os.path.join(tmp, "conflicts.json")),
+)
+dlg.top.update_idletasks()
+dlg.top.update()
+
+from PIL import ImageGrab
+x, y = dlg.top.winfo_rootx(), dlg.top.winfo_rooty()
+w, h = dlg.top.winfo_width(), dlg.top.winfo_height()
+ImageGrab.grab(bbox=(x - 8, y - 40, x + w + 8, y + h + 8)).save(OUT)
+print("SHOT OK:", OUT)
+```
+
+Run: `python <scratchpad>\shot_conflicts_dialog.py <scratchpad>\conflicts_vorher.png`
+Expected: `SHOT OK` + PNG des heutigen (hellen) Dialogs.
+
+- [ ] **Step 2: Imports + `__init__` umstellen**
+
+Import-Block ersetzen:
+
+```python
+import tkinter as tk
+
+from src import sync
+from src.theme import (
+    ACCENT, BG, ENTRY_BG, FONT, FONT_BOLD, TEXT,
+    center_dialog_on_parent, create_dialog, secondary_button,
+    set_secondary_button_enabled, themed_showerror,
+)
+from src.time_utils import format_iso_datetime
+```
+
+In `__init__` den Chrome-Block (heute: `self.top = tk.Toplevel(parent)` … `self.top.bind("<Escape>", …)`) ersetzen durch:
+
+```python
+        # Chrome komplett über den Konventions-Helfer (Audit H3): bringt
+        # NEU dunkle Titelleiste, BG, disable_min_max, resizable(False).
+        # transient übernimmt center_dialog_on_parent (gated, Tray-sicher).
+        self.top = create_dialog(parent, "Konflikte auflösen")
+
+        self._build()
+        self._refresh_list()
+        center_dialog_on_parent(self.top, parent)
+```
+
+(Der alte `self._build()`/`self._refresh_list()`-Aufruf am Ende von `__init__` entfällt zugunsten dieser Reihenfolge — `center` NACH dem Build, wie überall.)
+
+- [ ] **Step 3: `_build`, `_on_select`, `_resolve_with_candidate` themen**
+
+`_build` komplett ersetzen:
+
+```python
+    def _build(self):
+        left = tk.Frame(self.top, bg=BG)
+        left.pack(side="left", fill="y", padx=8, pady=8)
+
+        tk.Label(left, text="Offene Konflikte", font=FONT_BOLD,
+                 bg=BG, fg=TEXT).pack(anchor="w")
+        # Einzige Listbox der App: dunkel über die Palette (ENTRY_BG wie
+        # Eingabefelder, ACCENT-Selektion), flach ohne Fokusrahmen.
+        self.listbox = tk.Listbox(
+            left, width=40, height=15, font=FONT,
+            bg=ENTRY_BG, fg=TEXT,
+            selectbackground=ACCENT, selectforeground="#ffffff",
+            relief="flat", highlightthickness=0,
+        )
+        self.listbox.pack(fill="y", expand=True)
+        self.listbox.bind("<<ListboxSelect>>", lambda _e: self._on_select())
+
+        self.right = tk.Frame(self.top, bg=BG)
+        self.right.pack(side="right", fill="both", expand=True, padx=8, pady=8)
+
+        self.detail_label = tk.Label(self.right, text="Wähle einen Konflikt links.",
+                                      wraplength=400, justify="left",
+                                      font=FONT, bg=BG, fg=TEXT)
+        self.detail_label.pack(anchor="nw")
+
+        button_row = tk.Frame(self.right, bg=BG)
+        button_row.pack(side="bottom", fill="x", pady=(8, 0))
+        self.btn_a = secondary_button(
+            button_row, "Version A übernehmen",
+            lambda: self._resolve_with_candidate(0))
+        self.btn_b = secondary_button(
+            button_row, "Version B übernehmen",
+            lambda: self._resolve_with_candidate(1))
+        self.btn_a.pack(side="left", padx=4)
+        self.btn_b.pack(side="left", padx=4)
+        # Optik-only-Disable (Muster set_primary_button_enabled) — der
+        # No-op bei disabled läuft über den _selected-Guard im Callback.
+        set_secondary_button_enabled(self.btn_a, False)
+        set_secondary_button_enabled(self.btn_b, False)
+        secondary_button(button_row, "Schließen",
+                         self.top.destroy).pack(side="right")
+```
+
+In `_on_select` die zwei `config(state="normal")`-Zeilen ersetzen:
+
+```python
+        set_secondary_button_enabled(self.btn_a, True)
+        set_secondary_button_enabled(self.btn_b, True)
+```
+
+In `_resolve_with_candidate` den Erfolgs-Schluss ersetzen:
+
+```python
+        self._refresh_list()
+        # Guard-Reset ist PFLICHT: die gedimmten Buttons sind Optik-only —
+        # ohne _selected=None würde ein Klick den alten Konflikt erneut
+        # auflösen (die frühere state="disabled"-Sperre entfällt).
+        self._selected = None
+        set_secondary_button_enabled(self.btn_a, False)
+        set_secondary_button_enabled(self.btn_b, False)
+        self.detail_label.config(text="Konflikt aufgelöst. Wähle den nächsten.")
+```
+
+- [ ] **Step 4: Nachher-Screenshot + Funktions-Smoke**
+
+Run: `python <scratchpad>\shot_conflicts_dialog.py <scratchpad>\conflicts_nachher.png`
+Expected: `SHOT OK`; PNG zeigt dunklen Dialog (BG-Flächen, dunkle Listbox, gedimmte A/B-Buttons).
+Manueller Smoke im selben Skript-Setup optional per App; Pflicht-Check: Konflikt in der Liste anklicken → A/B werden hell; „Version A übernehmen" → Liste leer, Buttons wieder gedimmt, erneuter Klick auf gedimmtes A tut NICHTS (Guard).
+
+- [ ] **Step 5: Suite + Lint + Commit**
+
+Run: `python -m pytest -q ; ruff check .`
+Expected: 0 failed (inkl. `tests/test_conflicts_dialog.py`), lint clean.
+
+```powershell
+git add src/dialogs/conflicts_dialog.py
+git commit -m "fix(theme): conflicts_dialog ans gemeinsame Dialog-Theme (Audit H3)" -m "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Migration der `dialogs/`-Boilerplate (9 Stellen, M13)
+
+**Files:**
+- Modify: `src/dialogs/category_dialog.py:145-155`, `src/dialogs/import_dialog.py:101-112` und `:411-420`, `src/dialogs/share_dialog.py:43-53`, `src/dialogs/export_dialog.py:21-32`, `src/dialogs/settings_dialog.py:47-58`, `src/dialogs/entry_dialog.py:101-114`, `src/dialogs/send_dialog.py:22-30` und `:84-96` (Zeilennummern ≈ Stand master — nach Task 0 pro Stelle verifizieren)
+
+**Interfaces:**
+- Consumes: `create_dialog` (Task 1).
+- Produces: verhaltensgleiche Dialoge; keine API-Änderung.
+
+**Migrationsregel für jede Stelle:** Der Block von `tk.Toplevel(parent)` bis einschließlich `apply_app_icon(...)` (+ ggf. `resizable`/`grab_set`/`focus_set`/`configure(bg=BG)`/Escape-Bind) wird durch EINEN `create_dialog`-Aufruf ersetzt; alles andere (combobox/notebook/unfocus/center/transient) bleibt als Folgezeile stehen. Danach pro Datei den `from src.theme import …`-Block bereinigen: `create_dialog` ergänzen, jetzt ungenutzte Namen entfernen (`ruff check .` meldet F401 exakt; `BG` bleibt fast überall wegen Content-Frames in Benutzung).
+
+- [ ] **Step 1: `category_dialog.py` (Z. 145-155)**
+
+```python
+    dialog = create_dialog(parent, "Kategorien verwalten")
+    attach_unfocus_on_click(dialog)
+```
+
+- [ ] **Step 2: `import_dialog.py:101-112` (Import-Hauptdialog)**
+
+```python
+        self.top = create_dialog(parent, "Daten importieren")
+        apply_combobox_style(self.top)
+        attach_unfocus_on_click(self.top)
+```
+
+- [ ] **Step 3: `import_dialog.py:411-420` (Pro-Tag-Dialog)**
+
+```python
+        self.top = create_dialog(parent, f"Pro Tag entscheiden — {type_label}",
+                                 resizable=True)
+        # Ungegatetes transient wie bisher (Verhaltensgleichheit; das
+        # gegatete transient kommt zusätzlich über center_dialog_on_parent).
+        self.top.transient(parent)
+```
+
+- [ ] **Step 4: `share_dialog.py:43-53`**
+
+```python
+    dialog = create_dialog(parent, "Teilen")
+    attach_unfocus_on_click(dialog)
+```
+
+- [ ] **Step 5: `export_dialog.py:21-32`**
+
+```python
+    dialog = create_dialog(parent, "Als PDF exportieren")
+    apply_combobox_style(dialog)
+    attach_unfocus_on_click(dialog)
+```
+
+- [ ] **Step 6: `settings_dialog.py:47-58` (KEIN Escape — heutiges Verhalten!)**
+
+```python
+    dialog = create_dialog(parent, "Einstellungen", escape_closes=False)
+
+    apply_combobox_style(dialog)
+    apply_notebook_style(dialog)
+```
+
+- [ ] **Step 7: `entry_dialog.py:101-114`** (der focus-nach-grab-Kommentar ist in den Helfer-Docstring gewandert und entfällt hier)
+
+```python
+    dialog = create_dialog(parent, format_iso_weekday_date(date_str))
+    apply_combobox_style(dialog)
+    attach_unfocus_on_click(dialog)
+```
+
+- [ ] **Step 8: `send_dialog.py:22-30` (KEIN Escape) und `:84-96`**
+
+```python
+    dialog = create_dialog(parent, "Keine Zugangsdaten", escape_closes=False)
+```
+
+```python
+    dialog = create_dialog(parent, "Zeitraum wählen")
+
+    apply_combobox_style(dialog)
+    attach_unfocus_on_click(dialog)
+```
+
+- [ ] **Step 9: Imports bereinigen + Verifikation**
+
+Run: `ruff check .` → F401-Meldungen pro Datei abarbeiten (ungenutzte `apply_dark_titlebar`/`disable_min_max`/`apply_app_icon`-Importe entfernen), dann:
+Run: `python -m pytest -q ; ruff check .`
+Expected: 0 failed, lint clean.
+
+- [ ] **Step 10: App-Smoke (Stichproben)**
+
+Run: `python -m src.main` — öffnen/schließen: Tages-Dialog (Escape schließt), Einstellungen (Escape schließt NICHT), Senden→Zeitraum, Export. Optik unverändert dunkel, Dialoge zentriert.
+
+- [ ] **Step 11: Commit**
+
+```powershell
+git add src/dialogs
+git commit -m "refactor(dialogs): Chrome-Boilerplate auf theme.create_dialog migriert (Audit M13)" -m "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Migration der theme-internen Dialoge (3 Stellen, M13)
+
+**Files:**
+- Modify: `src/theme.py` — `themed_askyesno` (~Z. 820-827), `themed_ask_delete_choice` (~Z. 882-889), `_themed_ok_dialog` (~Z. 966-973, Stand nach #119 ohne accent) — pro Stelle gegen Post-Merge-Code verifizieren.
+
+**Interfaces:**
+- Consumes: `create_dialog` (gleiche Datei).
+- Produces: verhaltensgleiche themed_*-Familie.
+
+**Regel:** NUR die Präambel (`dialog = tk.Toplevel(parent)` … `dialog.focus_set()`) ersetzen; die komplette Ende-Mechanik (`<Return>`→click_yes, `<Escape>`→click_no, `WM_DELETE_WINDOW`, `center_dialog_on_parent → grab_set → wait_window`) und der Body bleiben unangetastet.
+
+- [ ] **Step 1: In allen drei Funktionen die Präambel ersetzen durch**
+
+```python
+    dialog = create_dialog(parent, title, modal=False, escape_closes=False)
+```
+
+(`modal=False`: grab läuft wie bisher am Ende vor `wait_window`; `escape_closes=False`: Escape bindet weiter unten auf `click_no`-Semantik. Bekannte, funktionsneutrale Abweichung: `focus_set` läuft jetzt vor `configure(bg)` statt am Präambel-Ende — dokumentiert in der Spec.)
+
+- [ ] **Step 2: Verifikation**
+
+Run: `python -m pytest -q ; ruff check .`
+Expected: 0 failed, lint clean.
+App-Smoke: Sync-Button bei deaktiviertem Sync klicken → themed_showinfo erscheint dunkel, zentriert, OK/Enter/Escape schließen; Rechtsklick-Löschen auf einem Tag mit Eintrag → themed_askyesno erscheint, „Nein"/Escape bricht ab.
+
+- [ ] **Step 3: Commit**
+
+```powershell
+git add src/theme.py
+git commit -m "refactor(theme): themed-Dialoge nutzen create_dialog (Audit M13)" -m "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Doku + Abschluss-Verifikation
+
+**Files:**
+- Modify: `CLAUDE.md` (Abschnitt „Dialog-Styling: ein gemeinsames Theme", kommt mit #119), `src/CLAUDE.md` (Abschnitt „Dialoge (`src/dialogs/`)")
+
+**Interfaces:** keine Code-Änderungen.
+
+- [ ] **Step 1: Root-`CLAUDE.md` ergänzen**
+
+Im Abschnitt „Dialog-Styling: ein gemeinsames Theme" nach dem Satz über die Fenster-Chrome-Helfer einfügen:
+
+```markdown
+Neue Dialoge entstehen über `theme.create_dialog(parent, title, …)` —
+nicht über handgebaute `Toplevel`-Boilerplate; der Helfer setzt die
+komplette Fenster-Chrome (BG, dunkle Titelleiste, disable_min_max,
+App-Icon, modal/Escape) konventionskonform. `center_dialog_on_parent`
+nach dem Widget-Aufbau bleibt Aufgabe des Dialogs.
+```
+
+- [ ] **Step 2: `src/CLAUDE.md` ergänzen**
+
+Im Abschnitt „Dialoge (`src/dialogs/`)" anfügen:
+
+```markdown
+Alle Dialoge beziehen ihre Fenster-Chrome über `theme.create_dialog(...)`
+(Audit M13); Content-Styles (`apply_combobox_style`/`apply_notebook_style`/
+`attach_unfocus_on_click`) und `center_dialog_on_parent` ruft jeder Dialog
+selbst nach dem Aufbau.
+```
+
+- [ ] **Step 3: Gesamtverifikation**
+
+Run: `python -m pytest -q ; ruff check .`
+Expected: 0 failed, lint clean.
+Grep-Check: `Grep "tk.Toplevel(" src/` → nur noch `tooltip.py` (kein Dialog) und `theme.py::create_dialog` selbst.
+
+- [ ] **Step 4: Commit**
+
+```powershell
+git add CLAUDE.md src/CLAUDE.md
+git commit -m "docs: create_dialog als Dialog-Konvention in CLAUDE.md verankert" -m "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Abschluss
+
+Nach Task 5: finaler Whole-Branch-Review, dann Screenshot-Abnahme durch den
+Nutzer (conflicts vorher/nachher via `SendUserFile`), dann
+`superpowers:finishing-a-development-branch` — Branch nach `origin` (Fork),
+PR gegen `margenheld/Zeiterfassung` `master` (Memory `pr-workflow-upstream`),
+kein `release:*`-Label. PR-Text: H3/M13 referenzieren, Spec verlinken,
+Verhaltensgleichheits-Garantie + die eine bewusste Logik-Änderung
+(`_selected = None`) benennen.

--- a/docs/superpowers/plans/2026-07-04-dialog-theme-helper.md
+++ b/docs/superpowers/plans/2026-07-04-dialog-theme-helper.md
@@ -10,7 +10,7 @@
 
 ## Global Constraints
 
-- **Gate:** Implementierung startet erst, wenn PR #119 UND PR #121 in `master` sind und `master` in diesen Branch gemergt wurde (Task 0). Alle Zeilennummern gelten „Stand nach Master-Merge — vor dem Edit verifizieren".
+- **Basis:** Der Branch enthält #119 (accent-bar) und #121 (threading) bereits als lokale Merges (Controller, vor Task 1). Der zugehörige **Reihenfolge-Hinweis gehört in den PR-Body** („baut auf #119 und #121 auf — bitte in dieser Reihenfolge mergen"), nicht mehr als Ausführungs-Gate. Zeilennummern gelten „Stand nach den Merges — vor dem Edit verifizieren".
 - **Verhaltensgleichheit pro Migrationsstelle** ist das Review-Kriterium: settings und send:22 haben KEIN Escape-Bind; import:411 bleibt resizable und behält seine ungegatete `transient(parent)`-Zeile; theme-interne Dialoge grabben am ENDE (center → grab_set → wait_window) — nichts davon „reparieren".
 - `create_dialog` hat **keinen** transient-Param (transient setzt `center_dialog_on_parent`, gated auf sichtbaren Parent — Tray-Fall).
 - Button-Disable ist **Optik-only** (Muster `set_primary_button_enabled`): Callback muss bei disabled selbst No-op sein.
@@ -22,30 +22,18 @@
 
 ---
 
-### Task 0: Gate prüfen, master mergen, Baseline
+### Task 0: Basis verifizieren (Merges bereits erledigt)
 
-**Files:** keine Quell-Änderungen (ggf. Merge-Commit).
+**Files:** keine Änderungen — nur Verifikation.
 
 **Interfaces:**
-- Produces: Branch-Stand mit #119 (`_themed_ok_dialog` ohne accent-Param, `WARNING`-Konstante entfernt) und #121 (`conflicts_dialog` mit `data_lock`-Param) — die Basis aller Code-Zitate in Tasks 1–5.
+- Produces: bestätigter Branch-Stand mit #119 (`_themed_ok_dialog` ohne accent-Param, `WARNING`-Konstante entfernt) und #121 (`conflicts_dialog` mit `data_lock`-Param) — die Basis aller Code-Zitate in Tasks 1–5. Die Merges (`a8e4f11`, `1ace7fb`) hat der Controller vor Task 1 gesetzt.
 
-- [ ] **Step 1: Gate prüfen**
-
-Run: `gh pr view 119 --repo margenheld/Zeiterfassung --json state ; gh pr view 121 --repo margenheld/Zeiterfassung --json state`
-Expected: beide `"state": "MERGED"`. Wenn nicht: **STOPP** — Task nicht fortsetzen, Controller informieren (BLOCKED).
-
-- [ ] **Step 2: master in den Branch mergen**
-
-```powershell
-git checkout master ; git pull ; git checkout fix/dialog-theme-helper ; git merge master
-```
-Expected: Merge ohne Konflikte (Branch enthält bisher nur Docs).
-
-- [ ] **Step 3: Basis verifizieren**
+- [ ] **Step 1: Basis verifizieren**
 
 Run: `python -m pytest -q ; ruff check .`
-Expected: 0 failed (≥744 passed), „All checks passed".
-Zusätzlich prüfen (Read): `src/theme.py` enthält KEINE `WARNING`-Konstante mehr und `_themed_ok_dialog(parent, title, message)` hat keinen accent-Param (#119 da); `src/dialogs/conflicts_dialog.py::__init__` hat `data_lock=None` (#121 da).
+Expected: 0 failed (744 passed/3 skipped), „All checks passed".
+Zusätzlich prüfen (Grep/Read): `src/theme.py` enthält KEINE `WARNING`-Konstante mehr und `_themed_ok_dialog(parent, title, message)` hat keinen accent-Param (#119 da); `src/dialogs/conflicts_dialog.py::__init__` hat `data_lock=None` (#121 da). Wenn eine Prämisse fehlt: **STOPP** (BLOCKED).
 
 ---
 
@@ -526,10 +514,17 @@ git commit -m "docs: create_dialog als Dialog-Konvention in CLAUDE.md verankert"
 
 ## Abschluss
 
-Nach Task 5: finaler Whole-Branch-Review, dann Screenshot-Abnahme durch den
-Nutzer (conflicts vorher/nachher via `SendUserFile`), dann
+Nach Task 5: finaler Whole-Branch-Review (Review-Range **ab dem zweiten
+Merge-Commit** `1ace7fb..HEAD` — nur die H3/M13-Arbeit, nicht die
+gemergten #119/#121-Commits), dann Screenshot-Abnahme durch den Nutzer
+(conflicts vorher/nachher via `SendUserFile`), dann
 `superpowers:finishing-a-development-branch` — Branch nach `origin` (Fork),
 PR gegen `margenheld/Zeiterfassung` `master` (Memory `pr-workflow-upstream`),
-kein `release:*`-Label. PR-Text: H3/M13 referenzieren, Spec verlinken,
-Verhaltensgleichheits-Garantie + die eine bewusste Logik-Änderung
-(`_selected = None`) benennen.
+kein `release:*`-Label.
+
+**PR-Body Pflichtinhalt:** (1) Reihenfolge-Hinweis „baut auf #119 und #121
+auf — bitte erst diese beiden mergen; solange sie offen sind, zeigt dieser
+PR-Diff auch deren Commits, danach nur noch die Dialog-Theme-Arbeit"; (2)
+H3/M13 referenzieren, Spec verlinken; (3) Verhaltensgleichheits-Garantie
+der Migration + die eine bewusste Logik-Änderung (`_selected = None`)
+benennen.

--- a/docs/superpowers/specs/2026-07-04-dialog-theme-helper-design.md
+++ b/docs/superpowers/specs/2026-07-04-dialog-theme-helper-design.md
@@ -188,10 +188,11 @@ Code verifizieren, v. a. nach #119):
 | `theme.py` themed_askyesno / themed_ask_delete_choice / `_themed_ok_dialog` (3 Stellen) | `modal=False, escape_closes=False` (verifiziert an themed_askyesno, theme.py:820-866; die anderen beiden folgen demselben Aufbau — beim Migrieren gegenprüfen) | komplette Ende-Mechanik: `<Return>`→click_yes, `<Escape>`→click_no, `WM_DELETE_WINDOW`-Protocol, `center_dialog_on_parent → grab_set → wait_window`; Body/Buttons |
 
 Sonderfälle, die die Params erzwingen (keine stillen „Verbesserungen"):
-settings/send:22 haben heute **kein** Escape; import:411 hat heute **kein**
-`resizable(False, False)` und sein transient bleibt als explizite Zeile;
-die theme-internen Dialoge grabben am Ende. Wer beim Migrieren eine
-Abweichung „reparieren" will, tut das NICHT in diesem PR
+settings/send:22 binden Escape separat weiter unten (nicht in der
+Chrome-Präambel) → `escape_closes=False` vermeidet einen Doppel-Bind;
+import:411 hat heute **kein** `resizable(False, False)` und sein transient
+bleibt als explizite Zeile; die theme-internen Dialoge grabben am Ende. Wer
+beim Migrieren eine Abweichung „reparieren" will, tut das NICHT in diesem PR
 (Verhaltensgleichheit ist das Review-Kriterium).
 
 ### 5. Doku

--- a/docs/superpowers/specs/2026-07-04-dialog-theme-helper-design.md
+++ b/docs/superpowers/specs/2026-07-04-dialog-theme-helper-design.md
@@ -1,0 +1,230 @@
+# Design: conflicts_dialog ans Dialog-Theme + create_dialog-Helfer (Audit H3 + M13)
+
+> Stand 2026-07-04 · Ansatz A aus dem Brainstorming zum Audit
+> `AUDIT-2026-07-04.md` (Findings H3, M13; Empfehlung #2).
+
+## Voraussetzungen / Sequenzierung
+
+**Dieser Durchgang setzt zwei offene PRs voraus und startet erst, wenn beide
+in `master` sind:**
+
+- **PR #119** (`fix/dialog-accent-bar`): entfernt den Akzentbalken in
+  `theme.py`s Warn-/Fehler-Dialogen — exakt die Funktionsregion, die M13
+  migriert — und enthält den CLAUDE.md-Konventionstext „ein gemeinsames
+  Dialog-Theme", auf den sich H3 stützt.
+- **PR #121** (`fix/datenschicht-threadsicherheit`): hat
+  `conflicts_dialog.py` um den `data_lock`-Parameter erweitert; das Theming
+  baut auf diesem Stand auf.
+
+Branch: `fix/dialog-theme-helper` ab `master` (kein Fork-Stacking;
+sequenzielle PRs). Spec + Plan werden sofort auf diesem Branch committet
+(reine Docs, konfliktfrei); die **Implementierung startet erst**, nachdem
+#119 und #121 gemerged sind und `master` in den Branch gemergt wurde —
+alle Zeilennummern/Code-Zitate sind dann gegen den aktualisierten Stand zu
+verifizieren.
+
+## Problem
+
+- **H3:** `src/dialogs/conflicts_dialog.py` verstößt komplett gegen das
+  gemeinsame Dialog-Theme: native `tk.Frame`/`Label`/`Listbox`/`Button` ohne
+  `BG`, kein `apply_dark_titlebar`/`disable_min_max`, kein
+  `resizable(False, False)`, kein `center_dialog_on_parent` — einziger
+  Theme-Aufruf ist `apply_app_icon` (Z. 51). Ergebnis: hellgrauer
+  System-Dialog mitten in der Dark-App. Alle anderen Dialoge halten die
+  Konvention ein.
+- **M13:** Die 8-Zeilen-Chrome-Boilerplate (`Toplevel → title → resizable →
+  grab_set/focus_set → configure(bg=BG) → apply_dark_titlebar →
+  disable_min_max → apply_app_icon`) ist ~12× dupliziert
+  (`entry_dialog.py:101`, `settings_dialog.py:47`, `send_dialog.py:22` und
+  `:84`, `export_dialog.py:21`, `share_dialog.py:43`, `import_dialog.py:101`
+  und `:411`, `category_dialog.py:145`, 3× `theme.py` in den themed-Dialogen
+  — Zeilennummern: master-Stand `86cd70d`, verschieben sich durch #119/#121
+  leicht). Genau diese fehlende Struktur ist die Lücke, durch die H3
+  gerutscht ist.
+
+## Ziele / Nicht-Ziele
+
+**Ziele:** conflicts_dialog vollständig ans Theme; `create_dialog`-Helfer,
+der die Chrome-Konvention strukturell erzwingt; alle 12 Bestandsstellen
+**verhaltensgleich** migriert; Konvention in CLAUDE.md um den Helfer ergänzt.
+
+**Nicht-Ziele:**
+- Kein Layout-/UX-Umbau des conflicts_dialog (Liste links, Details rechts,
+  A/B + Schließen bleiben).
+- Content-Styles bleiben Call-Site-Sache: `apply_combobox_style`,
+  `apply_notebook_style`, `attach_unfocus_on_click` und
+  `center_dialog_on_parent` (braucht die fertige Dialog-Größe → nach dem
+  Build) wandern NICHT in den Helfer.
+- Keine neuen Farben/Fonts außerhalb der bestehenden Palette.
+- Kein Tk-UI-Test-Framework (Chrome ist headless untestbar, wie gehabt —
+  Audit M16 bleibt offen).
+
+## Design
+
+### 1. `theme.create_dialog(...)` — der Chrome-Helfer
+
+```python
+def create_dialog(parent, title, *, resizable=False, modal=True,
+                  escape_closes=True):
+    """Erzeugt einen konventionskonformen Dialog-Toplevel (Chrome komplett):
+    title → [resizable(False, False)] → [grab_set] → focus_set →
+    configure(bg=BG) → apply_dark_titlebar → disable_min_max →
+    apply_app_icon → [<Escape>-Bind auf destroy]. Liefert das Toplevel.
+
+    focus_set() MUSS nach grab_set() laufen, sonst feuern Tastatur-
+    Bindungen (z.B. Escape) am Dialog nie (Kommentar aus entry_dialog
+    hierher übernommen — er gilt für alle Dialoge).
+
+    KEIN transient-Param: transient setzt center_dialog_on_parent —
+    bewusst gated auf sichtbaren Parent (Tray-Fall, siehe dessen
+    Docstring). Ein ungegatetes transient hier wäre genau die Falle,
+    die das Gating verhindert.
+
+    Content-Styles (apply_combobox_style/apply_notebook_style/
+    attach_unfocus_on_click) und center_dialog_on_parent (braucht die
+    fertige Größe) bleiben bewusst beim Aufrufer."""
+```
+
+Parameter-Semantik (bildet die reale Varianz der 12 Stellen ab):
+- `resizable=False` → ruft `resizable(False, False)`; `resizable=True` →
+  ruft **nichts** (Tk-Default bleibt, verhaltensgleich zu heutigen Stellen
+  ohne resizable-Zeile).
+- `modal=True` → `grab_set()`; `modal=False` → kein grab. Die
+  theme-internen Dialoge nutzen `modal=False`: ihr grab läuft heute am
+  **Ende** (`center_dialog_on_parent → grab_set → wait_window`,
+  theme.py:864-866) und bleibt dort — der Helfer ersetzt nur ihre
+  Chrome-Präambel.
+- `escape_closes=True` → `dialog.bind("<Escape>", lambda _e:
+  dialog.destroy())`; `False` → kein Bind. `False` gilt für settings,
+  send:22 (heute kein Escape) UND die theme-internen Dialoge (deren
+  Escape bindet auf `click_no()`/Result-Semantik + `WM_DELETE_WINDOW`-
+  Protocol — bleibt vollständig an der Call-Site).
+- **Kein `transient`-Param** (siehe Docstring). `import_dialog.py:411`
+  behält seine heutige ungegatete `self.top.transient(parent)`-Zeile
+  explizit an der Call-Site (Verhaltensgleichheit); alle zentrierenden
+  Dialoge bekommen transient ohnehin korrekt gated über
+  `center_dialog_on_parent`.
+- Reihenfolge im Helfer ist fix (siehe Docstring). Sie entspricht dem
+  Muster der `dialogs/`-Stellen; bei den theme-internen Stellen steht
+  `focus_set` heute am Ende der Präambel statt vor `configure(bg)` —
+  funktionsneutral (kein grab beteiligt), wird als bekannte, unschädliche
+  Reihenfolgen-Abweichung akzeptiert.
+
+Lage in `theme.py`: bei den anderen Fenster-Chrome-Helfern
+(`apply_dark_titlebar`/`disable_min_max`/…).
+
+### 2. `set_secondary_button_enabled(btn, enabled)` — bestehendes Muster verallgemeinern
+
+Die A/B-Buttons des conflicts_dialog brauchen Enabled/Disabled. Das Repo
+hat dafür **bereits ein etabliertes Muster**: `set_primary_button_enabled`
+(theme.py:353-371) — **Optik-only** (mutiert `_colors`, dimmt auf
+Disabled-Farben, Cursor arrow, kein Hover-Wechsel); die Klick-Bindung
+bleibt aktiv, und **der Callback selbst muss bei disabled ein No-op sein**
+(so dokumentiert es der bestehende Docstring). KEINE Änderung an
+`label_button`, KEIN neues `_enabled`-Flag — wir folgen dem Muster:
+
+```python
+def set_secondary_button_enabled(btn, enabled):
+    """Pendant zu set_primary_button_enabled für secondary_buttons:
+    enabled = CELL_BG/TEXT mit ENTRY_BG-Hover; disabled = CELL_BG/
+    TEXT_MUTED ohne Hover-Wechsel + Pfeil-Cursor. Nur Optik — der
+    Callback muss bei disabled selbst ein No-op machen (Muster von
+    set_primary_button_enabled)."""
+```
+
+**Callback-No-op-Vertrag im conflicts_dialog:** der bestehende Guard
+`if self._selected is None: return` in `_resolve_with_candidate` trägt
+das — **aber nur, wenn der Erfolgspfad `self._selected = None` setzt**
+(heute schützt `tk.Button(state="disabled")` hart; nach der Migration
+schützt der Guard, also MUSS nach erfolgreicher Resolution
+`self._selected = None` gesetzt werden, sonst löst ein Klick auf den
+gedimmten Button den alten Konflikt erneut aus). Diese eine Zeile ist
+die einzige beabsichtigte Logik-Änderung im Dialog.
+
+### 3. conflicts_dialog ans Theme (H3)
+
+Layout unverändert; nur Chrome + Widget-Theming:
+
+- Chrome: `self.top = create_dialog(parent, "Konflikte auflösen")`
+  (modal + Escape wie heute; NEU dazu: bg, dunkle Titelleiste,
+  disable_min_max, `resizable(False, False)`); nach `self._build()` NEU:
+  `center_dialog_on_parent(self.top, parent)` — das ersetzt zugleich das
+  heutige ungegatete `transient(parent)` durch die gegatete Variante
+  (Verhaltensänderung nur im Tray-Fall, dort die korrektere; der
+  reale Parent ist der immer sichtbare Settings-Dialog).
+- Frames: `bg=BG`. Labels: `bg=BG, fg=TEXT, font=FONT` („Offene Konflikte"
+  als `FONT_BOLD` analog zu Section-Headern anderer Dialoge).
+- **Listbox** (einzige im Repo — Palette-Anwendung, kein neues Konzept):
+  `bg=ENTRY_BG, fg=TEXT, selectbackground=ACCENT,
+  selectforeground="#ffffff", relief="flat", highlightthickness=0,
+  font=FONT`.
+- Buttons: `secondary_button` für „Version A übernehmen", „Version B
+  übernehmen" und „Schließen" (zwei gleichwertige Wahloptionen — bewusst
+  kein Primary-Akzent). A/B starten disabled
+  (`set_secondary_button_enabled(btn, False)`), werden bei Auswahl
+  enabled, nach Resolution wieder disabled + `self._selected = None`
+  (siehe Abschnitt 2 — ersetzt die heutige harte `state`-Sperre).
+- `data_lock`-Durchreichung aus PR #121 bleibt unangetastet.
+
+### 4. Migration der 12 Bestandsstellen (M13)
+
+**Eiserne Regel: verhaltensgleich pro Stelle.** Der Helfer wird mit exakt
+den Parametern aufgerufen, die den Ist-Zustand reproduzieren; was der
+Helfer nicht abdeckt, bleibt als Folgezeile an der Call-Site. Konkret
+(Ist-Stand master; vor der Umsetzung pro Stelle gegen den dann aktuellen
+Code verifizieren, v. a. nach #119):
+
+| Stelle | create_dialog-Params | bleibt an der Call-Site |
+|---|---|---|
+| `category_dialog.py:145` | Defaults | `attach_unfocus_on_click`, center (existiert) |
+| `import_dialog.py:101` | Defaults | combobox, unfocus, center |
+| `import_dialog.py:411` | `resizable=True` | explizite `self.top.transient(parent)`-Zeile (heutiges ungegatetes Verhalten), center |
+| `share_dialog.py:43` | Defaults | unfocus, center |
+| `export_dialog.py:21` | Defaults | combobox, unfocus, center |
+| `settings_dialog.py:47` | `escape_closes=False` | combobox, notebook, center |
+| `entry_dialog.py:101` | Defaults | combobox, unfocus, center; Warum-Kommentar zu focus-nach-grab wandert in den Helfer-Docstring |
+| `send_dialog.py:22` | `escape_closes=False` | center |
+| `send_dialog.py:84` | Defaults | combobox, unfocus, center |
+| `theme.py` themed_askyesno / themed_ask_delete_choice / `_themed_ok_dialog` (3 Stellen) | `modal=False, escape_closes=False` (verifiziert an themed_askyesno, theme.py:820-866; die anderen beiden folgen demselben Aufbau — beim Migrieren gegenprüfen) | komplette Ende-Mechanik: `<Return>`→click_yes, `<Escape>`→click_no, `WM_DELETE_WINDOW`-Protocol, `center_dialog_on_parent → grab_set → wait_window`; Body/Buttons |
+
+Sonderfälle, die die Params erzwingen (keine stillen „Verbesserungen"):
+settings/send:22 haben heute **kein** Escape; import:411 hat heute **kein**
+`resizable(False, False)` und sein transient bleibt als explizite Zeile;
+die theme-internen Dialoge grabben am Ende. Wer beim Migrieren eine
+Abweichung „reparieren" will, tut das NICHT in diesem PR
+(Verhaltensgleichheit ist das Review-Kriterium).
+
+### 5. Doku
+
+- Root-`CLAUDE.md`, Abschnitt „Dialog-Styling: ein gemeinsames Theme"
+  (kommt mit #119): `create_dialog` als Pflicht-Einstieg für neue Dialoge
+  ergänzen („Neue Dialoge entstehen über `theme.create_dialog(...)`, nicht
+  über handgebaute Toplevel-Boilerplate").
+- `src/CLAUDE.md`: Dialog-Abschnitt um einen Satz zum Helfer ergänzen.
+
+## Verifikation
+
+- `pytest` (Gesamtsuite grün — Dialog-Chrome ist Tk-gebunden, es gibt
+  bewusst keine neuen Headless-Tests; `set_secondary_button_enabled` ist
+  ebenfalls Tk-gebunden) + `ruff check .`.
+- **Screenshot-Abnahme** (Windows, etablierter Workflow): conflicts_dialog
+  vorher/nachher; Stichproben der migrierten Dialoge (entry, settings,
+  send, ein themed_showinfo), um Verhaltens-/Optikgleichheit zu belegen.
+  Dafür braucht der conflicts_dialog Testdaten: einen Konflikt lokal in
+  `conflicts.json` einspielen (dev-data-Modus, vgl. `--dev`-Branch-Ansatz —
+  oder minimal: temporäre conflicts.json mit einem unresolved-Eintrag).
+- Manueller Smoke: App-Start, Settings öffnen/schließen, Tages-Dialog
+  öffnen/speichern, Escape-Verhalten stichprobenartig (settings darf
+  NICHT auf Escape schließen — heutiges Verhalten).
+
+## Risiken
+
+- **Merge-Reihenfolge:** startet erst nach #119 + #121 (siehe
+  Voraussetzungen); Zeilennummern in dieser Spec verschieben sich —
+  Migrationsregel gilt gegen den dann aktuellen Code.
+- **theme.py-interne Dialoge:** deren Ende-Mechanik (center → grab →
+  wait_window) bleibt komplett an der Call-Site — der Helfer ersetzt nur
+  die Präambel; beim Migrieren pro Stelle gegen den Post-#119-Code prüfen.
+- **Optik-only-Disable:** ohne die neue Zeile `self._selected = None`
+  nach der Resolution wäre der gedimmte A/B-Button klickbar-wirksam
+  (Guard griffe nicht) — im Review explizit gegenprüfen.

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -159,6 +159,11 @@ löschen — siehe Root-`CLAUDE.md`): `entry_dialog` (Tages-Dialog, rein zum Spe
 `conflicts_dialog`. `period_picker` ist kein Dialog, sondern der von
 `send_dialog` + `export_dialog` geteilte Zeitraum+Kategorie+Vorschau-Baustein.
 
+Alle Dialoge beziehen ihre Fenster-Chrome über `theme.create_dialog(...)`
+(Audit M13); Content-Styles (`apply_combobox_style`/`apply_notebook_style`/
+`attach_unfocus_on_click`) und `center_dialog_on_parent` ruft jeder Dialog
+selbst nach dem Aufbau.
+
 ## Wo gehört neuer Code hin?
 
 - Rendering/Zell-Logik → `grid_renderer.py`. Neuer Hintergrund-Task → `background_tasks.py`

--- a/src/dialogs/category_dialog.py
+++ b/src/dialogs/category_dialog.py
@@ -13,9 +13,8 @@ import tkinter as tk
 from src.settings import WEEKDAY_KEYS
 from src.theme import (
     BG, FONT, FONT_BOLD, PAUSE_VALUES, TEXT, TEXT_MUTED, TIME_VALUES,
-    apply_app_icon, apply_dark_titlebar, attach_unfocus_on_click,
-    center_dialog_on_parent, dark_combo, dark_entry, disable_min_max,
-    primary_button, secondary_button, themed_askyesno,
+    attach_unfocus_on_click, center_dialog_on_parent, create_dialog,
+    dark_combo, dark_entry, primary_button, secondary_button, themed_askyesno,
 )
 from src.time_utils import DAYS_DE
 
@@ -142,17 +141,8 @@ def open_category_dialog(parent, settings, on_change=None):
     categories = list(settings.get("categories") or [])
     category_times = dict(settings.get("category_times") or {})
 
-    dialog = tk.Toplevel(parent)
-    dialog.title("Kategorien verwalten")
-    dialog.resizable(False, False)
-    dialog.grab_set()
-    dialog.focus_set()
-    dialog.configure(bg=BG)
-    apply_dark_titlebar(dialog)
-    disable_min_max(dialog)
-    apply_app_icon(dialog)
+    dialog = create_dialog(parent, "Kategorien verwalten")
     attach_unfocus_on_click(dialog)
-    dialog.bind("<Escape>", lambda _e: dialog.destroy())
 
     outer = tk.Frame(dialog, bg=BG)
     outer.pack(padx=12, pady=12)

--- a/src/dialogs/conflicts_dialog.py
+++ b/src/dialogs/conflicts_dialog.py
@@ -2,7 +2,11 @@
 import tkinter as tk
 
 from src import sync
-from src.theme import apply_app_icon, themed_showerror
+from src.theme import (
+    ACCENT, BG, ENTRY_BG, FONT, FONT_BOLD, TEXT,
+    center_dialog_on_parent, create_dialog, secondary_button,
+    set_secondary_button_enabled, themed_showerror,
+)
 from src.time_utils import format_iso_datetime
 
 
@@ -43,44 +47,56 @@ class ConflictsDialog:
         self._data_lock = data_lock
         self._selected = None
 
-        self.top = tk.Toplevel(parent)
-        self.top.title("Konflikte auflösen")
-        self.top.transient(parent)
-        self.top.grab_set()
-        self.top.focus_set()
-        apply_app_icon(self.top)
-        self.top.bind("<Escape>", lambda _e: self.top.destroy())
+        # Chrome komplett über den Konventions-Helfer (Audit H3): bringt
+        # NEU dunkle Titelleiste, BG, disable_min_max, resizable(False).
+        # transient übernimmt center_dialog_on_parent (gated, Tray-sicher).
+        self.top = create_dialog(parent, "Konflikte auflösen")
 
         self._build()
         self._refresh_list()
+        center_dialog_on_parent(self.top, parent)
 
     def _build(self):
-        left = tk.Frame(self.top)
+        left = tk.Frame(self.top, bg=BG)
         left.pack(side="left", fill="y", padx=8, pady=8)
 
-        tk.Label(left, text="Offene Konflikte").pack(anchor="w")
-        self.listbox = tk.Listbox(left, width=40, height=15)
+        tk.Label(left, text="Offene Konflikte", font=FONT_BOLD,
+                 bg=BG, fg=TEXT).pack(anchor="w")
+        # Einzige Listbox der App: dunkel über die Palette (ENTRY_BG wie
+        # Eingabefelder, ACCENT-Selektion), flach ohne Fokusrahmen.
+        self.listbox = tk.Listbox(
+            left, width=40, height=15, font=FONT,
+            bg=ENTRY_BG, fg=TEXT,
+            selectbackground=ACCENT, selectforeground="#ffffff",
+            relief="flat", highlightthickness=0,
+        )
         self.listbox.pack(fill="y", expand=True)
         self.listbox.bind("<<ListboxSelect>>", lambda _e: self._on_select())
 
-        self.right = tk.Frame(self.top)
+        self.right = tk.Frame(self.top, bg=BG)
         self.right.pack(side="right", fill="both", expand=True, padx=8, pady=8)
 
         self.detail_label = tk.Label(self.right, text="Wähle einen Konflikt links.",
-                                      wraplength=400, justify="left")
+                                      wraplength=400, justify="left",
+                                      font=FONT, bg=BG, fg=TEXT)
         self.detail_label.pack(anchor="nw")
 
-        button_row = tk.Frame(self.right)
+        button_row = tk.Frame(self.right, bg=BG)
         button_row.pack(side="bottom", fill="x", pady=(8, 0))
-        self.btn_a = tk.Button(button_row, text="Version A übernehmen",
-                               command=lambda: self._resolve_with_candidate(0),
-                               state="disabled")
-        self.btn_b = tk.Button(button_row, text="Version B übernehmen",
-                               command=lambda: self._resolve_with_candidate(1),
-                               state="disabled")
+        self.btn_a = secondary_button(
+            button_row, "Version A übernehmen",
+            lambda: self._resolve_with_candidate(0))
+        self.btn_b = secondary_button(
+            button_row, "Version B übernehmen",
+            lambda: self._resolve_with_candidate(1))
         self.btn_a.pack(side="left", padx=4)
         self.btn_b.pack(side="left", padx=4)
-        tk.Button(button_row, text="Schließen", command=self.top.destroy).pack(side="right")
+        # Optik-only-Disable (Muster set_primary_button_enabled) — der
+        # No-op bei disabled läuft über den _selected-Guard im Callback.
+        set_secondary_button_enabled(self.btn_a, False)
+        set_secondary_button_enabled(self.btn_b, False)
+        secondary_button(button_row, "Schließen",
+                         self.top.destroy).pack(side="right")
 
     def _refresh_list(self):
         self.listbox.delete(0, "end")
@@ -100,8 +116,8 @@ class ConflictsDialog:
             cand_a = _fmt_setting_candidate(c["candidates"][0])
             cand_b = _fmt_setting_candidate(c["candidates"][1])
         self.detail_label.config(text=f"Konflikt für {c['key']}\n\nA: {cand_a}\n\nB: {cand_b}")
-        self.btn_a.config(state="normal")
-        self.btn_b.config(state="normal")
+        set_secondary_button_enabled(self.btn_a, True)
+        set_secondary_button_enabled(self.btn_b, True)
         self._selected = c
 
     def _resolve_with_candidate(self, idx):
@@ -122,6 +138,10 @@ class ConflictsDialog:
             themed_showerror(self.top, "Konflikt-Resolution fehlgeschlagen", str(e))
             return
         self._refresh_list()
-        self.btn_a.config(state="disabled")
-        self.btn_b.config(state="disabled")
+        # Guard-Reset ist PFLICHT: die gedimmten Buttons sind Optik-only —
+        # ohne _selected=None würde ein Klick den alten Konflikt erneut
+        # auflösen (die frühere state="disabled"-Sperre entfällt).
+        self._selected = None
+        set_secondary_button_enabled(self.btn_a, False)
+        set_secondary_button_enabled(self.btn_b, False)
         self.detail_label.config(text="Konflikt aufgelöst. Wähle den nächsten.")

--- a/src/dialogs/entry_dialog.py
+++ b/src/dialogs/entry_dialog.py
@@ -6,9 +6,9 @@ from src.holidays_de import get_holidays
 from src.settings import WEEKDAY_KEYS
 from src.theme import (
     BG, FONT, FONT_BOLD, PAUSE_VALUES, STRAY_CLICK_GUARD_S, TEXT, TEXT_MUTED,
-    TIME_VALUES, apply_app_icon, apply_combobox_style, apply_dark_titlebar,
-    attach_unfocus_on_click, center_dialog_on_parent, dark_combo,
-    disable_min_max, primary_button, secondary_button,
+    TIME_VALUES, apply_combobox_style, attach_unfocus_on_click,
+    center_dialog_on_parent, create_dialog, dark_combo,
+    primary_button, secondary_button,
     set_primary_button_enabled, themed_askyesno, themed_showinfo,
 )
 from src.time_utils import format_iso_weekday_date, get_week_label, validate_slots
@@ -98,20 +98,9 @@ def open_entry_dialog(parent, date_str, storage, settings, on_change,
     default_end = settings.get(f"default_end_{weekday_key}")
     default_pause = settings.get("default_pause")
 
-    dialog = tk.Toplevel(parent)
-    dialog.title(format_iso_weekday_date(date_str))
-    dialog.resizable(False, False)
-    dialog.grab_set()
-    # focus_set() ist nach grab_set() Pflicht, sonst feuern Tastatur-Bindungen
-    # (z.B. Escape) am Dialog nie.
-    dialog.focus_set()
-    dialog.configure(bg=BG)
-    apply_dark_titlebar(dialog)
-    disable_min_max(dialog)
-    apply_app_icon(dialog)
+    dialog = create_dialog(parent, format_iso_weekday_date(date_str))
     apply_combobox_style(dialog)
     attach_unfocus_on_click(dialog)
-    dialog.bind("<Escape>", lambda _e: dialog.destroy())
 
     outer = tk.Frame(dialog, bg=BG)
     outer.pack(padx=12, pady=12)

--- a/src/dialogs/export_dialog.py
+++ b/src/dialogs/export_dialog.py
@@ -8,9 +8,8 @@ from src.time_utils import validate_period
 from src.dialogs.period_picker import build_period_picker
 from src.theme import (
     BG,
-    apply_app_icon, apply_combobox_style, apply_dark_titlebar,
-    attach_unfocus_on_click, center_dialog_on_parent,
-    disable_min_max, primary_button, secondary_button,
+    apply_combobox_style, attach_unfocus_on_click, center_dialog_on_parent,
+    create_dialog, primary_button, secondary_button,
     set_primary_button_enabled, themed_showerror, themed_showinfo,
 )
 
@@ -18,18 +17,9 @@ from src.theme import (
 def open_export_dialog(parent, storage, settings):
     """Modal: Zeitraum + Kategorien wählen, daraus die PDF erzeugen und lokal
     über einen 'Speichern unter'-Dialog speichern. Kein Gmail nötig."""
-    dialog = tk.Toplevel(parent)
-    dialog.title("Als PDF exportieren")
-    dialog.resizable(False, False)
-    dialog.grab_set()
-    dialog.focus_set()
-    dialog.configure(bg=BG)
-    apply_dark_titlebar(dialog)
-    disable_min_max(dialog)
-    apply_app_icon(dialog)
+    dialog = create_dialog(parent, "Als PDF exportieren")
     apply_combobox_style(dialog)
     attach_unfocus_on_click(dialog)
-    dialog.bind("<Escape>", lambda _e: dialog.destroy())
 
     picker_frame, picker = build_period_picker(
         dialog, storage, settings, on_change=lambda: _refresh_export_btn())

--- a/src/dialogs/import_dialog.py
+++ b/src/dialogs/import_dialog.py
@@ -20,9 +20,9 @@ from src.share import (
 from src.time_utils import format_iso_date
 from src.theme import (
     BG, CELL_BG, FONT, FONT_SMALL, TEXT, TEXT_MUTED,
-    apply_app_icon, apply_combobox_style, apply_dark_titlebar,
-    attach_unfocus_on_click, center_dialog_on_parent, disable_min_max,
-    dark_combo, primary_button, secondary_button, themed_showerror, themed_showinfo,
+    apply_combobox_style, attach_unfocus_on_click, center_dialog_on_parent,
+    create_dialog, dark_combo, primary_button, secondary_button,
+    themed_showerror, themed_showinfo,
 )
 
 
@@ -98,18 +98,9 @@ class _ImportSummaryDialog:
         if reservations:
             self.sections.append(self._make_section("reservations", "Reservierungen", reservations, False))
 
-        self.top = tk.Toplevel(parent)
-        self.top.title("Daten importieren")
-        self.top.resizable(False, False)
-        self.top.grab_set()
-        self.top.focus_set()
-        self.top.configure(bg=BG)
-        apply_dark_titlebar(self.top)
-        disable_min_max(self.top)
-        apply_app_icon(self.top)
+        self.top = create_dialog(parent, "Daten importieren")
         apply_combobox_style(self.top)
         attach_unfocus_on_click(self.top)
-        self.top.bind("<Escape>", lambda _e: self.top.destroy())
 
         self._build()
         center_dialog_on_parent(self.top, parent)
@@ -408,16 +399,11 @@ class _PerDayDialog:
         self.has_pause = has_pause
         self._result = None
 
-        self.top = tk.Toplevel(parent)
-        self.top.title(f"Pro Tag entscheiden — {type_label}")
+        self.top = create_dialog(parent, f"Pro Tag entscheiden — {type_label}",
+                                 resizable=True)
+        # Ungegatetes transient wie bisher (Verhaltensgleichheit; das
+        # gegatete transient kommt zusätzlich über center_dialog_on_parent).
         self.top.transient(parent)
-        self.top.grab_set()
-        self.top.focus_set()
-        self.top.configure(bg=BG)
-        apply_dark_titlebar(self.top)
-        disable_min_max(self.top)
-        apply_app_icon(self.top)
-        self.top.bind("<Escape>", lambda _e: self.top.destroy())
 
         self._build()
         center_dialog_on_parent(self.top, parent)

--- a/src/dialogs/send_dialog.py
+++ b/src/dialogs/send_dialog.py
@@ -10,24 +10,15 @@ from src.platform_open import open_folder
 from src.report import default_pdf_filename, generate_pdf, generate_report
 from src.theme import (
     BG, FONT, TEXT,
-    apply_app_icon, apply_combobox_style, apply_dark_titlebar,
-    attach_unfocus_on_click, center_dialog_on_parent,
-    disable_min_max, primary_button, secondary_button,
+    apply_combobox_style, attach_unfocus_on_click, center_dialog_on_parent,
+    create_dialog, primary_button, secondary_button,
     themed_showerror, themed_showinfo,
 )
 from src.time_utils import validate_period
 
 
 def show_missing_credentials_dialog(parent, base_path):
-    dialog = tk.Toplevel(parent)
-    dialog.title("Keine Zugangsdaten")
-    dialog.resizable(False, False)
-    dialog.grab_set()
-    dialog.focus_set()
-    dialog.configure(bg=BG)
-    apply_dark_titlebar(dialog)
-    disable_min_max(dialog)
-    apply_app_icon(dialog)
+    dialog = create_dialog(parent, "Keine Zugangsdaten", escape_closes=False)
 
     tk.Label(
         dialog,
@@ -81,19 +72,10 @@ def open_send_dialog(parent, storage, settings, base_path):
         show_missing_credentials_dialog(parent, base_path)
         return
 
-    dialog = tk.Toplevel(parent)
-    dialog.title("Zeitraum wählen")
-    dialog.resizable(False, False)
-    dialog.grab_set()
-    dialog.focus_set()
-    dialog.configure(bg=BG)
-    apply_dark_titlebar(dialog)
-    disable_min_max(dialog)
-    apply_app_icon(dialog)
+    dialog = create_dialog(parent, "Zeitraum wählen")
 
     apply_combobox_style(dialog)
     attach_unfocus_on_click(dialog)
-    dialog.bind("<Escape>", lambda _e: dialog.destroy())
 
     picker_frame, picker = build_period_picker(dialog, storage, settings)
     picker_frame.grid(row=0, column=0, sticky="w")

--- a/src/dialogs/settings_dialog.py
+++ b/src/dialogs/settings_dialog.py
@@ -13,9 +13,8 @@ from src.platform_open import open_folder
 from src.theme import (
     ACCENT, BG, CELL_BG, FONT, FONT_BOLD, FONT_SMALL,
     PAUSE_VALUES, STATUS_OK, TEXT, TEXT_MUTED, TIME_VALUES,
-    apply_app_icon, apply_combobox_style, apply_dark_titlebar,
-    apply_notebook_style, attach_unfocus_on_click,
-    center_dialog_on_parent, disable_min_max,
+    apply_combobox_style, apply_notebook_style, attach_unfocus_on_click,
+    center_dialog_on_parent, create_dialog,
     dark_combo, dark_entry, dark_text,
     primary_button, secondary_button,
     themed_askyesno, themed_showinfo, themed_showwarning, themed_showerror,
@@ -44,15 +43,7 @@ def open_settings_dialog(parent, settings, base_path, on_change, *,
     data_lock/sync_guard: geteilter Store-Lock + Sync-Guard für die Kompaktierung
     (Audit H1/H2) — von App durchgereicht.
     """
-    dialog = tk.Toplevel(parent)
-    dialog.title("Einstellungen")
-    dialog.resizable(False, False)
-    dialog.grab_set()
-    dialog.focus_set()
-    dialog.configure(bg=BG)
-    apply_dark_titlebar(dialog)
-    disable_min_max(dialog)
-    apply_app_icon(dialog)
+    dialog = create_dialog(parent, "Einstellungen", escape_closes=False)
 
     apply_combobox_style(dialog)
     apply_notebook_style(dialog)

--- a/src/dialogs/share_dialog.py
+++ b/src/dialogs/share_dialog.py
@@ -12,8 +12,7 @@ from src.mail import get_gmail_service, is_offline_error, send_email
 from src.share import build_share_doc, serialize_share_doc
 from src.theme import (
     BG, CELL_BG, FONT, TEXT,
-    apply_app_icon, apply_dark_titlebar, attach_unfocus_on_click,
-    center_dialog_on_parent, disable_min_max,
+    attach_unfocus_on_click, center_dialog_on_parent, create_dialog,
     dark_entry, primary_button, secondary_button,
     set_primary_button_enabled, themed_showerror, themed_showinfo,
 )
@@ -40,17 +39,8 @@ def open_share_dialog(parent, storage, settings, base_path, reservation_store=No
         )
         return
 
-    dialog = tk.Toplevel(parent)
-    dialog.title("Teilen")
-    dialog.resizable(False, False)
-    dialog.grab_set()
-    dialog.focus_set()
-    dialog.configure(bg=BG)
-    apply_dark_titlebar(dialog)
-    disable_min_max(dialog)
-    apply_app_icon(dialog)
+    dialog = create_dialog(parent, "Teilen")
     attach_unfocus_on_click(dialog)
-    dialog.bind("<Escape>", lambda _e: dialog.destroy())
 
     row = 0
     tk.Label(

--- a/src/theme.py
+++ b/src/theme.py
@@ -368,6 +368,25 @@ def set_primary_button_enabled(btn, enabled):
     btn._label.config(bg=c["bg"], fg=c["fg"], cursor=cursor)
 
 
+def set_secondary_button_enabled(btn, enabled):
+    """Pendant zu set_primary_button_enabled für `secondary_button`:
+    deaktiviert = gedämpfte Schrift (TEXT_MUTED) + Pfeil-Cursor, kein
+    Hover-Wechsel. Mutiert `_colors` (Enter/Leave lesen frisch daraus).
+    Wichtig: nur die OPTIK — die `command`/on_click-Bindung bleibt aktiv,
+    daher muss der Callback selbst bei disabled ein No-op machen."""
+    cursor = "hand2" if enabled else "arrow"
+    c = (
+        {"bg": CELL_BG, "fg": TEXT,
+         "hover_bg": ENTRY_BG, "hover_fg": TEXT}
+        if enabled else
+        {"bg": CELL_BG, "fg": TEXT_MUTED,
+         "hover_bg": CELL_BG, "hover_fg": TEXT_MUTED}
+    )
+    btn._colors = c
+    btn.config(bg=c["bg"], cursor=cursor)
+    btn._label.config(bg=c["bg"], fg=c["fg"], cursor=cursor)
+
+
 def _toggle_colors(active) -> _ToggleColors:
     if active:
         # Aktive Toggle-Variante: kein Hover-Farbwechsel (würde wie "klickbar" aussehen)
@@ -801,6 +820,44 @@ def _disable_min_max_now(window):
             SWP_NOSIZE | SWP_NOMOVE | SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED)
     except Exception:
         pass
+
+
+def create_dialog(parent, title, *, resizable=False, modal=True,
+                  escape_closes=True):
+    """Erzeugt einen konventionskonformen Dialog-Toplevel — DER Einstieg
+    für neue Dialoge (ersetzt die frühere 8-Zeilen-Chrome-Boilerplate).
+
+    Chrome in fester Reihenfolge: title → resizable(False, False) →
+    grab_set → focus_set → configure(bg=BG) → apply_dark_titlebar →
+    disable_min_max → apply_app_icon → <Escape>-Bind auf destroy.
+    focus_set() MUSS nach grab_set() laufen, sonst feuern Tastatur-
+    Bindungen (z.B. Escape) am Dialog nie.
+
+    resizable=True ruft resizable() bewusst NICHT auf (Tk-Default bleibt).
+    modal=False lässt grab_set() weg — für Dialoge, die wie die themed_*-
+    Familie am Ende selbst center→grab_set→wait_window fahren.
+    escape_closes=False lässt den Escape-Bind weg — für Dialoge ohne
+    Escape (Settings) oder mit eigener Escape-Semantik (themed_*).
+
+    KEIN transient-Param: transient setzt center_dialog_on_parent —
+    bewusst gated auf sichtbaren Parent (Tray-Fall, siehe dort).
+    Content-Styles (apply_combobox_style/apply_notebook_style/
+    attach_unfocus_on_click) und center_dialog_on_parent (braucht die
+    fertige Größe) bleiben beim Aufrufer."""
+    dialog = tk.Toplevel(parent)
+    dialog.title(title)
+    if not resizable:
+        dialog.resizable(False, False)
+    if modal:
+        dialog.grab_set()
+    dialog.focus_set()
+    dialog.configure(bg=BG)
+    apply_dark_titlebar(dialog)
+    disable_min_max(dialog)
+    apply_app_icon(dialog)
+    if escape_closes:
+        dialog.bind("<Escape>", lambda _e: dialog.destroy())
+    return dialog
 
 
 def themed_askyesno(parent, title: str, message: str, lock_ms: int = 0) -> bool:

--- a/src/theme.py
+++ b/src/theme.py
@@ -871,14 +871,7 @@ def themed_askyesno(parent, title: str, message: str, lock_ms: int = 0) -> bool:
     `themed_ask_delete_choice` — verhindert versehentliches Sofort-Bestätigen
     bei Lösch-Rückfragen (z.B. genau eine löschbare Einheit am Tag).
     """
-    dialog = tk.Toplevel(parent)
-    dialog.title(title)
-    dialog.resizable(False, False)
-    dialog.configure(bg=BG)
-    apply_dark_titlebar(dialog)
-    disable_min_max(dialog)
-    apply_app_icon(dialog)
-    dialog.focus_set()
+    dialog = create_dialog(parent, title, modal=False, escape_closes=False)
 
     result = {"value": False}
     unlock = {"ready": lock_ms <= 0}
@@ -933,14 +926,7 @@ def themed_ask_delete_choice(parent, title: str, message: str, options, lock_ms:
     (gedämpfter Rotton, nicht klickbar) — so kann der Klick nicht versehentlich
     den Dialog schließen und auf einem Kalendertag dahinter landen.
     """
-    dialog = tk.Toplevel(parent)
-    dialog.title(title)
-    dialog.resizable(False, False)
-    dialog.configure(bg=BG)
-    apply_dark_titlebar(dialog)
-    disable_min_max(dialog)
-    apply_app_icon(dialog)
-    dialog.focus_set()
+    dialog = create_dialog(parent, title, modal=False, escape_closes=False)
 
     result: dict[str, set[str] | None] = {"value": None}
     # Optionaler kurzer Lock nach dem Öffnen: verhindert versehentliches
@@ -1018,14 +1004,7 @@ def _themed_ok_dialog(parent, title: str, message: str) -> None:
     Eigener Toplevel mit Dark-Theme-Farben und gebrandeter Titelleiste
     (`tkinter.messagebox.*` ist eine Black-Box ohne Customization-Hooks).
     """
-    dialog = tk.Toplevel(parent)
-    dialog.title(title)
-    dialog.resizable(False, False)
-    dialog.configure(bg=BG)
-    apply_dark_titlebar(dialog)
-    disable_min_max(dialog)
-    apply_app_icon(dialog)
-    dialog.focus_set()
+    dialog = create_dialog(parent, title, modal=False, escape_closes=False)
 
     tk.Label(
         dialog, text=message, font=FONT, bg=BG, fg=TEXT,


### PR DESCRIPTION
## ⚠️ Gestapelt auf #119 und #121 — bitte in dieser Reihenfolge mergen

Dieser PR baut auf **#119** (`fix/dialog-accent-bar`) und **#121**
(`fix/datenschicht-threadsicherheit`) auf. Solange die beiden offen sind,
zeigt der Diff hier **auch deren Commits**; sobald #119 und #121 in `master`
sind, schrumpft der Diff automatisch auf die reine Dialog-Theme-Arbeit.
Merge-Reihenfolge: **#119 → #121 → dieser PR**.

## Zusammenfassung

Behebt zwei Audit-Findings (2026-07-04):

- **H3** — `conflicts_dialog.py` war ein hellgrauer System-Dialog mitten in der
  Dark-App (einziger Ausreißer). Jetzt vollständig am gemeinsamen Theme: dunkler
  BG, dunkle Titelleiste, dunkle Listbox (Palette-Farben), `secondary_button`s
  statt nativer `tk.Button`, `disable_min_max`, zentriert über dem Parent.
- **M13** — die ~8-Zeilen-Chrome-Boilerplate (`Toplevel → title → resizable →
  grab_set/focus_set → configure(bg) → apply_dark_titlebar → disable_min_max →
  apply_app_icon`) war **12×** dupliziert. Neuer Helfer
  `theme.create_dialog(parent, title, *, resizable=False, modal=True,
  escape_closes=True)` erzwingt die Konvention strukturell; alle 12 Stellen
  migriert. Grep bestätigt: kein `tk.Toplevel` mehr außerhalb `theme.py`
  (im Helfer selbst) und `tooltip.py` (kein Dialog).

## Design

- `create_dialog` kapselt nur die **Fenster-Chrome**; Content-Styles
  (`apply_combobox_style`/`apply_notebook_style`/`attach_unfocus_on_click`) und
  `center_dialog_on_parent` bleiben bewusst Call-Site (letzteres braucht die
  fertige Dialog-Größe). **Kein** `transient`-Param — transient setzt
  `center_dialog_on_parent` gegated auf sichtbaren Parent (Tray-sicher).
- `set_secondary_button_enabled` folgt dem bestehenden Optik-only-Muster von
  `set_primary_button_enabled` (kein `label_button`-Umbau).
- Migration ist **verhaltensgleich pro Stelle** (Review-Kriterium): `settings`
  und der „Keine Zugangsdaten"-Dialog nutzen `escape_closes=False` (sie binden
  Escape separat weiter unten → kein Doppel-Bind); `import_dialog._PerDayDialog`
  bleibt `resizable=True` und behält seine explizite `transient`-Zeile; die drei
  `themed_*`-Dialoge nutzen `modal=False` (grab läuft bei ihnen am Ende).

**Zwei bewusste Verhaltensänderungen** (beide reviewt):
1. `conflicts_dialog._resolve_with_candidate` setzt nach erfolgreicher Auflösung
   `self._selected = None` — nötig, weil das Button-Disable jetzt Optik-only ist
   (der Guard trägt den Klick-No-op, nicht mehr `tk.Button(state="disabled")`).
2. `conflicts_dialog` zentriert jetzt über dem Parent (vorher Tk-Default-Position)
   und sein `transient` ist gegated — Nebeneffekt der Theme-Angleichung.

## Tests / Verifikation

- Gesamtsuite **744 passed / 3 skipped**, `ruff check .` clean.
- Dialog-Chrome ist Tk-gebunden → keine neuen Headless-Tests (Konvention, Audit
  M16 bleibt offen); Verifikation über Suite + Screenshots + Tk-Smoke.
- H3 Screenshot vorher/nachher lokal abgenommen (heller System-Dialog →
  Dark-Theme).

Kein `release:*`-Label (reiner Fix/Refactor).

Spec/Plan: `docs/superpowers/specs/2026-07-04-dialog-theme-helper-design.md`,
`docs/superpowers/plans/2026-07-04-dialog-theme-helper.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016pPmbLT2BQqZx9qhfTXWFD
