### PR TITLE
refactor(settings): open_settings_dialog in Paket pro Tab zerlegt (Audit H4)

### DIFF
--- a/docs/superpowers/plans/2026-07-04-settings-dialog-split.md
+++ b/docs/superpowers/plans/2026-07-04-settings-dialog-split.md
@@ -1,0 +1,524 @@
+# Settings-Dialog Aufteilung pro Tab (Audit H4) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Die ~900-Zeilen-Funktion `open_settings_dialog` in ein Paket `src/dialogs/settings_dialog/` mit vier Tab-Klassen-Modulen zerlegen — verhaltensgleich, ohne einen einzigen Logik- oder UI-Unterschied.
+
+**Architecture:** Reiner Code-Move: `settings_dialog.py` wird Paket; jede Tab-Klasse bekommt den bestehenden Abschnitts-Code **verbatim** in ihren `__init__` (lokale Namen und verschachtelte Closures bleiben unangetastet — nur der Frame-Name wird zu `frame` und am Ende werden die Vertrags-Attribute per `self.x = x` exponiert). `save_settings` bleibt zentral in `dialog.py`, liest die Variablen aber über Tab-Handles (`work.start_vars` statt Closure-Scope). Import-Pfade bleiben über `__init__.py`-Re-Exports stabil.
+
+**Tech Stack:** Python 3.14, Tkinter, pytest, ruff. Keine neuen Dependencies.
+
+## Global Constraints
+
+- **Verhaltensgleich pro Stelle** (Spec): kein Logik-, Text-, Layout- oder Reihenfolge-Unterschied. Auch keine Gelegenheits-Fixes (hartkodierter Font `("Segoe UI", 8)`, M14-Duplikate, M10 — notieren, nicht fixen).
+- **`save_settings` bleibt zentral und ablaufidentisch** in `dialog.py`; nur Variablen-Zugriffe wechseln auf Tab-Attribute.
+- **Move-Technik:** Abschnitts-Code verbatim in `__init__` verschieben; innerhalb des verschobenen Blocks NUR den Tab-Frame-Namen ersetzen (`tab_work` → `frame` usw.); Vertrags-Attribute am Ende des `__init__` als `self.x = x`-Zuweisungen. Interne Closures/Locals NICHT auf `self._x` umschreiben.
+- **H5-Invarianten unangetastet:** die `runner.run`-Worker, `winfo_exists`-Guards und Persistenz-im-`fn` ziehen unverändert mit um.
+- **Import-Stabilität:** `from src.dialogs.settings_dialog import open_settings_dialog` (ui.py) funktioniert nach jedem Task; `build_oauth_enable_task` bleibt aus dem Paket importierbar.
+- **Nach jedem Task grün:** `.venv/Scripts/python.exe -m pytest -q` → 750 passed / 3 skipped; `.venv/Scripts/python.exe -m ruff check .` → clean; Import-Smoke `.venv/Scripts/python.exe -c "import src.ui; print('ok')"`.
+- **Zeilennummern** in den Tasks beziehen sich auf `src/dialogs/settings_dialog.py` @ Branch-Start (Commit von H5, 977 Zeilen). Nach Task 1 heißt die Datei `src/dialogs/settings_dialog/dialog.py` und die Nummern verschieben sich um ~44 nach oben — **die Banner-Kommentare `# ===================== Tab: … =====================` sind die verlässlichen Anker**, immer zuerst den umgebenden Code verifizieren.
+
+Design-Referenz: `docs/superpowers/specs/2026-07-04-settings-dialog-split-design.md`.
+
+---
+
+## Task 1: Paket-Skelett — Datei-Move + `oauth_task.py` + Re-Exports
+
+`settings_dialog.py` → `settings_dialog/dialog.py` (inhaltlich unverändert bis auf den Auszug von `build_oauth_enable_task`), neues Modul `oauth_task.py`, `__init__.py`-Re-Exports, Test-Import angepasst. Noch keine Tab-Extraktion.
+
+**Files:**
+- Move: `src/dialogs/settings_dialog.py` → `src/dialogs/settings_dialog/dialog.py` (per `git mv`)
+- Create: `src/dialogs/settings_dialog/__init__.py`
+- Create: `src/dialogs/settings_dialog/oauth_task.py`
+- Modify: `tests/test_settings_dialog.py:1-8` (Import-Kopf)
+
+**Interfaces:**
+- Consumes: nichts.
+- Produces: Paket `src.dialogs.settings_dialog` mit `open_settings_dialog` (aus `.dialog`) und `build_oauth_enable_task` (aus `.oauth_task`) im `__init__`-Namespace. `dialog.py` importiert `from src.dialogs.settings_dialog.oauth_task import build_oauth_enable_task`.
+
+- [ ] **Step 1: Datei in Paket verschieben**
+
+```bash
+mkdir -p src/dialogs/settings_dialog
+git mv src/dialogs/settings_dialog.py src/dialogs/settings_dialog/dialog.py
+```
+
+- [ ] **Step 2: `oauth_task.py` anlegen — `build_oauth_enable_task` ausschneiden**
+
+Aus `src/dialogs/settings_dialog/dialog.py` die komplette Funktion `build_oauth_enable_task` (Original-Z. 32–72, inkl. Docstring) **ausschneiden** und in die neue Datei einfügen:
+
+```python
+# src/dialogs/settings_dialog/oauth_task.py
+"""Generischer (fn, on_done)-Builder für OAuth-Aktivieren-Toggles (Audit H5).
+
+Eigenes Modul (statt tab_google), weil der Builder keinen Tab-Bezug hat und
+tests/test_settings_dialog.py sein messagebox im Funktions-Modul monkeypatcht.
+"""
+
+import traceback
+from tkinter import messagebox
+
+
+<hier die ausgeschnittene Funktion build_oauth_enable_task 1:1 einfügen>
+```
+
+In `dialog.py` dafür den Import ergänzen (bei den `from src...`-Imports):
+
+```python
+from src.dialogs.settings_dialog.oauth_task import build_oauth_enable_task
+```
+
+`dialog.py`-Importkopf prüfen: `traceback` und `messagebox` werden dort weiterhin gebraucht (Google-Tab-Worker) — **nicht** entfernen.
+
+- [ ] **Step 3: `__init__.py` anlegen**
+
+```python
+# src/dialogs/settings_dialog/__init__.py
+"""Einstellungen-Dialog als Paket (Audit H4): dialog.py trägt Chrome +
+zentrales save_settings, die vier Tabs sind eigene Klassen-Module.
+Öffentliche API unverändert re-exportiert."""
+
+from src.dialogs.settings_dialog.dialog import open_settings_dialog
+from src.dialogs.settings_dialog.oauth_task import build_oauth_enable_task
+
+__all__ = ["open_settings_dialog", "build_oauth_enable_task"]
+```
+
+- [ ] **Step 4: Test-Import anpassen**
+
+In `tests/test_settings_dialog.py` den Kopf (Z. 4–8):
+
+```python
+from unittest.mock import MagicMock
+
+import src.dialogs.settings_dialog as sd
+from src.dialogs.settings_dialog import build_oauth_enable_task
+```
+
+ersetzen durch (Alias `sd` bleibt, damit die `monkeypatch.setattr(sd.messagebox, …)`-Aufrufe im Rest der Datei unverändert weiter funktionieren — sie müssen das Modul patchen, in dem die Funktion lebt):
+
+```python
+from unittest.mock import MagicMock
+
+import src.dialogs.settings_dialog.oauth_task as sd
+from src.dialogs.settings_dialog.oauth_task import build_oauth_enable_task
+```
+
+- [ ] **Step 5: Suite + Ruff + Import-Smoke**
+
+```bash
+.venv/Scripts/python.exe -m pytest -q
+.venv/Scripts/python.exe -m ruff check .
+.venv/Scripts/python.exe -c "import src.ui; print('ok')"
+```
+Expected: 750 passed / 3 skipped; All checks passed; `ok`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A src/dialogs/settings_dialog tests/test_settings_dialog.py
+git commit -m "refactor(settings): settings_dialog als Paket — dialog.py + oauth_task.py + Re-Exports (H4 Schritt 1)"
+```
+
+---
+
+## Task 2: `_shared.py` + `WorkTab`
+
+Grid-Helfer `label`/`subheader` in `_shared.py`; Arbeitszeit-Tab als `WorkTab`-Klasse. `dialog.py` verliert seine lokalen Helfer-Defs (die verbleibenden Inline-Tabs nutzen ab jetzt die importierten — identische Signatur, identisches Verhalten).
+
+**Files:**
+- Create: `src/dialogs/settings_dialog/_shared.py`
+- Create: `src/dialogs/settings_dialog/tab_work.py`
+- Modify: `src/dialogs/settings_dialog/dialog.py` (Helfer-Defs raus, Work-Block raus, `WorkTab` instanziieren, `save_settings`-Zugriffe umstellen)
+
+**Interfaces:**
+- Consumes: Paketstruktur aus Task 1.
+- Produces:
+  - `_shared.label(parent_frame, text, row, col=0, **grid_kw)` und `_shared.subheader(parent_frame, text, row, top_pad=16)` — byte-gleich zu Original-Z. 109–120.
+  - `WorkTab(frame, dialog, settings)` mit Attributen `frame`, `start_vars`, `end_vars` (je `dict[str, tk.StringVar]`), `pause_var`, `wsl_enabled_var`, `wsl_start_vars`, `wsl_end_vars` (je `(day, month, year)`-Tupel von `tk.StringVar`), `wsl_hours_var`.
+
+- [ ] **Step 1: `_shared.py` anlegen**
+
+```python
+# src/dialogs/settings_dialog/_shared.py
+"""Gemeinsame Grid-Helfer der Settings-Tabs (label/subheader)."""
+
+import tkinter as tk
+from typing import Any
+
+from src.theme import BG, FONT, FONT_BOLD, TEXT, TEXT_MUTED
+
+
+def label(parent_frame, text, row, col=0, **grid_kw):
+    kw: dict[str, Any] = dict(padx=10, pady=8, sticky="w")
+    kw.update(grid_kw)
+    lbl = tk.Label(parent_frame, text=text, font=FONT, bg=BG, fg=TEXT)
+    lbl.grid(row=row, column=col, **kw)
+    return lbl
+
+
+def subheader(parent_frame, text, row, top_pad=16):
+    tk.Label(
+        parent_frame, text=f"— {text} —", font=FONT_BOLD,
+        bg=BG, fg=TEXT_MUTED,
+    ).grid(row=row, column=0, columnspan=2, padx=10, pady=(top_pad, 4))
+```
+
+- [ ] **Step 2: `tab_work.py` anlegen — Work-Block verbatim verschieben**
+
+Neue Datei mit dieser Struktur; der Body ist der **verbatim ausgeschnittene** Block von Original-Z. 123–212 (Anker: von `label(tab_work, "Standardzeiten:", …)` bis einschließlich des „Kategorien verwalten"-`secondary_button`-Blocks). Im verschobenen Block **einzige Änderung:** jedes `tab_work` → `frame`.
+
+```python
+# src/dialogs/settings_dialog/tab_work.py
+"""Tab „Arbeitszeit": Standardzeiten, Pause, Werkstudenten-Limit, Kategorien."""
+
+import calendar
+import datetime
+import tkinter as tk
+
+from src.dialogs.category_dialog import open_category_dialog
+from src.dialogs.settings_dialog._shared import label, subheader
+from src.settings import WEEKDAY_KEYS
+from src.theme import (
+    BG, CELL_BG, FONT, FONT_SMALL, PAUSE_VALUES, TEXT, TEXT_MUTED,
+    TIME_VALUES, dark_combo, dark_entry, secondary_button,
+)
+from src.time_utils import DAYS_DE
+
+
+class WorkTab:
+    """Baut den Arbeitszeit-Tab; exponiert die Tk-Variablen, die
+    save_settings in dialog.py liest (Vertrag siehe Spec H4)."""
+
+    def __init__(self, frame, dialog, settings):
+        <verbatim verschobener Block Z. 123–212, tab_work→frame>
+
+        self.frame = frame
+        self.start_vars = start_vars
+        self.end_vars = end_vars
+        self.pause_var = pause_var
+        self.wsl_enabled_var = wsl_enabled_var
+        self.wsl_start_vars = wsl_start_vars
+        self.wsl_end_vars = wsl_end_vars
+        self.wsl_hours_var = wsl_hours_var
+```
+
+Hinweis: `_wsl_date_row` bleibt als verschachtelte Funktion im `__init__` (Move-Technik, Global Constraints); `dialog` wird nur vom „Kategorien verwalten"-Lambda genutzt.
+
+- [ ] **Step 3: `dialog.py` umbauen**
+
+1. Die lokalen Defs `label` (Z. 109–114) und `subheader` (Z. 116–120) **löschen**; Import ergänzen: `from src.dialogs.settings_dialog._shared import label, subheader`. (Mail/Google/App-Blöcke rufen sie mit identischer Signatur weiter auf.)
+2. Den Work-Block (Z. 122–212 inkl. Banner-Kommentar) **ersetzen** durch:
+   ```python
+   # ===================== Tab: Arbeitszeit =====================
+   work = WorkTab(tab_work, dialog, settings)
+   ```
+   Import ergänzen: `from src.dialogs.settings_dialog.tab_work import WorkTab`.
+3. In `save_settings` und im `tabs`-Dict die Work-Zugriffe umstellen (Substitutionstabelle — gilt für **jede** Vorkommnis in `dialog.py`):
+
+   | alt | neu |
+   |---|---|
+   | `start_vars` | `work.start_vars` |
+   | `end_vars` | `work.end_vars` |
+   | `pause_var` | `work.pause_var` |
+   | `wsl_enabled_var` | `work.wsl_enabled_var` |
+   | `wsl_start_vars` | `work.wsl_start_vars` |
+   | `wsl_end_vars` | `work.wsl_end_vars` |
+   | `wsl_hours_var` | `work.wsl_hours_var` |
+   | `tabs = {"work": tab_work, …}` | `tabs = {"work": work.frame, …}` (übrige Einträge unverändert) |
+
+4. Import-Kopf von `dialog.py` trimmen: `calendar`, `open_category_dialog`, `PAUSE_VALUES`, `TIME_VALUES`, `dark_combo`*, `dark_entry`*, `DAYS_DE`* nur entfernen, wenn sie in `dialog.py` **nirgends mehr** vorkommen (`DAYS_DE` wird in `save_settings` Z. 841 weiter gebraucht → bleibt; `dark_combo`/`dark_entry` werden von Mail/Google/App-Blöcken noch gebraucht → bleiben vorerst). Verifikation per grep, nicht raten.
+
+- [ ] **Step 4: Verifikation + grep**
+
+```bash
+.venv/Scripts/python.exe -m pytest -q
+.venv/Scripts/python.exe -m ruff check .
+.venv/Scripts/python.exe -c "import src.ui; print('ok')"
+grep -n "start_vars\|wsl_" src/dialogs/settings_dialog/dialog.py
+```
+Expected: grün/clean/ok; alle grep-Treffer tragen das Präfix `work.`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A src/dialogs/settings_dialog
+git commit -m "refactor(settings): WorkTab + _shared-Helfer extrahiert (H4 Schritt 2)"
+```
+
+---
+
+## Task 3: `MailTab`
+
+**Files:**
+- Create: `src/dialogs/settings_dialog/tab_mail.py`
+- Modify: `src/dialogs/settings_dialog/dialog.py`
+
+**Interfaces:**
+- Consumes: `_shared.label`, `_shared.subheader` (Task 2).
+- Produces: `MailTab(frame, settings)` mit Attributen `frame`, `recipient_var`, `name_var`, `rate_var`, `subject_var`, `greeting_var`, `content_text` (tk.Text), `closing_text` (tk.Text).
+
+- [ ] **Step 1: `tab_mail.py` anlegen — Mail-Block verbatim verschieben**
+
+Block = Original-Z. 214–253 (Anker: Banner `# ===================== Tab: Bericht & Mail` bis zur Platzhalter-Hinweiszeile `…{zeitraum}, {gesamt}…` einschließlich). Einzige Änderung im Block: `tab_mail` → `frame`. Der hartkodierte Font `("Segoe UI", 8)` zieht **unverändert** mit (Audit-Randnotiz, bewusst kein Fix — Global Constraints).
+
+```python
+# src/dialogs/settings_dialog/tab_mail.py
+"""Tab „Bericht & Mail": Empfänger, Name, Stundenlohn, Mail-Vorlage."""
+
+import tkinter as tk
+
+from src.dialogs.settings_dialog._shared import label, subheader
+from src.theme import BG, FONT_SMALL, TEXT_MUTED, dark_entry, dark_text
+
+
+class MailTab:
+    """Baut den Bericht-&-Mail-Tab; exponiert die Variablen für save_settings."""
+
+    def __init__(self, frame, settings):
+        <verbatim verschobener Block Z. 214–253, tab_mail→frame>
+
+        self.frame = frame
+        self.recipient_var = recipient_var
+        self.name_var = name_var
+        self.rate_var = rate_var
+        self.subject_var = subject_var
+        self.greeting_var = greeting_var
+        self.content_text = content_text
+        self.closing_text = closing_text
+```
+
+(Import-Liste beim Verschieben gegen den tatsächlichen Block prüfen — sie muss exakt die im Block verwendeten Namen decken, nicht mehr.)
+
+- [ ] **Step 2: `dialog.py` umbauen**
+
+Mail-Block ersetzen durch `mail = MailTab(tab_mail, settings)` (Banner-Kommentar davor behalten); Import `from src.dialogs.settings_dialog.tab_mail import MailTab`. Substitutionen in `save_settings`:
+
+| alt | neu |
+|---|---|
+| `recipient_var` | `mail.recipient_var` |
+| `name_var` | `mail.name_var` |
+| `rate_var` | `mail.rate_var` |
+| `subject_var` | `mail.subject_var` |
+| `greeting_var` | `mail.greeting_var` |
+| `content_text` | `mail.content_text` |
+| `closing_text` | `mail.closing_text` |
+| `tabs`-Eintrag `"mail": tab_mail` | `"mail": mail.frame` |
+
+Import-Kopf trimmen (nur grep-verifiziert; `dark_text` dürfte jetzt aus `dialog.py` verschwinden).
+
+- [ ] **Step 3: Verifikation + Commit**
+
+```bash
+.venv/Scripts/python.exe -m pytest -q && .venv/Scripts/python.exe -m ruff check . && .venv/Scripts/python.exe -c "import src.ui; print('ok')"
+grep -n "recipient_var\|content_text\|closing_text" src/dialogs/settings_dialog/dialog.py
+git add -A src/dialogs/settings_dialog
+git commit -m "refactor(settings): MailTab extrahiert (H4 Schritt 3)"
+```
+Expected: grün/clean/ok; grep-Treffer nur mit `mail.`-Präfix.
+
+---
+
+## Task 4: `AppTab`
+
+**Files:**
+- Create: `src/dialogs/settings_dialog/tab_app.py`
+- Modify: `src/dialogs/settings_dialog/dialog.py`
+
+**Interfaces:**
+- Consumes: `_shared.label`.
+- Produces: `AppTab(frame, settings)` mit Attributen `frame`, `state_var`, `show_weekend_var`, `autostart_var`, `always_on_top_var`, `minimize_to_tray_var`, `scale_var` (tk.DoubleVar), `reminders_enabled_var`, `reminder_minutes_var`.
+
+- [ ] **Step 1: `tab_app.py` anlegen — App-Block verbatim verschieben**
+
+Block = Original-Z. 698–835 (Anker: Banner `# ===================== Tab: App` bis zur Hinweiszeile „Nur für Reservierungen mit Kategorie."). Änderungen im Block: `tab_app` → `frame`, und **eine** dokumentierte Äquivalenz-Anpassung: `ttk.Style(dialog)` (Original-Z. 767) → `ttk.Style(frame)` — ttk-Styles sind Interpreter-global, der Master dient nur der Interpreter-Bindung; `AppTab` braucht dadurch kein `dialog`-Handle (Spec-Festlegung).
+
+```python
+# src/dialogs/settings_dialog/tab_app.py
+"""Tab „App": Bundesland, UI-Optionen, Skalierung, Benachrichtigungen."""
+
+import tkinter as tk
+from tkinter import ttk
+
+from src.autostart import is_autostart_enabled
+from src.dialogs.settings_dialog._shared import label
+from src.holidays_de import STATES
+from src.theme import (
+    ACCENT, BG, CELL_BG, FONT, FONT_BOLD, FONT_SMALL, TEXT, TEXT_MUTED,
+    dark_combo,
+)
+
+
+class AppTab:
+    """Baut den App-Tab; exponiert die Variablen für save_settings."""
+
+    def __init__(self, frame, settings):
+        <verbatim verschobener Block Z. 698–835, tab_app→frame,
+         ttk.Style(dialog)→ttk.Style(frame)>
+
+        self.frame = frame
+        self.state_var = state_var
+        self.show_weekend_var = show_weekend_var
+        self.autostart_var = autostart_var
+        self.always_on_top_var = always_on_top_var
+        self.minimize_to_tray_var = minimize_to_tray_var
+        self.scale_var = scale_var
+        self.reminders_enabled_var = reminders_enabled_var
+        self.reminder_minutes_var = reminder_minutes_var
+```
+
+- [ ] **Step 2: `dialog.py` umbauen**
+
+App-Block ersetzen durch `app = AppTab(tab_app, settings)`; Import `from src.dialogs.settings_dialog.tab_app import AppTab`. Substitutionen:
+
+| alt | neu |
+|---|---|
+| `state_var` | `app.state_var` |
+| `show_weekend_var` | `app.show_weekend_var` |
+| `autostart_var` | `app.autostart_var` |
+| `always_on_top_var` | `app.always_on_top_var` |
+| `minimize_to_tray_var` | `app.minimize_to_tray_var` |
+| `scale_var` | `app.scale_var` |
+| `reminders_enabled_var` | `app.reminders_enabled_var` |
+| `reminder_minutes_var` | `app.reminder_minutes_var` |
+| `tabs`-Eintrag `"app": tab_app` | `"app": app.frame` |
+
+Achtung Import-Trim: `is_autostart_enabled` wird in `save_settings` (Z. 877 `old_autostart = is_autostart_enabled()`) **weiter gebraucht** → bleibt in `dialog.py`. `STATES` verschwindet aus `dialog.py` (`code_for_state_label` bleibt). Grep-verifizieren.
+
+- [ ] **Step 3: Verifikation + Commit**
+
+```bash
+.venv/Scripts/python.exe -m pytest -q && .venv/Scripts/python.exe -m ruff check . && .venv/Scripts/python.exe -c "import src.ui; print('ok')"
+grep -n "state_var\|scale_var\|autostart_var\|minimize_to_tray\|reminders_enabled\|reminder_minutes" src/dialogs/settings_dialog/dialog.py
+git add -A src/dialogs/settings_dialog
+git commit -m "refactor(settings): AppTab extrahiert (H4 Schritt 4)"
+```
+Expected: grün/clean/ok; grep-Treffer nur mit `app.`-Präfix (plus die `is_autostart_enabled`-Zeile ohne Var-Bezug).
+
+---
+
+## Task 5: `GoogleTab` (der Brocken)
+
+**Files:**
+- Create: `src/dialogs/settings_dialog/tab_google.py`
+- Modify: `src/dialogs/settings_dialog/dialog.py`
+
+**Interfaces:**
+- Consumes: `_shared.label`, `_shared.subheader`, `oauth_task.build_oauth_enable_task`.
+- Produces: `GoogleTab(frame, dialog, settings, base_path, on_change, runner, storage, conflicts_store, reservation_store, data_lock, sync_guard)` mit Attributen `frame`, `cal_map` (dict, wird von `_populate_calendars` **mutiert** — dieselbe Instanz muss `save_settings` erreichen), `cal_var`.
+
+- [ ] **Step 1: `tab_google.py` anlegen — Google-Block verbatim verschieben**
+
+Block = Original-Z. 256–696 (Anker: Banner `# ===================== Tab: Google` bis einschließlich `if settings.get("gcal_enabled"): _load_calendars()`). **Zusätzlich** wandert `creds_path = os.path.join(base_path, "credentials.json")` (Original-Z. 95) an den Anfang des `__init__` — es wird nur im Google-Block genutzt. Einzige Block-Änderung: `tab_google` → `frame`. Alle anderen Namen (`dialog`, `settings`, `base_path`, `on_change`, `runner`, `storage`, `conflicts_store`, `reservation_store`, `data_lock`, `sync_guard`) sind Konstruktor-Parameter mit **identischen Namen** — der verschobene Code referenziert sie unverändert.
+
+```python
+# src/dialogs/settings_dialog/tab_google.py
+"""Tab „Google": Konto/Status, Absender, Drive-Sync (Konflikte/Import/
+Reconnect/Kompaktierung) und Google-Kalender — inkl. der H5-Worker
+(runner.run, Persistenz im fn, winfo_exists-Guards)."""
+
+import logging
+import os
+import tkinter as tk
+import traceback
+from tkinter import messagebox
+
+from src.dialogs.settings_dialog._shared import label, subheader
+from src.dialogs.settings_dialog.oauth_task import build_oauth_enable_task
+from src.platform_open import open_folder
+from src.theme import (
+    ACCENT, BG, CELL_BG, FONT, FONT_SMALL, STATUS_OK, TEXT, TEXT_MUTED,
+    dark_combo, secondary_button, themed_askyesno, themed_showerror,
+    themed_showinfo, themed_showwarning,
+)
+from src.time_utils import format_iso_date
+
+
+class GoogleTab:
+    """Baut den Google-Tab; exponiert cal_map/cal_var für save_settings."""
+
+    def __init__(self, frame, dialog, settings, base_path, on_change, runner,
+                 storage, conflicts_store, reservation_store,
+                 data_lock, sync_guard):
+        creds_path = os.path.join(base_path, "credentials.json")
+
+        <verbatim verschobener Block Z. 256–696, tab_google→frame>
+
+        self.frame = frame
+        self.cal_map = cal_map
+        self.cal_var = cal_var
+```
+
+(Die Lazy-Imports im Block — `from src.dialogs.conflicts_dialog import ConflictsDialog`, `from src.dialogs.import_dialog import open_import_dialog`, `from src import drive`, `from src import gcal`, `from src.main import _run_compaction_blocking`, `from src.sync import NEWER_REMOTE_VERSION_MSG` — bleiben lazy an Ort und Stelle; CI-Konvention.)
+
+- [ ] **Step 2: `dialog.py` umbauen**
+
+1. Google-Block (Z. 256–696) ersetzen durch:
+   ```python
+   # ===================== Tab: Google =====================
+   google = GoogleTab(
+       tab_google, dialog, settings, base_path, on_change, runner,
+       storage, conflicts_store, reservation_store, data_lock, sync_guard)
+   ```
+   Import `from src.dialogs.settings_dialog.tab_google import GoogleTab`; die Zeile `creds_path = …` (jetzt ~Z. 51) in `dialog.py` **löschen**.
+2. Substitutionen: `cal_map` → `google.cal_map`, `cal_var` → `google.cal_var`, `tabs`-Eintrag `"google": tab_google` → `"google": google.frame`.
+3. Import-Kopf von `dialog.py` **grep-verifiziert** trimmen — voraussichtlich fallen jetzt: `logging`, `os`, `traceback`, `messagebox`, `open_folder`, `format_iso_date`, `build_oauth_enable_task`-Import, `ACCENT`, `CELL_BG`, `FONT_SMALL`, `STATUS_OK`, `TEXT_MUTED`, `dark_combo`, `dark_entry`, `themed_askyesno`, `themed_showinfo`, `label`/`subheader`-Import (kein Inline-Block mehr) u. a. Behalten sicher: `datetime`, `tk`, `ttk`, `create_dialog`-Familie, `primary_button`, `secondary_button`, `themed_showerror`, `themed_showwarning`, Autostart-Namen, Settings-/time_utils-/weekly_limit-Namen, `WEEKDAY_KEYS`, `DAYS_DE`, `code_for_state_label`. **Jede Streichung nur nach grep** `grep -n "<name>" src/dialogs/settings_dialog/dialog.py`.
+
+- [ ] **Step 3: Verifikation + Commit**
+
+```bash
+.venv/Scripts/python.exe -m pytest -q && .venv/Scripts/python.exe -m ruff check . && .venv/Scripts/python.exe -c "import src.ui; print('ok')"
+grep -n "cal_map\|cal_var" src/dialogs/settings_dialog/dialog.py
+git add -A src/dialogs/settings_dialog
+git commit -m "refactor(settings): GoogleTab extrahiert (H4 Schritt 5)"
+```
+Expected: grün/clean/ok; grep nur `google.`-präfixiert.
+
+---
+
+## Task 6: Doku + Abschluss-Bilanz
+
+**Files:**
+- Modify: `src/CLAUDE.md` (Dialoge-Absatz)
+
+**Interfaces:**
+- Consumes: fertige Paketstruktur aus Tasks 1–5.
+- Produces: aktualisierte Architektur-Doku; Abnahme-Metriken.
+
+- [ ] **Step 1: `src/CLAUDE.md` aktualisieren**
+
+Im Abschnitt „## Dialoge (`src/dialogs/`)" den `settings_dialog`-Teil der Aufzählung („`settings_dialog` (4 Tabs über `ttk.Notebook` …)") ersetzen durch:
+
+```
+`settings_dialog/` (Paket, Audit H4: `dialog.py` trägt Chrome + zentrales,
+ablaufidentisches `save_settings`; je Tab eine Klasse in `tab_work/`
+`tab_mail`/`tab_google`/`tab_app`.py, die ihre Tk-Variablen als Attribute
+für `save_settings` exponiert; `oauth_task.py` = H5-OAuth-Toggle-Builder;
+Dark-Styling weiter via `theme.apply_notebook_style`)
+```
+
+- [ ] **Step 2: Abschluss-Bilanz erheben (Abnahme-Kriterien der Spec)**
+
+```bash
+wc -l src/dialogs/settings_dialog/*.py
+grep -c "def \|class " src/dialogs/settings_dialog/dialog.py
+grep -rn "settings_dialog" src/ tests/ --include="*.py" | grep -v "src/dialogs/settings_dialog/" | grep -v "settings_dialog import\|settings_dialog\." | head
+```
+Expected: `dialog.py` ≤ ~300 Zeilen; kein Modul außer `tab_google.py` (~470) über ~200; keine verwaisten Referenzen auf das alte Modul-Layout.
+
+- [ ] **Step 3: Suite + Ruff final, Commit**
+
+```bash
+.venv/Scripts/python.exe -m pytest -q && .venv/Scripts/python.exe -m ruff check .
+git add src/CLAUDE.md
+git commit -m "docs(architektur): settings_dialog-Paketstruktur dokumentiert (H4 Schritt 6)"
+```
+
+---
+
+## Self-Review-Notiz (bereits geprüft)
+
+- **Spec-Abdeckung:** Ziel-Struktur (Tasks 1–5 je Modul), zentrales `save_settings` (Substitutionstabellen 2–5), Move-Technik + Vertrags-Attribute (Global Constraints + jede Klasse), `oauth_task.py`-Begründung + Test-Umstellung (Task 1), `ttk.Style(frame)`-Äquivalenz (Task 4), `creds_path`-Umzug (Task 5), Doku + Zeilen-Bilanz (Task 6), Verifikation nach jedem Task.
+- **Interaktiver End-Smoke** (Spec „Verifikation") ist bewusst KEIN Plan-Task: er obliegt Controller/Nutzer nach Abschluss (Tk-gebunden), wie bei H5.
+- **Typ-/Namens-Konsistenz:** Handle-Namen `work`/`mail`/`google`/`app` durchgängig; Attribut-Listen identisch zwischen „Produces" und `self.x`-Blöcken; `tabs`-Dict wechselt in jedem Task genau seinen einen Eintrag auf `<handle>.frame`.
+- **Bewusste Nicht-Änderungen:** hartkodierter Font zieht mit um (Task 3), H5-Worker unangetastet (Task 5), keine `validate()`/`collect()`-Verteilung.

--- a/docs/superpowers/plans/2026-07-04-settings-dialog-split.md
+++ b/docs/superpowers/plans/2026-07-04-settings-dialog-split.md
@@ -17,6 +17,7 @@
 - **Import-Stabilität:** `from src.dialogs.settings_dialog import open_settings_dialog` (ui.py) funktioniert nach jedem Task; `build_oauth_enable_task` bleibt aus dem Paket importierbar.
 - **Nach jedem Task grün:** `.venv/Scripts/python.exe -m pytest -q` → 750 passed / 3 skipped; `.venv/Scripts/python.exe -m ruff check .` → clean; Import-Smoke `.venv/Scripts/python.exe -c "import src.ui; print('ok')"`.
 - **Zeilennummern** in den Tasks beziehen sich auf `src/dialogs/settings_dialog.py` @ Branch-Start (Commit von H5, 977 Zeilen). Nach Task 1 heißt die Datei `src/dialogs/settings_dialog/dialog.py` und die Nummern verschieben sich um ~44 nach oben — **die Banner-Kommentare `# ===================== Tab: … =====================` sind die verlässlichen Anker**, immer zuerst den umgebenden Code verifizieren.
+- **Banner-Regel (einheitlich für Tasks 2–5):** Der Banner-Kommentar bleibt in `dialog.py` (über der Handle-Zuweisung); der Move-Range ist immer nur der **Content** darunter. Move-Ranges enden immer am Ende des letzten vollständigen **Statements** (mehrzeilige Aufrufe bis zur schließenden Klammer mitnehmen!) — die Verbatim-Technik hat keinen Puffer, ein abgeschnittenes Statement ist sofort ein SyntaxError in beiden Dateien.
 
 Design-Referenz: `docs/superpowers/specs/2026-07-04-settings-dialog-split-design.md`.
 
@@ -227,7 +228,7 @@ Hinweis: `_wsl_date_row` bleibt als verschachtelte Funktion im `__init__` (Move-
    | `wsl_hours_var` | `work.wsl_hours_var` |
    | `tabs = {"work": tab_work, …}` | `tabs = {"work": work.frame, …}` (übrige Einträge unverändert) |
 
-4. Import-Kopf von `dialog.py` trimmen: `calendar`, `open_category_dialog`, `PAUSE_VALUES`, `TIME_VALUES`, `dark_combo`*, `dark_entry`*, `DAYS_DE`* nur entfernen, wenn sie in `dialog.py` **nirgends mehr** vorkommen (`DAYS_DE` wird in `save_settings` Z. 841 weiter gebraucht → bleibt; `dark_combo`/`dark_entry` werden von Mail/Google/App-Blöcken noch gebraucht → bleiben vorerst). Verifikation per grep, nicht raten.
+4. Import-Kopf von `dialog.py` trimmen: `calendar`, `open_category_dialog`, `PAUSE_VALUES`, `TIME_VALUES`, **`Any` (`from typing import Any` — wurde nur vom gelöschten lokalen `label`-Helfer genutzt)**, `dark_combo`*, `dark_entry`*, `DAYS_DE`* nur entfernen, wenn sie in `dialog.py` **nirgends mehr** vorkommen (`DAYS_DE` wird in `save_settings` Z. 841 weiter gebraucht → bleibt; `dark_combo`/`dark_entry` werden von Mail/Google/App-Blöcken noch gebraucht → bleiben vorerst). Verifikation per grep, nicht raten.
 
 - [ ] **Step 4: Verifikation + grep**
 
@@ -260,7 +261,7 @@ git commit -m "refactor(settings): WorkTab + _shared-Helfer extrahiert (H4 Schri
 
 - [ ] **Step 1: `tab_mail.py` anlegen — Mail-Block verbatim verschieben**
 
-Block = Original-Z. 214–253 (Anker: Banner `# ===================== Tab: Bericht & Mail` bis zur Platzhalter-Hinweiszeile `…{zeitraum}, {gesamt}…` einschließlich). Einzige Änderung im Block: `tab_mail` → `frame`. Der hartkodierte Font `("Segoe UI", 8)` zieht **unverändert** mit (Audit-Randnotiz, bewusst kein Fix — Global Constraints).
+Block = Original-Z. **215–254** (Content unter dem Banner `# ===================== Tab: Bericht & Mail`; **Achtung Block-Ende:** die letzte Anweisung ist das mehrzeilige Platzhalter-`tk.Label(...)`, dessen schließendes `).grid(row=8, …)` auf **Z. 254** steht — bis dorthin mitnehmen, sonst SyntaxError in beiden Dateien). Einzige Änderung im Block: `tab_mail` → `frame`. Der hartkodierte Font `("Segoe UI", 8)` zieht **unverändert** mit (Audit-Randnotiz, bewusst kein Fix — Global Constraints).
 
 ```python
 # src/dialogs/settings_dialog/tab_mail.py
@@ -276,7 +277,7 @@ class MailTab:
     """Baut den Bericht-&-Mail-Tab; exponiert die Variablen für save_settings."""
 
     def __init__(self, frame, settings):
-        <verbatim verschobener Block Z. 214–253, tab_mail→frame>
+        <verbatim verschobener Block Z. 215–254, tab_mail→frame>
 
         self.frame = frame
         self.recipient_var = recipient_var
@@ -331,7 +332,7 @@ Expected: grün/clean/ok; grep-Treffer nur mit `mail.`-Präfix.
 
 - [ ] **Step 1: `tab_app.py` anlegen — App-Block verbatim verschieben**
 
-Block = Original-Z. 698–835 (Anker: Banner `# ===================== Tab: App` bis zur Hinweiszeile „Nur für Reservierungen mit Kategorie."). Änderungen im Block: `tab_app` → `frame`, und **eine** dokumentierte Äquivalenz-Anpassung: `ttk.Style(dialog)` (Original-Z. 767) → `ttk.Style(frame)` — ttk-Styles sind Interpreter-global, der Master dient nur der Interpreter-Bindung; `AppTab` braucht dadurch kein `dialog`-Handle (Spec-Festlegung).
+Block = Original-Z. **699–835** (Content unter dem Banner `# ===================== Tab: App`, Banner-Regel; Ende = Hinweiszeile „Nur für Reservierungen mit Kategorie." — das schließende `).pack(anchor="w", pady=(2, 0))` des mehrzeiligen `tk.Label` auf Z. 835 mitnehmen). Änderungen im Block: `tab_app` → `frame`, und **eine** dokumentierte Äquivalenz-Anpassung: `ttk.Style(dialog)` (Original-Z. 767) → `ttk.Style(frame)` — ttk-Styles sind Interpreter-global, der Master dient nur der Interpreter-Bindung; `AppTab` braucht dadurch kein `dialog`-Handle (Spec-Festlegung).
 
 ```python
 # src/dialogs/settings_dialog/tab_app.py
@@ -353,7 +354,7 @@ class AppTab:
     """Baut den App-Tab; exponiert die Variablen für save_settings."""
 
     def __init__(self, frame, settings):
-        <verbatim verschobener Block Z. 698–835, tab_app→frame,
+        <verbatim verschobener Block Z. 699–835, tab_app→frame,
          ttk.Style(dialog)→ttk.Style(frame)>
 
         self.frame = frame
@@ -409,7 +410,7 @@ Expected: grün/clean/ok; grep-Treffer nur mit `app.`-Präfix (plus die `is_auto
 
 - [ ] **Step 1: `tab_google.py` anlegen — Google-Block verbatim verschieben**
 
-Block = Original-Z. 256–696 (Anker: Banner `# ===================== Tab: Google` bis einschließlich `if settings.get("gcal_enabled"): _load_calendars()`). **Zusätzlich** wandert `creds_path = os.path.join(base_path, "credentials.json")` (Original-Z. 95) an den Anfang des `__init__` — es wird nur im Google-Block genutzt. Einzige Block-Änderung: `tab_google` → `frame`. Alle anderen Namen (`dialog`, `settings`, `base_path`, `on_change`, `runner`, `storage`, `conflicts_store`, `reservation_store`, `data_lock`, `sync_guard`) sind Konstruktor-Parameter mit **identischen Namen** — der verschobene Code referenziert sie unverändert.
+Block = Original-Z. **257–696** (Content unter dem Banner `# ===================== Tab: Google`, Banner-Regel; bis einschließlich `if settings.get("gcal_enabled"): _load_calendars()` Z. 695–696). **Zusätzlich** wandert `creds_path = os.path.join(base_path, "credentials.json")` (Original-Z. 95) an den Anfang des `__init__` — es wird nur im Google-Block genutzt. Einzige Block-Änderung: `tab_google` → `frame`. Alle anderen Namen (`dialog`, `settings`, `base_path`, `on_change`, `runner`, `storage`, `conflicts_store`, `reservation_store`, `data_lock`, `sync_guard`) sind Konstruktor-Parameter mit **identischen Namen** — der verschobene Code referenziert sie unverändert.
 
 ```python
 # src/dialogs/settings_dialog/tab_google.py
@@ -442,14 +443,14 @@ class GoogleTab:
                  data_lock, sync_guard):
         creds_path = os.path.join(base_path, "credentials.json")
 
-        <verbatim verschobener Block Z. 256–696, tab_google→frame>
+        <verbatim verschobener Block Z. 257–696, tab_google→frame>
 
         self.frame = frame
         self.cal_map = cal_map
         self.cal_var = cal_var
 ```
 
-(Die Lazy-Imports im Block — `from src.dialogs.conflicts_dialog import ConflictsDialog`, `from src.dialogs.import_dialog import open_import_dialog`, `from src import drive`, `from src import gcal`, `from src.main import _run_compaction_blocking`, `from src.sync import NEWER_REMOTE_VERSION_MSG` — bleiben lazy an Ort und Stelle; CI-Konvention.)
+(Die Lazy-Imports im Block — `from src.dialogs.conflicts_dialog import ConflictsDialog`, `from src.dialogs.import_dialog import open_import_dialog`, `from src.dialogs.send_dialog import show_missing_credentials_dialog`, `from src.mail import fetch_user_email, get_gmail_service`, `from src import drive`, `from src import gcal`, `from src.main import _run_compaction_blocking`, `from src.sync import NEWER_REMOTE_VERSION_MSG` — bleiben lazy an Ort und Stelle; CI-Konvention.)
 
 - [ ] **Step 2: `dialog.py` umbauen**
 
@@ -462,7 +463,7 @@ class GoogleTab:
    ```
    Import `from src.dialogs.settings_dialog.tab_google import GoogleTab`; die Zeile `creds_path = …` (jetzt ~Z. 51) in `dialog.py` **löschen**.
 2. Substitutionen: `cal_map` → `google.cal_map`, `cal_var` → `google.cal_var`, `tabs`-Eintrag `"google": tab_google` → `"google": google.frame`.
-3. Import-Kopf von `dialog.py` **grep-verifiziert** trimmen — voraussichtlich fallen jetzt: `logging`, `os`, `traceback`, `messagebox`, `open_folder`, `format_iso_date`, `build_oauth_enable_task`-Import, `ACCENT`, `CELL_BG`, `FONT_SMALL`, `STATUS_OK`, `TEXT_MUTED`, `dark_combo`, `dark_entry`, `themed_askyesno`, `themed_showinfo`, `label`/`subheader`-Import (kein Inline-Block mehr) u. a. Behalten sicher: `datetime`, `tk`, `ttk`, `create_dialog`-Familie, `primary_button`, `secondary_button`, `themed_showerror`, `themed_showwarning`, Autostart-Namen, Settings-/time_utils-/weekly_limit-Namen, `WEEKDAY_KEYS`, `DAYS_DE`, `code_for_state_label`. **Jede Streichung nur nach grep** `grep -n "<name>" src/dialogs/settings_dialog/dialog.py`.
+3. Import-Kopf von `dialog.py` **grep-verifiziert** trimmen — voraussichtlich fallen jetzt: `logging`, `os`, `traceback`, `messagebox`, `open_folder`, `format_iso_date`, `build_oauth_enable_task`-Import, `ACCENT`, `CELL_BG`, **`FONT`, `FONT_BOLD`, `TEXT`** (lebten nur in Tab-Blöcken bzw. den früheren `label`/`subheader`-Helfern), `FONT_SMALL`, `STATUS_OK`, `TEXT_MUTED`, `dark_combo`, `dark_entry`, `themed_askyesno`, `themed_showinfo`, `label`/`subheader`-Import (kein Inline-Block mehr). Behalten sicher: `datetime`, `tk`, `ttk`, `BG`, `create_dialog`-Familie, `primary_button`, `secondary_button`, `themed_showerror`, `themed_showwarning`, Autostart-Namen, Settings-/time_utils-/weekly_limit-Namen, `WEEKDAY_KEYS`, `DAYS_DE`, `code_for_state_label`. **Jede Streichung nur nach grep** `grep -n "<name>" src/dialogs/settings_dialog/dialog.py`; die Liste ist Erwartung, nicht abschließend — maßgeblich sind grep + ruff.
 
 - [ ] **Step 3: Verifikation + Commit**
 

--- a/docs/superpowers/specs/2026-07-04-settings-dialog-split-design.md
+++ b/docs/superpowers/specs/2026-07-04-settings-dialog-split-design.md
@@ -13,7 +13,7 @@ vollständig aus **einer** Funktion `open_settings_dialog` (Z. 75–977):
 |---|---|---|
 | Chrome + Notebook + `label`/`subheader`-Helfer | 75–121 | ~50 |
 | Tab Arbeitszeit (Wochentag-Zeiten, Pause, WSL) | 123–212 | ~90 |
-| Tab Bericht & Mail | 215–253 | ~40 |
+| Tab Bericht & Mail | 215–254 | ~40 |
 | Tab Google (Konto/Sync/Kalender, alle 6 H5-Worker) | 256–696 | **~440** |
 | Tab App (Bundesland, Checkboxen, Reminder, Skalierung) | 699–835 | ~140 |
 | `save_settings` (Cross-Tab-Validierung + Persist) | 840–968 | ~130 |

--- a/docs/superpowers/specs/2026-07-04-settings-dialog-split-design.md
+++ b/docs/superpowers/specs/2026-07-04-settings-dialog-split-design.md
@@ -1,0 +1,172 @@
+# Settings-Dialog: Aufteilung pro Tab (Audit H4)
+
+> Design-Spec, 2026-07-04. Behebt Audit-Finding **H4** — `open_settings_dialog`
+> ist eine ~900-Zeilen-God-Function. Branch `fix/settings-dialog-split`
+> (gestackt auf #123 `fix/settings-dialog-threadvertrag`, da dieselbe Datei).
+
+## Problem
+
+`src/dialogs/settings_dialog.py` (Stand nach H5: 977 Zeilen) besteht fast
+vollständig aus **einer** Funktion `open_settings_dialog` (Z. 75–977):
+
+| Abschnitt | Zeilen | Umfang |
+|---|---|---|
+| Chrome + Notebook + `label`/`subheader`-Helfer | 75–121 | ~50 |
+| Tab Arbeitszeit (Wochentag-Zeiten, Pause, WSL) | 123–212 | ~90 |
+| Tab Bericht & Mail | 215–253 | ~40 |
+| Tab Google (Konto/Sync/Kalender, alle 6 H5-Worker) | 256–696 | **~440** |
+| Tab App (Bundesland, Checkboxen, Reminder, Skalierung) | 699–835 | ~140 |
+| `save_settings` (Cross-Tab-Validierung + Persist) | 840–968 | ~130 |
+| Buttons/Escape/Center | 970–977 | ~8 |
+
+Dutzende Closures teilen sich einen Scope; `save_settings` liest ~25
+Tk-Variablen aus allen vier Tabs plus `cal_map`/`tabs`/`notebook`. `src/CLAUDE.md`
+beschreibt `App` als „kein God-Object mehr" — die Komplexität ist faktisch in
+diesen Dialog gewandert (so auch das Audit).
+
+## Entscheidungen (mit dem Nutzer abgestimmt)
+
+1. **Ansatz A — Paket-Split pro Tab.** `settings_dialog.py` wird zum Paket;
+   eine Klasse pro Tab (Audit-Hinweis „analog `_ImportSummaryDialog` als
+   Klasse"). Kein Ansatz B (Funktions-Extraktion im selben File) und kein
+   Ansatz C (verteilter `validate()`/`collect()`-Tab-Vertrag).
+2. **`save_settings` bleibt zentral und ablaufidentisch** in `dialog.py` —
+   die heikle Reihenfolge (Work-Validierung → WSL-Datum → Autostart-Toggle
+   mit Abbruch **vor** jedem Persist → Reminder-Validierung → ein
+   `apply_updates` → gcal-Kalender-ID nur bei geladener `cal_map` →
+   WSL-Perioden-Scan → `on_change()` → `destroy()` → ggf.
+   `on_request_restart`) wird **nicht** auf die Tabs verteilt. Nur die
+   Variablen-Zugriffe wechseln von Closure-Scope auf Tab-Attribute.
+3. **Verhaltensgleich pro Stelle** — reiner Struktur-Umbau, keine
+   UI-/Logik-Änderung. Review-Kriterium wie bei den Refactors #49/DT-3.
+
+## Ziel-Struktur
+
+```
+src/dialogs/settings_dialog/
+  __init__.py     — re-exportiert open_settings_dialog + build_oauth_enable_task
+  dialog.py       — open_settings_dialog: Chrome, Notebook, Tab-Instanzen,
+                    save_settings, Buttons/Escape/Center        (~260 Zeilen)
+  oauth_task.py   — build_oauth_enable_task (generischer OAuth-Toggle-Builder,
+                    kein Tab-Bezug — eigenes Modul statt tab_google, damit die
+                    bestehenden Tests genau EINE neue Import-Stelle haben)
+  _shared.py      — label(...) / subheader(...) Grid-Helfer     (~25 Zeilen)
+  tab_work.py     — class WorkTab                               (~150 Zeilen)
+  tab_mail.py     — class MailTab                               (~70 Zeilen)
+  tab_google.py   — class GoogleTab                             (~450 Zeilen)
+  tab_app.py      — class AppTab                                (~170 Zeilen)
+```
+
+Alle bestehenden Import-Pfade bleiben gültig:
+- `src/ui.py`: `from src.dialogs.settings_dialog import open_settings_dialog` —
+  unverändert (Re-Export in `__init__.py`).
+- `tests/test_settings_dialog.py`: importiert künftig aus
+  `src.dialogs.settings_dialog.oauth_task` (einzige nötige Test-Änderung,
+  weil der Test `sd.messagebox` **im Modul der Funktion** monkeypatcht —
+  ein Paket-`__init__`-Re-Export reicht dafür nicht).
+
+`tab_google.py` mit ~450 Zeilen bleibt das größte Modul — bewusst: eine
+Verantwortlichkeit (Google-Integrations-UI), vom Audit ist nur der
+Per-Tab-Schnitt gefordert. Eine weitere Unterteilung (Konto/Sync/Kalender)
+ist YAGNI.
+
+## Tab-Klassen-Vertrag
+
+Jede Tab-Klasse baut in `__init__` ihre Widgets in den übergebenen
+Notebook-Frame und exponiert als **Attribute** genau das, was `dialog.py`
+(insb. `save_settings`) liest. Kein `validate()`/`collect()`-Protokoll.
+
+```python
+class WorkTab:
+    def __init__(self, frame, dialog, settings): ...
+    # frame           — der Notebook-Tab-Frame (für notebook.select bei Fehlern)
+    # start_vars      — dict[weekday_key, tk.StringVar]
+    # end_vars        — dict[weekday_key, tk.StringVar]
+    # pause_var       — tk.StringVar
+    # wsl_enabled_var — tk.BooleanVar
+    # wsl_start_vars  — (day_var, month_var, year_var)  je tk.StringVar
+    # wsl_end_vars    — (day_var, month_var, year_var)
+    # wsl_hours_var   — tk.StringVar
+    # (dialog nur als Parent für open_category_dialog)
+
+class MailTab:
+    def __init__(self, frame, settings): ...
+    # frame, recipient_var, name_var, rate_var, subject_var, greeting_var,
+    # content_text (tk.Text), closing_text (tk.Text)
+
+class GoogleTab:
+    def __init__(self, frame, dialog, settings, base_path, on_change, runner,
+                 storage, conflicts_store, reservation_store,
+                 data_lock, sync_guard): ...
+    # frame, cal_map (dict summary->id, von _populate_calendars mutiert,
+    #                 von save_settings gelesen), cal_var (tk.StringVar)
+    # Alles andere (creds-Status-Timer, Absender, Sync-Toggle, Konflikte,
+    # Import, Reconnect, Kompaktierung, Kalenderliste) bleibt intern.
+
+class AppTab:
+    def __init__(self, frame, settings): ...
+    # frame, state_var, show_weekend_var, autostart_var, always_on_top_var,
+    # minimize_to_tray_var, scale_var (tk.DoubleVar),
+    # reminders_enabled_var, reminder_minutes_var
+```
+
+Festlegungen im Detail:
+
+- **`_shared.py`:** `label(parent_frame, text, row, col=0, **grid_kw)` und
+  `subheader(parent_frame, text, row, top_pad=16)` — byte-gleich zu heute
+  (Z. 109–120), nur `parent_frame` explizit statt Closure-`BG`/`FONT`-Zugriff
+  (die Theme-Konstanten importiert `_shared.py` selbst).
+- **`WorkTab`** enthält `_wsl_date_row` als private Methode; der
+  „Kategorien verwalten"-Button nutzt `dialog` als Parent (deshalb der Param).
+- **`GoogleTab`** übernimmt `creds_path = os.path.join(base_path,
+  "credentials.json")` (heute Z. 95 — wird nur im Google-Tab genutzt) und den
+  periodischen `dialog.after(500, refresh_status)`-Timer unverändert. Die
+  H5-Worker (`runner.run`-Muster, `winfo_exists`-Guards, Persistenz im `fn`)
+  ziehen **unverändert** mit um — H4 darf H5 nicht aufweichen.
+- **`AppTab`:** der `ttk.Style` für den Skalierungs-Slider wird mit dem
+  Tab-Frame als Master erzeugt (`ttk.Style(frame)`) — Styles sind
+  Interpreter-global, das `dialog`-Handle ist dafür nicht nötig.
+- **`dialog.py`** behält: `create_dialog`, `apply_combobox_style`/
+  `apply_notebook_style`, Notebook + 4 Frames, `tabs`-Dict
+  (`{"work": work.frame, ...}`), `save_settings` (liest `work.*`, `mail.*`,
+  `google.cal_map`/`cal_var`, `app.*`), Speichern/Abbrechen-Buttons,
+  `attach_unfocus_on_click`, Escape-Bind, `center_dialog_on_parent`.
+- **`oauth_task.py`:** `build_oauth_enable_task` zieht unverändert um
+  (inkl. Docstring); `tab_google.py` importiert es von dort.
+
+## Migrationspfad (pro Schritt grün)
+
+1. **Paket-Skelett:** `settings_dialog.py` → `settings_dialog/dialog.py`
+   (inhaltlich unverändert) + `__init__.py`-Re-Exports +
+   `build_oauth_enable_task` → `oauth_task.py` + Test-Import angepasst.
+2. **`_shared.py` + `WorkTab`** herauslösen; `save_settings` liest `work.*`.
+3. **`MailTab`**, 4. **`AppTab`**, 5. **`GoogleTab`** (der Brocken, zuletzt —
+   das Muster steht dann).
+6. **Doku:** `src/CLAUDE.md` (Dialoge-Absatz: Paket-Struktur + Tab-Vertrag;
+   der Satz zur H5-Runner-Konvention bleibt korrekt).
+
+Nach jedem Schritt: Gesamtsuite (750) + `ruff check .` grün. Kein Schritt
+lässt die App in einem nicht-lauffähigen Zwischenzustand.
+
+## Verifikation
+
+- **Suite + Ruff** nach jedem Migrationsschritt (die 5 Builder-Tests aus H5
+  laufen weiter; nur ihr Import-Pfad ändert sich in Schritt 1).
+- **Import-Smoke:** `python -c "import src.ui"` nach jedem Schritt.
+- **Interaktiver End-Smoke (Nutzer):** Dialog öffnen, alle 4 Tabs durchsehen,
+  einmal Speichern mit geänderten Werten, einmal Validierungsfehler
+  provozieren (z. B. Reminder-Minuten „abc") → springt auf den App-Tab.
+- **Zeilen-Bilanz als Abnahme:** `dialog.py` ≤ ~300 Zeilen; kein Modul außer
+  `tab_google.py` über ~200; `open_settings_dialog` enthält keine
+  Widget-Bau-Blöcke der Tabs mehr.
+
+## Ausdrücklich außerhalb des Scopes
+
+- **Keine Verhaltensänderung** — auch keine „Gelegenheits-Fixes" (z. B. der
+  hartkodierte Font `("Segoe UI", 8)` in Z. 252 / Audit-Randnotiz, M14
+  Datums-Zeilen-Deduplizierung, M10 Blocking-Sendepfad). Solche Funde werden
+  notiert, nicht gefixt.
+- **Kein Tab-Vertrag mit `validate()`/`collect()`** (Ansatz C) — bewusst
+  verworfen, siehe Entscheidungen.
+- **Keine neuen Tests für Tk-gebundene Tab-Klassen** (M16-Konvention);
+  abgesichert wird über Suite + Smoke.

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -158,7 +158,11 @@ Das Tray-Icon läuft, sobald `minimize_to_tray` **oder** `reminders_enabled` akt
 Modale Tk-Dialoge, von `App` geroutet (Klick-Modell: Linksklick = bearbeiten, Rechtsklick =
 löschen — siehe Root-`CLAUDE.md`): `entry_dialog` (Tages-Dialog, rein zum Speichern),
 `send_dialog`, `export_dialog` (Zeitraum-Modal → PDF lokal speichern),
-`settings_dialog` (4 Tabs über `ttk.Notebook`: Arbeitszeit / Bericht & Mail / Google / App; Dark-Styling via `theme.apply_notebook_style`), `share_dialog`, `import_dialog`, `category_dialog`,
+`settings_dialog/` (Paket, Audit H4: `dialog.py` trägt Chrome + zentrales,
+ablaufidentisches `save_settings`; je Tab eine Klasse in `tab_work/`
+`tab_mail`/`tab_google`/`tab_app`.py, die ihre Tk-Variablen als Attribute
+für `save_settings` exponiert; `oauth_task.py` = H5-OAuth-Toggle-Builder;
+Dark-Styling weiter via `theme.apply_notebook_style`), `share_dialog`, `import_dialog`, `category_dialog`,
 `conflicts_dialog`. `period_picker` ist kein Dialog, sondern der von
 `send_dialog` + `export_dialog` geteilte Zeitraum+Kategorie+Vorschau-Baustein.
 

--- a/src/dialogs/settings_dialog/__init__.py
+++ b/src/dialogs/settings_dialog/__init__.py
@@ -1,0 +1,8 @@
+"""Einstellungen-Dialog als Paket (Audit H4): dialog.py trägt Chrome +
+zentrales save_settings, die vier Tabs sind eigene Klassen-Module.
+Öffentliche API unverändert re-exportiert."""
+
+from src.dialogs.settings_dialog.dialog import open_settings_dialog
+from src.dialogs.settings_dialog.oauth_task import build_oauth_enable_task
+
+__all__ = ["open_settings_dialog", "build_oauth_enable_task"]

--- a/src/dialogs/settings_dialog/_shared.py
+++ b/src/dialogs/settings_dialog/_shared.py
@@ -1,0 +1,21 @@
+"""Gemeinsame Grid-Helfer der Settings-Tabs (label/subheader)."""
+
+import tkinter as tk
+from typing import Any
+
+from src.theme import BG, FONT, FONT_BOLD, TEXT, TEXT_MUTED
+
+
+def label(parent_frame, text, row, col=0, **grid_kw):
+    kw: dict[str, Any] = dict(padx=10, pady=8, sticky="w")
+    kw.update(grid_kw)
+    lbl = tk.Label(parent_frame, text=text, font=FONT, bg=BG, fg=TEXT)
+    lbl.grid(row=row, column=col, **kw)
+    return lbl
+
+
+def subheader(parent_frame, text, row, top_pad=16):
+    tk.Label(
+        parent_frame, text=f"— {text} —", font=FONT_BOLD,
+        bg=BG, fg=TEXT_MUTED,
+    ).grid(row=row, column=0, columnspan=2, padx=10, pady=(top_pad, 4))

--- a/src/dialogs/settings_dialog/dialog.py
+++ b/src/dialogs/settings_dialog/dialog.py
@@ -27,49 +27,7 @@ from src.settings import (
 from src.time_utils import format_iso_date, validate_period
 from src.time_utils import DAYS_DE, validate_entry
 from src.weekly_limit import format_limit_warnings, period_scan_needed, scan_period_for_warnings
-
-
-def build_oauth_enable_task(*, service_fn, settings, setting_key, checkbox,
-                            toggle_var, on_change, dialog, error_title,
-                            on_success_dialog_ui=None):
-    """Baut (fn, on_done) für einen OAuth-Aktivieren-Toggle (Drive-Sync / Kalender).
-
-    fn (Worker-Thread): ruft service_fn() und persistiert setting_key=True bei
-    Erfolg — läuft im Thread und überlebt daher einen Dialog-Close. Fängt seine
-    Exceptions selbst, wirft nie.
-
-    on_done (UI-Thread via App._marshal_to_ui): ruft on_change() (App-/root-scoped)
-    VOR dem winfo_exists-Guard, danach die Dialog-Kosmetik (checkbox, toggle_var,
-    Messagebox, optional on_success_dialog_ui) — übersprungen, wenn der Dialog weg
-    ist. on_success_dialog_ui ist Dialog-Kosmetik (z.B. Kalenderliste laden) und
-    läuft daher NACH dem Guard.
-    """
-    def fn():
-        try:
-            service_fn()
-        except Exception as e:
-            return {"ok": False, "error": e, "tb": traceback.format_exc()}
-        settings.set(setting_key, True)
-        return {"ok": True}
-
-    def on_done(res):
-        if res["ok"]:
-            on_change()
-        if not checkbox.winfo_exists():
-            return
-        checkbox.config(state="normal")
-        if res["ok"]:
-            if on_success_dialog_ui is not None:
-                on_success_dialog_ui()
-        else:
-            toggle_var.set(False)
-            messagebox.showerror(
-                error_title,
-                f"OAuth-Flow fehlgeschlagen:\n\n{res['error']}\n\n{res['tb']}",
-                parent=dialog,
-            )
-
-    return fn, on_done
+from src.dialogs.settings_dialog.oauth_task import build_oauth_enable_task
 
 
 def open_settings_dialog(parent, settings, base_path, on_change, *,

--- a/src/dialogs/settings_dialog/dialog.py
+++ b/src/dialogs/settings_dialog/dialog.py
@@ -12,7 +12,7 @@ from src.theme import (
     STATUS_OK, TEXT, TEXT_MUTED,
     apply_combobox_style, apply_notebook_style, attach_unfocus_on_click,
     center_dialog_on_parent, create_dialog,
-    dark_combo, dark_entry, dark_text,
+    dark_combo,
     primary_button, secondary_button,
     themed_askyesno, themed_showinfo, themed_showwarning, themed_showerror,
 )
@@ -26,6 +26,7 @@ from src.time_utils import DAYS_DE, validate_entry
 from src.weekly_limit import format_limit_warnings, period_scan_needed, scan_period_for_warnings
 from src.dialogs.settings_dialog._shared import label, subheader
 from src.dialogs.settings_dialog.oauth_task import build_oauth_enable_task
+from src.dialogs.settings_dialog.tab_mail import MailTab
 from src.dialogs.settings_dialog.tab_work import WorkTab
 
 
@@ -67,46 +68,7 @@ def open_settings_dialog(parent, settings, base_path, on_change, *,
     work = WorkTab(tab_work, dialog, settings)
 
     # ===================== Tab: Bericht & Mail =====================
-    label(tab_mail, "Empfänger:", row=0, pady=(10, 8))
-    recipient_var = tk.StringVar(value=settings.get("recipient"))
-    dark_entry(tab_mail, recipient_var, width=25).grid(row=0, column=1, padx=10, pady=(10, 8))
-
-    label(tab_mail, "Name:", row=1)
-    name_var = tk.StringVar(value=settings.get("name"))
-    dark_entry(tab_mail, name_var, width=25).grid(row=1, column=1, padx=10, pady=8)
-
-    label(tab_mail, "Stundenlohn (€):", row=2)
-    rate_var = tk.StringVar(value=str(settings.get("hourly_rate") or ""))
-    dark_entry(tab_mail, rate_var, width=10).grid(row=2, column=1, padx=10, pady=8, sticky="w")
-    tk.Label(
-        tab_mail, text="(optional – nur für dich sichtbar)", font=FONT_SMALL,
-        bg=BG, fg=TEXT_MUTED,
-    ).grid(row=2, column=1, padx=(120, 10), pady=8, sticky="w")
-
-    subheader(tab_mail, "Mail-Vorlage", row=3)
-
-    label(tab_mail, "Betreff:", row=4, pady=4)
-    subject_var = tk.StringVar(value=settings.get("mail_subject"))
-    dark_entry(tab_mail, subject_var, width=35).grid(row=4, column=1, padx=10, pady=4)
-
-    label(tab_mail, "Anrede:", row=5, pady=4)
-    greeting_var = tk.StringVar(value=settings.get("mail_greeting"))
-    dark_entry(tab_mail, greeting_var, width=35).grid(row=5, column=1, padx=10, pady=4)
-
-    label(tab_mail, "Inhalt:", row=6, pady=4, sticky="nw")
-    content_text = dark_text(tab_mail, 35, 3)
-    content_text.grid(row=6, column=1, padx=10, pady=4)
-    content_text.insert("1.0", settings.get("mail_content"))
-
-    label(tab_mail, "Gruß:", row=7, pady=4, sticky="nw")
-    closing_text = dark_text(tab_mail, 35, 2)
-    closing_text.grid(row=7, column=1, padx=10, pady=4)
-    closing_text.insert("1.0", settings.get("mail_closing"))
-
-    tk.Label(
-        tab_mail, text="Platzhalter: {zeitraum}, {gesamt}", font=("Segoe UI", 8),
-        bg=BG, fg=TEXT_MUTED,
-    ).grid(row=8, column=0, columnspan=2, padx=10, pady=(0, 8))
+    mail = MailTab(tab_mail, settings)
 
     # ===================== Tab: Google =====================
     subheader(tab_google, "Google-Konto", row=0, top_pad=10)
@@ -690,7 +652,7 @@ def open_settings_dialog(parent, settings, base_path, on_change, *,
     ).pack(anchor="w", pady=(2, 0))
 
     # ===================== Speichern / Buttons =====================
-    tabs = {"work": work.frame, "mail": tab_mail, "google": tab_google, "app": tab_app}
+    tabs = {"work": work.frame, "mail": mail.frame, "google": tab_google, "app": tab_app}
 
     def save_settings():
         for key, lbl in zip(WEEKDAY_KEYS, DAYS_DE):
@@ -758,7 +720,7 @@ def open_settings_dialog(parent, settings, base_path, on_change, *,
             )
             return
 
-        hourly_rate = parse_hourly_rate(rate_var.get())
+        hourly_rate = parse_hourly_rate(mail.rate_var.get())
         selected_code = code_for_state_label(state_var.get())
         old_scale = settings.get("ui_scale")
         new_scale = clamp_ui_scale((round(scale_var.get() / 5) * 5) / 100)
@@ -766,12 +728,12 @@ def open_settings_dialog(parent, settings, base_path, on_change, *,
         updates = {
             "autostart": new_autostart,
             "default_pause": int(work.pause_var.get()),
-            "recipient": recipient_var.get(),
-            "name": name_var.get(),
-            "mail_subject": subject_var.get(),
-            "mail_greeting": greeting_var.get(),
-            "mail_content": content_text.get("1.0", "end-1c"),
-            "mail_closing": closing_text.get("1.0", "end-1c"),
+            "recipient": mail.recipient_var.get(),
+            "name": mail.name_var.get(),
+            "mail_subject": mail.subject_var.get(),
+            "mail_greeting": mail.greeting_var.get(),
+            "mail_content": mail.content_text.get("1.0", "end-1c"),
+            "mail_closing": mail.closing_text.get("1.0", "end-1c"),
             "hourly_rate": hourly_rate,
             "state": selected_code,
             "show_weekend": show_weekend_var.get(),

--- a/src/dialogs/settings_dialog/dialog.py
+++ b/src/dialogs/settings_dialog/dialog.py
@@ -1,24 +1,21 @@
-import calendar
 import datetime
 import logging
 import os
 import tkinter as tk
 import traceback
 from tkinter import messagebox, ttk
-from typing import Any
 
 from src.autostart import disable_autostart, enable_autostart, is_autostart_enabled, resolve_autostart_target
 from src.platform_open import open_folder
 from src.theme import (
     ACCENT, BG, CELL_BG, FONT, FONT_BOLD, FONT_SMALL,
-    PAUSE_VALUES, STATUS_OK, TEXT, TEXT_MUTED, TIME_VALUES,
+    STATUS_OK, TEXT, TEXT_MUTED,
     apply_combobox_style, apply_notebook_style, attach_unfocus_on_click,
     center_dialog_on_parent, create_dialog,
     dark_combo, dark_entry, dark_text,
     primary_button, secondary_button,
     themed_askyesno, themed_showinfo, themed_showwarning, themed_showerror,
 )
-from src.dialogs.category_dialog import open_category_dialog
 from src.holidays_de import STATES, code_for_state_label
 from src.settings import (
     WEEKDAY_KEYS, clamp_ui_scale, parse_hourly_rate,
@@ -27,7 +24,9 @@ from src.settings import (
 from src.time_utils import format_iso_date, validate_period
 from src.time_utils import DAYS_DE, validate_entry
 from src.weekly_limit import format_limit_warnings, period_scan_needed, scan_period_for_warnings
+from src.dialogs.settings_dialog._shared import label, subheader
 from src.dialogs.settings_dialog.oauth_task import build_oauth_enable_task
+from src.dialogs.settings_dialog.tab_work import WorkTab
 
 
 def open_settings_dialog(parent, settings, base_path, on_change, *,
@@ -64,110 +63,8 @@ def open_settings_dialog(parent, settings, base_path, on_change, *,
     notebook.add(tab_google, text="Google")
     notebook.add(tab_app, text="App")
 
-    def label(parent_frame, text, row, col=0, **grid_kw):
-        kw: dict[str, Any] = dict(padx=10, pady=8, sticky="w")
-        kw.update(grid_kw)
-        lbl = tk.Label(parent_frame, text=text, font=FONT, bg=BG, fg=TEXT)
-        lbl.grid(row=row, column=col, **kw)
-        return lbl
-
-    def subheader(parent_frame, text, row, top_pad=16):
-        tk.Label(
-            parent_frame, text=f"— {text} —", font=FONT_BOLD,
-            bg=BG, fg=TEXT_MUTED,
-        ).grid(row=row, column=0, columnspan=2, padx=10, pady=(top_pad, 4))
-
     # ===================== Tab: Arbeitszeit =====================
-    label(tab_work, "Standardzeiten:", row=0, pady=(10, 4), sticky="nw")
-    times_frame = tk.Frame(tab_work, bg=BG)
-    times_frame.grid(row=0, column=1, padx=10, pady=(10, 4), sticky="w")
-
-    tk.Label(times_frame, text="Start", font=FONT_SMALL, bg=BG, fg=TEXT_MUTED).grid(
-        row=0, column=1, padx=2)
-    tk.Label(times_frame, text="Ende", font=FONT_SMALL, bg=BG, fg=TEXT_MUTED).grid(
-        row=0, column=2, padx=2)
-
-    start_vars = {}
-    end_vars = {}
-    for i, (key, lbl) in enumerate(zip(WEEKDAY_KEYS, DAYS_DE), start=1):
-        tk.Label(times_frame, text=lbl, font=FONT, bg=BG, fg=TEXT, width=3, anchor="w").grid(
-            row=i, column=0, padx=(0, 8), pady=2)
-        start_vars[key] = tk.StringVar(value=settings.get(f"default_start_{key}"))
-        dark_combo(times_frame, start_vars[key], TIME_VALUES).grid(
-            row=i, column=1, padx=2, pady=2)
-        end_vars[key] = tk.StringVar(value=settings.get(f"default_end_{key}"))
-        dark_combo(times_frame, end_vars[key], TIME_VALUES).grid(
-            row=i, column=2, padx=2, pady=2)
-
-    label(tab_work, "Standard-Pause (Min):", row=1)
-    pause_var = tk.StringVar(value=str(settings.get("default_pause")))
-    dark_combo(tab_work, pause_var, PAUSE_VALUES).grid(
-        row=1, column=1, padx=10, pady=8, sticky="w")
-
-    subheader(tab_work, "Werkstudenten-Limit", row=2)
-    wsl_frame = tk.Frame(tab_work, bg=BG)
-    wsl_frame.grid(row=3, column=0, columnspan=2, padx=10, pady=(0, 4), sticky="we")
-
-    wsl_enabled_var = tk.BooleanVar(value=settings.get("werkstudent_limit_enabled"))
-    tk.Checkbutton(
-        wsl_frame, text="Wochenstunden-Limit aktivieren", variable=wsl_enabled_var,
-        font=FONT, bg=BG, fg=TEXT, selectcolor=CELL_BG,
-        activebackground=BG, activeforeground=TEXT, cursor="hand2",
-    ).pack(anchor="w")
-
-    def _wsl_date_row(parent_frame, label_text, default_date):
-        row = tk.Frame(parent_frame, bg=BG)
-        row.pack(anchor="w", pady=(4, 0))
-        tk.Label(row, text=label_text, font=FONT, bg=BG, fg=TEXT).pack(
-            side=tk.LEFT, padx=(0, 5))
-        month_values = [str(m) for m in range(1, 13)]
-        year_values = [str(y) for y in range(2020, datetime.date.today().year + 3)]
-        day_var = tk.StringVar(value=str(default_date.day))
-        max_day = calendar.monthrange(default_date.year, default_date.month)[1]
-        day_cb = dark_combo(row, day_var, [str(d) for d in range(1, max_day + 1)], width=3)
-        day_cb.pack(side=tk.LEFT, padx=2)
-        tk.Label(row, text=".", font=FONT, bg=BG, fg=TEXT).pack(side=tk.LEFT)
-        month_var = tk.StringVar(value=str(default_date.month))
-        dark_combo(row, month_var, month_values, width=3).pack(side=tk.LEFT, padx=2)
-        tk.Label(row, text=".", font=FONT, bg=BG, fg=TEXT).pack(side=tk.LEFT)
-        year_var = tk.StringVar(value=str(default_date.year))
-        dark_combo(row, year_var, year_values, width=5).pack(side=tk.LEFT, padx=2)
-
-        def _update_days(*_a):
-            try:
-                m = int(month_var.get())
-                y = int(year_var.get())
-                md = calendar.monthrange(y, m)[1]
-            except (ValueError, KeyError):
-                md = 31
-            day_cb["values"] = [str(d) for d in range(1, md + 1)]
-            if int(day_var.get()) > md:
-                day_var.set(str(md))
-
-        month_var.trace_add("write", _update_days)
-        year_var.trace_add("write", _update_days)
-        return day_var, month_var, year_var
-
-    wsl_start_default = (
-        datetime.date.fromisoformat(settings.get("werkstudent_limit_start"))
-        if settings.get("werkstudent_limit_start") else datetime.date.today())
-    wsl_end_default = (
-        datetime.date.fromisoformat(settings.get("werkstudent_limit_end"))
-        if settings.get("werkstudent_limit_end") else datetime.date.today())
-    wsl_start_vars = _wsl_date_row(wsl_frame, "Zeitraum von:", wsl_start_default)
-    wsl_end_vars = _wsl_date_row(wsl_frame, "bis:", wsl_end_default)
-
-    wsl_hours_row = tk.Frame(wsl_frame, bg=BG)
-    wsl_hours_row.pack(anchor="w", pady=(4, 0))
-    tk.Label(wsl_hours_row, text="Limit (Stunden/Woche):", font=FONT, bg=BG, fg=TEXT).pack(
-        side=tk.LEFT, padx=(0, 5))
-    wsl_hours_var = tk.StringVar(value=str(settings.get("werkstudent_limit_max_hours")))
-    dark_entry(wsl_hours_row, wsl_hours_var, width=6).pack(side=tk.LEFT)
-
-    secondary_button(
-        tab_work, "Kategorien verwalten",
-        lambda: open_category_dialog(dialog, settings),
-    ).grid(row=4, column=0, columnspan=2, padx=10, pady=(12, 8), sticky="w")
+    work = WorkTab(tab_work, dialog, settings)
 
     # ===================== Tab: Bericht & Mail =====================
     label(tab_mail, "Empfänger:", row=0, pady=(10, 8))
@@ -793,11 +690,11 @@ def open_settings_dialog(parent, settings, base_path, on_change, *,
     ).pack(anchor="w", pady=(2, 0))
 
     # ===================== Speichern / Buttons =====================
-    tabs = {"work": tab_work, "mail": tab_mail, "google": tab_google, "app": tab_app}
+    tabs = {"work": work.frame, "mail": tab_mail, "google": tab_google, "app": tab_app}
 
     def save_settings():
         for key, lbl in zip(WEEKDAY_KEYS, DAYS_DE):
-            ok, msg = validate_entry(start_vars[key].get(), end_vars[key].get())
+            ok, msg = validate_entry(work.start_vars[key].get(), work.end_vars[key].get())
             if not ok:
                 notebook.select(tabs["work"])
                 themed_showerror(
@@ -808,14 +705,14 @@ def open_settings_dialog(parent, settings, base_path, on_change, *,
                 return
 
         wsl_start_date = datetime.date(
-            int(wsl_start_vars[2].get()), int(wsl_start_vars[1].get()),
-            int(wsl_start_vars[0].get()))
+            int(work.wsl_start_vars[2].get()), int(work.wsl_start_vars[1].get()),
+            int(work.wsl_start_vars[0].get()))
         wsl_end_date = datetime.date(
-            int(wsl_end_vars[2].get()), int(wsl_end_vars[1].get()),
-            int(wsl_end_vars[0].get()))
+            int(work.wsl_end_vars[2].get()), int(work.wsl_end_vars[1].get()),
+            int(work.wsl_end_vars[0].get()))
         wsl_start_iso = wsl_start_date.isoformat()
         wsl_end_iso = wsl_end_date.isoformat()
-        if wsl_enabled_var.get():
+        if work.wsl_enabled_var.get():
             ok, msg = validate_period(wsl_start_iso, wsl_end_iso)
             if not ok:
                 notebook.select(tabs["work"])
@@ -823,7 +720,7 @@ def open_settings_dialog(parent, settings, base_path, on_change, *,
                 return
         old_wsl_max_hours = settings.get("werkstudent_limit_max_hours")
         try:
-            wsl_max_hours = float(wsl_hours_var.get())
+            wsl_max_hours = float(work.wsl_hours_var.get())
         except ValueError:
             wsl_max_hours = old_wsl_max_hours
 
@@ -868,7 +765,7 @@ def open_settings_dialog(parent, settings, base_path, on_change, *,
 
         updates = {
             "autostart": new_autostart,
-            "default_pause": int(pause_var.get()),
+            "default_pause": int(work.pause_var.get()),
             "recipient": recipient_var.get(),
             "name": name_var.get(),
             "mail_subject": subject_var.get(),
@@ -883,14 +780,14 @@ def open_settings_dialog(parent, settings, base_path, on_change, *,
             "reminders_enabled": reminders_enabled_var.get(),
             "reminder_minutes_before": reminder_minutes,
             "ui_scale": new_scale,
-            "werkstudent_limit_enabled": wsl_enabled_var.get(),
+            "werkstudent_limit_enabled": work.wsl_enabled_var.get(),
             "werkstudent_limit_start": wsl_start_iso,
             "werkstudent_limit_end": wsl_end_iso,
             "werkstudent_limit_max_hours": wsl_max_hours,
         }
         for key in WEEKDAY_KEYS:
-            updates[f"default_start_{key}"] = start_vars[key].get()
-            updates[f"default_end_{key}"] = end_vars[key].get()
+            updates[f"default_start_{key}"] = work.start_vars[key].get()
+            updates[f"default_end_{key}"] = work.end_vars[key].get()
         settings.apply_updates(updates)
         # Kalender-Auswahl: Klarname zurück auf ID mappen, als Sync-Setting
         # speichern. Nur wenn die Kalenderliste schon geladen ist (cal_map
@@ -906,7 +803,7 @@ def open_settings_dialog(parent, settings, base_path, on_change, *,
             "max_hours": old_wsl_max_hours,
         }
         new_wsl = {
-            "enabled": wsl_enabled_var.get(), "start": wsl_start_iso, "end": wsl_end_iso,
+            "enabled": work.wsl_enabled_var.get(), "start": wsl_start_iso, "end": wsl_end_iso,
             "max_hours": wsl_max_hours,
         }
         if storage is not None and period_scan_needed(old_wsl, new_wsl):

--- a/src/dialogs/settings_dialog/dialog.py
+++ b/src/dialogs/settings_dialog/dialog.py
@@ -8,7 +8,7 @@ from tkinter import messagebox, ttk
 from src.autostart import disable_autostart, enable_autostart, is_autostart_enabled, resolve_autostart_target
 from src.platform_open import open_folder
 from src.theme import (
-    ACCENT, BG, CELL_BG, FONT, FONT_BOLD, FONT_SMALL,
+    ACCENT, BG, CELL_BG, FONT, FONT_SMALL,
     STATUS_OK, TEXT, TEXT_MUTED,
     apply_combobox_style, apply_notebook_style, attach_unfocus_on_click,
     center_dialog_on_parent, create_dialog,
@@ -16,7 +16,7 @@ from src.theme import (
     primary_button, secondary_button,
     themed_askyesno, themed_showinfo, themed_showwarning, themed_showerror,
 )
-from src.holidays_de import STATES, code_for_state_label
+from src.holidays_de import code_for_state_label
 from src.settings import (
     WEEKDAY_KEYS, clamp_ui_scale, parse_hourly_rate,
     parse_reminder_minutes, resolve_calendar_id,
@@ -26,6 +26,7 @@ from src.time_utils import DAYS_DE, validate_entry
 from src.weekly_limit import format_limit_warnings, period_scan_needed, scan_period_for_warnings
 from src.dialogs.settings_dialog._shared import label, subheader
 from src.dialogs.settings_dialog.oauth_task import build_oauth_enable_task
+from src.dialogs.settings_dialog.tab_app import AppTab
 from src.dialogs.settings_dialog.tab_mail import MailTab
 from src.dialogs.settings_dialog.tab_work import WorkTab
 
@@ -513,146 +514,10 @@ def open_settings_dialog(parent, settings, base_path, on_change, *,
         _load_calendars()
 
     # ===================== Tab: App =====================
-    label(tab_app, "Bundesland:", row=0, pady=(10, 8))
-    state_labels = [lbl for _, lbl in STATES]
-    current_code = settings.get("state")
-    current_label = next(
-        (lbl for code, lbl in STATES if code == current_code),
-        STATES[0][1],
-    )
-    state_var = tk.StringVar(value=current_label)
-    dark_combo(tab_app, state_var, state_labels, width=22).grid(
-        row=0, column=1, padx=10, pady=(10, 8), sticky="w")
-
-    # Gerätelokale UI-Optionen. Alle in app_frame (ein Grid-Member), damit die
-    # pack-Interna dieses Frames unberührt bleiben.
-    app_frame = tk.Frame(tab_app, bg=BG)
-    app_frame.grid(row=1, column=0, columnspan=2, padx=10, pady=(4, 4), sticky="we")
-
-    show_weekend_var = tk.BooleanVar(value=settings.get("show_weekend"))
-    tk.Checkbutton(
-        app_frame, text="Wochenende (Sa/So) im Kalender anzeigen",
-        variable=show_weekend_var, font=FONT,
-        bg=BG, fg=TEXT, selectcolor=CELL_BG,
-        activebackground=BG, activeforeground=TEXT,
-        cursor="hand2",
-    ).pack(anchor="w")
-
-    autostart_var = tk.BooleanVar(value=is_autostart_enabled())
-    tk.Checkbutton(
-        app_frame, text="Autostart (minimiert bei Anmeldung)",
-        variable=autostart_var, font=FONT,
-        bg=BG, fg=TEXT, selectcolor=CELL_BG,
-        activebackground=BG, activeforeground=TEXT,
-        cursor="hand2",
-    ).pack(anchor="w")
-
-    always_on_top_var = tk.BooleanVar(value=settings.get("always_on_top"))
-    tk.Checkbutton(
-        app_frame, text="Immer im Vordergrund",
-        variable=always_on_top_var, font=FONT,
-        bg=BG, fg=TEXT, selectcolor=CELL_BG,
-        activebackground=BG, activeforeground=TEXT,
-        cursor="hand2",
-    ).pack(anchor="w")
-
-    minimize_to_tray_var = tk.BooleanVar(value=settings.get("minimize_to_tray"))
-    tk.Checkbutton(
-        app_frame, text="Beim Schließen in den Infobereich minimieren",
-        variable=minimize_to_tray_var, font=FONT,
-        bg=BG, fg=TEXT, selectcolor=CELL_BG,
-        activebackground=BG, activeforeground=TEXT,
-        cursor="hand2",
-    ).pack(anchor="w")
-
-    # --- Darstellung (UI-Skalierung, gerätelokal) ---
-    tk.Label(
-        app_frame, text="— Darstellung —", font=FONT_BOLD,
-        bg=BG, fg=TEXT_MUTED,
-    ).pack(pady=(12, 4))
-    scale_row = tk.Frame(app_frame, bg=BG)
-    scale_row.pack(fill="x")
-    tk.Label(
-        scale_row, text="Skalierung:", font=FONT, bg=BG, fg=TEXT,
-    ).pack(side=tk.LEFT, padx=(0, 8))
-
-    # ttk.Scale statt klassischer tk.Scale: das clam-Theme ist via
-    # apply_combobox_style aktiv, klassische tk.Scale rendert unter Windows
-    # einen hellen System-Trough/-Regler. Wert in eigenem Label (kein
-    # showvalue-Kasten); auf 5er-Schritte gerastert (ttk.Scale kennt kein
-    # resolution). Akzent analog dark_entry: Ruhe TEXT_MUTED, Press ACCENT.
-    scale_style = ttk.Style(dialog)
-    scale_style.configure(
-        "Display.Horizontal.TScale",
-        background=TEXT_MUTED, troughcolor=CELL_BG,
-        bordercolor=CELL_BG, darkcolor=TEXT_MUTED, lightcolor=TEXT_MUTED,
-    )
-    scale_style.map(
-        "Display.Horizontal.TScale",
-        background=[("pressed", ACCENT)],
-        darkcolor=[("pressed", ACCENT)],
-        lightcolor=[("pressed", ACCENT)],
-    )
-    scale_var = tk.DoubleVar(value=round(settings.get("ui_scale") * 100))
-    scale_value_label = tk.Label(
-        scale_row, text=f"{round(scale_var.get() / 5) * 5} %", font=FONT,
-        bg=BG, fg=TEXT_MUTED, width=5, anchor="w",
-    )
-
-    def _on_scale(_raw):
-        scale_value_label.config(text=f"{round(scale_var.get() / 5) * 5} %")
-
-    scale_widget = ttk.Scale(
-        scale_row, from_=75, to=200, orient="horizontal",
-        variable=scale_var, command=_on_scale, length=200,
-        style="Display.Horizontal.TScale",
-    )
-    scale_widget.bind(
-        "<ButtonPress-1>", lambda _e: scale_value_label.config(fg=ACCENT), add="+",
-    )
-    scale_widget.bind(
-        "<ButtonRelease-1>", lambda _e: scale_value_label.config(fg=TEXT_MUTED), add="+",
-    )
-    scale_widget.pack(side=tk.LEFT)
-    scale_value_label.pack(side=tk.LEFT, padx=(8, 0))
-    tk.Label(
-        app_frame, text="Änderung startet die App neu.", font=FONT_SMALL,
-        bg=BG, fg=TEXT_MUTED,
-    ).pack(anchor="w", pady=(2, 0))
-
-    # --- Benachrichtigungen (Reservierungs-Erinnerungen, gerätelokal) ---
-    tk.Label(
-        app_frame, text="— Benachrichtigungen —", font=FONT_BOLD,
-        bg=BG, fg=TEXT_MUTED,
-    ).pack(pady=(12, 4))
-
-    reminders_enabled_var = tk.BooleanVar(value=settings.get("reminders_enabled"))
-    tk.Checkbutton(
-        app_frame, text="Erinnerungen als Toast anzeigen",
-        variable=reminders_enabled_var, font=FONT,
-        bg=BG, fg=TEXT, selectcolor=CELL_BG,
-        activebackground=BG, activeforeground=TEXT, cursor="hand2",
-    ).pack(anchor="w")
-
-    reminder_row = tk.Frame(app_frame, bg=BG)
-    reminder_row.pack(anchor="w", pady=(4, 0))
-    tk.Label(
-        reminder_row, text="Erinnerung Minuten vor Ende der Reservierung:",
-        font=FONT, bg=BG, fg=TEXT,
-    ).pack(side=tk.LEFT, padx=(0, 8))
-    reminder_minutes_var = tk.StringVar(
-        value=str(settings.get("reminder_minutes_before")))
-    dark_combo(
-        reminder_row, reminder_minutes_var,
-        [str(m) for m in range(0, 121, 5)], width=4,
-    ).pack(side=tk.LEFT)
-    tk.Label(
-        app_frame, text="Nur für Reservierungen mit Kategorie.", font=FONT_SMALL,
-        bg=BG, fg=TEXT_MUTED,
-    ).pack(anchor="w", pady=(2, 0))
+    app = AppTab(tab_app, settings)
 
     # ===================== Speichern / Buttons =====================
-    tabs = {"work": work.frame, "mail": mail.frame, "google": tab_google, "app": tab_app}
+    tabs = {"work": work.frame, "mail": mail.frame, "google": tab_google, "app": app.frame}
 
     def save_settings():
         for key, lbl in zip(WEEKDAY_KEYS, DAYS_DE):
@@ -690,7 +555,7 @@ def open_settings_dialog(parent, settings, base_path, on_change, *,
         old_wsl_start = settings.get("werkstudent_limit_start")
         old_wsl_end = settings.get("werkstudent_limit_end")
 
-        new_autostart = autostart_var.get()
+        new_autostart = app.autostart_var.get()
         old_autostart = is_autostart_enabled()
 
         # Autostart-Toggle muss vor dem Settings-Write passieren, weil
@@ -711,7 +576,7 @@ def open_settings_dialog(parent, settings, base_path, on_change, *,
                 )
                 return
 
-        reminder_minutes = parse_reminder_minutes(reminder_minutes_var.get())
+        reminder_minutes = parse_reminder_minutes(app.reminder_minutes_var.get())
         if reminder_minutes is None:
             notebook.select(tabs["app"])
             themed_showerror(
@@ -721,9 +586,9 @@ def open_settings_dialog(parent, settings, base_path, on_change, *,
             return
 
         hourly_rate = parse_hourly_rate(mail.rate_var.get())
-        selected_code = code_for_state_label(state_var.get())
+        selected_code = code_for_state_label(app.state_var.get())
         old_scale = settings.get("ui_scale")
-        new_scale = clamp_ui_scale((round(scale_var.get() / 5) * 5) / 100)
+        new_scale = clamp_ui_scale((round(app.scale_var.get() / 5) * 5) / 100)
 
         updates = {
             "autostart": new_autostart,
@@ -736,10 +601,10 @@ def open_settings_dialog(parent, settings, base_path, on_change, *,
             "mail_closing": mail.closing_text.get("1.0", "end-1c"),
             "hourly_rate": hourly_rate,
             "state": selected_code,
-            "show_weekend": show_weekend_var.get(),
-            "always_on_top": always_on_top_var.get(),
-            "minimize_to_tray": minimize_to_tray_var.get(),
-            "reminders_enabled": reminders_enabled_var.get(),
+            "show_weekend": app.show_weekend_var.get(),
+            "always_on_top": app.always_on_top_var.get(),
+            "minimize_to_tray": app.minimize_to_tray_var.get(),
+            "reminders_enabled": app.reminders_enabled_var.get(),
             "reminder_minutes_before": reminder_minutes,
             "ui_scale": new_scale,
             "werkstudent_limit_enabled": work.wsl_enabled_var.get(),

--- a/src/dialogs/settings_dialog/dialog.py
+++ b/src/dialogs/settings_dialog/dialog.py
@@ -1,32 +1,25 @@
 import datetime
-import logging
-import os
 import tkinter as tk
-import traceback
-from tkinter import messagebox, ttk
+from tkinter import ttk
 
 from src.autostart import disable_autostart, enable_autostart, is_autostart_enabled, resolve_autostart_target
-from src.platform_open import open_folder
 from src.theme import (
-    ACCENT, BG, CELL_BG, FONT, FONT_SMALL,
-    STATUS_OK, TEXT, TEXT_MUTED,
+    BG,
     apply_combobox_style, apply_notebook_style, attach_unfocus_on_click,
     center_dialog_on_parent, create_dialog,
-    dark_combo,
     primary_button, secondary_button,
-    themed_askyesno, themed_showinfo, themed_showwarning, themed_showerror,
+    themed_showwarning, themed_showerror,
 )
 from src.holidays_de import code_for_state_label
 from src.settings import (
     WEEKDAY_KEYS, clamp_ui_scale, parse_hourly_rate,
     parse_reminder_minutes, resolve_calendar_id,
 )
-from src.time_utils import format_iso_date, validate_period
+from src.time_utils import validate_period
 from src.time_utils import DAYS_DE, validate_entry
 from src.weekly_limit import format_limit_warnings, period_scan_needed, scan_period_for_warnings
-from src.dialogs.settings_dialog._shared import label, subheader
-from src.dialogs.settings_dialog.oauth_task import build_oauth_enable_task
 from src.dialogs.settings_dialog.tab_app import AppTab
+from src.dialogs.settings_dialog.tab_google import GoogleTab
 from src.dialogs.settings_dialog.tab_mail import MailTab
 from src.dialogs.settings_dialog.tab_work import WorkTab
 
@@ -51,8 +44,6 @@ def open_settings_dialog(parent, settings, base_path, on_change, *,
     apply_combobox_style(dialog)
     apply_notebook_style(dialog)
 
-    creds_path = os.path.join(base_path, "credentials.json")
-
     notebook = ttk.Notebook(dialog, style="Dark.TNotebook")
     notebook.pack(fill="both", expand=True, padx=8, pady=(8, 0))
 
@@ -72,452 +63,15 @@ def open_settings_dialog(parent, settings, base_path, on_change, *,
     mail = MailTab(tab_mail, settings)
 
     # ===================== Tab: Google =====================
-    subheader(tab_google, "Google-Konto", row=0, top_pad=10)
-
-    label(tab_google, "Datenordner:", row=1, pady=4)
-    creds_row = tk.Frame(tab_google, bg=BG)
-    creds_row.grid(row=1, column=1, padx=10, pady=4, sticky="w")
-
-    def open_data_folder():
-        try:
-            open_folder(base_path)
-        except Exception as e:
-            logging.getLogger(__name__).exception("Datenordner konnte nicht geöffnet werden")
-            messagebox.showerror(
-                "Ordner konnte nicht geöffnet werden",
-                f"{type(e).__name__}: {e}\n\n{traceback.format_exc()}",
-                parent=dialog,
-            )
-
-    secondary_button(creds_row, "Ordner öffnen", open_data_folder, padx=12, pady=2).pack(side=tk.LEFT)
-
-    status_label = tk.Label(creds_row, text="", font=FONT_SMALL, bg=BG)
-    status_label.pack(side=tk.LEFT, padx=(10, 0))
-
-    def refresh_status():
-        if not status_label.winfo_exists():
-            return
-        if os.path.exists(creds_path):
-            status_label.config(text="✓ credentials.json vorhanden", fg=STATUS_OK)
-        else:
-            status_label.config(text="✗ credentials.json fehlt", fg=ACCENT)
-        dialog.after(500, refresh_status)
-
-    refresh_status()
-
-    # Absender-Zeile: zeigt die authentifizierte E-Mail-Adresse, die ui.py
-    # im Hintergrund über OAuth2-userinfo abruft und in settings cached.
-    label(tab_google, "Absender:", row=2, pady=(0, 4))
-    sender_row = tk.Frame(tab_google, bg=BG)
-    sender_row.grid(row=2, column=1, padx=10, pady=(0, 4), sticky="w")
-    sender_label = tk.Label(
-        sender_row,
-        text=settings.get("sender_email") or "(noch nicht ermittelt)",
-        font=FONT, bg=BG, fg=TEXT_MUTED,
-    )
-    sender_label.pack(side=tk.LEFT)
-
-    def _set_sender_btn_text(text):
-        # secondary_button ist ein Frame+Label-Konstrukt (kein tk.Button),
-        # der Text liegt am inneren `_label`. Kein -state-Option — wir
-        # markieren den laufenden Zustand nur über den Text.
-        if hasattr(sender_btn, "_label"):
-            sender_btn._label.config(text=text)
-
-    def _refresh_sender():
-        """OAuth-Flow + userinfo-Fetch im Thread, danach Label aktualisieren."""
-        from src.dialogs.send_dialog import show_missing_credentials_dialog
-
-        if not os.path.exists(creds_path):
-            # Konsistent mit Senden/Teilen: freundlicher Hinweis + „Datenordner
-            # öffnen" statt OAuth-Traceback bei fehlender credentials.json.
-            show_missing_credentials_dialog(dialog, base_path)
-            return
-
-        _set_sender_btn_text("Verbinde…")
-
-        def _fn():
-            from src.mail import fetch_user_email, get_gmail_service
-            try:
-                get_gmail_service(
-                    os.path.join(base_path, "credentials.json"),
-                    os.path.join(base_path, "token.json"),
-                    sync_enabled=settings.get("sync_enabled"),
-                    gcal_enabled=settings.get("gcal_enabled"),
-                )
-                email = fetch_user_email(
-                    os.path.join(base_path, "token.json"),
-                    sync_enabled=settings.get("sync_enabled"),
-                    gcal_enabled=settings.get("gcal_enabled"),
-                )
-            except Exception as e:
-                return {"ok": False, "error": e, "tb": traceback.format_exc()}
-            if email:
-                settings.set("sender_email", email)   # Cache überlebt Close
-            return {"ok": True, "email": email}
-
-        def _on_done(res):
-            if not sender_label.winfo_exists():
-                return
-            _set_sender_btn_text("Aktualisieren")
-            if not res["ok"]:
-                messagebox.showerror(
-                    "Anmeldung fehlgeschlagen",
-                    "OAuth-Flow oder Userinfo-Aufruf fehlgeschlagen:\n\n"
-                    f"{res['error']}\n\n{res['tb']}",
-                    parent=dialog,
-                )
-                return
-            email = res["email"]
-            sender_label.config(
-                text=email if email
-                else "(nicht verfügbar — Scope fehlt evtl.)")
-
-        runner.run(_fn, _on_done)
-
-    sender_btn = secondary_button(
-        sender_row,
-        "Aktualisieren" if settings.get("sender_email") else "Anmelden",
-        _refresh_sender,
-        padx=12, pady=2,
-    )
-    sender_btn.pack(side=tk.LEFT, padx=(10, 0))
-
-    subheader(tab_google, "Synchronisation", row=3)
-    tk.Label(
-        tab_google, text="Diese Schalter wirken sofort (Anmeldung im Browser).",
-        font=FONT_SMALL, bg=BG, fg=TEXT_MUTED,
-    ).grid(row=4, column=0, columnspan=2, padx=10, pady=(0, 4), sticky="w")
-
-    var_sync = tk.BooleanVar(value=settings.get("sync_enabled"))
-
-    # Forward-Deklaration: die Closures unten referenzieren cb_sync, das erst
-    # weiter unten als Checkbutton erzeugt wird. Beim ersten Aufruf der
-    # Closures (User-Interaktion) ist cb_sync garantiert gesetzt — das assert
-    # narrowt den Typ für Pylance.
-    cb_sync: tk.Checkbutton | None = None
-
-    def _on_sync_toggled():
-        assert cb_sync is not None
-        new_state = var_sync.get()
-        if new_state and not settings.get("sync_enabled"):
-            cb_sync.config(state="disabled")
-
-            def _service():
-                from src import drive
-                drive.get_drive_service(
-                    os.path.join(base_path, "credentials.json"),
-                    os.path.join(base_path, "token.json"),
-                    gcal_enabled=settings.get("gcal_enabled"),
-                )
-
-            fn, on_done = build_oauth_enable_task(
-                service_fn=_service, settings=settings,
-                setting_key="sync_enabled", checkbox=cb_sync,
-                toggle_var=var_sync, on_change=on_change, dialog=dialog,
-                error_title="Synchronisation aktivieren",
-            )
-            runner.run(fn, on_done)
-            return
-        if not new_state and settings.get("sync_enabled"):
-            settings.set("sync_enabled", False)
-            on_change()
-
-    cb_sync = tk.Checkbutton(
-        tab_google, text="Mit Google Drive synchronisieren",
-        variable=var_sync, font=FONT,
-        bg=BG, fg=TEXT, selectcolor=CELL_BG,
-        activebackground=BG, activeforeground=TEXT,
-        cursor="hand2",
-        command=_on_sync_toggled,
-    )
-    cb_sync.grid(row=5, column=0, columnspan=2, padx=10, pady=(4, 0), sticky="w")
-
-    device_id = settings.get("device_id") or "(noch nicht gesetzt)"
-    device_id_short = device_id[:8] + "…" if len(device_id) > 8 else device_id
-    tk.Label(
-        tab_google, text=f"Geräte-ID: {device_id_short}", font=FONT_SMALL,
-        bg=BG, fg=TEXT_MUTED,
-    ).grid(row=6, column=0, columnspan=2, padx=10, pady=(2, 0), sticky="w")
-
-    last = format_iso_date(settings.get("last_pull_at"), fallback="noch nie")
-    tk.Label(
-        tab_google, text=f"Letzte Synchronisation: {last}", font=FONT_SMALL,
-        bg=BG, fg=TEXT_MUTED,
-    ).grid(row=7, column=0, columnspan=2, padx=10, pady=(2, 4), sticky="w")
-
-    # Ab hier wachsen im Google-Tab optionale Zeilen (Konflikte, Kompaktieren)
-    # dynamisch — deshalb eine laufende Row-Nummer statt fixer Konstanten.
-    next_google_row = 8
-    unresolved = 0
-    if conflicts_store is not None:
-        unresolved = conflicts_store.count_unresolved()
-    if unresolved > 0:
-        def _open_conflicts_dialog():
-            from src.dialogs.conflicts_dialog import ConflictsDialog
-            # data_lock durchgereicht bis zu sync.resolve_conflict
-            # (Review-Finding: RMW-Spanne muss atomar gegen Hintergrund-Sync sein).
-            ConflictsDialog(dialog, storage, settings, conflicts_store, data_lock=data_lock)
-
-        secondary_button(
-            tab_google,
-            f"Konflikte ansehen ({unresolved})",
-            _open_conflicts_dialog,
-            padx=12, pady=2,
-        ).grid(row=next_google_row, column=0, columnspan=2, padx=10, pady=(0, 8), sticky="w")
-        next_google_row += 1
-
-    def _open_import_dialog():
-        from src.dialogs.import_dialog import open_import_dialog
-
-        def _after_import():
-            on_change()
-            dialog.destroy()
-
-        open_import_dialog(
-            dialog, storage, settings, _after_import,
-            reservation_store=reservation_store,
-        )
-
-    btn_row = tk.Frame(tab_google, bg=BG)
-    btn_row.grid(row=next_google_row, column=0, columnspan=2, padx=10, pady=(4, 8), sticky="w")
-    next_google_row += 1
-
-    # label_button liefert einen tk.Frame (keine -state-Option) — Doppelklick-
-    # Schutz daher über ein Flag statt cb.config(state=...).
-    reconnect_busy = {"value": False}
-
-    def _reconnect_google():
-        if reconnect_busy["value"]:
-            return
-        if not themed_askyesno(
-            dialog, "Google neu verbinden",
-            "Die App fragt die Google-Berechtigungen neu ab. Dazu öffnet sich "
-            "ein Browser-Fenster zur Anmeldung — bitte dort die Freigabe "
-            "bestätigen.\n\nFortfahren?",
-        ):
-            return
-        reconnect_busy["value"] = True
-
-        def _fn():
-            from src import drive
-            try:
-                drive.reconnect(
-                    os.path.join(base_path, "credentials.json"),
-                    os.path.join(base_path, "token.json"),
-                    gcal_enabled=settings.get("gcal_enabled"),
-                )
-            except Exception as e:
-                return {"ok": False, "error": e, "tb": traceback.format_exc()}
-            return {"ok": True}
-
-        def _on_done(res):
-            reconnect_busy["value"] = False
-            if not dialog.winfo_exists():
-                return
-            if res["ok"]:
-                themed_showinfo(
-                    dialog, "Google neu verbunden",
-                    "Die Google-Berechtigungen wurden erneuert. Die "
-                    "Synchronisation sollte jetzt wieder funktionieren.",
-                )
-                return
-            messagebox.showerror(
-                "Google neu verbinden",
-                "Die Neuverbindung ist fehlgeschlagen:\n\n"
-                f"{res['error']}\n\n{res['tb']}",
-                parent=dialog,
-            )
-
-        runner.run(_fn, _on_done)
-
-    reconnect_btn = secondary_button(
-        btn_row, "Google neu verbinden", _reconnect_google, padx=12, pady=2)
-    reconnect_btn.pack(side=tk.LEFT)
-
-    if storage is not None:
-        secondary_button(
-            btn_row, "Daten importieren", _open_import_dialog, padx=12, pady=2,
-        ).pack(side=tk.LEFT, padx=(8, 0))
-
-    if settings.get("sync_enabled") and storage is not None and conflicts_store is not None:
-        def _on_compact_clicked():
-            confirmed = themed_askyesno(
-                dialog,
-                "Sync-Daten kompaktieren",
-                "Entfernt alte gelöschte Einträge endgültig aus dem Sync.\n\n"
-                "Nur ausführen, wenn ALLE deine Geräte auf der aktuellen Version "
-                "sind und kürzlich synchronisiert haben.\n\nFortfahren?",
-            )
-            if not confirmed:
-                return
-
-            def _show(res):
-                if not dialog.winfo_exists():
-                    return
-                if res.get("skipped"):
-                    themed_showinfo(
-                        dialog,
-                        "Kompaktierung",
-                        "Eine Synchronisation läuft gerade — bitte kurz "
-                        "warten und erneut versuchen.",
-                    )
-                    return
-                if res.get("reason") == "old_version":
-                    themed_showwarning(
-                        dialog,
-                        "Kompaktierung abgebrochen",
-                        "Ein Gerät nutzt noch eine ältere Version — bitte erst "
-                        "alle Geräte aktualisieren und synchronisieren.",
-                    )
-                elif res.get("reason") == "newer_version":
-                    from src.sync import NEWER_REMOTE_VERSION_MSG
-                    themed_showwarning(
-                        dialog, "Update erforderlich", NEWER_REMOTE_VERSION_MSG,
-                    )
-                elif not res.get("ok"):
-                    detail = f"{res.get('error', '?')}\n\n{res.get('tb', '')}"
-                    themed_showerror(
-                        dialog,
-                        "Kompaktierung fehlgeschlagen",
-                        f"Die Kompaktierung ist fehlgeschlagen:\n\n{detail}",
-                    )
-                else:
-                    themed_showinfo(
-                        dialog,
-                        "Kompaktierung", "Sync-Daten wurden kompaktiert.",
-                    )
-
-            def _fn():
-                from src.main import _run_compaction_blocking
-                return _run_compaction_blocking(
-                    storage, settings, conflicts_store, base_path,
-                    data_lock=data_lock, sync_guard=sync_guard)
-
-            runner.run(_fn, _show)
-
-        secondary_button(
-            tab_google, "Sync-Daten kompaktieren", _on_compact_clicked,
-            padx=12, pady=2,
-        ).grid(row=next_google_row, column=0, columnspan=2, padx=10, pady=(0, 8), sticky="w")
-        next_google_row += 1
-
-    subheader(tab_google, "Google Kalender", row=next_google_row)
-    next_google_row += 1
-
-    var_gcal = tk.BooleanVar(value=settings.get("gcal_enabled"))
-    cb_gcal: tk.Checkbutton | None = None
-
-    # Kalender-Auswahl: Combobox zeigt Klarnamen, gespeichert wird die ID.
-    # cal_map summary->id wird im Hintergrund per API befüllt.
-    cal_map: dict[str, str] = {}
-    cal_var = tk.StringVar(value=settings.get("gcal_calendar_id") or "primary")
-
-    gcal_check_row = next_google_row
-    cal_label_row = next_google_row + 1
-    cal_status_row = next_google_row + 2
-
-    cb_gcal = tk.Checkbutton(
-        tab_google, text="Reservierungen mit Google Kalender abgleichen",
-        variable=var_gcal, font=FONT,
-        bg=BG, fg=TEXT, selectcolor=CELL_BG,
-        activebackground=BG, activeforeground=TEXT,
-        cursor="hand2",
-    )
-    cb_gcal.grid(row=gcal_check_row, column=0, columnspan=2, padx=10, pady=(4, 0), sticky="w")
-
-    tk.Label(tab_google, text="Kalender:", font=FONT, bg=BG, fg=TEXT).grid(
-        row=cal_label_row, column=0, padx=10, pady=4, sticky="w")
-    cal_combo = dark_combo(tab_google, cal_var, [cal_var.get()], width=30)
-    cal_combo.grid(row=cal_label_row, column=1, padx=10, pady=4, sticky="w")
-
-    cal_status = tk.Label(tab_google, text="", font=FONT_SMALL, bg=BG, fg=TEXT_MUTED)
-    cal_status.grid(row=cal_status_row, column=0, columnspan=2, padx=10, pady=(0, 4), sticky="w")
-
-    def _populate_calendars(items):
-        if not cal_combo.winfo_exists():
-            return
-        cal_map.clear()
-        for it in items:
-            cal_map[it["summary"]] = it["id"]
-        cal_combo["values"] = list(cal_map.keys()) or [cal_var.get()]
-        # Gespeicherte ID auf den passenden Klarnamen zurückmappen.
-        stored_id = settings.get("gcal_calendar_id") or "primary"
-        for summary, cid in cal_map.items():
-            if cid == stored_id:
-                cal_var.set(summary)
-                break
-        cal_status.config(text="")
-
-    def _load_calendars():
-        cal_status.config(text="Kalenderliste wird geladen…")
-
-        def _fn():
-            from src import gcal
-            try:
-                service = gcal.get_calendar_service(
-                    os.path.join(base_path, "credentials.json"),
-                    os.path.join(base_path, "token.json"),
-                    sync_enabled=settings.get("sync_enabled"),
-                )
-                items = gcal.list_calendars(service)
-            except Exception as e:
-                return {"ok": False, "error": e, "tb": traceback.format_exc()}
-            return {"ok": True, "items": items}
-
-        def _on_done(res):
-            if not cal_status.winfo_exists():
-                return
-            if not res["ok"]:
-                cal_status.config(text="Kalenderliste nicht verfügbar")
-                messagebox.showerror(
-                    "Google Kalender",
-                    "Kalenderliste konnte nicht geladen werden:\n\n"
-                    f"{res['error']}\n\n{res['tb']}",
-                    parent=dialog,
-                )
-                return
-            _populate_calendars(res["items"])
-
-        runner.run(_fn, _on_done)
-
-    def _on_gcal_toggled():
-        assert cb_gcal is not None
-        new_state = var_gcal.get()
-        if new_state and not settings.get("gcal_enabled"):
-            cb_gcal.config(state="disabled")
-
-            def _service():
-                from src import gcal
-                gcal.get_calendar_service(
-                    os.path.join(base_path, "credentials.json"),
-                    os.path.join(base_path, "token.json"),
-                    sync_enabled=settings.get("sync_enabled"),
-                )
-
-            fn, on_done = build_oauth_enable_task(
-                service_fn=_service, settings=settings,
-                setting_key="gcal_enabled", checkbox=cb_gcal,
-                toggle_var=var_gcal, on_change=on_change, dialog=dialog,
-                error_title="Google Kalender aktivieren",
-                on_success_dialog_ui=_load_calendars,
-            )
-            runner.run(fn, on_done)
-            return
-        if not new_state and settings.get("gcal_enabled"):
-            settings.set("gcal_enabled", False)
-            on_change()
-
-    cb_gcal.config(command=_on_gcal_toggled)
-
-    if settings.get("gcal_enabled"):
-        _load_calendars()
+    google = GoogleTab(
+        tab_google, dialog, settings, base_path, on_change, runner,
+        storage, conflicts_store, reservation_store, data_lock, sync_guard)
 
     # ===================== Tab: App =====================
     app = AppTab(tab_app, settings)
 
     # ===================== Speichern / Buttons =====================
-    tabs = {"work": work.frame, "mail": mail.frame, "google": tab_google, "app": app.frame}
+    tabs = {"work": work.frame, "mail": mail.frame, "google": google.frame, "app": app.frame}
 
     def save_settings():
         for key, lbl in zip(WEEKDAY_KEYS, DAYS_DE):
@@ -619,9 +173,9 @@ def open_settings_dialog(parent, settings, base_path, on_change, *,
         # Kalender-Auswahl: Klarname zurück auf ID mappen, als Sync-Setting
         # speichern. Nur wenn die Kalenderliste schon geladen ist (cal_map
         # gefüllt) — sonst würde ein vorschnelles Speichern "primary" festschreiben.
-        if settings.get("gcal_enabled") and cal_map:
+        if settings.get("gcal_enabled") and google.cal_map:
             selected_cal_id = resolve_calendar_id(
-                cal_map, cal_var.get(), settings.get("gcal_calendar_id"))
+                google.cal_map, google.cal_var.get(), settings.get("gcal_calendar_id"))
             if selected_cal_id != settings.get("gcal_calendar_id"):
                 settings.set_synced("gcal_calendar_id", selected_cal_id)
 

--- a/src/dialogs/settings_dialog/oauth_task.py
+++ b/src/dialogs/settings_dialog/oauth_task.py
@@ -1,0 +1,51 @@
+"""Generischer (fn, on_done)-Builder für OAuth-Aktivieren-Toggles (Audit H5).
+
+Eigenes Modul (statt tab_google), weil der Builder keinen Tab-Bezug hat und
+tests/test_settings_dialog.py sein messagebox im Funktions-Modul monkeypatcht.
+"""
+
+import traceback
+from tkinter import messagebox
+
+
+def build_oauth_enable_task(*, service_fn, settings, setting_key, checkbox,
+                            toggle_var, on_change, dialog, error_title,
+                            on_success_dialog_ui=None):
+    """Baut (fn, on_done) für einen OAuth-Aktivieren-Toggle (Drive-Sync / Kalender).
+
+    fn (Worker-Thread): ruft service_fn() und persistiert setting_key=True bei
+    Erfolg — läuft im Thread und überlebt daher einen Dialog-Close. Fängt seine
+    Exceptions selbst, wirft nie.
+
+    on_done (UI-Thread via App._marshal_to_ui): ruft on_change() (App-/root-scoped)
+    VOR dem winfo_exists-Guard, danach die Dialog-Kosmetik (checkbox, toggle_var,
+    Messagebox, optional on_success_dialog_ui) — übersprungen, wenn der Dialog weg
+    ist. on_success_dialog_ui ist Dialog-Kosmetik (z.B. Kalenderliste laden) und
+    läuft daher NACH dem Guard.
+    """
+    def fn():
+        try:
+            service_fn()
+        except Exception as e:
+            return {"ok": False, "error": e, "tb": traceback.format_exc()}
+        settings.set(setting_key, True)
+        return {"ok": True}
+
+    def on_done(res):
+        if res["ok"]:
+            on_change()
+        if not checkbox.winfo_exists():
+            return
+        checkbox.config(state="normal")
+        if res["ok"]:
+            if on_success_dialog_ui is not None:
+                on_success_dialog_ui()
+        else:
+            toggle_var.set(False)
+            messagebox.showerror(
+                error_title,
+                f"OAuth-Flow fehlgeschlagen:\n\n{res['error']}\n\n{res['tb']}",
+                parent=dialog,
+            )
+
+    return fn, on_done

--- a/src/dialogs/settings_dialog/tab_app.py
+++ b/src/dialogs/settings_dialog/tab_app.py
@@ -1,0 +1,165 @@
+"""Tab „App": Bundesland, UI-Optionen, Skalierung, Benachrichtigungen."""
+
+import tkinter as tk
+from tkinter import ttk
+
+from src.autostart import is_autostart_enabled
+from src.dialogs.settings_dialog._shared import label
+from src.holidays_de import STATES
+from src.theme import (
+    ACCENT, BG, CELL_BG, FONT, FONT_BOLD, FONT_SMALL, TEXT, TEXT_MUTED,
+    dark_combo,
+)
+
+
+class AppTab:
+    """Baut den App-Tab; exponiert die Variablen für save_settings."""
+
+    def __init__(self, frame, settings):
+        label(frame, "Bundesland:", row=0, pady=(10, 8))
+        state_labels = [lbl for _, lbl in STATES]
+        current_code = settings.get("state")
+        current_label = next(
+            (lbl for code, lbl in STATES if code == current_code),
+            STATES[0][1],
+        )
+        state_var = tk.StringVar(value=current_label)
+        dark_combo(frame, state_var, state_labels, width=22).grid(
+            row=0, column=1, padx=10, pady=(10, 8), sticky="w")
+
+        # Gerätelokale UI-Optionen. Alle in app_frame (ein Grid-Member), damit die
+        # pack-Interna dieses Frames unberührt bleiben.
+        app_frame = tk.Frame(frame, bg=BG)
+        app_frame.grid(row=1, column=0, columnspan=2, padx=10, pady=(4, 4), sticky="we")
+
+        show_weekend_var = tk.BooleanVar(value=settings.get("show_weekend"))
+        tk.Checkbutton(
+            app_frame, text="Wochenende (Sa/So) im Kalender anzeigen",
+            variable=show_weekend_var, font=FONT,
+            bg=BG, fg=TEXT, selectcolor=CELL_BG,
+            activebackground=BG, activeforeground=TEXT,
+            cursor="hand2",
+        ).pack(anchor="w")
+
+        autostart_var = tk.BooleanVar(value=is_autostart_enabled())
+        tk.Checkbutton(
+            app_frame, text="Autostart (minimiert bei Anmeldung)",
+            variable=autostart_var, font=FONT,
+            bg=BG, fg=TEXT, selectcolor=CELL_BG,
+            activebackground=BG, activeforeground=TEXT,
+            cursor="hand2",
+        ).pack(anchor="w")
+
+        always_on_top_var = tk.BooleanVar(value=settings.get("always_on_top"))
+        tk.Checkbutton(
+            app_frame, text="Immer im Vordergrund",
+            variable=always_on_top_var, font=FONT,
+            bg=BG, fg=TEXT, selectcolor=CELL_BG,
+            activebackground=BG, activeforeground=TEXT,
+            cursor="hand2",
+        ).pack(anchor="w")
+
+        minimize_to_tray_var = tk.BooleanVar(value=settings.get("minimize_to_tray"))
+        tk.Checkbutton(
+            app_frame, text="Beim Schließen in den Infobereich minimieren",
+            variable=minimize_to_tray_var, font=FONT,
+            bg=BG, fg=TEXT, selectcolor=CELL_BG,
+            activebackground=BG, activeforeground=TEXT,
+            cursor="hand2",
+        ).pack(anchor="w")
+
+        # --- Darstellung (UI-Skalierung, gerätelokal) ---
+        tk.Label(
+            app_frame, text="— Darstellung —", font=FONT_BOLD,
+            bg=BG, fg=TEXT_MUTED,
+        ).pack(pady=(12, 4))
+        scale_row = tk.Frame(app_frame, bg=BG)
+        scale_row.pack(fill="x")
+        tk.Label(
+            scale_row, text="Skalierung:", font=FONT, bg=BG, fg=TEXT,
+        ).pack(side=tk.LEFT, padx=(0, 8))
+
+        # ttk.Scale statt klassischer tk.Scale: das clam-Theme ist via
+        # apply_combobox_style aktiv, klassische tk.Scale rendert unter Windows
+        # einen hellen System-Trough/-Regler. Wert in eigenem Label (kein
+        # showvalue-Kasten); auf 5er-Schritte gerastert (ttk.Scale kennt kein
+        # resolution). Akzent analog dark_entry: Ruhe TEXT_MUTED, Press ACCENT.
+        scale_style = ttk.Style(frame)
+        scale_style.configure(
+            "Display.Horizontal.TScale",
+            background=TEXT_MUTED, troughcolor=CELL_BG,
+            bordercolor=CELL_BG, darkcolor=TEXT_MUTED, lightcolor=TEXT_MUTED,
+        )
+        scale_style.map(
+            "Display.Horizontal.TScale",
+            background=[("pressed", ACCENT)],
+            darkcolor=[("pressed", ACCENT)],
+            lightcolor=[("pressed", ACCENT)],
+        )
+        scale_var = tk.DoubleVar(value=round(settings.get("ui_scale") * 100))
+        scale_value_label = tk.Label(
+            scale_row, text=f"{round(scale_var.get() / 5) * 5} %", font=FONT,
+            bg=BG, fg=TEXT_MUTED, width=5, anchor="w",
+        )
+
+        def _on_scale(_raw):
+            scale_value_label.config(text=f"{round(scale_var.get() / 5) * 5} %")
+
+        scale_widget = ttk.Scale(
+            scale_row, from_=75, to=200, orient="horizontal",
+            variable=scale_var, command=_on_scale, length=200,
+            style="Display.Horizontal.TScale",
+        )
+        scale_widget.bind(
+            "<ButtonPress-1>", lambda _e: scale_value_label.config(fg=ACCENT), add="+",
+        )
+        scale_widget.bind(
+            "<ButtonRelease-1>", lambda _e: scale_value_label.config(fg=TEXT_MUTED), add="+",
+        )
+        scale_widget.pack(side=tk.LEFT)
+        scale_value_label.pack(side=tk.LEFT, padx=(8, 0))
+        tk.Label(
+            app_frame, text="Änderung startet die App neu.", font=FONT_SMALL,
+            bg=BG, fg=TEXT_MUTED,
+        ).pack(anchor="w", pady=(2, 0))
+
+        # --- Benachrichtigungen (Reservierungs-Erinnerungen, gerätelokal) ---
+        tk.Label(
+            app_frame, text="— Benachrichtigungen —", font=FONT_BOLD,
+            bg=BG, fg=TEXT_MUTED,
+        ).pack(pady=(12, 4))
+
+        reminders_enabled_var = tk.BooleanVar(value=settings.get("reminders_enabled"))
+        tk.Checkbutton(
+            app_frame, text="Erinnerungen als Toast anzeigen",
+            variable=reminders_enabled_var, font=FONT,
+            bg=BG, fg=TEXT, selectcolor=CELL_BG,
+            activebackground=BG, activeforeground=TEXT, cursor="hand2",
+        ).pack(anchor="w")
+
+        reminder_row = tk.Frame(app_frame, bg=BG)
+        reminder_row.pack(anchor="w", pady=(4, 0))
+        tk.Label(
+            reminder_row, text="Erinnerung Minuten vor Ende der Reservierung:",
+            font=FONT, bg=BG, fg=TEXT,
+        ).pack(side=tk.LEFT, padx=(0, 8))
+        reminder_minutes_var = tk.StringVar(
+            value=str(settings.get("reminder_minutes_before")))
+        dark_combo(
+            reminder_row, reminder_minutes_var,
+            [str(m) for m in range(0, 121, 5)], width=4,
+        ).pack(side=tk.LEFT)
+        tk.Label(
+            app_frame, text="Nur für Reservierungen mit Kategorie.", font=FONT_SMALL,
+            bg=BG, fg=TEXT_MUTED,
+        ).pack(anchor="w", pady=(2, 0))
+
+        self.frame = frame
+        self.state_var = state_var
+        self.show_weekend_var = show_weekend_var
+        self.autostart_var = autostart_var
+        self.always_on_top_var = always_on_top_var
+        self.minimize_to_tray_var = minimize_to_tray_var
+        self.scale_var = scale_var
+        self.reminders_enabled_var = reminders_enabled_var
+        self.reminder_minutes_var = reminder_minutes_var

--- a/src/dialogs/settings_dialog/tab_google.py
+++ b/src/dialogs/settings_dialog/tab_google.py
@@ -1,0 +1,473 @@
+"""Tab „Google": Konto/Status, Absender, Drive-Sync (Konflikte/Import/
+Reconnect/Kompaktierung) und Google-Kalender — inkl. der H5-Worker
+(runner.run, Persistenz im fn, winfo_exists-Guards)."""
+
+import logging
+import os
+import tkinter as tk
+import traceback
+from tkinter import messagebox
+
+from src.dialogs.settings_dialog._shared import label, subheader
+from src.dialogs.settings_dialog.oauth_task import build_oauth_enable_task
+from src.platform_open import open_folder
+from src.theme import (
+    ACCENT, BG, CELL_BG, FONT, FONT_SMALL, STATUS_OK, TEXT, TEXT_MUTED,
+    dark_combo, secondary_button, themed_askyesno, themed_showerror,
+    themed_showinfo, themed_showwarning,
+)
+from src.time_utils import format_iso_date
+
+
+class GoogleTab:
+    """Baut den Google-Tab; exponiert cal_map/cal_var für save_settings."""
+
+    def __init__(self, frame, dialog, settings, base_path, on_change, runner,
+                 storage, conflicts_store, reservation_store,
+                 data_lock, sync_guard):
+        creds_path = os.path.join(base_path, "credentials.json")
+
+        subheader(frame, "Google-Konto", row=0, top_pad=10)
+
+        label(frame, "Datenordner:", row=1, pady=4)
+        creds_row = tk.Frame(frame, bg=BG)
+        creds_row.grid(row=1, column=1, padx=10, pady=4, sticky="w")
+
+        def open_data_folder():
+            try:
+                open_folder(base_path)
+            except Exception as e:
+                logging.getLogger(__name__).exception("Datenordner konnte nicht geöffnet werden")
+                messagebox.showerror(
+                    "Ordner konnte nicht geöffnet werden",
+                    f"{type(e).__name__}: {e}\n\n{traceback.format_exc()}",
+                    parent=dialog,
+                )
+
+        secondary_button(creds_row, "Ordner öffnen", open_data_folder, padx=12, pady=2).pack(side=tk.LEFT)
+
+        status_label = tk.Label(creds_row, text="", font=FONT_SMALL, bg=BG)
+        status_label.pack(side=tk.LEFT, padx=(10, 0))
+
+        def refresh_status():
+            if not status_label.winfo_exists():
+                return
+            if os.path.exists(creds_path):
+                status_label.config(text="✓ credentials.json vorhanden", fg=STATUS_OK)
+            else:
+                status_label.config(text="✗ credentials.json fehlt", fg=ACCENT)
+            dialog.after(500, refresh_status)
+
+        refresh_status()
+
+        # Absender-Zeile: zeigt die authentifizierte E-Mail-Adresse, die ui.py
+        # im Hintergrund über OAuth2-userinfo abruft und in settings cached.
+        label(frame, "Absender:", row=2, pady=(0, 4))
+        sender_row = tk.Frame(frame, bg=BG)
+        sender_row.grid(row=2, column=1, padx=10, pady=(0, 4), sticky="w")
+        sender_label = tk.Label(
+            sender_row,
+            text=settings.get("sender_email") or "(noch nicht ermittelt)",
+            font=FONT, bg=BG, fg=TEXT_MUTED,
+        )
+        sender_label.pack(side=tk.LEFT)
+
+        def _set_sender_btn_text(text):
+            # secondary_button ist ein Frame+Label-Konstrukt (kein tk.Button),
+            # der Text liegt am inneren `_label`. Kein -state-Option — wir
+            # markieren den laufenden Zustand nur über den Text.
+            if hasattr(sender_btn, "_label"):
+                sender_btn._label.config(text=text)
+
+        def _refresh_sender():
+            """OAuth-Flow + userinfo-Fetch im Thread, danach Label aktualisieren."""
+            from src.dialogs.send_dialog import show_missing_credentials_dialog
+
+            if not os.path.exists(creds_path):
+                # Konsistent mit Senden/Teilen: freundlicher Hinweis + „Datenordner
+                # öffnen" statt OAuth-Traceback bei fehlender credentials.json.
+                show_missing_credentials_dialog(dialog, base_path)
+                return
+
+            _set_sender_btn_text("Verbinde…")
+
+            def _fn():
+                from src.mail import fetch_user_email, get_gmail_service
+                try:
+                    get_gmail_service(
+                        os.path.join(base_path, "credentials.json"),
+                        os.path.join(base_path, "token.json"),
+                        sync_enabled=settings.get("sync_enabled"),
+                        gcal_enabled=settings.get("gcal_enabled"),
+                    )
+                    email = fetch_user_email(
+                        os.path.join(base_path, "token.json"),
+                        sync_enabled=settings.get("sync_enabled"),
+                        gcal_enabled=settings.get("gcal_enabled"),
+                    )
+                except Exception as e:
+                    return {"ok": False, "error": e, "tb": traceback.format_exc()}
+                if email:
+                    settings.set("sender_email", email)   # Cache überlebt Close
+                return {"ok": True, "email": email}
+
+            def _on_done(res):
+                if not sender_label.winfo_exists():
+                    return
+                _set_sender_btn_text("Aktualisieren")
+                if not res["ok"]:
+                    messagebox.showerror(
+                        "Anmeldung fehlgeschlagen",
+                        "OAuth-Flow oder Userinfo-Aufruf fehlgeschlagen:\n\n"
+                        f"{res['error']}\n\n{res['tb']}",
+                        parent=dialog,
+                    )
+                    return
+                email = res["email"]
+                sender_label.config(
+                    text=email if email
+                    else "(nicht verfügbar — Scope fehlt evtl.)")
+
+            runner.run(_fn, _on_done)
+
+        sender_btn = secondary_button(
+            sender_row,
+            "Aktualisieren" if settings.get("sender_email") else "Anmelden",
+            _refresh_sender,
+            padx=12, pady=2,
+        )
+        sender_btn.pack(side=tk.LEFT, padx=(10, 0))
+
+        subheader(frame, "Synchronisation", row=3)
+        tk.Label(
+            frame, text="Diese Schalter wirken sofort (Anmeldung im Browser).",
+            font=FONT_SMALL, bg=BG, fg=TEXT_MUTED,
+        ).grid(row=4, column=0, columnspan=2, padx=10, pady=(0, 4), sticky="w")
+
+        var_sync = tk.BooleanVar(value=settings.get("sync_enabled"))
+
+        # Forward-Deklaration: die Closures unten referenzieren cb_sync, das erst
+        # weiter unten als Checkbutton erzeugt wird. Beim ersten Aufruf der
+        # Closures (User-Interaktion) ist cb_sync garantiert gesetzt — das assert
+        # narrowt den Typ für Pylance.
+        cb_sync: tk.Checkbutton | None = None
+
+        def _on_sync_toggled():
+            assert cb_sync is not None
+            new_state = var_sync.get()
+            if new_state and not settings.get("sync_enabled"):
+                cb_sync.config(state="disabled")
+
+                def _service():
+                    from src import drive
+                    drive.get_drive_service(
+                        os.path.join(base_path, "credentials.json"),
+                        os.path.join(base_path, "token.json"),
+                        gcal_enabled=settings.get("gcal_enabled"),
+                    )
+
+                fn, on_done = build_oauth_enable_task(
+                    service_fn=_service, settings=settings,
+                    setting_key="sync_enabled", checkbox=cb_sync,
+                    toggle_var=var_sync, on_change=on_change, dialog=dialog,
+                    error_title="Synchronisation aktivieren",
+                )
+                runner.run(fn, on_done)
+                return
+            if not new_state and settings.get("sync_enabled"):
+                settings.set("sync_enabled", False)
+                on_change()
+
+        cb_sync = tk.Checkbutton(
+            frame, text="Mit Google Drive synchronisieren",
+            variable=var_sync, font=FONT,
+            bg=BG, fg=TEXT, selectcolor=CELL_BG,
+            activebackground=BG, activeforeground=TEXT,
+            cursor="hand2",
+            command=_on_sync_toggled,
+        )
+        cb_sync.grid(row=5, column=0, columnspan=2, padx=10, pady=(4, 0), sticky="w")
+
+        device_id = settings.get("device_id") or "(noch nicht gesetzt)"
+        device_id_short = device_id[:8] + "…" if len(device_id) > 8 else device_id
+        tk.Label(
+            frame, text=f"Geräte-ID: {device_id_short}", font=FONT_SMALL,
+            bg=BG, fg=TEXT_MUTED,
+        ).grid(row=6, column=0, columnspan=2, padx=10, pady=(2, 0), sticky="w")
+
+        last = format_iso_date(settings.get("last_pull_at"), fallback="noch nie")
+        tk.Label(
+            frame, text=f"Letzte Synchronisation: {last}", font=FONT_SMALL,
+            bg=BG, fg=TEXT_MUTED,
+        ).grid(row=7, column=0, columnspan=2, padx=10, pady=(2, 4), sticky="w")
+
+        # Ab hier wachsen im Google-Tab optionale Zeilen (Konflikte, Kompaktieren)
+        # dynamisch — deshalb eine laufende Row-Nummer statt fixer Konstanten.
+        next_google_row = 8
+        unresolved = 0
+        if conflicts_store is not None:
+            unresolved = conflicts_store.count_unresolved()
+        if unresolved > 0:
+            def _open_conflicts_dialog():
+                from src.dialogs.conflicts_dialog import ConflictsDialog
+                # data_lock durchgereicht bis zu sync.resolve_conflict
+                # (Review-Finding: RMW-Spanne muss atomar gegen Hintergrund-Sync sein).
+                ConflictsDialog(dialog, storage, settings, conflicts_store, data_lock=data_lock)
+
+            secondary_button(
+                frame,
+                f"Konflikte ansehen ({unresolved})",
+                _open_conflicts_dialog,
+                padx=12, pady=2,
+            ).grid(row=next_google_row, column=0, columnspan=2, padx=10, pady=(0, 8), sticky="w")
+            next_google_row += 1
+
+        def _open_import_dialog():
+            from src.dialogs.import_dialog import open_import_dialog
+
+            def _after_import():
+                on_change()
+                dialog.destroy()
+
+            open_import_dialog(
+                dialog, storage, settings, _after_import,
+                reservation_store=reservation_store,
+            )
+
+        btn_row = tk.Frame(frame, bg=BG)
+        btn_row.grid(row=next_google_row, column=0, columnspan=2, padx=10, pady=(4, 8), sticky="w")
+        next_google_row += 1
+
+        # label_button liefert einen tk.Frame (keine -state-Option) — Doppelklick-
+        # Schutz daher über ein Flag statt cb.config(state=...).
+        reconnect_busy = {"value": False}
+
+        def _reconnect_google():
+            if reconnect_busy["value"]:
+                return
+            if not themed_askyesno(
+                dialog, "Google neu verbinden",
+                "Die App fragt die Google-Berechtigungen neu ab. Dazu öffnet sich "
+                "ein Browser-Fenster zur Anmeldung — bitte dort die Freigabe "
+                "bestätigen.\n\nFortfahren?",
+            ):
+                return
+            reconnect_busy["value"] = True
+
+            def _fn():
+                from src import drive
+                try:
+                    drive.reconnect(
+                        os.path.join(base_path, "credentials.json"),
+                        os.path.join(base_path, "token.json"),
+                        gcal_enabled=settings.get("gcal_enabled"),
+                    )
+                except Exception as e:
+                    return {"ok": False, "error": e, "tb": traceback.format_exc()}
+                return {"ok": True}
+
+            def _on_done(res):
+                reconnect_busy["value"] = False
+                if not dialog.winfo_exists():
+                    return
+                if res["ok"]:
+                    themed_showinfo(
+                        dialog, "Google neu verbunden",
+                        "Die Google-Berechtigungen wurden erneuert. Die "
+                        "Synchronisation sollte jetzt wieder funktionieren.",
+                    )
+                    return
+                messagebox.showerror(
+                    "Google neu verbinden",
+                    "Die Neuverbindung ist fehlgeschlagen:\n\n"
+                    f"{res['error']}\n\n{res['tb']}",
+                    parent=dialog,
+                )
+
+            runner.run(_fn, _on_done)
+
+        reconnect_btn = secondary_button(
+            btn_row, "Google neu verbinden", _reconnect_google, padx=12, pady=2)
+        reconnect_btn.pack(side=tk.LEFT)
+
+        if storage is not None:
+            secondary_button(
+                btn_row, "Daten importieren", _open_import_dialog, padx=12, pady=2,
+            ).pack(side=tk.LEFT, padx=(8, 0))
+
+        if settings.get("sync_enabled") and storage is not None and conflicts_store is not None:
+            def _on_compact_clicked():
+                confirmed = themed_askyesno(
+                    dialog,
+                    "Sync-Daten kompaktieren",
+                    "Entfernt alte gelöschte Einträge endgültig aus dem Sync.\n\n"
+                    "Nur ausführen, wenn ALLE deine Geräte auf der aktuellen Version "
+                    "sind und kürzlich synchronisiert haben.\n\nFortfahren?",
+                )
+                if not confirmed:
+                    return
+
+                def _show(res):
+                    if not dialog.winfo_exists():
+                        return
+                    if res.get("skipped"):
+                        themed_showinfo(
+                            dialog,
+                            "Kompaktierung",
+                            "Eine Synchronisation läuft gerade — bitte kurz "
+                            "warten und erneut versuchen.",
+                        )
+                        return
+                    if res.get("reason") == "old_version":
+                        themed_showwarning(
+                            dialog,
+                            "Kompaktierung abgebrochen",
+                            "Ein Gerät nutzt noch eine ältere Version — bitte erst "
+                            "alle Geräte aktualisieren und synchronisieren.",
+                        )
+                    elif res.get("reason") == "newer_version":
+                        from src.sync import NEWER_REMOTE_VERSION_MSG
+                        themed_showwarning(
+                            dialog, "Update erforderlich", NEWER_REMOTE_VERSION_MSG,
+                        )
+                    elif not res.get("ok"):
+                        detail = f"{res.get('error', '?')}\n\n{res.get('tb', '')}"
+                        themed_showerror(
+                            dialog,
+                            "Kompaktierung fehlgeschlagen",
+                            f"Die Kompaktierung ist fehlgeschlagen:\n\n{detail}",
+                        )
+                    else:
+                        themed_showinfo(
+                            dialog,
+                            "Kompaktierung", "Sync-Daten wurden kompaktiert.",
+                        )
+
+                def _fn():
+                    from src.main import _run_compaction_blocking
+                    return _run_compaction_blocking(
+                        storage, settings, conflicts_store, base_path,
+                        data_lock=data_lock, sync_guard=sync_guard)
+
+                runner.run(_fn, _show)
+
+            secondary_button(
+                frame, "Sync-Daten kompaktieren", _on_compact_clicked,
+                padx=12, pady=2,
+            ).grid(row=next_google_row, column=0, columnspan=2, padx=10, pady=(0, 8), sticky="w")
+            next_google_row += 1
+
+        subheader(frame, "Google Kalender", row=next_google_row)
+        next_google_row += 1
+
+        var_gcal = tk.BooleanVar(value=settings.get("gcal_enabled"))
+        cb_gcal: tk.Checkbutton | None = None
+
+        # Kalender-Auswahl: Combobox zeigt Klarnamen, gespeichert wird die ID.
+        # cal_map summary->id wird im Hintergrund per API befüllt.
+        cal_map: dict[str, str] = {}
+        cal_var = tk.StringVar(value=settings.get("gcal_calendar_id") or "primary")
+
+        gcal_check_row = next_google_row
+        cal_label_row = next_google_row + 1
+        cal_status_row = next_google_row + 2
+
+        cb_gcal = tk.Checkbutton(
+            frame, text="Reservierungen mit Google Kalender abgleichen",
+            variable=var_gcal, font=FONT,
+            bg=BG, fg=TEXT, selectcolor=CELL_BG,
+            activebackground=BG, activeforeground=TEXT,
+            cursor="hand2",
+        )
+        cb_gcal.grid(row=gcal_check_row, column=0, columnspan=2, padx=10, pady=(4, 0), sticky="w")
+
+        tk.Label(frame, text="Kalender:", font=FONT, bg=BG, fg=TEXT).grid(
+            row=cal_label_row, column=0, padx=10, pady=4, sticky="w")
+        cal_combo = dark_combo(frame, cal_var, [cal_var.get()], width=30)
+        cal_combo.grid(row=cal_label_row, column=1, padx=10, pady=4, sticky="w")
+
+        cal_status = tk.Label(frame, text="", font=FONT_SMALL, bg=BG, fg=TEXT_MUTED)
+        cal_status.grid(row=cal_status_row, column=0, columnspan=2, padx=10, pady=(0, 4), sticky="w")
+
+        def _populate_calendars(items):
+            if not cal_combo.winfo_exists():
+                return
+            cal_map.clear()
+            for it in items:
+                cal_map[it["summary"]] = it["id"]
+            cal_combo["values"] = list(cal_map.keys()) or [cal_var.get()]
+            # Gespeicherte ID auf den passenden Klarnamen zurückmappen.
+            stored_id = settings.get("gcal_calendar_id") or "primary"
+            for summary, cid in cal_map.items():
+                if cid == stored_id:
+                    cal_var.set(summary)
+                    break
+            cal_status.config(text="")
+
+        def _load_calendars():
+            cal_status.config(text="Kalenderliste wird geladen…")
+
+            def _fn():
+                from src import gcal
+                try:
+                    service = gcal.get_calendar_service(
+                        os.path.join(base_path, "credentials.json"),
+                        os.path.join(base_path, "token.json"),
+                        sync_enabled=settings.get("sync_enabled"),
+                    )
+                    items = gcal.list_calendars(service)
+                except Exception as e:
+                    return {"ok": False, "error": e, "tb": traceback.format_exc()}
+                return {"ok": True, "items": items}
+
+            def _on_done(res):
+                if not cal_status.winfo_exists():
+                    return
+                if not res["ok"]:
+                    cal_status.config(text="Kalenderliste nicht verfügbar")
+                    messagebox.showerror(
+                        "Google Kalender",
+                        "Kalenderliste konnte nicht geladen werden:\n\n"
+                        f"{res['error']}\n\n{res['tb']}",
+                        parent=dialog,
+                    )
+                    return
+                _populate_calendars(res["items"])
+
+            runner.run(_fn, _on_done)
+
+        def _on_gcal_toggled():
+            assert cb_gcal is not None
+            new_state = var_gcal.get()
+            if new_state and not settings.get("gcal_enabled"):
+                cb_gcal.config(state="disabled")
+
+                def _service():
+                    from src import gcal
+                    gcal.get_calendar_service(
+                        os.path.join(base_path, "credentials.json"),
+                        os.path.join(base_path, "token.json"),
+                        sync_enabled=settings.get("sync_enabled"),
+                    )
+
+                fn, on_done = build_oauth_enable_task(
+                    service_fn=_service, settings=settings,
+                    setting_key="gcal_enabled", checkbox=cb_gcal,
+                    toggle_var=var_gcal, on_change=on_change, dialog=dialog,
+                    error_title="Google Kalender aktivieren",
+                    on_success_dialog_ui=_load_calendars,
+                )
+                runner.run(fn, on_done)
+                return
+            if not new_state and settings.get("gcal_enabled"):
+                settings.set("gcal_enabled", False)
+                on_change()
+
+        cb_gcal.config(command=_on_gcal_toggled)
+
+        if settings.get("gcal_enabled"):
+            _load_calendars()
+
+        self.frame = frame
+        self.cal_map = cal_map
+        self.cal_var = cal_var

--- a/src/dialogs/settings_dialog/tab_mail.py
+++ b/src/dialogs/settings_dialog/tab_mail.py
@@ -1,0 +1,61 @@
+"""Tab „Bericht & Mail": Empfänger, Name, Stundenlohn, Mail-Vorlage."""
+
+import tkinter as tk
+
+from src.dialogs.settings_dialog._shared import label, subheader
+from src.theme import BG, FONT_SMALL, TEXT_MUTED, dark_entry, dark_text
+
+
+class MailTab:
+    """Baut den Bericht-&-Mail-Tab; exponiert die Variablen für save_settings."""
+
+    def __init__(self, frame, settings):
+        label(frame, "Empfänger:", row=0, pady=(10, 8))
+        recipient_var = tk.StringVar(value=settings.get("recipient"))
+        dark_entry(frame, recipient_var, width=25).grid(row=0, column=1, padx=10, pady=(10, 8))
+
+        label(frame, "Name:", row=1)
+        name_var = tk.StringVar(value=settings.get("name"))
+        dark_entry(frame, name_var, width=25).grid(row=1, column=1, padx=10, pady=8)
+
+        label(frame, "Stundenlohn (€):", row=2)
+        rate_var = tk.StringVar(value=str(settings.get("hourly_rate") or ""))
+        dark_entry(frame, rate_var, width=10).grid(row=2, column=1, padx=10, pady=8, sticky="w")
+        tk.Label(
+            frame, text="(optional – nur für dich sichtbar)", font=FONT_SMALL,
+            bg=BG, fg=TEXT_MUTED,
+        ).grid(row=2, column=1, padx=(120, 10), pady=8, sticky="w")
+
+        subheader(frame, "Mail-Vorlage", row=3)
+
+        label(frame, "Betreff:", row=4, pady=4)
+        subject_var = tk.StringVar(value=settings.get("mail_subject"))
+        dark_entry(frame, subject_var, width=35).grid(row=4, column=1, padx=10, pady=4)
+
+        label(frame, "Anrede:", row=5, pady=4)
+        greeting_var = tk.StringVar(value=settings.get("mail_greeting"))
+        dark_entry(frame, greeting_var, width=35).grid(row=5, column=1, padx=10, pady=4)
+
+        label(frame, "Inhalt:", row=6, pady=4, sticky="nw")
+        content_text = dark_text(frame, 35, 3)
+        content_text.grid(row=6, column=1, padx=10, pady=4)
+        content_text.insert("1.0", settings.get("mail_content"))
+
+        label(frame, "Gruß:", row=7, pady=4, sticky="nw")
+        closing_text = dark_text(frame, 35, 2)
+        closing_text.grid(row=7, column=1, padx=10, pady=4)
+        closing_text.insert("1.0", settings.get("mail_closing"))
+
+        tk.Label(
+            frame, text="Platzhalter: {zeitraum}, {gesamt}", font=("Segoe UI", 8),
+            bg=BG, fg=TEXT_MUTED,
+        ).grid(row=8, column=0, columnspan=2, padx=10, pady=(0, 8))
+
+        self.frame = frame
+        self.recipient_var = recipient_var
+        self.name_var = name_var
+        self.rate_var = rate_var
+        self.subject_var = subject_var
+        self.greeting_var = greeting_var
+        self.content_text = content_text
+        self.closing_text = closing_text

--- a/src/dialogs/settings_dialog/tab_work.py
+++ b/src/dialogs/settings_dialog/tab_work.py
@@ -1,0 +1,120 @@
+"""Tab „Arbeitszeit": Standardzeiten, Pause, Werkstudenten-Limit, Kategorien."""
+
+import calendar
+import datetime
+import tkinter as tk
+
+from src.dialogs.category_dialog import open_category_dialog
+from src.dialogs.settings_dialog._shared import label, subheader
+from src.settings import WEEKDAY_KEYS
+from src.theme import (
+    BG, CELL_BG, FONT, FONT_SMALL, PAUSE_VALUES, TEXT, TEXT_MUTED,
+    TIME_VALUES, dark_combo, dark_entry, secondary_button,
+)
+from src.time_utils import DAYS_DE
+
+
+class WorkTab:
+    """Baut den Arbeitszeit-Tab; exponiert die Tk-Variablen, die
+    save_settings in dialog.py liest (Vertrag siehe Spec H4)."""
+
+    def __init__(self, frame, dialog, settings):
+        label(frame, "Standardzeiten:", row=0, pady=(10, 4), sticky="nw")
+        times_frame = tk.Frame(frame, bg=BG)
+        times_frame.grid(row=0, column=1, padx=10, pady=(10, 4), sticky="w")
+
+        tk.Label(times_frame, text="Start", font=FONT_SMALL, bg=BG, fg=TEXT_MUTED).grid(
+            row=0, column=1, padx=2)
+        tk.Label(times_frame, text="Ende", font=FONT_SMALL, bg=BG, fg=TEXT_MUTED).grid(
+            row=0, column=2, padx=2)
+
+        start_vars = {}
+        end_vars = {}
+        for i, (key, lbl) in enumerate(zip(WEEKDAY_KEYS, DAYS_DE), start=1):
+            tk.Label(times_frame, text=lbl, font=FONT, bg=BG, fg=TEXT, width=3, anchor="w").grid(
+                row=i, column=0, padx=(0, 8), pady=2)
+            start_vars[key] = tk.StringVar(value=settings.get(f"default_start_{key}"))
+            dark_combo(times_frame, start_vars[key], TIME_VALUES).grid(
+                row=i, column=1, padx=2, pady=2)
+            end_vars[key] = tk.StringVar(value=settings.get(f"default_end_{key}"))
+            dark_combo(times_frame, end_vars[key], TIME_VALUES).grid(
+                row=i, column=2, padx=2, pady=2)
+
+        label(frame, "Standard-Pause (Min):", row=1)
+        pause_var = tk.StringVar(value=str(settings.get("default_pause")))
+        dark_combo(frame, pause_var, PAUSE_VALUES).grid(
+            row=1, column=1, padx=10, pady=8, sticky="w")
+
+        subheader(frame, "Werkstudenten-Limit", row=2)
+        wsl_frame = tk.Frame(frame, bg=BG)
+        wsl_frame.grid(row=3, column=0, columnspan=2, padx=10, pady=(0, 4), sticky="we")
+
+        wsl_enabled_var = tk.BooleanVar(value=settings.get("werkstudent_limit_enabled"))
+        tk.Checkbutton(
+            wsl_frame, text="Wochenstunden-Limit aktivieren", variable=wsl_enabled_var,
+            font=FONT, bg=BG, fg=TEXT, selectcolor=CELL_BG,
+            activebackground=BG, activeforeground=TEXT, cursor="hand2",
+        ).pack(anchor="w")
+
+        def _wsl_date_row(parent_frame, label_text, default_date):
+            row = tk.Frame(parent_frame, bg=BG)
+            row.pack(anchor="w", pady=(4, 0))
+            tk.Label(row, text=label_text, font=FONT, bg=BG, fg=TEXT).pack(
+                side=tk.LEFT, padx=(0, 5))
+            month_values = [str(m) for m in range(1, 13)]
+            year_values = [str(y) for y in range(2020, datetime.date.today().year + 3)]
+            day_var = tk.StringVar(value=str(default_date.day))
+            max_day = calendar.monthrange(default_date.year, default_date.month)[1]
+            day_cb = dark_combo(row, day_var, [str(d) for d in range(1, max_day + 1)], width=3)
+            day_cb.pack(side=tk.LEFT, padx=2)
+            tk.Label(row, text=".", font=FONT, bg=BG, fg=TEXT).pack(side=tk.LEFT)
+            month_var = tk.StringVar(value=str(default_date.month))
+            dark_combo(row, month_var, month_values, width=3).pack(side=tk.LEFT, padx=2)
+            tk.Label(row, text=".", font=FONT, bg=BG, fg=TEXT).pack(side=tk.LEFT)
+            year_var = tk.StringVar(value=str(default_date.year))
+            dark_combo(row, year_var, year_values, width=5).pack(side=tk.LEFT, padx=2)
+
+            def _update_days(*_a):
+                try:
+                    m = int(month_var.get())
+                    y = int(year_var.get())
+                    md = calendar.monthrange(y, m)[1]
+                except (ValueError, KeyError):
+                    md = 31
+                day_cb["values"] = [str(d) for d in range(1, md + 1)]
+                if int(day_var.get()) > md:
+                    day_var.set(str(md))
+
+            month_var.trace_add("write", _update_days)
+            year_var.trace_add("write", _update_days)
+            return day_var, month_var, year_var
+
+        wsl_start_default = (
+            datetime.date.fromisoformat(settings.get("werkstudent_limit_start"))
+            if settings.get("werkstudent_limit_start") else datetime.date.today())
+        wsl_end_default = (
+            datetime.date.fromisoformat(settings.get("werkstudent_limit_end"))
+            if settings.get("werkstudent_limit_end") else datetime.date.today())
+        wsl_start_vars = _wsl_date_row(wsl_frame, "Zeitraum von:", wsl_start_default)
+        wsl_end_vars = _wsl_date_row(wsl_frame, "bis:", wsl_end_default)
+
+        wsl_hours_row = tk.Frame(wsl_frame, bg=BG)
+        wsl_hours_row.pack(anchor="w", pady=(4, 0))
+        tk.Label(wsl_hours_row, text="Limit (Stunden/Woche):", font=FONT, bg=BG, fg=TEXT).pack(
+            side=tk.LEFT, padx=(0, 5))
+        wsl_hours_var = tk.StringVar(value=str(settings.get("werkstudent_limit_max_hours")))
+        dark_entry(wsl_hours_row, wsl_hours_var, width=6).pack(side=tk.LEFT)
+
+        secondary_button(
+            frame, "Kategorien verwalten",
+            lambda: open_category_dialog(dialog, settings),
+        ).grid(row=4, column=0, columnspan=2, padx=10, pady=(12, 8), sticky="w")
+
+        self.frame = frame
+        self.start_vars = start_vars
+        self.end_vars = end_vars
+        self.pause_var = pause_var
+        self.wsl_enabled_var = wsl_enabled_var
+        self.wsl_start_vars = wsl_start_vars
+        self.wsl_end_vars = wsl_end_vars
+        self.wsl_hours_var = wsl_hours_var

--- a/tests/test_settings_dialog.py
+++ b/tests/test_settings_dialog.py
@@ -3,8 +3,8 @@ headless (der Dialog selbst ist Tk-gebunden, M16)."""
 
 from unittest.mock import MagicMock
 
-import src.dialogs.settings_dialog as sd
-from src.dialogs.settings_dialog import build_oauth_enable_task
+import src.dialogs.settings_dialog.oauth_task as sd
+from src.dialogs.settings_dialog.oauth_task import build_oauth_enable_task
 
 
 class _FakeSettings:


### PR DESCRIPTION
## ⚠️ Gestapelt auf #119, #121, #122, #123 — bitte in dieser Reihenfolge mergen

Dieser PR baut auf **#119**, **#121**, **#122** und **#123** auf. Solange die
offen sind, zeigt der Diff hier auch deren Commits; sobald sie in `master` sind,
schrumpft er auf die reine H4-Arbeit. Merge-Reihenfolge:
**#119 → #121 → #122 → #123 → dieser PR**.

## Zusammenfassung

Behebt Audit-Finding **H4** (2026-07-04): `open_settings_dialog` war eine
**~900-Zeilen-God-Function** — dutzende Closures teilten sich einen Scope,
`save_settings` las ~25 Tk-Variablen aus allen vier Tabs. Das Audit hielt fest,
dass die Komplexität, die `App` verlassen hat, faktisch in diesen Dialog gewandert
ist.

`settings_dialog.py` wird jetzt zum **Paket** — eine Klasse pro Tab (analog dem
bestehenden Muster `_ImportSummaryDialog`):

```
src/dialogs/settings_dialog/
  dialog.py      (977 → 213 Z.)  Chrome, Notebook, zentrales save_settings, Buttons
  tab_work.py    (120 Z.)        class WorkTab
  tab_mail.py    (61 Z.)         class MailTab
  tab_google.py  (473 Z.)        class GoogleTab  (inkl. der H5-Worker)
  tab_app.py     (165 Z.)        class AppTab
  oauth_task.py  (51 Z.)         build_oauth_enable_task (H5-OAuth-Toggle-Builder)
  _shared.py     (21 Z.)         label/subheader Grid-Helfer
  __init__.py    (8 Z.)          Re-Exports (öffentliche API unverändert)
```

Jede Tab-Klasse baut ihre Widgets in den Notebook-Frame und exponiert die
Tk-Variablen, die `save_settings` liest, als Attribute (`work.start_vars`,
`mail.recipient_var`, `google.cal_map`, `app.scale_var`, …).

## Reiner Move-Refactor — verhaltensgleich

- **Kein** Logik-/Text-/Layout-/Reihenfolge-Unterschied. Verschobene Blöcke
  byte-identisch außer `tab_X` → `frame` (+ zwei dokumentierte Sonderfälle:
  `ttk.Style(dialog)` → `ttk.Style(frame)` in AppTab, `creds_path`-Umzug in
  GoogleTab).
- **`save_settings` bleibt zentral und ablaufidentisch** — die heikle Reihenfolge
  (Validierungen → Autostart-Toggle mit Abbruch vor jedem Persist → ein
  `apply_updates` → gcal-ID nur bei geladener `cal_map` → Perioden-Scan →
  `on_change` → `destroy`) unverändert; nur die Variablen-Zugriffe laufen über
  Tab-Handles.
- **H5-Invarianten unangetastet:** die `runner.run`-Worker, `winfo_exists`-Guards
  und die Persistenz-im-`fn` im Google-Tab ziehen 1:1 mit um.
- **Öffentliche API stabil:** `from src.dialogs.settings_dialog import
  open_settings_dialog` (ui.py) unverändert.

## Tests / Verifikation

- Gesamtsuite **750 passed / 3 skipped**, `ruff check .` clean nach jedem Schritt.
- **Headless-Instanziierungs-Smoke:** `open_settings_dialog` real geöffnet (alle
  vier Tab-`__init__` mit aktiven Sync-/Kalender-Toggles → Konflikt-/
  Kompaktier-/Kalender-Widgets gebaut) — kein NameError/ImportError. Das deckt
  genau die Regressionsklasse ab, die die (dialog-lose, Tk-gebundene) Suite nicht
  erreicht.
- App-Start-Smoke stabil; interaktiver Durchklick aller vier Tabs + Speichern +
  Validierungsfehler (Tab-Sprung) lokal abgenommen.

Kein `release:*`-Label (reiner Refactor).

Spec/Plan: `docs/superpowers/specs/2026-07-04-settings-dialog-split-design.md`,
`docs/superpowers/plans/2026-07-04-settings-dialog-split.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016pPmbLT2BQqZx9qhfTXWFD
