### PR TITLE
ci: Pyright-Typecheck-Gate + saubere Baseline (Audit M18)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,3 +32,19 @@ jobs:
           python-version: '3.10'
       - run: pip install ruff==0.15.10
       - run: ruff check .
+
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.10'
+      # Gleiche Minimal-Deps wie der test-Job, damit unsere eigenen Typen
+      # (google-*, holidays, pytest) auflösen. Die plattform-optionalen
+      # Lazy-Imports (xhtml2pdf/Pillow/pystray/pyobjc) sind an der Import-Zeile
+      # per `# pyright: ignore[reportMissingImports]` entschärft — kein
+      # requirements.txt nötig (pycairo/pyobjc wären hier ohnehin nicht baubar).
+      # pyright pinnen: neuere Versionen ziehen strengere Checks nach.
+      - run: pip install pyright==1.1.411 pytest "holidays==0.99" google-api-python-client google-auth google-auth-oauthlib
+      - run: pyright

--- a/src/report.py
+++ b/src/report.py
@@ -330,7 +330,7 @@ def generate_pdf(date_from, date_to, all_entries, name="", categories=None,
     category_breakdown: True = "Summe je Kategorie"-Tabelle anhängen (Default);
     False = weglassen, nur das Gesamt der Tagestabelle.
     """
-    from xhtml2pdf import pisa
+    from xhtml2pdf import pisa  # pyright: ignore[reportMissingImports]  # lazy, nicht in CI-Test-Deps
 
     range_entries = _filter_entries(date_from, date_to, all_entries)
     if range_entries:

--- a/src/tray.py
+++ b/src/tray.py
@@ -113,7 +113,7 @@ class _PystrayBackend:
         """Lädt das App-Icon als PIL-Bild. Fallback auf weiße Rechteck-Grafik,
         falls die PNG-Datei nicht da ist (sollte nicht passieren — assets sind
         in PyInstaller-Bundle mit drin)."""
-        from PIL import Image
+        from PIL import Image  # pyright: ignore[reportMissingImports]  # Pillow: nicht in CI-Test-Deps
         png = os.path.join(self.base_path, "assets", "margenheld-icon.png")
         if os.path.exists(png):
             return Image.open(png)
@@ -124,7 +124,7 @@ class _PystrayBackend:
         """Startet das Tray-Icon im Hintergrundthread. Wirft die zugrunde
         liegende Exception, wenn pystray das Backend nicht laden kann —
         Aufrufer muss das fangen und auf Tray-Verzicht zurückfallen."""
-        import pystray
+        import pystray  # pyright: ignore[reportMissingImports]  # nicht in CI-Test-Deps
 
         def _on_show_click(icon, item):
             self._on_show()
@@ -214,7 +214,7 @@ class _PystrayBackend:
         if platform.system() != "Windows":
             return False
         try:
-            from pystray._util import win32
+            from pystray._util import win32  # pyright: ignore[reportMissingImports]  # nicht in CI-Test-Deps
             handle = getattr(self._icon, "_icon_handle", None)
             # _message ist eine pystray-Interne (nicht im Type-Stub) — wie
             # _icon_handle per getattr holen: entfernt die Pylance-Warnung und

--- a/src/tray_mac.py
+++ b/src/tray_mac.py
@@ -44,7 +44,7 @@ class MacTrayBackend:
         self._dynamic_items = []  # [(NSMenuItem, visible_callable)]
 
     def _load_image(self):
-        from AppKit import NSImage
+        from AppKit import NSImage  # pyright: ignore[reportMissingImports]  # pyobjc, nur macOS
         png = os.path.join(self.base_path, "assets", "margenheld-icon.png")
         if not os.path.exists(png):
             return None
@@ -54,10 +54,10 @@ class MacTrayBackend:
         return image
 
     def start(self):
-        from AppKit import (
+        from AppKit import (  # pyright: ignore[reportMissingImports]  # pyobjc, nur macOS
             NSStatusBar, NSMenu, NSMenuItem, NSVariableStatusItemLength,
         )
-        from Foundation import NSObject
+        from Foundation import NSObject  # pyright: ignore[reportMissingImports]  # pyobjc, nur macOS
 
         model = build_menu_model(self._on_show, self._on_quit, self._actions)
 
@@ -125,7 +125,7 @@ class MacTrayBackend:
         (sync_orchestrator._on_tray_done) ist ein on_done-Callback und läuft
         bereits über _marshal_to_ui auf dem Tk-/Main-Thread (verifiziert)."""
         try:
-            from Foundation import (
+            from Foundation import (  # pyright: ignore[reportMissingImports]  # pyobjc, nur macOS
                 NSUserNotification, NSUserNotificationCenter,
             )
             note = NSUserNotification.alloc().init()
@@ -140,7 +140,7 @@ class MacTrayBackend:
         """Entfernt das Status-Item und löst die Referenzen. Idempotent."""
         if self._status_item is not None:
             try:
-                from AppKit import NSStatusBar
+                from AppKit import NSStatusBar  # pyright: ignore[reportMissingImports]  # pyobjc, nur macOS
                 NSStatusBar.systemStatusBar().removeStatusItem_(
                     self._status_item)
             except Exception:

--- a/tests/test_gcal.py
+++ b/tests/test_gcal.py
@@ -153,7 +153,7 @@ def test_delete_event_swallows_already_gone():
             class _E:
                 def delete(self, **kwargs):
                     class _Boom:
-                        def execute(self_):
+                        def execute(self_):  # pyright: ignore[reportSelfClsParameterName]  # self_ bewusst gegen Shadowing
                             err = Exception("gone")
                             err.resp = _GoneResp()
                             raise err


### PR DESCRIPTION
Schließt Audit-Finding **M18**: Pyright war in `pyproject.toml` sorgfältig konfiguriert, aber nirgends enforced — Typfehler konnten still driften. Dieser PR macht daraus ein CI-Gate. Follow-up zu #125 (M15).

## Der Blocker und die Entscheidung
Ein Gate scheiterte bislang an der unsauberen Baseline: lazy, plattform-/optional-gegatete Imports (`xhtml2pdf`, `Pillow`, `pystray`, `AppKit`/`Foundation`), die in CI bewusst nicht installiert sind (kein `requirements.txt` → pycairo/pyobjc wären auf ubuntu ohnehin nicht baubar). Statt `reportMissingImports` global abzuschalten, ist jede der 9 Import-Zeilen gezielt mit `# pyright: ignore[reportMissingImports]` (+ Begründung) entschärft. So bleiben **echte** fehlende/vertippte Imports weiterhin ein Fehler — der Gate ist strikt.

## Änderungen
- **Baseline sauber** (`report.py`, `tray.py`, `tray_mac.py`): 9 gezielte Suppress-Kommentare an den optionalen Lazy-Imports; plus die eine `reportSelfClsParameterName`-Warning in `test_gcal.py` (`self_` bewusst gegen Shadowing).
- **Gate** (`test.yml`): neuer `typecheck`-Job, `pyright==1.1.411` gepinnt, gleiche Minimal-Deps wie der `test`-Job.

## Verifikation
- `pyright` → **0 errors, 0 warnings, 0 informations**
- Vollständigkeit geprüft: alle 3rd-party-Imports in `src/` **und** `tests/` sind entweder CI-Deps (google-*/holidays/pytest) oder suppressed — keine Lücke.
- `pytest` — 717 passed, 3 skipped · `ruff check .` — clean

## Hinweis
Berührt `test.yml` wie #125 (M15). Falls #125 zuerst merged, ist das unkritisch — der `typecheck`-Job ist distinkt, allenfalls ein trivialer Merge im `jobs:`-Block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
