### PR TITLE
test(conflicts): Doppel-Resolve-Guard headless absichern (#134)

### DIFF
--- a/tests/test_conflicts_dialog.py
+++ b/tests/test_conflicts_dialog.py
@@ -1,4 +1,10 @@
-from src.dialogs.conflicts_dialog import _entry_chosen, _fmt_entry_candidate
+import types
+from unittest.mock import MagicMock
+
+from src.dialogs import conflicts_dialog
+from src.dialogs.conflicts_dialog import (
+    ConflictsDialog, _entry_chosen, _fmt_entry_candidate,
+)
 
 
 def _cand(slots=None, deleted=False, modified_at="2026-05-20T10:00:00Z", device_id="devABCDEF"):
@@ -37,3 +43,74 @@ def test_fmt_entry_candidate_lists_slots():
 
 def test_fmt_entry_candidate_deleted():
     assert "GELÖSCHT" in _fmt_entry_candidate(_cand(slots=[], deleted=True))
+
+
+# --- Doppel-Resolve-Guard (Follow-up #134 / Audit H3) -----------------------
+# Seit #122 sind die A/B-Buttons nur noch OPTISCH disabled — der command feuert
+# weiter. Gegen einen zweiten Klick auf den bereits aufgelösten Konflikt schützt
+# allein der _selected-Guard in _resolve_with_candidate (is-None-Check + Reset
+# auf None nach dem Resolve). Headless getestet über einen Stub-`self`, ohne
+# Tk-Root: sync.resolve_conflict wird gezählt, die Tk-berührenden Helfer sind
+# gemockt.
+
+def _dialog_stub(selected):
+    stub = types.SimpleNamespace(
+        _selected=selected,
+        _data_lock=None,
+        settings=MagicMock(),
+        storage=MagicMock(),
+        conflicts_store=MagicMock(),
+        top=MagicMock(),
+        btn_a=MagicMock(),
+        btn_b=MagicMock(),
+        detail_label=MagicMock(),
+        _refresh_list=MagicMock(),
+    )
+    stub.settings.get.return_value = "devABCDEF"
+    return stub
+
+
+def _setting_conflict():
+    return {"id": "c1", "kind": "setting", "key": "stundenlohn",
+            "candidates": [{"value": "A"}, {"value": "B"}]}
+
+
+def test_resolve_noop_when_nothing_selected(monkeypatch):
+    calls = []
+    monkeypatch.setattr(conflicts_dialog.sync, "resolve_conflict",
+                        lambda *a, **k: calls.append(1))
+    stub = _dialog_stub(selected=None)
+
+    ConflictsDialog._resolve_with_candidate(stub, 0)
+
+    assert calls == []
+    stub._refresh_list.assert_not_called()
+
+
+def test_resolve_resets_selected_after_success(monkeypatch):
+    monkeypatch.setattr(conflicts_dialog.sync, "resolve_conflict",
+                        lambda *a, **k: None)
+    monkeypatch.setattr(conflicts_dialog, "set_secondary_button_enabled",
+                        lambda *a, **k: None)
+    stub = _dialog_stub(selected=_setting_conflict())
+
+    ConflictsDialog._resolve_with_candidate(stub, 0)
+
+    # Guard-Reset ist PFLICHT — sonst löst ein Folgeklick den alten Konflikt neu.
+    assert stub._selected is None
+    stub._refresh_list.assert_called_once()
+
+
+def test_second_resolve_is_noop(monkeypatch):
+    calls = []
+    monkeypatch.setattr(conflicts_dialog.sync, "resolve_conflict",
+                        lambda *a, **k: calls.append(1))
+    monkeypatch.setattr(conflicts_dialog, "set_secondary_button_enabled",
+                        lambda *a, **k: None)
+    stub = _dialog_stub(selected=_setting_conflict())
+
+    ConflictsDialog._resolve_with_candidate(stub, 0)  # löst auf
+    ConflictsDialog._resolve_with_candidate(stub, 0)  # muss No-op sein
+
+    assert len(calls) == 1
+    stub._refresh_list.assert_called_once()


### PR DESCRIPTION
Schließt #134.

## Kontext
PR #122 (Audit H3/M13) hat die A/B-Buttons im `conflicts_dialog` von `state="disabled"` auf **optisches** Disable umgestellt — der `command` bleibt aktiv. Ein Doppelklick auf den bereits aufgelösten Konflikt wird seither allein über den `_selected`-Guard in `_resolve_with_candidate` abgefangen (is-None-Check + Reset auf `None` nach dem Resolve). Dieser Guard war bislang **nur sichtgeprüft**.

## Änderung
Drei billige **Headless**-Tests (kein Tk-Root — die Methode über die Klasse mit einem Stub-`self` aufgerufen, `sync.resolve_conflict` gezählt, die Tk-berührenden Helfer gemockt):

1. `_selected is None` → sofortiger Return, `sync.resolve_conflict` **nie** aufgerufen, kein `_refresh_list`.
2. Erfolgreicher Resolve setzt `_selected` zurück auf `None` (Guard-Reset ist Pflicht).
3. Zweiter Aufruf direkt danach ist ein **No-op** — `sync.resolve_conflict` bleibt bei genau einem Aufruf.

Nur neue Tests, **kein Produktivcode** angefasst.

## Verifikation
- `pytest tests/test_conflicts_dialog.py` → 8 passed; volle Suite **775 passed / 3 skipped**; `ruff check` sauber.
- **Mutationstest** gegen den Guard: Entfernen des `is None`-Checks bzw. des `self._selected = None`-Resets lässt je zwei der neuen Tests fallen — der Schutz ist also echt abgesichert, nicht nur zufällig grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
