### PR TITLE
fix(oauth): token.json-Schreiben gegen transiente Windows-PermissionError absichern (#135)

### DIFF
--- a/src/oauth_utils.py
+++ b/src/oauth_utils.py
@@ -13,6 +13,7 @@ import json
 import os
 import stat
 import tempfile
+import time
 
 
 def write_token(creds, token_path):
@@ -37,7 +38,22 @@ def write_token(creds, token_path):
             os.chmod(tmp_path, stat.S_IRUSR | stat.S_IWUSR)  # 0o600
         except OSError:
             pass
-        os.replace(tmp_path, token_path)
+        # os.replace mit Retry gegen transiente Windows-PermissionError: ein
+        # Virenscanner, der die frisch erzeugte .token-*.tmp scannt, oder ein
+        # noch offenes Handle auf token.json blockiert den atomaren Rename kurz
+        # (WinError 5/32 -> beide PermissionError). Kurzer Backoff überbrückt das;
+        # bleibt es dabei, wird der Fehler durchgereicht (Issue #135, Muster wie
+        # #117). Gezielt PermissionError, damit echte Fehler (fehlende tmp,
+        # Zielverzeichnis) nicht maskiert werden.
+        attempts = 5
+        for attempt in range(attempts):
+            try:
+                os.replace(tmp_path, token_path)
+                break
+            except PermissionError:
+                if attempt == attempts - 1:
+                    raise
+                time.sleep(0.2)
     except BaseException:
         try:
             os.remove(tmp_path)

--- a/tests/test_oauth_utils.py
+++ b/tests/test_oauth_utils.py
@@ -8,6 +8,8 @@ import os
 import stat
 from unittest.mock import MagicMock
 
+import pytest
+
 from src.oauth_utils import write_token, discard_token_for_scope_upgrade
 
 
@@ -58,6 +60,56 @@ def test_write_token_overwrites_existing(tmp_path):
 
     with open(path) as f:
         assert f.read() == "new"
+
+
+def test_write_token_retries_transient_permission_error(tmp_path, monkeypatch):
+    """Regression #135: ein transienter Windows-PermissionError (AV-Scan/offenes
+    Handle blockiert os.replace, WinError 5/32) wird per Retry überbrückt — der
+    Token landet trotzdem sauber auf der Platte."""
+    path = str(tmp_path / "token.json")
+    creds = MagicMock()
+    creds.to_json.return_value = '{"token": "abc"}'
+
+    real_replace = os.replace
+    calls = {"n": 0}
+
+    def flaky_replace(src, dst):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise PermissionError(13, "Zugriff verweigert")
+        return real_replace(src, dst)
+
+    monkeypatch.setattr("src.oauth_utils.os.replace", flaky_replace)
+    monkeypatch.setattr("time.sleep", lambda _s: None)
+
+    write_token(creds, path)
+
+    assert calls["n"] == 2  # ein Fehlschlag, dann Erfolg
+    with open(path) as f:
+        assert f.read() == '{"token": "abc"}'
+
+
+def test_write_token_reraises_persistent_permission_error(tmp_path, monkeypatch):
+    """Bleibt der PermissionError dauerhaft, werden alle Versuche ausgeschöpft
+    und der Fehler durchgereicht (nicht still verschluckt); keine Temp-Reste."""
+    path = str(tmp_path / "token.json")
+    creds = MagicMock()
+    creds.to_json.return_value = "{}"
+
+    calls = {"n": 0}
+
+    def always_fail(src, dst):
+        calls["n"] += 1
+        raise PermissionError(13, "Zugriff verweigert")
+
+    monkeypatch.setattr("src.oauth_utils.os.replace", always_fail)
+    monkeypatch.setattr("time.sleep", lambda _s: None)
+
+    with pytest.raises(PermissionError):
+        write_token(creds, path)
+
+    assert calls["n"] > 1  # es wurde wiederholt, nicht nur einmal versucht
+    assert os.listdir(str(tmp_path)) == []  # tmp aufgeräumt, kein token.json
 
 
 def _write_token_file(path, scopes):


### PR DESCRIPTION
## Problem

Unter Windows scheiterte die Token-Persistenz intermittierend: `os.replace` in `write_token` (`src/oauth_utils.py`) warf `PermissionError [WinError 5]` — ein Virenscanner der frisch erzeugten `.token-*.tmp` oder ein offenes Handle auf `token.json` blockierte den atomaren Rename kurz. Das ließ den kompletten Sync-Pull abbrechen („Sync pull failed", #135).

## Fix

`os.replace` bekommt einen kurzen Retry gegen **gezielt** `PermissionError` (deckt WinError 5 *und* 32/Sharing-Violation ab): 5 Versuche mit 0,2 s Backoff. Überbrückt den transienten AV-/Handle-Lock; bleibt der Fehler dauerhaft, wird er nach dem letzten Versuch durchgereicht (kein stilles Verschlucken). Retry-Muster wie #117 (holidays), aber **enger gefasst** — echte Fehler (`IsADirectoryError`, fehlende tmp) werden nicht maskiert.

Plattformneutral: reine Retry-Logik, kein plattformspezifischer Zweig. Auf POSIX ein No-op (dort wirft `os.replace` selten `PermissionError`).

## Verifikation

- 2 neue Regression-Tests (`test_write_token_retries_transient_permission_error`, `test_write_token_reraises_persistent_permission_error`): rot → grün. `os.replace` gemockt (fail-then-succeed / always-fail), da der WinError-5-Race intermittierend und nicht deterministisch reproduzierbar ist.
- Volle Suite: **772 passed**, 3 skipped. `ruff` + Pyright 1.1.411 (`src`+`tests`): **0/0/0**.

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)
