### PR TITLE
fix: Audit-Kleinfixes N11/N28/N30 (Header-Injection, Installer-URL, Doku)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,4 +214,4 @@ Lokal: `pytest` aus dem Repo-Root. Alle Tests müssen vor dem PR-Merge grün sei
 - `src/version.py` — Einzige Quelle für die App-Version (von Workflow & `installer.iss` gelesen)
 - `installer.iss` — Inno Setup Script, Version wird per `/DAppVer=...` vom Workflow übergeben
 
-Hinweis: Es gibt **keine** `Zeiterfassung.spec`-Datei (entgegen der README-Erwähnung) — Build läuft komplett über `build.py` mit expliziten PyInstaller-Args.
+Hinweis: Es gibt **keine** `Zeiterfassung.spec`-Datei — Build läuft komplett über `build.py` mit expliziten PyInstaller-Args.

--- a/installer.iss
+++ b/installer.iss
@@ -2,7 +2,7 @@
 AppName=Zeiterfassung
 AppVersion={#AppVer}
 AppPublisher=Margenheld
-AppPublisherURL=https://github.com/Sven-MH/Zeiterfassung
+AppPublisherURL=https://github.com/margenheld/Zeiterfassung
 DefaultDirName={autopf}\Zeiterfassung
 DefaultGroupName=Zeiterfassung
 UninstallDisplayIcon={app}\Zeiterfassung.exe

--- a/src/mail.py
+++ b/src/mail.py
@@ -274,6 +274,11 @@ def send_email(service, to, subject, html_body,
         attachment_filename = attachment_filename or pdf_filename
         attachment_subtype = "pdf"
 
+    # Header-Injection verhindern (Audit N11): CR/LF/NUL aus dem Empfänger
+    # strippen, bevor er in den To-Header wandert. Der Wert kommt aus den
+    # Settings — nur Selbst-Injection, aber die Invariante muss sauber sein.
+    to = to.replace("\r", "").replace("\n", "").replace("\x00", "")
+
     if attachment_bytes:
         message = MIMEMultipart()
         message["to"] = to

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -232,6 +232,30 @@ def test_send_email_json_attachment_uses_subtype():
     assert "share.json" in raw
 
 
+def test_send_email_strips_newlines_from_recipient():
+    """Audit N11: CR/LF im Empfänger dürfen keine zusätzlichen Header injizieren."""
+    from unittest.mock import MagicMock
+    from src.mail import send_email
+
+    service = MagicMock()
+    service.users().messages().send().execute.return_value = {"id": "mid-2"}
+
+    send_email(
+        service,
+        "victim@example.com\r\nBcc: attacker@evil.com",
+        "Subj",
+        "<p>body</p>",
+    )
+
+    call_kwargs = service.users().messages().send.call_args
+    body = call_kwargs.kwargs.get("body") or call_kwargs.args[-1]
+    import base64
+    raw = base64.urlsafe_b64decode(body["raw"]).decode()
+    # Kein injizierter Bcc-Header auf eigener Zeile
+    assert "\nBcc:" not in raw
+    assert "\rBcc:" not in raw
+
+
 import platform  # noqa: E402
 
 


### PR DESCRIPTION
Drei kleine Cleanups aus dem Code-Audit (2026-07-04), thematisch „Zwei-Minuten-Fixes". Je ein Commit pro Finding, unabhängig vom offenen Audit-PR-Stack (#121–#127), sitzt sauber auf `master`.

## N11 — Mail-Header-Injection über Empfänger
`send_email` übernahm `to` ungeprüft in den `To`-Header. Die `compat32`-Policy des `email`-Moduls sanitisiert eingebettete `\r`/`\n` nicht → ein Newline im Empfänger (aus den Settings) konnte zusätzliche Header (z. B. `Bcc:`) injizieren. Praktisch nur Selbst-Injection, aber die Invariante war unsauber. `\r`/`\n`/`\0` werden jetzt zentral in `send_email` gestrippt (deckt `send_dialog` **und** `share_dialog`). Regressionstest ergänzt.

## N28 — veraltete Publisher-URL im Installer
`installer.iss` `AppPublisherURL` zeigte noch auf den alten Owner `github.com/Sven-MH/Zeiterfassung` (landet sichtbar in Windows „Apps & Features") → auf `github.com/margenheld/Zeiterfassung` korrigiert.

## N30 — falsche README-Behauptung in CLAUDE.md
Der `Zeiterfassung.spec`-Hinweis behauptete „entgegen der README-Erwähnung" — das README erwähnt aber längst keine spec-Datei mehr (CHANGELOG dokumentiert die Bereinigung). Falsche Klammer gestrichen, korrekte Kernaussage bleibt.

## Verifikation
- `pytest` — 752 passed, 3 skipped (inkl. neuem `test_send_email_strips_newlines_from_recipient`)
- `ruff check .` — All checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
