### PR TITLE
fix(settings): Thread-Vertrag der 6 Dialog-Worker + überlebende OAuth-Persistenz (Audit H5)

### DIFF
--- a/docs/superpowers/plans/2026-07-04-settings-dialog-threadvertrag.md
+++ b/docs/superpowers/plans/2026-07-04-settings-dialog-threadvertrag.md
@@ -1,0 +1,581 @@
+# Settings-Dialog Thread-Vertrag (Audit H5) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Die sechs Hintergrund-Worker in `settings_dialog.py` auf das eine sanktionierte Muster (`BackgroundTaskRunner.run(fn, on_done)`) umstellen, sodass die OAuth-Aktivieren-Persistenz einen Dialog-Close überlebt und kein Worker mehr am dokumentierten Thread-Vertrag vorbei arbeitet.
+
+**Architecture:** `open_settings_dialog` bekommt den bestehenden `BackgroundTaskRunner` (`App._bg`) injiziert. Jeder Worker wird `runner.run(fn, on_done)`: `fn` läuft im Daemon-Thread und enthält Blocking-I/O **plus** die überlebende Persistenz (`settings.set(...)`, thread-safe seit #121); `on_done` läuft via `App._marshal_to_ui` auf dem UI-Thread, ruft root-scoped Survivor (`on_change`) zuerst und schützt danach jeden Dialog-Widget-Zugriff mit `winfo_exists`. Die zwei near-identischen OAuth-Aktivieren-Toggles (#2/#6) teilen sich einen modulweiten, headless-testbaren Builder `build_oauth_enable_task`.
+
+**Tech Stack:** Python 3.14, Tkinter, pytest. Kein neuer Dependency.
+
+## Global Constraints
+
+- **Ein Muster (CLAUDE.md):** Hintergrundarbeit ausschließlich über `BackgroundTaskRunner.run(fn, on_done)`; Rückgabe über `App._marshal_to_ui` (root.after, TclError-gesichert). Nach diesem Plan **kein** `threading.Thread` und **kein** `dialog.after(0, …)` mehr in `settings_dialog.py`. Der reine UI-Timer `dialog.after(500, refresh_status)` (Z. 242) ist **kein** Worker und bleibt unangetastet.
+- **Persistenz überlebt Dialog-Close:** `settings.set(...)` steht im `fn` (Worker-Thread), nie hinter einem Dialog-Widget-Zugriff. `settings.set` ist seit #121 thread-safe (geteilter `data_lock`).
+- **`on_done`-Reihenfolge:** root-scoped Survivor (`on_change()`) **vor** dem `winfo_exists`-Guard; Dialog-Widget-Kosmetik (`config`/`var.set`/Messagebox/`_load_calendars`) **danach**, jeweils übersprungen wenn der Dialog weg ist.
+- **`fn` wirft nie:** jedes `fn` fängt seine Exceptions selbst und gibt ein Result-Dict zurück (`{"ok": True, ...}` / `{"ok": False, "error": e, "tb": str}`). Damit kein stiller Thread-Tod.
+- **Result-Dict-Form:** `{"ok": bool}`; im Fehlerfall zusätzlich `"error"` (Exception) und `"tb"` (str). Worker mit Nutzlast ergänzen einen eigenen Schlüssel (`"email"`, `"items"`); die Kompaktierung reicht das Result von `_run_compaction_blocking` unverändert durch.
+- **Tests:** Gesamtsuite `pytest` grün, `ruff check .` sauber. Der Dialog ist Tk-gebunden (M16) → **headless getestet wird nur der Builder** `build_oauth_enable_task`; die Verdrahtung der übrigen Worker wird über die grüne Gesamtsuite + einen manuellen Tk-Smoke abgesichert.
+- **Außerhalb Scope:** H4 (God-Function-Split), N19 (`threading.excepthook`), M10 (andere Dialoge). Nicht anfassen.
+
+Design-Referenz: `docs/superpowers/specs/2026-07-04-settings-dialog-threadvertrag-design.md`.
+
+---
+
+## Task 1: `build_oauth_enable_task`-Builder (modulweit, TDD)
+
+Der DRY-Kern für #2/#6: baut ein testbares `(fn, on_done)`-Paar für einen OAuth-Aktivieren-Toggle. Wird in Task 2 verdrahtet; hier nur der Helfer + seine Tests. Noch **kein** Aufrufer im Dialog.
+
+**Files:**
+- Modify: `src/dialogs/settings_dialog.py` (neuer modulweiter Helfer nach den Imports, vor `def open_settings_dialog`)
+- Test: `tests/test_settings_dialog.py` (neu)
+
+**Interfaces:**
+- Consumes: nichts (nur stdlib `traceback` + `messagebox`, beide bereits in `settings_dialog.py` importiert)
+- Produces:
+  ```python
+  build_oauth_enable_task(*, service_fn, settings, setting_key, checkbox,
+                          toggle_var, on_change, dialog, error_title,
+                          on_success_dialog_ui=None) -> tuple[fn, on_done]
+  # fn() -> {"ok": True} | {"ok": False, "error": Exception, "tb": str}
+  # on_done(res) -> None
+  ```
+  Verhalten: `fn` ruft `service_fn()`; bei Erfolg `settings.set(setting_key, True)` (überlebt Close) und `{"ok": True}`, sonst `{"ok": False, "error", "tb"}`. `on_done`: bei Erfolg `on_change()` (vor Guard); dann `if not checkbox.winfo_exists(): return`; `checkbox.config(state="normal")`; bei Erfolg `on_success_dialog_ui()` (falls gesetzt), bei Fehler `toggle_var.set(False)` + `messagebox.showerror(error_title, …, parent=dialog)`.
+
+- [ ] **Step 1: Failing-Test-Datei anlegen**
+
+Datei `tests/test_settings_dialog.py`:
+
+```python
+"""build_oauth_enable_task: fn/on_done-Kontrakt eines OAuth-Aktivieren-Toggles,
+headless (der Dialog selbst ist Tk-gebunden, M16)."""
+
+from unittest.mock import MagicMock
+
+import src.dialogs.settings_dialog as sd
+from src.dialogs.settings_dialog import build_oauth_enable_task
+
+
+class _FakeSettings:
+    def __init__(self):
+        self.sets = []
+
+    def set(self, key, value):
+        self.sets.append((key, value))
+
+
+class _FakeCheckbox:
+    """Fake tk.Checkbutton: steuerbares winfo_exists + config-Rekorder."""
+    def __init__(self, alive=True):
+        self._alive = alive
+        self.config_calls = []
+
+    def winfo_exists(self):
+        return self._alive
+
+    def config(self, **kwargs):
+        self.config_calls.append(kwargs)
+
+
+class _FakeVar:
+    def __init__(self):
+        self.value = True
+
+    def set(self, v):
+        self.value = v
+
+
+def _build(*, service_ok=True, alive=True, on_success_ui=None):
+    settings = _FakeSettings()
+    checkbox = _FakeCheckbox(alive=alive)
+    var = _FakeVar()
+    on_change = MagicMock()
+
+    def service_fn():
+        if not service_ok:
+            raise RuntimeError("boom")
+
+    fn, on_done = build_oauth_enable_task(
+        service_fn=service_fn, settings=settings, setting_key="sync_enabled",
+        checkbox=checkbox, toggle_var=var, on_change=on_change,
+        dialog=object(), error_title="Titel",
+        on_success_dialog_ui=on_success_ui,
+    )
+    return settings, checkbox, var, on_change, fn, on_done
+
+
+def test_success_persists_and_updates_ui(monkeypatch):
+    monkeypatch.setattr(sd.messagebox, "showerror", lambda *a, **k: None)
+    ui = MagicMock()
+    settings, checkbox, var, on_change, fn, on_done = _build(on_success_ui=ui)
+    on_done(fn())
+    assert settings.sets == [("sync_enabled", True)]
+    on_change.assert_called_once_with()
+    assert {"state": "normal"} in checkbox.config_calls
+    ui.assert_called_once_with()
+    assert var.value is True  # kein Revert
+
+
+def test_success_persists_even_when_dialog_closed(monkeypatch):
+    monkeypatch.setattr(sd.messagebox, "showerror", lambda *a, **k: None)
+    ui = MagicMock()
+    settings, checkbox, var, on_change, fn, on_done = _build(alive=False,
+                                                             on_success_ui=ui)
+    on_done(fn())
+    assert settings.sets == [("sync_enabled", True)]   # Persistenz überlebt
+    on_change.assert_called_once_with()                 # root-scoped, läuft
+    assert checkbox.config_calls == []                  # kein Widget-Zugriff
+    ui.assert_not_called()                              # Dialog-Kosmetik übersprungen
+
+
+def test_failure_no_persist_and_reverts(monkeypatch):
+    errors = []
+    monkeypatch.setattr(sd.messagebox, "showerror",
+                        lambda *a, **k: errors.append(a))
+    settings, checkbox, var, on_change, fn, on_done = _build(service_ok=False)
+    on_done(fn())
+    assert settings.sets == []          # keine Persistenz bei Fehler
+    on_change.assert_not_called()
+    assert {"state": "normal"} in checkbox.config_calls
+    assert var.value is False           # Revert
+    assert errors                       # Fehler-Messagebox gezeigt
+
+
+def test_failure_dialog_closed_skips_all_ui(monkeypatch):
+    errors = []
+    monkeypatch.setattr(sd.messagebox, "showerror",
+                        lambda *a, **k: errors.append(a))
+    settings, checkbox, var, on_change, fn, on_done = _build(service_ok=False,
+                                                             alive=False)
+    on_done(fn())
+    assert settings.sets == []
+    on_change.assert_not_called()
+    assert checkbox.config_calls == []
+    assert var.value is True            # kein Revert (Dialog weg)
+    assert errors == []
+
+
+def test_success_without_on_success_ui(monkeypatch):
+    monkeypatch.setattr(sd.messagebox, "showerror", lambda *a, **k: None)
+    settings, checkbox, var, on_change, fn, on_done = _build(on_success_ui=None)
+    on_done(fn())  # darf nicht werfen
+    assert settings.sets == [("sync_enabled", True)]
+    assert {"state": "normal"} in checkbox.config_calls
+```
+
+- [ ] **Step 2: Test laufen lassen — muss fehlschlagen**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/test_settings_dialog.py -q`
+Expected: FAIL — `ImportError: cannot import name 'build_oauth_enable_task'`.
+
+- [ ] **Step 3: Builder implementieren**
+
+In `src/dialogs/settings_dialog.py` **nach dem Import-Block** (nach Z. 30) und **vor** `def open_settings_dialog` einfügen:
+
+```python
+def build_oauth_enable_task(*, service_fn, settings, setting_key, checkbox,
+                            toggle_var, on_change, dialog, error_title,
+                            on_success_dialog_ui=None):
+    """Baut (fn, on_done) für einen OAuth-Aktivieren-Toggle (Drive-Sync / Kalender).
+
+    fn (Worker-Thread): ruft service_fn() und persistiert setting_key=True bei
+    Erfolg — läuft im Thread und überlebt daher einen Dialog-Close. Fängt seine
+    Exceptions selbst, wirft nie.
+
+    on_done (UI-Thread via App._marshal_to_ui): ruft on_change() (App-/root-scoped)
+    VOR dem winfo_exists-Guard, danach die Dialog-Kosmetik (checkbox, toggle_var,
+    Messagebox, optional on_success_dialog_ui) — übersprungen, wenn der Dialog weg
+    ist. on_success_dialog_ui ist Dialog-Kosmetik (z.B. Kalenderliste laden) und
+    läuft daher NACH dem Guard.
+    """
+    def fn():
+        try:
+            service_fn()
+        except Exception as e:
+            return {"ok": False, "error": e, "tb": traceback.format_exc()}
+        settings.set(setting_key, True)
+        return {"ok": True}
+
+    def on_done(res):
+        if res["ok"]:
+            on_change()
+        if not checkbox.winfo_exists():
+            return
+        checkbox.config(state="normal")
+        if res["ok"]:
+            if on_success_dialog_ui is not None:
+                on_success_dialog_ui()
+        else:
+            toggle_var.set(False)
+            messagebox.showerror(
+                error_title,
+                f"OAuth-Flow fehlgeschlagen:\n\n{res['error']}\n\n{res['tb']}",
+                parent=dialog,
+            )
+
+    return fn, on_done
+```
+
+- [ ] **Step 4: Test laufen lassen — muss bestehen**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/test_settings_dialog.py -q`
+Expected: PASS (5 passed).
+
+- [ ] **Step 5: Ruff + Commit**
+
+Run: `.venv/Scripts/python.exe -m ruff check src/dialogs/settings_dialog.py tests/test_settings_dialog.py`
+Expected: All checks passed.
+
+```bash
+git add src/dialogs/settings_dialog.py tests/test_settings_dialog.py
+git commit -m "feat(settings): build_oauth_enable_task — testbarer OAuth-Toggle-Task (H5)"
+```
+
+---
+
+## Task 2: Runner verdrahten + #2/#6 auf den Builder umstellen
+
+`open_settings_dialog` bekommt den `runner`-Parameter, `ui.py` reicht `self._bg` durch, und die zwei OAuth-Aktivieren-Toggles nutzen `build_oauth_enable_task` + `runner.run`. Die alten `_finish_oauth`/`_finish_gcal_oauth`-Callbacks und ihre Threads entfallen.
+
+**Files:**
+- Modify: `src/dialogs/settings_dialog.py` (Signatur; `_on_sync_toggled`; `_on_gcal_toggled`; Löschen von `_finish_oauth`, `_finish_gcal_oauth`)
+- Modify: `src/ui.py:356-365` (Aufruf um `runner=self._bg` ergänzen)
+
+**Interfaces:**
+- Consumes: `build_oauth_enable_task(...)` aus Task 1; `App._bg` (bestehender `BackgroundTaskRunner` mit `.run(fn, on_done)`)
+- Produces: `open_settings_dialog(parent, settings, base_path, on_change, *, runner, conflicts_store=None, storage=None, reservation_store=None, on_request_restart=None, data_lock=None, sync_guard=None)` — `runner` ist **required keyword-only**.
+
+- [ ] **Step 1: Signatur um `runner` erweitern**
+
+In `src/dialogs/settings_dialog.py` die Signatur (aktuell Z. 33-36) ändern zu:
+
+```python
+def open_settings_dialog(parent, settings, base_path, on_change, *,
+                         runner, conflicts_store=None, storage=None,
+                         reservation_store=None, on_request_restart=None,
+                         data_lock=None, sync_guard=None):
+```
+
+Und den Docstring-Absatz (nach „…von App durchgereicht.") um eine Zeile ergänzen:
+
+```
+    runner: der App-BackgroundTaskRunner (App._bg); alle Hintergrund-Worker des
+    Dialogs laufen über runner.run(fn, on_done) (Audit H5).
+```
+
+- [ ] **Step 2: Aufrufer in `ui.py` anpassen**
+
+In `src/ui.py` den Aufruf (Z. 356-365) um `runner=self._bg,` ergänzen:
+
+```python
+        open_settings_dialog(
+            self.root, self.settings, self.base_path,
+            on_change=_on_change,
+            runner=self._bg,
+            conflicts_store=self.conflicts_store,
+            storage=self.storage,
+            reservation_store=self.reservation_store,
+            on_request_restart=self.restart_for_scaling,
+            data_lock=self._data_lock,
+            sync_guard=self._sync_guard,
+        )
+```
+
+- [ ] **Step 3: #2 Drive-Sync-Toggle umstellen**
+
+In `src/dialogs/settings_dialog.py` die Funktion `_finish_oauth` (aktuell Z. 343-355) **löschen** und `_on_sync_toggled` (aktuell Z. 357-382) ersetzen durch:
+
+```python
+    def _on_sync_toggled():
+        assert cb_sync is not None
+        new_state = var_sync.get()
+        if new_state and not settings.get("sync_enabled"):
+            cb_sync.config(state="disabled")
+
+            def _service():
+                from src import drive
+                drive.get_drive_service(
+                    os.path.join(base_path, "credentials.json"),
+                    os.path.join(base_path, "token.json"),
+                    gcal_enabled=settings.get("gcal_enabled"),
+                )
+
+            fn, on_done = build_oauth_enable_task(
+                service_fn=_service, settings=settings,
+                setting_key="sync_enabled", checkbox=cb_sync,
+                toggle_var=var_sync, on_change=on_change, dialog=dialog,
+                error_title="Synchronisation aktivieren",
+            )
+            runner.run(fn, on_done)
+            return
+        if not new_state and settings.get("sync_enabled"):
+            settings.set("sync_enabled", False)
+            on_change()
+```
+
+Hinweis: `cb_sync` ist ein echtes `tk.Checkbutton` — `config(state="disabled")` ist hier gültig (anders als beim icon_button). Diese synchrone Vor-Deaktivierung bleibt im Toggle-Handler.
+
+- [ ] **Step 4: #6 Kalender-Toggle umstellen**
+
+`_finish_gcal_oauth` (aktuell Z. 645-660) **löschen** und `_on_gcal_toggled` (aktuell Z. 662-685) ersetzen durch:
+
+```python
+    def _on_gcal_toggled():
+        assert cb_gcal is not None
+        new_state = var_gcal.get()
+        if new_state and not settings.get("gcal_enabled"):
+            cb_gcal.config(state="disabled")
+
+            def _service():
+                from src import gcal
+                gcal.get_calendar_service(
+                    os.path.join(base_path, "credentials.json"),
+                    os.path.join(base_path, "token.json"),
+                    sync_enabled=settings.get("sync_enabled"),
+                )
+
+            fn, on_done = build_oauth_enable_task(
+                service_fn=_service, settings=settings,
+                setting_key="gcal_enabled", checkbox=cb_gcal,
+                toggle_var=var_gcal, on_change=on_change, dialog=dialog,
+                error_title="Google Kalender aktivieren",
+                on_success_dialog_ui=_load_calendars,
+            )
+            runner.run(fn, on_done)
+            return
+        if not new_state and settings.get("gcal_enabled"):
+            settings.set("gcal_enabled", False)
+            on_change()
+```
+
+`_load_calendars` ist oberhalb bereits definiert (aktuell Z. 611) und damit im Closure sichtbar.
+
+- [ ] **Step 5: Gesamtsuite + Ruff**
+
+Run: `.venv/Scripts/python.exe -m pytest -q`
+Expected: alle grün (bestehende Zahl + 5 aus Task 1), keine Fehler.
+
+Run: `.venv/Scripts/python.exe -m ruff check .`
+Expected: All checks passed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/dialogs/settings_dialog.py src/ui.py
+git commit -m "refactor(settings): #2/#6 OAuth-Toggles über runner.run; Persistenz überlebt Close (H5)"
+```
+
+---
+
+## Task 3: Restliche Worker migrieren, `import threading` entfernen, Doku
+
+Die vier verbleibenden Worker (#1 Absender-Mail, #3 Neu verbinden, #4 Kompaktierung, #5 Kalenderliste) auf `runner.run` umstellen, den nun unbenutzten `import threading` entfernen und `src/CLAUDE.md` aktualisieren. #1 zieht `settings.set("sender_email", …)` in den Worker.
+
+**Files:**
+- Modify: `src/dialogs/settings_dialog.py` (`_refresh_sender`/#1, `_reconnect_google`/#3, `_on_compact_clicked`/#4, `_load_calendars`/#5; `_finish_refresh_ok`, `_finish_refresh_error`, `_finish_reconnect`, `_load_calendars_error` löschen/einfalten; `import threading` entfernen)
+- Modify: `src/CLAUDE.md:92`
+
+**Interfaces:**
+- Consumes: `runner` (Signatur aus Task 2), `_run_compaction_blocking` (lazy aus `src.main`), `_populate_calendars` (bestehender Helfer, bleibt)
+- Produces: nichts Neues (interne Umstellung)
+
+- [ ] **Step 1: #1 Absender-Mail (`_refresh_sender`) umstellen**
+
+`_refresh_sender` (aktuell Z. 265-299) den Thread-Block ersetzen und `_finish_refresh_ok`/`_finish_refresh_error` (Z. 301-319) **löschen**. Neu — ab `_set_sender_btn_text("Verbinde…")`:
+
+```python
+        _set_sender_btn_text("Verbinde…")
+
+        def _fn():
+            from src.mail import fetch_user_email, get_gmail_service
+            try:
+                get_gmail_service(
+                    os.path.join(base_path, "credentials.json"),
+                    os.path.join(base_path, "token.json"),
+                    sync_enabled=settings.get("sync_enabled"),
+                    gcal_enabled=settings.get("gcal_enabled"),
+                )
+                email = fetch_user_email(
+                    os.path.join(base_path, "token.json"),
+                    sync_enabled=settings.get("sync_enabled"),
+                    gcal_enabled=settings.get("gcal_enabled"),
+                )
+            except Exception as e:
+                return {"ok": False, "error": e, "tb": traceback.format_exc()}
+            if email:
+                settings.set("sender_email", email)   # Cache überlebt Close
+            return {"ok": True, "email": email}
+
+        def _on_done(res):
+            if not sender_label.winfo_exists():
+                return
+            _set_sender_btn_text("Aktualisieren")
+            if not res["ok"]:
+                messagebox.showerror(
+                    "Anmeldung fehlgeschlagen",
+                    "OAuth-Flow oder Userinfo-Aufruf fehlgeschlagen:\n\n"
+                    f"{res['error']}\n\n{res['tb']}",
+                    parent=dialog,
+                )
+                return
+            email = res["email"]
+            sender_label.config(
+                text=email if email
+                else "(nicht verfügbar — Scope fehlt evtl.)")
+
+        runner.run(_fn, _on_done)
+```
+
+Der `import`-Zeilenkopf von `_refresh_sender` (aktuell Z. 267-268 `from src.dialogs.send_dialog import …` / `from src.mail import …`) bleibt für den synchronen `show_missing_credentials_dialog`-Pfad wie gehabt; der `from src.mail import …` dort wird nicht mehr gebraucht (er steht jetzt im `_fn`) — entferne die `from src.mail import fetch_user_email, get_gmail_service`-Zeile aus `_refresh_sender`, die `from src.dialogs.send_dialog import show_missing_credentials_dialog`-Zeile bleibt.
+
+- [ ] **Step 2: #3 Google-neu-verbinden (`_reconnect_google`) umstellen**
+
+`_finish_reconnect` (aktuell Z. 448-463) **löschen** und den Thread-Block in `_reconnect_google` (aktuell Z. 477-490, ab `def _do():`) ersetzen durch:
+
+```python
+        def _fn():
+            from src import drive
+            try:
+                drive.reconnect(
+                    os.path.join(base_path, "credentials.json"),
+                    os.path.join(base_path, "token.json"),
+                    gcal_enabled=settings.get("gcal_enabled"),
+                )
+            except Exception as e:
+                return {"ok": False, "error": e, "tb": traceback.format_exc()}
+            return {"ok": True}
+
+        def _on_done(res):
+            reconnect_busy["value"] = False
+            if not dialog.winfo_exists():
+                return
+            if res["ok"]:
+                themed_showinfo(
+                    dialog, "Google neu verbunden",
+                    "Die Google-Berechtigungen wurden erneuert. Die "
+                    "Synchronisation sollte jetzt wieder funktionieren.",
+                )
+                return
+            messagebox.showerror(
+                "Google neu verbinden",
+                "Die Neuverbindung ist fehlgeschlagen:\n\n"
+                f"{res['error']}\n\n{res['tb']}",
+                parent=dialog,
+            )
+
+        runner.run(_fn, _on_done)
+```
+
+- [ ] **Step 3: #4 Kompaktierung (`_on_compact_clicked`) umstellen**
+
+Den Thread-Block (aktuell Z. 549-556, `def _do(): … threading.Thread(...)`) ersetzen durch:
+
+```python
+            def _fn():
+                from src.main import _run_compaction_blocking
+                return _run_compaction_blocking(
+                    storage, settings, conflicts_store, base_path,
+                    data_lock=data_lock, sync_guard=sync_guard)
+
+            runner.run(_fn, _show)
+```
+
+`_show(res)` (aktuell Z. 513-547) bleibt unverändert — es ist bereits `winfo_exists`-geschützt und dient direkt als `on_done`.
+
+- [ ] **Step 4: #5 Kalenderliste (`_load_calendars`) umstellen**
+
+`_load_calendars` (aktuell Z. 611-634) den Thread-Block ersetzen und `_load_calendars_error` (aktuell Z. 636-643) **löschen** (in `_on_done` eingefaltet). `_populate_calendars` (aktuell Z. 597-609) **bleibt**. Neu:
+
+```python
+    def _load_calendars():
+        cal_status.config(text="Kalenderliste wird geladen…")
+
+        def _fn():
+            from src import gcal
+            try:
+                service = gcal.get_calendar_service(
+                    os.path.join(base_path, "credentials.json"),
+                    os.path.join(base_path, "token.json"),
+                    sync_enabled=settings.get("sync_enabled"),
+                )
+                items = gcal.list_calendars(service)
+            except Exception as e:
+                return {"ok": False, "error": e, "tb": traceback.format_exc()}
+            return {"ok": True, "items": items}
+
+        def _on_done(res):
+            if not cal_status.winfo_exists():
+                return
+            if not res["ok"]:
+                cal_status.config(text="Kalenderliste nicht verfügbar")
+                messagebox.showerror(
+                    "Google Kalender",
+                    "Kalenderliste konnte nicht geladen werden:\n\n"
+                    f"{res['error']}\n\n{res['tb']}",
+                    parent=dialog,
+                )
+                return
+            _populate_calendars(res["items"])
+
+        runner.run(_fn, _on_done)
+```
+
+- [ ] **Step 5: `import threading` entfernen + verifizieren**
+
+Prüfen, dass kein `threading`-Bezug mehr übrig ist:
+
+Run: `.venv/Scripts/python.exe -m pytest -q` — noch nichts geändert außer Steps 1-4; hier nur als Zwischenlauf optional.
+
+Dann `import threading` (aktuell Z. 5) in `src/dialogs/settings_dialog.py` löschen. Verifikation:
+
+Run (Bash): `grep -n "threading" src/dialogs/settings_dialog.py`
+Expected: keine Ausgabe (leer).
+
+- [ ] **Step 6: `src/CLAUDE.md` aktualisieren**
+
+In `src/CLAUDE.md` den Satz (Z. 91-92):
+
+```
+gegen `TclError` abgesichert, falls das Fenster zwischenzeitlich zu ist). Keine direkten
+`threading.Thread`-Aufrufe in `ui.py` mehr.
+```
+
+ersetzen durch:
+
+```
+gegen `TclError` abgesichert, falls das Fenster zwischenzeitlich zu ist). Keine direkten
+`threading.Thread`-Aufrufe in `ui.py` **oder den Dialogen** mehr — auch `settings_dialog`
+routet seine Worker seit Audit H5 über einen injizierten `BackgroundTaskRunner`
+(`open_settings_dialog(..., runner=App._bg)`): Persistenz im Worker (überlebt
+Dialog-Close), UI-Feedback im `winfo_exists`-geschützten `on_done`.
+```
+
+- [ ] **Step 7: Gesamtsuite + Ruff**
+
+Run: `.venv/Scripts/python.exe -m pytest -q`
+Expected: alle grün.
+
+Run: `.venv/Scripts/python.exe -m ruff check .`
+Expected: All checks passed.
+
+- [ ] **Step 8: Manueller Tk-Smoke (Sichtprüfung der Verdrahtung)**
+
+Da die Verdrahtung Tk-gebunden ist, einmal den Dialog real öffnen:
+
+Run: `.venv/Scripts/python.exe -m src.main`
+Prüfen: Einstellungen öffnen → Google-Tab → „Aktualisieren" (Absender) löst Fetch aus ohne Crash; Dialog schließen und erneut öffnen funktioniert. (OAuth-Toggles nur prüfen, falls `credentials.json` vorhanden — sonst kommt der freundliche Hinweis, ebenfalls ok.)
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/dialogs/settings_dialog.py src/CLAUDE.md
+git commit -m "refactor(settings): restliche Worker über runner.run, import threading raus, Doku (H5)"
+```
+
+---
+
+## Self-Review-Notiz (bereits geprüft)
+
+- **Spec-Abdeckung:** alle 6 Worker (Task 2: #2/#6; Task 3: #1/#3/#4/#5), Builder + Tests (Task 1), Persistenz-im-Worker (#2/#6/#1), `on_change`-vor-Guard, `_load_calendars` hinter Guard (Task 2 Step 4 via `on_success_dialog_ui`), `import threading`-Entfernung + Doku (Task 3), `after(500)`-Timer bewusst unangetastet.
+- **Signatur-Konsistenz:** `build_oauth_enable_task(...)` identisch in Task 1 (Definition) und Task 2 (Aufruf #2/#6); Result-Dict `{"ok", "error", "tb"}` durchgängig; `runner`-Param in Task 2 eingeführt, in Task 3 genutzt.
+- **Reihenfolge-Abhängigkeit:** Task 1 → 2 → 3 (Task 2 führt `runner` ein, Task 3 nutzt es; `import threading` fällt erst in Task 3, wenn alle Worker migriert sind).

--- a/docs/superpowers/specs/2026-07-04-settings-dialog-threadvertrag-design.md
+++ b/docs/superpowers/specs/2026-07-04-settings-dialog-threadvertrag-design.md
@@ -1,0 +1,219 @@
+# Settings-Dialog: Thread-Vertrag & überlebende Persistenz (Audit H5)
+
+> Design-Spec, 2026-07-04. Behebt Audit-Finding **H5** — die sechs Worker im
+> `settings_dialog` umgehen den dokumentierten Thread-Vertrag und verlieren bei
+> geschlossenem Dialog Ergebnisse. Branch `fix/settings-dialog-threadvertrag`
+> (gestapelt auf #122 `fix/dialog-theme-helper`, da beide `settings_dialog.py`
+> anfassen).
+
+## Problem
+
+`src/dialogs/settings_dialog.py` startet an sechs Stellen (Z. 299/378/490/556/634/681)
+direkt `threading.Thread(target=…, daemon=True).start()` und liefert das Ergebnis
+per **ungeschütztem** `dialog.after(0, …)` zurück. `src/CLAUDE.md` schreibt aber
+**genau ein** Muster vor: Hintergrundarbeit über `BackgroundTaskRunner.run(fn, on_done)`,
+Rückgabe über `App._marshal_to_ui` (gegen `TclError` abgesichert). Der Dialog ist die
+einzige Ausnahme (auch im Audit als Positiv-Punkt 1 vermerkt: „Ausnahme ist nur
+`settings_dialog`").
+
+Der konkrete Schaden trifft die zwei OAuth-**Aktivieren**-Toggles:
+
+- **#2 Drive-Sync aktivieren** (`_finish_oauth`, Z. 343): `cb_sync.config(state="normal")`
+  läuft **vor** `settings.set("sync_enabled", True)`. Schließt der Nutzer den Dialog
+  während des (minutenlangen) OAuth-Browser-Flows, wirft `dialog.after(0, …)` bzw.
+  `cb_sync.config` einen `TclError` → der Daemon-Thread stirbt unbehandelt, und
+  `settings.set("sync_enabled", True)` läuft **nie**, obwohl der Consent erfolgreich war.
+- **#6 Kalender aktivieren** (`_finish_gcal_oauth`, Z. 645): `if not cb_gcal.winfo_exists():
+    return` steht **vor** `settings.set("gcal_enabled", True)` → bei geschlossenem Dialog
+  wird die Persistenz sauber, aber genauso folgenlos übersprungen. Gleicher Netto-Bug,
+  andere Ursache.
+
+Verschärfend: `src/logging_setup.py` installiert nur `sys.excepthook` + Tk-Hook, **kein**
+`threading.excepthook`. Der Thread-Tod aus #2 landet damit nur auf dem per `--noconsole`
+unterdrückten stderr — spurlos.
+
+## Kategorisierung der sechs Worker
+
+| # | Zeile | Worker | Persistiert Zustand? | Close-Verhalten heute |
+|---|-------|--------|----------------------|-----------------------|
+| #2 | 378 | Drive-Sync aktivieren (OAuth) | **ja** `sync_enabled=True` | Crash → Persistenz verloren |
+| #6 | 681 | Kalender aktivieren (OAuth) | **ja** `gcal_enabled=True` | Guard-Skip → Persistenz verloren |
+| #4 | 556 | Sync-Kompaktierung | Nebeneffekt im Worker | korrekt (`winfo_exists`-Guard) |
+| #1 | 299 | Absender-Mail „Aktualisieren" | nein | UI-Display; Nebeneffekt überlebt im Worker |
+| #3 | 490 | Google neu verbinden | nein | Token-Refresh überlebt; UI-Feedback verloren |
+| #5 | 634 | Kalenderliste laden | nein | Combobox-Populate |
+
+Nur #2/#6 verlieren echte Persistenz. Die anderen vier sind reines UI-Feedback bzw.
+haben ihren Nebeneffekt bereits im Worker (überlebt ohnehin) — sie werden **aus
+Konventionsgründen** mitmigriert, ihr Verhalten bleibt identisch.
+
+## Entscheidungen (mit dem Nutzer abgestimmt)
+
+1. **Umfang:** Alle sechs Worker einheitlich auf `BackgroundTaskRunner.run` umstellen
+   (nicht nur die zwei Persistenz-Bugs). Verhindert strukturell den nächsten H5.
+   **H4** (God-Function pro Tab entflechten) bleibt ein **separater** Punkt.
+2. **OAuth-Semantik:** Schließt der Nutzer den Dialog während eines erfolgreichen
+   OAuth-Flows, **überlebt die Persistenz** — `settings.set(…, True)` läuft trotzdem,
+   das Feature ist beim nächsten Öffnen aktiv. Nur das UI-Feedback (Checkbox/Messagebox)
+   entfällt. So liest auch das Audit den Bug.
+
+## Kernmechanismus
+
+`open_settings_dialog(...)` bekommt einen **keyword-only Parameter `runner`**
+(= `App._bg`, der bestehende `BackgroundTaskRunner`), von `ui.py` durchgereicht.
+Es gibt genau einen Aufrufer (`App._open_settings`); Tests injizieren einen Fake-Runner.
+
+Jeder Worker wird zu:
+
+```python
+runner.run(fn, on_done)
+```
+
+mit einer klaren Zweiteilung:
+
+- **`fn` — läuft im Daemon-Worker, überlebt den Dialog-Close.**
+  Enthält das Blocking-I/O (OAuth-Flow, Netz-Call, Kompaktierung) **und die
+  Persistenz, die überleben muss** (`settings.set(...)` — thread-safe seit dem
+  Datenschicht-Lock aus #121). `fn` fängt seine Exceptions selbst und gibt ein
+  Result-Dict zurück (`{"ok": True}` / `{"ok": False, "error": e, "tb": …}`); es
+  **wirft nie** → kein stiller Thread-Tod, N19 (fehlendes try um `fn()` im Runner)
+  bleibt unberührt und irrelevant für diesen Pfad.
+
+- **`on_done(res)` — läuft auf dem UI-Thread über `App._marshal_to_ui` (TclError-gesichert).**
+  Reihenfolge ist verbindlich:
+  1. **überlebende UI zuerst:** `on_change()` (App-/root-scoped: Kalender-Refresh,
+     Sync-Status-Label, Tray/Reminder, Absender-Fetch — **nicht** dialoggebunden) und
+     ggf. `_load_calendars()`. Läuft auch bei geschlossenem Dialog, solange die Root
+     lebt; der Marshal-Guard fängt den Shutdown-Sonderfall.
+  2. **dann Dialog-Widget-Kosmetik:** `cb.config(...)`, `var.set(...)`, Messageboxen
+     mit `parent=dialog` — jede über einen `winfo_exists`-Guard geschützt und
+     übersprungen, wenn der Dialog weg ist.
+
+Damit ist die Persistenz **strukturell** von der Dialog-Lebensdauer entkoppelt: sie
+sitzt im `fn` (Worker) bzw. in der root-scoped ersten Hälfte von `on_done`, nie hinter
+einem Dialog-Widget-Zugriff, der abbrechen könnte.
+
+Alle sechs `threading.Thread(...)`- und alle `dialog.after(0, …)`-Stellen im Dialog
+entfallen. `import threading` wird im Dialog überflüssig (prüfen und entfernen).
+
+## Per-Worker-Umsetzung
+
+### #2 Drive-Sync aktivieren (`_on_sync_toggled` / `_do_oauth` / `_finish_oauth`)
+
+Das (fn, on_done)-Paar entsteht über den gemeinsamen `build_oauth_enable_task`-Helfer
+(s. Tests); der folgende Code zeigt das erzeugte Verhalten:
+
+```python
+def _on_sync_toggled():
+    assert cb_sync is not None
+    new_state = var_sync.get()
+    if new_state and not settings.get("sync_enabled"):
+        cb_sync.config(state="disabled")
+
+        def fn():
+            try:
+                from src import drive
+                drive.get_drive_service(
+                    os.path.join(base_path, "credentials.json"),
+                    os.path.join(base_path, "token.json"),
+                    gcal_enabled=settings.get("gcal_enabled"),
+                )
+            except Exception as e:
+                return {"ok": False, "error": e, "tb": traceback.format_exc()}
+            settings.set("sync_enabled", True)   # überlebt Dialog-Close
+            return {"ok": True}
+
+        def on_done(res):
+            if res["ok"]:
+                on_change()                       # root-scoped, überlebt
+            if not cb_sync.winfo_exists():
+                return                            # Dialog weg -> Kosmetik überspringen
+            cb_sync.config(state="normal")
+            if not res["ok"]:
+                var_sync.set(False)
+                messagebox.showerror(
+                    "Synchronisation aktivieren",
+                    f"OAuth-Flow fehlgeschlagen:\n\n{res['error']}\n\n{res['tb']}",
+                    parent=dialog,
+                )
+
+        runner.run(fn, on_done)
+        return
+    if not new_state and settings.get("sync_enabled"):
+        settings.set("sync_enabled", False)
+        on_change()
+```
+
+### #6 Kalender aktivieren (`_on_gcal_toggled` / `_finish_gcal_oauth`)
+
+Analog zu #2. `fn` persistiert bei Erfolg `settings.set("gcal_enabled", True)`.
+`on_done` bei Erfolg: `on_change()` **und** `_load_calendars()` (beide root-/App-scoped
+bzw. selbst wieder ein `runner.run` — s. #5) **vor** der Dialog-Kosmetik `cb_gcal.config`.
+Fehlerpfad: `var_gcal.set(False)` + Messagebox, `winfo_exists`-geschützt.
+
+### #4 Sync-Kompaktierung (`_on_compact_clicked` / `_show`)
+
+`fn` = `_run_compaction_blocking(...)` (Nebeneffekt bereits im Worker). `on_done` = das
+bestehende `_show(res)` (bereits `winfo_exists`-korrekt), nur von `dialog.after` auf
+`runner.run` umgestellt. Verhalten unverändert.
+
+### #1 Absender-Mail „Aktualisieren", #3 Google neu verbinden, #5 Kalenderliste laden
+
+Reine UI-Worker ohne persistierten Zustand. Umstellung von `threading.Thread` +
+`dialog.after` auf `runner.run(fn, on_done)`; die bestehenden `_finish_*`-Callbacks
+werden zu `on_done`, ihre Dialog-Widget-Zugriffe über `winfo_exists` geschützt (teils
+schon vorhanden, z. B. `_load_calendars_error` prüft `cal_status.winfo_exists()`).
+`reconnect_busy["value"] = False` im `on_done` von #3. Verhalten unverändert.
+
+## Betroffene Dateien
+
+- `src/dialogs/settings_dialog.py` — sechs Worker umgestellt, `import threading` entfernt,
+  `runner`-Parameter ergänzt.
+- `src/ui.py` — `open_settings_dialog(..., runner=self._bg)` durchreichen.
+- `src/CLAUDE.md` — Positiv-Notiz „Ausnahme ist nur `settings_dialog` (H5)" streichen bzw.
+  auf „behoben" aktualisieren; im `settings_dialog`-Absatz den Runner-Vertrag festhalten.
+- `tests/test_settings_dialog.py` — **neu**, siehe unten.
+
+## Tests
+
+Der Dialog wird bislang von **keinem** Test aufgerufen (Tk-gebunden, M16). Der injizierte
+Runner macht die fn/on_done-Kontrakte erstmals headless prüfbar. Muster wie `_FakeRunner`
+in `tests/test_sync_orchestrator.py`: synchroner Runner, der `fn()` sofort ausführt und
+`on_done(result)` aufruft.
+
+Da die Worker heute als Closures **innerhalb** `open_settings_dialog` leben, sind sie
+nicht direkt aufrufbar. #2 und #6 sind zudem near-identisch (nur Service-Call +
+Settings-Key unterscheiden sich). Beide werden daher über **einen gemeinsamen
+modulweiten Builder** gelöst, z. B.
+
+```python
+def build_oauth_enable_task(*, service_fn, settings, setting_key,
+                            checkbox, toggle_var, on_change, dialog):
+    """Baut (fn, on_done) für einen OAuth-Aktivieren-Toggle: fn ruft service_fn()
+    und persistiert setting_key=True bei Erfolg (überlebt Dialog-Close); on_done
+    ruft on_change() (root-scoped) und danach die winfo_exists-geschützte
+    Dialog-Kosmetik. Rückgabe: (fn, on_done) für runner.run(...)."""
+```
+
+Das entfernt zugleich die Duplikation zwischen #2 und #6. Der Builder ist ohne echten
+Tk-Dialog testbar: Fake-`settings`, ein Fake-Widget mit steuerbarem `winfo_exists()`,
+ein Recorder-`on_change` und ein Fake-Service-Callable (Erfolg vs. Exception). Abgedeckt:
+
+1. **Persistenz überlebt Close:** OAuth-Erfolg + Widget `winfo_exists()→False` →
+   `settings.set("sync_enabled", True)` wurde aufgerufen **und** `on_change` genau einmal;
+   **kein** `cb.config`/Messagebox auf totem Widget.
+2. **Normalfall (Dialog offen):** Erfolg → Persist + `on_change` + `cb.config("normal")`.
+3. **Fehlerpfad:** OAuth wirft → **keine** Persistenz, `var.set(False)` + Fehler-Messagebox
+   (bei offenem Dialog), sauberes Überspringen bei geschlossenem.
+4. **gcal analog** inkl. `_load_calendars`-Auslösung bei Erfolg.
+
+Gesamtsuite muss grün bleiben (`pytest`), `ruff check .` sauber. Ein optionaler
+Tk-Smoke (echter Dialog, ein Toggle) ist Kür; primär die headless-Kontrakte.
+
+## Ausdrücklich außerhalb des Scopes
+
+- **H4** — Aufteilung der ~930-Zeilen-`open_settings_dialog` pro Tab. Eigener Punkt/Branch.
+- **N19** — fehlendes try um `fn()` in `BackgroundTaskRunner.run` bzw. globales
+  `threading.excepthook`. Dieser Fix macht jedes `fn` selbstfangend, braucht N19 nicht.
+- **M10** — `send_dialog`/`share_dialog`/`export_dialog` blockieren den Main-Thread.
+  Eigenes Finding, anderer Dialog.

--- a/docs/superpowers/specs/2026-07-04-settings-dialog-threadvertrag-design.md
+++ b/docs/superpowers/specs/2026-07-04-settings-dialog-threadvertrag-design.md
@@ -39,13 +39,16 @@ unterdrückten stderr — spurlos.
 | #2 | 378 | Drive-Sync aktivieren (OAuth) | **ja** `sync_enabled=True` | Crash → Persistenz verloren |
 | #6 | 681 | Kalender aktivieren (OAuth) | **ja** `gcal_enabled=True` | Guard-Skip → Persistenz verloren |
 | #4 | 556 | Sync-Kompaktierung | Nebeneffekt im Worker | korrekt (`winfo_exists`-Guard) |
-| #1 | 299 | Absender-Mail „Aktualisieren" | nein | UI-Display; Nebeneffekt überlebt im Worker |
+| #1 | 299 | Absender-Mail „Aktualisieren" | **ja** `sender_email` (Cache, low-harm) | `settings.set` hinter `winfo_exists`-Guard → bei Close übersprungen |
 | #3 | 490 | Google neu verbinden | nein | Token-Refresh überlebt; UI-Feedback verloren |
 | #5 | 634 | Kalenderliste laden | nein | Combobox-Populate |
 
-Nur #2/#6 verlieren echte Persistenz. Die anderen vier sind reines UI-Feedback bzw.
-haben ihren Nebeneffekt bereits im Worker (überlebt ohnehin) — sie werden **aus
-Konventionsgründen** mitmigriert, ihr Verhalten bleibt identisch.
+#2/#6 verlieren funktionale Persistenz (Feature-Enable). #1 verliert einen
+**Display-Cache** (`sender_email`) — low-harm, weil `ui.py` ihn nach jedem Speichern
+ohnehin neu holt (`_on_change` → `self._bg.fetch_sender_email()`), aber nach demselben
+Prinzip gehört `settings.set("sender_email", email)` in den Worker. #3/#5 persistieren
+nichts (Nebeneffekt bereits im Worker bzw. reines UI). Alle sechs werden migriert;
+Verhalten der nicht-funktionalen bleibt identisch.
 
 ## Entscheidungen (mit dem Nutzer abgestimmt)
 
@@ -170,11 +173,20 @@ bestehende `_show(res)` (bereits `winfo_exists`-korrekt), nur von `dialog.after`
 
 ### #1 Absender-Mail „Aktualisieren", #3 Google neu verbinden, #5 Kalenderliste laden
 
-Reine UI-Worker ohne persistierten Zustand. Umstellung von `threading.Thread` +
-`dialog.after` auf `runner.run(fn, on_done)`; die bestehenden `_finish_*`-Callbacks
-werden zu `on_done`, ihre Dialog-Widget-Zugriffe über `winfo_exists` geschützt (teils
-schon vorhanden, z. B. `_load_calendars_error` prüft `cal_status.winfo_exists()`).
-`reconnect_busy["value"] = False` im `on_done` von #3. Verhalten unverändert.
+Umstellung von `threading.Thread` + `dialog.after` auf `runner.run(fn, on_done)`; die
+bestehenden `_finish_*`-Callbacks werden zu `on_done`, ihre Dialog-Widget-Zugriffe über
+`winfo_exists` geschützt (teils schon vorhanden, z. B. `_load_calendars_error` prüft
+`cal_status.winfo_exists()`).
+
+- **#1** persistiert einen Display-Cache: `fetch_user_email` läuft im `fn`, und
+  `settings.set("sender_email", email)` wandert **in den Worker** (bei nicht-leerer
+  Mail), damit der Cache den Close überlebt. `on_done` setzt nur noch das Label
+  (`winfo_exists`-geschützt) bzw. zeigt die Fehler-Messagebox.
+- **#3** persistiert nichts (Token-Refresh im Worker). `reconnect_busy["value"] = False`
+  im `on_done` (plain dict, kein Tk — unbedingt), danach die `winfo_exists`-geschützte
+  Info-/Fehler-Messagebox.
+- **#5** reines Combobox-Populate; `_populate_calendars`/`_load_calendars_error` als
+  `on_done`, `winfo_exists`-geschützt.
 
 ## Betroffene Dateien
 

--- a/docs/superpowers/specs/2026-07-04-settings-dialog-threadvertrag-design.md
+++ b/docs/superpowers/specs/2026-07-04-settings-dialog-threadvertrag-design.md
@@ -95,6 +95,14 @@ einem Dialog-Widget-Zugriff, der abbrechen könnte.
 
 Alle sechs `threading.Thread(...)`- und alle `dialog.after(0, …)`-Stellen im Dialog
 entfallen. `import threading` wird im Dialog überflüssig (prüfen und entfernen).
+**Nicht betroffen:** der periodische UI-Timer `dialog.after(500, refresh_status)`
+(Z. 242) — der läuft auf dem UI-Thread, verletzt keinen Thread-Vertrag und bleibt.
+
+**Akzeptierter Randfall (Bestandsverhalten):** Schließt der Nutzer den Dialog während
+eines laufenden OAuth-Flows und öffnet ihn sofort neu, liest der neue Dialog noch
+`sync_enabled/gcal_enabled = False` und erlaubt einen zweiten Flow. Das konnte der
+alte Code genauso; der zweite Flow nutzt das inzwischen gespeicherte Token (kein
+zweiter Browser-Consent) und die zweite Persistenz ist idempotent. Kein Fix nötig.
 
 ## Per-Worker-Umsetzung
 
@@ -147,9 +155,12 @@ def _on_sync_toggled():
 ### #6 Kalender aktivieren (`_on_gcal_toggled` / `_finish_gcal_oauth`)
 
 Analog zu #2. `fn` persistiert bei Erfolg `settings.set("gcal_enabled", True)`.
-`on_done` bei Erfolg: `on_change()` **und** `_load_calendars()` (beide root-/App-scoped
-bzw. selbst wieder ein `runner.run` — s. #5) **vor** der Dialog-Kosmetik `cb_gcal.config`.
-Fehlerpfad: `var_gcal.set(False)` + Messagebox, `winfo_exists`-geschützt.
+`on_done` bei Erfolg: **nur** `on_change()` ist root-scoped und läuft vor dem Guard.
+`_load_calendars()` ist dagegen **Dialog-Kosmetik** (setzt sofort
+`cal_status.config(...)` und populiert die Dialog-Combobox) und gehört **hinter**
+den `winfo_exists`-Guard — bei geschlossenem Dialog ist die Kalenderliste sinnlos
+und der Widget-Zugriff würde werfen. Fehlerpfad: `var_gcal.set(False)` + Messagebox,
+ebenfalls `winfo_exists`-geschützt.
 
 ### #4 Sync-Kompaktierung (`_on_compact_clicked` / `_show`)
 
@@ -188,11 +199,15 @@ modulweiten Builder** gelöst, z. B.
 
 ```python
 def build_oauth_enable_task(*, service_fn, settings, setting_key,
-                            checkbox, toggle_var, on_change, dialog):
+                            checkbox, toggle_var, on_change, dialog,
+                            error_title, on_success_dialog_ui=None):
     """Baut (fn, on_done) für einen OAuth-Aktivieren-Toggle: fn ruft service_fn()
     und persistiert setting_key=True bei Erfolg (überlebt Dialog-Close); on_done
-    ruft on_change() (root-scoped) und danach die winfo_exists-geschützte
-    Dialog-Kosmetik. Rückgabe: (fn, on_done) für runner.run(...)."""
+    ruft on_change() (root-scoped, vor dem Guard) und danach die winfo_exists-
+    geschützte Dialog-Kosmetik. on_success_dialog_ui (optional) läuft bei Erfolg
+    NACH dem Guard — #6 hängt hier _load_calendars ein (Dialog-Kosmetik, s.o.);
+    #2 lässt es weg. error_title ist der Messagebox-Titel des Fehlerpfads.
+    Rückgabe: (fn, on_done) für runner.run(...)."""
 ```
 
 Das entfernt zugleich die Duplikation zwischen #2 und #6. Der Builder ist ohne echten
@@ -205,7 +220,8 @@ ein Recorder-`on_change` und ein Fake-Service-Callable (Erfolg vs. Exception). A
 2. **Normalfall (Dialog offen):** Erfolg → Persist + `on_change` + `cb.config("normal")`.
 3. **Fehlerpfad:** OAuth wirft → **keine** Persistenz, `var.set(False)` + Fehler-Messagebox
    (bei offenem Dialog), sauberes Überspringen bei geschlossenem.
-4. **gcal analog** inkl. `_load_calendars`-Auslösung bei Erfolg.
+4. **gcal analog** inkl. `on_success_dialog_ui` (= `_load_calendars`): wird bei Erfolg
+   **und offenem Dialog** aufgerufen, bei geschlossenem übersprungen.
 
 Gesamtsuite muss grün bleiben (`pytest`), `ruff check .` sauber. Ein optionaler
 Tk-Smoke (echter Dialog, ein Toggle) ist Kür; primär die headless-Kontrakte.

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -89,7 +89,10 @@ das fixe Fenster auf die geänderte Banner-Höhe nachzieht (sonst Footer abgesch
 Genau ein Muster: Hintergrundarbeit über `BackgroundTaskRunner.run(fn, on_done)`; jede
 State-/Widget-Mutation aus einem Worker läuft über `App._marshal_to_ui` (`root.after(0, …)`,
 gegen `TclError` abgesichert, falls das Fenster zwischenzeitlich zu ist). Keine direkten
-`threading.Thread`-Aufrufe in `ui.py` mehr.
+`threading.Thread`-Aufrufe in `ui.py` **oder den Dialogen** mehr — auch `settings_dialog`
+routet seine Worker seit Audit H5 über einen injizierten `BackgroundTaskRunner`
+(`open_settings_dialog(..., runner=App._bg)`): Persistenz im Worker (überlebt
+Dialog-Close), UI-Feedback im `winfo_exists`-geschützten `on_done`.
 
 **Datenschicht-Locking (Audit H1/H2/M1):** Alle vier Stores
 (`storage`/`settings`/`conflicts_store`/`reservations`) teilen sich einen in

--- a/src/dialogs/settings_dialog.py
+++ b/src/dialogs/settings_dialog.py
@@ -30,6 +30,49 @@ from src.time_utils import DAYS_DE, validate_entry
 from src.weekly_limit import format_limit_warnings, period_scan_needed, scan_period_for_warnings
 
 
+def build_oauth_enable_task(*, service_fn, settings, setting_key, checkbox,
+                            toggle_var, on_change, dialog, error_title,
+                            on_success_dialog_ui=None):
+    """Baut (fn, on_done) für einen OAuth-Aktivieren-Toggle (Drive-Sync / Kalender).
+
+    fn (Worker-Thread): ruft service_fn() und persistiert setting_key=True bei
+    Erfolg — läuft im Thread und überlebt daher einen Dialog-Close. Fängt seine
+    Exceptions selbst, wirft nie.
+
+    on_done (UI-Thread via App._marshal_to_ui): ruft on_change() (App-/root-scoped)
+    VOR dem winfo_exists-Guard, danach die Dialog-Kosmetik (checkbox, toggle_var,
+    Messagebox, optional on_success_dialog_ui) — übersprungen, wenn der Dialog weg
+    ist. on_success_dialog_ui ist Dialog-Kosmetik (z.B. Kalenderliste laden) und
+    läuft daher NACH dem Guard.
+    """
+    def fn():
+        try:
+            service_fn()
+        except Exception as e:
+            return {"ok": False, "error": e, "tb": traceback.format_exc()}
+        settings.set(setting_key, True)
+        return {"ok": True}
+
+    def on_done(res):
+        if res["ok"]:
+            on_change()
+        if not checkbox.winfo_exists():
+            return
+        checkbox.config(state="normal")
+        if res["ok"]:
+            if on_success_dialog_ui is not None:
+                on_success_dialog_ui()
+        else:
+            toggle_var.set(False)
+            messagebox.showerror(
+                error_title,
+                f"OAuth-Flow fehlgeschlagen:\n\n{res['error']}\n\n{res['tb']}",
+                parent=dialog,
+            )
+
+    return fn, on_done
+
+
 def open_settings_dialog(parent, settings, base_path, on_change, *,
                          conflicts_store=None, storage=None,
                          reservation_store=None, on_request_restart=None,

--- a/src/dialogs/settings_dialog.py
+++ b/src/dialogs/settings_dialog.py
@@ -2,7 +2,6 @@ import calendar
 import datetime
 import logging
 import os
-import threading
 import tkinter as tk
 import traceback
 from tkinter import messagebox, ttk
@@ -310,7 +309,6 @@ def open_settings_dialog(parent, settings, base_path, on_change, *,
     def _refresh_sender():
         """OAuth-Flow + userinfo-Fetch im Thread, danach Label aktualisieren."""
         from src.dialogs.send_dialog import show_missing_credentials_dialog
-        from src.mail import fetch_user_email, get_gmail_service
 
         if not os.path.exists(creds_path):
             # Konsistent mit Senden/Teilen: freundlicher Hinweis + „Datenordner
@@ -320,9 +318,9 @@ def open_settings_dialog(parent, settings, base_path, on_change, *,
 
         _set_sender_btn_text("Verbinde…")
 
-        def _do():
+        def _fn():
+            from src.mail import fetch_user_email, get_gmail_service
             try:
-                # OAuth-Flow läuft, falls Token fehlt oder Scopes upgegradet werden müssen.
                 get_gmail_service(
                     os.path.join(base_path, "credentials.json"),
                     os.path.join(base_path, "token.json"),
@@ -335,33 +333,29 @@ def open_settings_dialog(parent, settings, base_path, on_change, *,
                     gcal_enabled=settings.get("gcal_enabled"),
                 )
             except Exception as e:
-                err = e
-                tb = traceback.format_exc()
-                dialog.after(0, lambda: _finish_refresh_error(err, tb))
+                return {"ok": False, "error": e, "tb": traceback.format_exc()}
+            if email:
+                settings.set("sender_email", email)   # Cache überlebt Close
+            return {"ok": True, "email": email}
+
+        def _on_done(res):
+            if not sender_label.winfo_exists():
                 return
-            dialog.after(0, lambda: _finish_refresh_ok(email))
+            _set_sender_btn_text("Aktualisieren")
+            if not res["ok"]:
+                messagebox.showerror(
+                    "Anmeldung fehlgeschlagen",
+                    "OAuth-Flow oder Userinfo-Aufruf fehlgeschlagen:\n\n"
+                    f"{res['error']}\n\n{res['tb']}",
+                    parent=dialog,
+                )
+                return
+            email = res["email"]
+            sender_label.config(
+                text=email if email
+                else "(nicht verfügbar — Scope fehlt evtl.)")
 
-        threading.Thread(target=_do, daemon=True).start()
-
-    def _finish_refresh_ok(email):
-        if not sender_label.winfo_exists():
-            return
-        _set_sender_btn_text("Aktualisieren")
-        if email:
-            settings.set("sender_email", email)
-            sender_label.config(text=email)
-        else:
-            sender_label.config(text="(nicht verfügbar — Scope fehlt evtl.)")
-
-    def _finish_refresh_error(err, tb):
-        if not sender_label.winfo_exists():
-            return
-        _set_sender_btn_text("Aktualisieren")
-        messagebox.showerror(
-            "Anmeldung fehlgeschlagen",
-            f"OAuth-Flow oder Userinfo-Aufruf fehlgeschlagen:\n\n{err}\n\n{tb}",
-            parent=dialog,
-        )
+        runner.run(_fn, _on_done)
 
     sender_btn = secondary_button(
         sender_row,
@@ -475,23 +469,6 @@ def open_settings_dialog(parent, settings, base_path, on_change, *,
     # Schutz daher über ein Flag statt cb.config(state=...).
     reconnect_busy = {"value": False}
 
-    def _finish_reconnect(err, tb):
-        reconnect_busy["value"] = False
-        if not dialog.winfo_exists():
-            return
-        if err is None:
-            themed_showinfo(
-                dialog, "Google neu verbunden",
-                "Die Google-Berechtigungen wurden erneuert. Die "
-                "Synchronisation sollte jetzt wieder funktionieren.",
-            )
-            return
-        messagebox.showerror(
-            "Google neu verbinden",
-            f"Die Neuverbindung ist fehlgeschlagen:\n\n{err}\n\n{tb}",
-            parent=dialog,
-        )
-
     def _reconnect_google():
         if reconnect_busy["value"]:
             return
@@ -504,20 +481,37 @@ def open_settings_dialog(parent, settings, base_path, on_change, *,
             return
         reconnect_busy["value"] = True
 
-        def _do():
-            err, tb = None, ""
+        def _fn():
+            from src import drive
             try:
-                from src import drive
                 drive.reconnect(
                     os.path.join(base_path, "credentials.json"),
                     os.path.join(base_path, "token.json"),
                     gcal_enabled=settings.get("gcal_enabled"),
                 )
             except Exception as e:
-                err, tb = e, traceback.format_exc()
-            dialog.after(0, lambda: _finish_reconnect(err, tb))
+                return {"ok": False, "error": e, "tb": traceback.format_exc()}
+            return {"ok": True}
 
-        threading.Thread(target=_do, daemon=True).start()
+        def _on_done(res):
+            reconnect_busy["value"] = False
+            if not dialog.winfo_exists():
+                return
+            if res["ok"]:
+                themed_showinfo(
+                    dialog, "Google neu verbunden",
+                    "Die Google-Berechtigungen wurden erneuert. Die "
+                    "Synchronisation sollte jetzt wieder funktionieren.",
+                )
+                return
+            messagebox.showerror(
+                "Google neu verbinden",
+                "Die Neuverbindung ist fehlgeschlagen:\n\n"
+                f"{res['error']}\n\n{res['tb']}",
+                parent=dialog,
+            )
+
+        runner.run(_fn, _on_done)
 
     reconnect_btn = secondary_button(
         btn_row, "Google neu verbinden", _reconnect_google, padx=12, pady=2)
@@ -576,14 +570,13 @@ def open_settings_dialog(parent, settings, base_path, on_change, *,
                         "Kompaktierung", "Sync-Daten wurden kompaktiert.",
                     )
 
-            def _do():
+            def _fn():
                 from src.main import _run_compaction_blocking
-                res = _run_compaction_blocking(
+                return _run_compaction_blocking(
                     storage, settings, conflicts_store, base_path,
                     data_lock=data_lock, sync_guard=sync_guard)
-                dialog.after(0, lambda: _show(res))
 
-            threading.Thread(target=_do, daemon=True).start()
+            runner.run(_fn, _show)
 
         secondary_button(
             tab_google, "Sync-Daten kompaktieren", _on_compact_clicked,
@@ -641,9 +634,9 @@ def open_settings_dialog(parent, settings, base_path, on_change, *,
     def _load_calendars():
         cal_status.config(text="Kalenderliste wird geladen…")
 
-        def _do():
+        def _fn():
+            from src import gcal
             try:
-                from src import gcal
                 service = gcal.get_calendar_service(
                     os.path.join(base_path, "credentials.json"),
                     os.path.join(base_path, "token.json"),
@@ -651,26 +644,24 @@ def open_settings_dialog(parent, settings, base_path, on_change, *,
                 )
                 items = gcal.list_calendars(service)
             except Exception as e:
-                tb = traceback.format_exc()
-                # e/tb als Default-Argumente binden: das Lambda läuft via
-                # dialog.after() VERZÖGERT — bis dahin hat Python die
-                # except-Variable `e` am Blockende gelöscht (impliziter del),
-                # ein freier Zugriff gäbe NameError.
-                dialog.after(
-                    0, lambda e=e, tb=tb: _load_calendars_error(e, tb))
+                return {"ok": False, "error": e, "tb": traceback.format_exc()}
+            return {"ok": True, "items": items}
+
+        def _on_done(res):
+            if not cal_status.winfo_exists():
                 return
-            dialog.after(0, lambda: _populate_calendars(items))
+            if not res["ok"]:
+                cal_status.config(text="Kalenderliste nicht verfügbar")
+                messagebox.showerror(
+                    "Google Kalender",
+                    "Kalenderliste konnte nicht geladen werden:\n\n"
+                    f"{res['error']}\n\n{res['tb']}",
+                    parent=dialog,
+                )
+                return
+            _populate_calendars(res["items"])
 
-        threading.Thread(target=_do, daemon=True).start()
-
-    def _load_calendars_error(err, tb):
-        if cal_status.winfo_exists():
-            cal_status.config(text="Kalenderliste nicht verfügbar")
-        messagebox.showerror(
-            "Google Kalender",
-            f"Kalenderliste konnte nicht geladen werden:\n\n{err}\n\n{tb}",
-            parent=dialog,
-        )
+        runner.run(_fn, _on_done)
 
     def _on_gcal_toggled():
         assert cb_gcal is not None

--- a/src/dialogs/settings_dialog.py
+++ b/src/dialogs/settings_dialog.py
@@ -74,7 +74,7 @@ def build_oauth_enable_task(*, service_fn, settings, setting_key, checkbox,
 
 
 def open_settings_dialog(parent, settings, base_path, on_change, *,
-                         conflicts_store=None, storage=None,
+                         runner, conflicts_store=None, storage=None,
                          reservation_store=None, on_request_restart=None,
                          data_lock=None, sync_guard=None):
     """Modaler Dialog zum Bearbeiten der App-Einstellungen, aufgeteilt auf vier
@@ -85,6 +85,8 @@ def open_settings_dialog(parent, settings, base_path, on_change, *,
     gesetzt, erscheint im Google-Tab der Sync-Block mit Konflikte-Button.
     data_lock/sync_guard: geteilter Store-Lock + Sync-Guard für die Kompaktierung
     (Audit H1/H2) — von App durchgereicht.
+    runner: der App-BackgroundTaskRunner (App._bg); alle Hintergrund-Worker des
+    Dialogs laufen über runner.run(fn, on_done) (Audit H5).
     """
     dialog = create_dialog(parent, "Einstellungen", escape_closes=False)
 
@@ -383,42 +385,27 @@ def open_settings_dialog(parent, settings, base_path, on_change, *,
     # narrowt den Typ für Pylance.
     cb_sync: tk.Checkbutton | None = None
 
-    def _finish_oauth(err, tb):
-        assert cb_sync is not None
-        cb_sync.config(state="normal")
-        if err is None:
-            settings.set("sync_enabled", True)
-            on_change()
-            return
-        messagebox.showerror(
-            "Synchronisation aktivieren",
-            f"OAuth-Flow fehlgeschlagen:\n\n{err}\n\n{tb}",
-            parent=dialog,
-        )
-        var_sync.set(False)
-
     def _on_sync_toggled():
         assert cb_sync is not None
         new_state = var_sync.get()
         if new_state and not settings.get("sync_enabled"):
             cb_sync.config(state="disabled")
 
-            def _do_oauth():
-                err = None
-                tb = ""
-                try:
-                    from src import drive
-                    drive.get_drive_service(
-                        os.path.join(base_path, "credentials.json"),
-                        os.path.join(base_path, "token.json"),
-                        gcal_enabled=settings.get("gcal_enabled"),
-                    )
-                except Exception as e:
-                    err = e
-                    tb = traceback.format_exc()
-                dialog.after(0, lambda: _finish_oauth(err, tb))
+            def _service():
+                from src import drive
+                drive.get_drive_service(
+                    os.path.join(base_path, "credentials.json"),
+                    os.path.join(base_path, "token.json"),
+                    gcal_enabled=settings.get("gcal_enabled"),
+                )
 
-            threading.Thread(target=_do_oauth, daemon=True).start()
+            fn, on_done = build_oauth_enable_task(
+                service_fn=_service, settings=settings,
+                setting_key="sync_enabled", checkbox=cb_sync,
+                toggle_var=var_sync, on_change=on_change, dialog=dialog,
+                error_title="Synchronisation aktivieren",
+            )
+            runner.run(fn, on_done)
             return
         if not new_state and settings.get("sync_enabled"):
             settings.set("sync_enabled", False)
@@ -685,43 +672,28 @@ def open_settings_dialog(parent, settings, base_path, on_change, *,
             parent=dialog,
         )
 
-    def _finish_gcal_oauth(err, tb):
-        assert cb_gcal is not None
-        if not cb_gcal.winfo_exists():
-            return  # Dialog wurde während des OAuth-Flows geschlossen.
-        cb_gcal.config(state="normal")
-        if err is None:
-            settings.set("gcal_enabled", True)
-            on_change()
-            _load_calendars()
-            return
-        messagebox.showerror(
-            "Google Kalender aktivieren",
-            f"OAuth-Flow fehlgeschlagen:\n\n{err}\n\n{tb}",
-            parent=dialog,
-        )
-        var_gcal.set(False)
-
     def _on_gcal_toggled():
         assert cb_gcal is not None
         new_state = var_gcal.get()
         if new_state and not settings.get("gcal_enabled"):
             cb_gcal.config(state="disabled")
 
-            def _do_oauth():
-                err, tb = None, ""
-                try:
-                    from src import gcal
-                    gcal.get_calendar_service(
-                        os.path.join(base_path, "credentials.json"),
-                        os.path.join(base_path, "token.json"),
-                        sync_enabled=settings.get("sync_enabled"),
-                    )
-                except Exception as e:
-                    err, tb = e, traceback.format_exc()
-                dialog.after(0, lambda: _finish_gcal_oauth(err, tb))
+            def _service():
+                from src import gcal
+                gcal.get_calendar_service(
+                    os.path.join(base_path, "credentials.json"),
+                    os.path.join(base_path, "token.json"),
+                    sync_enabled=settings.get("sync_enabled"),
+                )
 
-            threading.Thread(target=_do_oauth, daemon=True).start()
+            fn, on_done = build_oauth_enable_task(
+                service_fn=_service, settings=settings,
+                setting_key="gcal_enabled", checkbox=cb_gcal,
+                toggle_var=var_gcal, on_change=on_change, dialog=dialog,
+                error_title="Google Kalender aktivieren",
+                on_success_dialog_ui=_load_calendars,
+            )
+            runner.run(fn, on_done)
             return
         if not new_state and settings.get("gcal_enabled"):
             settings.set("gcal_enabled", False)

--- a/src/ui.py
+++ b/src/ui.py
@@ -356,6 +356,7 @@ class App:
         open_settings_dialog(
             self.root, self.settings, self.base_path,
             on_change=_on_change,
+            runner=self._bg,
             conflicts_store=self.conflicts_store,
             storage=self.storage,
             reservation_store=self.reservation_store,

--- a/tests/test_settings_dialog.py
+++ b/tests/test_settings_dialog.py
@@ -1,0 +1,114 @@
+"""build_oauth_enable_task: fn/on_done-Kontrakt eines OAuth-Aktivieren-Toggles,
+headless (der Dialog selbst ist Tk-gebunden, M16)."""
+
+from unittest.mock import MagicMock
+
+import src.dialogs.settings_dialog as sd
+from src.dialogs.settings_dialog import build_oauth_enable_task
+
+
+class _FakeSettings:
+    def __init__(self):
+        self.sets = []
+
+    def set(self, key, value):
+        self.sets.append((key, value))
+
+
+class _FakeCheckbox:
+    """Fake tk.Checkbutton: steuerbares winfo_exists + config-Rekorder."""
+    def __init__(self, alive=True):
+        self._alive = alive
+        self.config_calls = []
+
+    def winfo_exists(self):
+        return self._alive
+
+    def config(self, **kwargs):
+        self.config_calls.append(kwargs)
+
+
+class _FakeVar:
+    def __init__(self):
+        self.value = True
+
+    def set(self, v):
+        self.value = v
+
+
+def _build(*, service_ok=True, alive=True, on_success_ui=None):
+    settings = _FakeSettings()
+    checkbox = _FakeCheckbox(alive=alive)
+    var = _FakeVar()
+    on_change = MagicMock()
+
+    def service_fn():
+        if not service_ok:
+            raise RuntimeError("boom")
+
+    fn, on_done = build_oauth_enable_task(
+        service_fn=service_fn, settings=settings, setting_key="sync_enabled",
+        checkbox=checkbox, toggle_var=var, on_change=on_change,
+        dialog=object(), error_title="Titel",
+        on_success_dialog_ui=on_success_ui,
+    )
+    return settings, checkbox, var, on_change, fn, on_done
+
+
+def test_success_persists_and_updates_ui(monkeypatch):
+    monkeypatch.setattr(sd.messagebox, "showerror", lambda *a, **k: None)
+    ui = MagicMock()
+    settings, checkbox, var, on_change, fn, on_done = _build(on_success_ui=ui)
+    on_done(fn())
+    assert settings.sets == [("sync_enabled", True)]
+    on_change.assert_called_once_with()
+    assert {"state": "normal"} in checkbox.config_calls
+    ui.assert_called_once_with()
+    assert var.value is True  # kein Revert
+
+
+def test_success_persists_even_when_dialog_closed(monkeypatch):
+    monkeypatch.setattr(sd.messagebox, "showerror", lambda *a, **k: None)
+    ui = MagicMock()
+    settings, checkbox, var, on_change, fn, on_done = _build(alive=False,
+                                                             on_success_ui=ui)
+    on_done(fn())
+    assert settings.sets == [("sync_enabled", True)]   # Persistenz überlebt
+    on_change.assert_called_once_with()                 # root-scoped, läuft
+    assert checkbox.config_calls == []                  # kein Widget-Zugriff
+    ui.assert_not_called()                              # Dialog-Kosmetik übersprungen
+
+
+def test_failure_no_persist_and_reverts(monkeypatch):
+    errors = []
+    monkeypatch.setattr(sd.messagebox, "showerror",
+                        lambda *a, **k: errors.append(a))
+    settings, checkbox, var, on_change, fn, on_done = _build(service_ok=False)
+    on_done(fn())
+    assert settings.sets == []          # keine Persistenz bei Fehler
+    on_change.assert_not_called()
+    assert {"state": "normal"} in checkbox.config_calls
+    assert var.value is False           # Revert
+    assert errors                       # Fehler-Messagebox gezeigt
+
+
+def test_failure_dialog_closed_skips_all_ui(monkeypatch):
+    errors = []
+    monkeypatch.setattr(sd.messagebox, "showerror",
+                        lambda *a, **k: errors.append(a))
+    settings, checkbox, var, on_change, fn, on_done = _build(service_ok=False,
+                                                             alive=False)
+    on_done(fn())
+    assert settings.sets == []
+    on_change.assert_not_called()
+    assert checkbox.config_calls == []
+    assert var.value is True            # kein Revert (Dialog weg)
+    assert errors == []
+
+
+def test_success_without_on_success_ui(monkeypatch):
+    monkeypatch.setattr(sd.messagebox, "showerror", lambda *a, **k: None)
+    settings, checkbox, var, on_change, fn, on_done = _build(on_success_ui=None)
+    on_done(fn())  # darf nicht werfen
+    assert settings.sets == [("sync_enabled", True)]
+    assert {"state": "normal"} in checkbox.config_calls


### PR DESCRIPTION
## ⚠️ Gestapelt auf #119, #121 und #122 — bitte in dieser Reihenfolge mergen

Dieser PR baut auf **#119** (accent-bar), **#121** (Datenschicht-Threadsicherheit)
und **#122** (Dialog-Theme-Helfer) auf. Solange die offen sind, zeigt der Diff hier
auch deren Commits; sobald sie in `master` sind, schrumpft er auf die reine H5-Arbeit.
Merge-Reihenfolge: **#119 → #121 → #122 → dieser PR**.

> Hinweis: #121 und #122 wurden soeben aktualisiert — #121 trägt jetzt einen
> Folgefix (Sync-Button-Klick warf `TclError: unknown option "-state"`, weil der
> Themed `icon_button` kein natives `-state` kennt; Optik-only-Disable + Guard-Flag).

## Zusammenfassung

Behebt Audit-Finding **H5** (2026-07-04): Die sechs Hintergrund-Worker im
`settings_dialog` liefen an der dokumentierten Thread-Konvention vorbei — rohe
`threading.Thread` + ungeschütztes `dialog.after(0, …)` statt des einen
sanktionierten Musters (`BackgroundTaskRunner.run(fn, on_done)` über
`App._marshal_to_ui`). Konkreter Schaden: schließt der Nutzer den Dialog während
eines OAuth-Flows, ging die erfolgreiche Aktivierung verloren
(`settings.set("sync_enabled"/"gcal_enabled", True)` lief nie), und der Thread-Tod
landete nur auf dem per `--noconsole` unterdrückten stderr.

Jetzt laufen **alle sechs** Worker über den injizierten `runner`:

- **Persistenz überlebt den Dialog-Close:** `settings.set(...)` sitzt im `fn`
  (Worker-Thread, thread-safe seit #121), nie hinter einem Dialog-Widget-Zugriff.
  Betrifft Drive-Sync, Kalender und den `sender_email`-Cache.
- **UI-Feedback ist `winfo_exists`-geschützt** und wird sauber übersprungen, wenn
  der Dialog weg ist; der root-scoped `on_change()` läuft davor.
- Die zwei near-identischen OAuth-Aktivieren-Toggles teilen sich einen testbaren
  Builder `build_oauth_enable_task` (entfernt zugleich die Duplikation).
- `import threading` und alle `dialog.after(0, …)` sind aus dem Dialog verschwunden
  (der reine UI-Timer `after(500, …)` bleibt).

## Design-Entscheidungen (abgestimmt)

- **Alle 6 einheitlich** über `runner.run` (nicht nur die zwei Persistenz-Bugs) —
  verhindert strukturell den nächsten H5. H4 (God-Function-Split) bleibt separat.
- **OAuth-Semantik:** Consent erfolgreich + Dialog vorher geschlossen → Aktivierung
  **persistiert trotzdem** (Token liegt bereits, Feature ist beim nächsten Öffnen
  aktiv); nur das UI-Feedback entfällt.

## Tests / Verifikation

- Neuer, erstmals headless-testbarer Builder: `tests/test_settings_dialog.py`
  (5 Tests — Persistenz überlebt bei offenem *und* geschlossenem Dialog,
  kein Persist bei Fehler, UI-Skip bei Close, `on_success_dialog_ui`-Hook).
- Gesamtsuite **750 passed / 3 skipped**, `ruff check .` clean.
- App-Start-Smoke stabil; interaktiver Dialog-Klick (Toggles / „Aktualisieren" /
  „Neu verbinden") lokal abgenommen.
- Die reine Dialog-Verdrahtung bleibt Tk-gebunden (M16) → keine neuen Tk-Tests.

Kein `release:*`-Label (reiner Fix/Refactor).

Spec/Plan: `docs/superpowers/specs/2026-07-04-settings-dialog-threadvertrag-design.md`,
`docs/superpowers/plans/2026-07-04-settings-dialog-threadvertrag.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016pPmbLT2BQqZx9qhfTXWFD
