### PR TITLE
fix(mail): Empfänger mit Steuerzeichen abweisen statt still strippen (#133)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ src/build_info.py
 .aider*
 credentials.lnk
 release-artifacts/
+# graphify knowledge-graph output (lokal via `graphify update .`, nicht committen)
+graphify-out/

--- a/src/mail.py
+++ b/src/mail.py
@@ -264,10 +264,17 @@ def send_email(service, to, subject, html_body,
         attachment_filename = attachment_filename or pdf_filename
         attachment_subtype = "pdf"
 
-    # Header-Injection verhindern (Audit N11): CR/LF/NUL aus dem Empfänger
-    # strippen, bevor er in den To-Header wandert. Der Wert kommt aus den
-    # Settings — nur Selbst-Injection, aber die Invariante muss sauber sein.
-    to = to.replace("\r", "").replace("\n", "").replace("\x00", "")
+    # Header-Injection UND stille Falschzustellung verhindern (Audit N11 / #133):
+    # Steuerzeichen im Empfänger abweisen, statt sie still zu strippen — ein
+    # gestripptes "a@b\nBcc: c" würde sonst an die vermurkste Adresse "a@bBcc: c"
+    # gesendet, ohne dass der Nutzer es merkt. Der Wert kommt aus den Settings,
+    # der Fehler wird im Sende-Dialog sichtbar gemacht (classify_mail_error).
+    if "\r" in to or "\n" in to or "\x00" in to:
+        raise ValueError(
+            "Die Empfängeradresse enthält unzulässige Steuerzeichen "
+            "(Zeilenumbruch oder Nullbyte). Bitte korrigiere die Adresse "
+            "in den Einstellungen."
+        )
 
     if attachment_bytes:
         message = MIMEMultipart()

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -232,28 +232,28 @@ def test_send_email_json_attachment_uses_subtype():
     assert "share.json" in raw
 
 
-def test_send_email_strips_newlines_from_recipient():
-    """Audit N11: CR/LF im Empfänger dürfen keine zusätzlichen Header injizieren."""
+def test_send_email_rejects_recipient_with_control_chars():
+    """Audit N11 / #133: CR/LF/NUL im Empfänger werden abgewiesen (ValueError),
+    statt still gestrippt und an eine vermurkste Adresse gesendet zu werden.
+
+    Verhindert Header-Injection UND stille Falschzustellung: ein gestripptes
+    "a@b\\nBcc: c" würde sonst an "a@bBcc: c" gehen, ohne dass der Nutzer es merkt.
+    """
     from unittest.mock import MagicMock
     from src.mail import send_email
 
     service = MagicMock()
-    service.users().messages().send().execute.return_value = {"id": "mid-2"}
 
-    send_email(
-        service,
-        "victim@example.com\r\nBcc: attacker@evil.com",
-        "Subj",
-        "<p>body</p>",
-    )
+    with pytest.raises(ValueError):
+        send_email(
+            service,
+            "victim@example.com\r\nBcc: attacker@evil.com",
+            "Subj",
+            "<p>body</p>",
+        )
 
-    call_kwargs = service.users().messages().send.call_args
-    body = call_kwargs.kwargs.get("body") or call_kwargs.args[-1]
-    import base64
-    raw = base64.urlsafe_b64decode(body["raw"]).decode()
-    # Kein injizierter Bcc-Header auf eigener Zeile
-    assert "\nBcc:" not in raw
-    assert "\rBcc:" not in raw
+    # Es darf nichts gesendet worden sein.
+    service.users().messages().send.assert_not_called()
 
 
 import platform  # noqa: E402


### PR DESCRIPTION
## Problem

`send_email` (`src/mail.py`) strippte CR/LF/NUL still aus dem Empfänger (Audit N11, #128). Das schloss zwar die Header-Injection, sendete eine dabei entstellte Adresse aber **trotzdem still** ab: `a@b\nBcc: c` → `a@bBcc: c` → die Mail geht an eine falsche Adresse, ohne dass der Nutzer etwas merkt (#133).

## Fix

Statt still zu strippen, wird eine Adresse mit Steuerzeichen (CR/LF/NUL) mit `ValueError` **abgewiesen**. Die Abweisung passiert vor dem Header-Aufbau (Injection bleibt verhindert), und der Fehler wird über den bestehenden `classify_mail_error`-Pfad im Sende-Dialog sichtbar. Betrifft `send`- und `share`-Pfad konsistent (beide über `send_email`).

Bewusst minimal gehalten: der Fehler erscheint im „Senden fehlgeschlagen"-Dialog **mit** Traceback (wie andere Versandfehler). Eine traceback-freie Klartext-Meldung (eigener `kind` wie bei `filenotfound`) wäre ein optionaler Zusatz über `mail_task` + beide Dialoge — bewusst nicht in dieses kleine Fix gezogen.

## Verifikation

- Strip-Test auf Reject-Verhalten umgestellt (`test_send_email_rejects_recipient_with_control_chars`): rot → grün.
- Volle Suite: **770 passed**, 3 skipped. `ruff` + Pyright 1.1.411 (`src`+`tests`): **0/0/0**.

## Enthält außerdem

- `chore(gitignore)`: `graphify-out/` (lokaler graphify Knowledge-Graph-Output) ignorieren — klein & unkritisch, wie besprochen mit reingepackt.

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)
