### PR TITLE
fix(mail): kein Gmail-getProfile mehr — behebt 403 insufficientPermissions beim Start

### DIFF
--- a/src/mail.py
+++ b/src/mail.py
@@ -41,10 +41,11 @@ SCOPES = [GMAIL_SEND_SCOPE]
 def fetch_user_email(token_path="token.json", sync_enabled=False, gcal_enabled=False):
     """Liest die E-Mail-Adresse des authentifizierten Users.
 
-    Versucht zuerst Gmail's `users().getProfile()` (klappt in der Praxis oft
-    auch mit `gmail.send`-Scope, obwohl die Doku read-Scopes verlangt), und
-    fällt sonst auf den `tokeninfo`-Endpoint zurück, der die E-Mail aus dem
-    Access-Token meldet wenn der `userinfo.email`-Scope authorisiert ist.
+    Nutzt den `tokeninfo`-Endpoint, der die E-Mail aus dem Access-Token meldet,
+    sofern der `userinfo.email`-Scope autorisiert ist. (Ein früher zuerst
+    versuchter Gmail-`users().getProfile()`-Call ist mit dem `gmail.send`-Scope
+    nicht erlaubt und warf jedes Mal nur ein 403 insufficientPermissions in den
+    Log — die E-Mail kommt ohnehin aus tokeninfo, siehe #136.)
 
     Liefert die E-Mail oder leeren String bei fehlendem/ungültigem Token
     oder Fehler. Diese Funktion soll im Hintergrundthread laufen, weil sie
@@ -86,18 +87,7 @@ def fetch_user_email(token_path="token.json", sync_enabled=False, gcal_enabled=F
         log.exception("fetch_user_email: setup failed")
         return ""
 
-    # Pfad 1: Gmail-API getProfile mit dem bereits autorisierten Service.
-    try:
-        from googleapiclient.discovery import build
-        service = build("gmail", "v1", credentials=creds)
-        profile = service.users().getProfile(userId="me").execute()
-        email = profile.get("emailAddress", "")
-        if email:
-            return email
-    except Exception:
-        pass
-
-    # Pfad 2: Tokeninfo — liest die E-Mail direkt aus dem Access-Token, sofern
+    # Tokeninfo — liest die E-Mail direkt aus dem Access-Token, sofern
     # userinfo.email-Scope autorisiert ist. Kein API-Auth nötig (Token kommt
     # als Query-Param), daher kein 401-Risiko.
     try:

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -293,6 +293,44 @@ def test_get_scopes_without_gcal_has_no_calendar_scopes():
     assert not any("calendar" in s for s in scopes)
 
 
+def test_fetch_user_email_uses_tokeninfo_not_gmail_getprofile(tmp_path):
+    """Regression #136: fetch_user_email darf keinen Gmail-getProfile-Call machen.
+
+    Mit dem einzigen gewährten Gmail-Scope `gmail.send` wirft
+    `users().getProfile()` ein 403 insufficientPermissions (reiner Log-Noise) —
+    die E-Mail kommt stattdessen aus dem tokeninfo-Endpoint (userinfo.email).
+    Erwartet: es wird kein Gmail-Service gebaut, das Ergebnis stammt aus tokeninfo.
+    """
+    from src.mail import fetch_user_email
+
+    path = str(tmp_path / "token.json")
+    open(path, "w").close()
+
+    fake_creds = MagicMock()
+    fake_creds.valid = True
+    fake_creds.expired = False
+    fake_creds.token = "access-token"
+
+    class _Resp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def read(self):
+            return b'{"email": "me@example.com"}'
+
+    with patch("google.oauth2.credentials.Credentials.from_authorized_user_file",
+               return_value=fake_creds), \
+         patch("googleapiclient.discovery.build") as mock_build, \
+         patch("urllib.request.urlopen", return_value=_Resp()):
+        result = fetch_user_email(path)
+
+    assert result == "me@example.com"
+    mock_build.assert_not_called()
+
+
 def _named_exc(name):
     """Erzeugt eine Exception-Klasse mit exakt diesem __name__ — simuliert
     bibliotheksspezifische Netzwerkfehler (httplib2, requests, google.auth)


### PR DESCRIPTION
## Problem

Bei jedem App-Start warf `googleapiclient` ein `403 Forbidden "insufficientPermissions"` in den Log (#136). Ursache: `fetch_user_email` (`src/mail.py`) versuchte zuerst Gmail `users().getProfile()` — das ist mit dem einzigen gewährten Gmail-Scope `gmail.send` **nicht** erlaubt und schlug jedes Mal fehl. Der Fehler wurde von `except Exception: pass` geschluckt, aber `googleapiclient.http` loggte ihn vorher als WARNING.

## Fix

Der getProfile-Pfad war toter Fallback-Code auf einer falschen Doku-Annahme — die E-Mail kommt ohnehin zuverlässig aus dem `tokeninfo`-Endpoint (`userinfo.email`-Scope). Pfad 1 (getProfile) entfernt, Docstring/Kommentar bereinigt.

Verworfene Alternative: einen Read-Scope (`gmail.readonly`) *hinzufügen*, damit getProfile klappt — mehr Consent-Reibung und Berechtigungen für etwas, das `tokeninfo` bereits liefert.

## Verifikation

- Neuer Regression-Test `test_fetch_user_email_uses_tokeninfo_not_gmail_getprofile` (rot → grün): kein Gmail-Service-Build, E-Mail stammt aus `tokeninfo`.
- Volle Test-Suite: **770 passed**, 3 skipped.
- `ruff check`: sauber. Pyright 1.1.411 (CI-Gate, `src`+`tests`): **0/0/0**.

Vorbestehendes Finding, keine Regression durch die Audit-Merges.

Closes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)
