### PR TITLE
fix(data/sync): Store-/Sync-Robustheit (M4/M5/M6) + Robustheits-Kleinfixes (M9/N1/N2/N13/N15/N16/N18/N19 + N3/N4/N5/N7)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,7 +232,8 @@ Lokal: `pytest` aus dem Repo-Root. Alle Tests müssen vor dem PR-Merge grün sei
 - `src/report.py` — HTML-Mail und PDF (dark/light Theme), gruppiert pro ISO-Kalenderwoche; `xhtml2pdf`-Import ist **lazy** in `generate_pdf` (siehe Tests/CI)
 - `src/mail.py` — Gmail-API-Wrapper (OAuth2, `token.json` / `credentials.json`)
 - `src/drive.py` — Google-Drive-API-Wrapper für den Multi-Device-Sync (`appDataFolder`, Scope `drive.appdata`)
-- `src/sync.py` — Sync-Engine (pure Logik: LWW-Merge der Entries/Settings, Konflikterkennung); importiert `SYNCED_SETTING_KEYS` aus `settings.py` (Single Source of Truth, nicht hier neu definieren)
+- `src/sync.py` — Sync-Engine (pure Logik: LWW-Merge der Entries/Settings, Konflikterkennung); importiert `SYNCED_SETTING_KEYS` aus `settings.py` (Single Source of Truth, nicht hier neu definieren); `validate_remote_doc` prüft ein Remote-Doc auf die Merge-Invarianten vor dem Merge (Audit M5)
+- `src/sync_journal.py` — Crash-Recovery für `sync.apply_merged_doc` via Write-Ahead-Journal (`sync-apply.journal`); beim Start holt `recover_pending_apply` einen unvollständigen Apply idempotent nach (Audit M6)
 - `src/conflicts_store.py` — lokale JSON-Persistenz der Sync-Konfliktliste
 - `src/share.py` — Export/Import von Arbeitszeiten als Share-JSON (Teilen per Mail-Anhang)
 - `src/reservations.py` — Reservierungen (zukünftige Soll-Zeiten, eigenes Konzept neben Ist-Zeiten)

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -124,7 +124,20 @@ müssen beide Locks respektieren. Design:
   (zukünftige Soll-Zeiten, eigenes Konzept). `settings.py` — Einstellungen mit Defaults.
 - `conflicts_store.py` — lokale Sync-Konfliktliste. `category_defaults.py` — Default-Kategorien.
 - `sync.py` — pure Sync-Logik (LWW-Merge, Konflikterkennung); importiert
-  `SYNCED_SETTING_KEYS` aus `settings.py` (Single Source of Truth, nicht hier neu definieren).
+  `SYNCED_SETTING_KEYS` aus `settings.py` **und** `_REQUIRED_ENTRY_KEYS` aus `storage.py`
+  (beide Single Source of Truth, nicht hier neu definieren). `validate_remote_doc`
+  prüft ein migriertes Remote-Doc auf die Merge-Invarianten (Pflichtfelder,
+  `modified_at`-Typ), bevor ein `KeyError`/`ValueError` mitten im Merge landet
+  (Audit M5) — die Sync-Flows in `main.py` behandeln ein invalides Doc wie
+  korruptes JSON (quarantänen/leer weitermergen).
+- `sync_journal.py` — Crash-Recovery für `sync.apply_merged_doc` (Audit M6): dessen
+  vier Store-Writes sind einzeln atomar, die Sequenz nicht. `apply_merged_doc_journaled`
+  schreibt den `merged_doc` erst durable (`fsync`) in ein Write-Ahead-Journal
+  (`sync-apply.journal` im Base-Dir), dann die Stores, dann löscht es das Journal.
+  `main.py` ruft die drei Sync-Apply-Stellen (Pull/Push/Kompaktierung) darüber; beim
+  Start holt `recover_pending_apply` ein übriggebliebenes Journal idempotent nach
+  (alle vier Ops sind Full-Replace). **Kein** Sync-Doc-Feld — rein lokaler
+  Recovery-Zustand.
   `share.py` — Export/Import als Share-JSON. `weekly_limit.py` — pure Wochenstunden-Limit-Check
   (Werkstudenten-Privileg, #98). Kein eigener Persistenz-Zustand, operiert auf
   `Storage.get_all()`-Dicts und den `werkstudent_limit_*`-Settings-Keys.

--- a/src/background_tasks.py
+++ b/src/background_tasks.py
@@ -34,7 +34,16 @@ class BackgroundTaskRunner:
         """Fuehrt fn() in einem Daemon-Thread aus und liefert dessen Rueckgabe
         via marshal an on_done auf dem UI-Thread."""
         def worker():
-            result = fn()
+            try:
+                result = fn()
+            except Exception:
+                # N19: Auffangnetz. Ohne dieses stirbt der Worker bei einem
+                # unerwarteten fn()-Fehler still (Daemon-Thread, kein
+                # threading.excepthook) und on_done feuert nie — ein Status-Label
+                # bliebe z.B. auf "Synchronisiere…" haengen. Die Aufrufer gaten
+                # ihre fn zwar selbst, der Runner verlaesst sich aber nicht darauf.
+                log.exception("Hintergrund-Task fehlgeschlagen")
+                return
             if on_done is not None:
                 # Lokale Bindung: Pyright traegt das None-Narrowing sonst nicht
                 # in die Closure (reportOptionalCall-FP).

--- a/src/conflicts_store.py
+++ b/src/conflicts_store.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+import logging
 import os
 import threading
 
@@ -23,7 +24,13 @@ class ConflictsStore:
                 data = json.load(f)
         except (json.JSONDecodeError, ValueError):
             stamp = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
-            os.replace(self.filepath, f"{self.filepath}.corrupt-{stamp}")
+            target = f"{self.filepath}.corrupt-{stamp}"
+            os.replace(self.filepath, target)
+            logging.getLogger(__name__).warning(
+                "%s korrupt (JSON nicht parsebar) — nach %s in Quarantäne "
+                "verschoben, starte leer",
+                os.path.basename(self.filepath), os.path.basename(target),
+            )
             return
         if isinstance(data, list):
             self._conflicts = data

--- a/src/conflicts_store.py
+++ b/src/conflicts_store.py
@@ -39,6 +39,9 @@ class ConflictsStore:
         tmp = self.filepath + ".tmp"
         with open(tmp, "w", encoding="utf-8") as f:
             json.dump(self._conflicts, f, indent=2, ensure_ascii=False)
+            # N1: fsync vor os.replace (Durability bei Crash/Stromausfall).
+            f.flush()
+            os.fsync(f.fileno())
         try:
             os.replace(tmp, self.filepath)
         except OSError:

--- a/src/mail.py
+++ b/src/mail.py
@@ -82,7 +82,10 @@ def fetch_user_email(token_path="token.json", sync_enabled=False, gcal_enabled=F
                 _td = _json.load(f)
             log.info("fetch_user_email: granted scopes = %r", _td.get("scopes"))
         except Exception:
-            pass
+            # N13: reine Diagnose — Fehler darf den Flow nicht kippen, aber auch
+            # nicht spurlos verschwinden.
+            log.debug("fetch_user_email: granted-scopes-Diagnose fehlgeschlagen",
+                      exc_info=True)
     except Exception:
         log.exception("fetch_user_email: setup failed")
         return ""

--- a/src/main.py
+++ b/src/main.py
@@ -13,6 +13,12 @@ import uuid
 # userinfo.email automatisch 'openid' hinzu — die Lib wirft dann
 # "Scope has changed". Diese Env-Variable lockert den Check; muss VOR dem
 # Import von google_auth_oauthlib stehen (frühester Punkt: main.py).
+#
+# N15 (bewusste, eng begrenzte Sicherheits-Lockerung): entschärft NUR die
+# Client-seitige Scope-Gleichheitsprüfung von oauthlib. Welche Scopes tatsächlich
+# gewährt wurden, erzwingt weiterhin Google serverseitig; ein echter Scope-Upgrade
+# (fehlender Scope im Token) wird separat über discard_token_for_scope_upgrade
+# (oauth_utils.py) erkannt und per frischem Consent nachgeholt. Kein Blankoscheck.
 os.environ.setdefault("OAUTHLIB_RELAX_TOKEN_SCOPE", "1")
 
 from src.conflicts_store import ConflictsStore
@@ -397,6 +403,9 @@ def main():
         setup_logging(base)
         logging.getLogger(__name__).info("Zeiterfassung v%s gestartet", VERSION)
     except Exception:
+        # N13: bewusst still — schlägt das Logging-Setup selbst fehl, gibt es
+        # keinen Kanal, in den man den Fehler schreiben könnte (und --noconsole
+        # schluckt stderr). Setup-Fehler sind nicht-fatal, die App läuft weiter.
         pass
 
     from src import single_instance

--- a/src/main.py
+++ b/src/main.py
@@ -79,7 +79,7 @@ def _run_pull_in_background(storage, settings, conflicts_store, base, ui_callbac
     data_lock (geteilter Store-RLock, Audit H1): klammert
     Snapshot→Merge→Apply atomar gegen parallele UI-Saves. Wird NICHT über
     den Download gehalten."""
-    from src import drive, sync
+    from src import drive, sync, sync_journal
     if sync_guard is not None and not sync_guard.acquire(blocking=False):
         return
     try:
@@ -116,12 +116,26 @@ def _run_pull_in_background(storage, settings, conflicts_store, base, ui_callbac
             # gemergt (absorb-and-upgrade). Dass ältere Geräte ein hochgezogenes
             # v4-Doc nicht überschreiben, sichert deren Push-Guard (ab v1.15.2).
             remote_doc = sync.migrate_doc_to_current(remote_doc)
+            ok, reason = sync.validate_remote_doc(remote_doc)
+            if not ok:
+                # Strukturell defektes Remote-Doc (fehlende Pflichtfelder etc.)
+                # wie korruptes JSON behandeln (Audit M5): quarantänen und leer
+                # weitermergen, damit der lokale Stand zur neuen Remote-Wahrheit
+                # wird — statt mitten im Merge mit KeyError/ValueError im
+                # generischen except zu landen.
+                logging.getLogger(__name__).warning(
+                    "Remote-Sync-Doc ungültig (%s) — quarantäniert, starte leer", reason)
+                if file_id is not None:
+                    _quarantine(file_id)
+                remote_doc = {"schema_version": 1, "entries": {}, "settings": {}, "conflicts": []}
             # Snapshot→Merge→Apply atomar: kein UI-Save kann zwischen
             # build_local_doc und apply_merged_doc interleaven (Audit H1).
             with _lock_ctx(data_lock):
                 local_doc = sync.build_local_doc(storage, settings, conflicts_store)
                 merged = sync.merge(local_doc, remote_doc, settings.get("last_pull_at") or "")
-                sync.apply_merged_doc(merged, storage, settings, conflicts_store)
+                sync_journal.apply_merged_doc_journaled(
+                    merged, storage, settings, conflicts_store,
+                    os.path.join(base, sync_journal.JOURNAL_FILENAME))
                 settings.set_many({
                     "last_pull_at": sync._utc_now_iso(),
                     "drive_etag": etag,
@@ -151,7 +165,7 @@ def _run_push_blocking(storage, settings, conflicts_store, base, timeout_seconds
     data_lock (Audit H1): klammert Snapshot→Merge→Apply→Upload-Snapshot
     atomar; der Upload selbst läuft OHNE Daten-Lock (nie Lock über Netz)."""
     import json
-    from src import drive, sync
+    from src import drive, sync, sync_journal
 
     result = {}
 
@@ -194,12 +208,23 @@ def _run_push_blocking(storage, settings, conflicts_store, base, timeout_seconds
                 # Älteres Remote (v1/v2) absorbieren: aufs aktuelle Schema migrieren,
                 # dann mergen — sonst gingen v2-only-Stände beim Upload verloren.
                 remote_doc = sync.migrate_doc_to_current(remote_doc)
+                ok, reason = sync.validate_remote_doc(remote_doc)
+                if not ok:
+                    # Defektes Remote wie korruptes JSON behandeln (Audit M5):
+                    # leer weitermergen, der lokale Stand wird beim Upload zur
+                    # neuen Remote-Wahrheit. (Der Push quarantänt nicht separat —
+                    # der Upload überschreibt das defekte Remote ohnehin.)
+                    logging.getLogger(__name__).warning(
+                        "Remote-Sync-Doc ungültig (%s) — ignoriert, lokaler Stand gewinnt", reason)
+                    remote_doc = {"schema_version": 1, "entries": {}, "settings": {}, "conflicts": []}
                 # Snapshot→Merge→Apply→Upload-Snapshot atomar (Audit H1);
                 # der Upload danach läuft bewusst ungelockt.
                 with _lock_ctx(data_lock):
                     local_doc = sync.build_local_doc(storage, settings, conflicts_store)
                     merged = sync.merge(local_doc, remote_doc, settings.get("last_pull_at") or "")
-                    sync.apply_merged_doc(merged, storage, settings, conflicts_store)
+                    sync_journal.apply_merged_doc_journaled(
+                        merged, storage, settings, conflicts_store,
+                        os.path.join(base, sync_journal.JOURNAL_FILENAME))
                     doc = sync.build_local_doc(storage, settings, conflicts_store)
                     content = json.dumps(doc, ensure_ascii=False).encode("utf-8")
                 new_id, new_etag = drive.upload(service, content, file_id, expected_etag="")
@@ -241,7 +266,7 @@ def _run_compaction_blocking(storage, settings, conflicts_store, base, timeout_s
     inneren _do-Threads. data_lock: klammert Merge/Apply/Kompaktierung atomar;
     der Upload läuft ungelockt (Invarianten wie _run_push_blocking)."""
     import json
-    from src import drive, sync
+    from src import drive, sync, sync_journal
 
     result = {}
 
@@ -275,6 +300,14 @@ def _run_compaction_blocking(storage, settings, conflicts_store, base, timeout_s
 
                 # Älteres Remote (v1/v2) absorbieren: aufs aktuelle Schema migrieren.
                 remote_doc = sync.migrate_doc_to_current(remote_doc)
+                ok, reason = sync.validate_remote_doc(remote_doc)
+                if not ok:
+                    # Defektes Remote wie korruptes JSON behandeln (Audit M5):
+                    # leer weitermergen; die Kompaktierung schreibt danach den
+                    # lokalen Stand als neue Remote-Wahrheit hoch.
+                    logging.getLogger(__name__).warning(
+                        "Remote-Sync-Doc ungültig (%s) — ignoriert, lokaler Stand gewinnt", reason)
+                    remote_doc = {"schema_version": 1, "entries": {}, "settings": {}, "conflicts": []}
                 now = sync._utc_now_iso()
                 # Merge + Apply + Watermark/Strippung + Upload-Snapshot atomar
                 # (Audit H1); der Upload danach läuft bewusst ungelockt.
@@ -282,7 +315,9 @@ def _run_compaction_blocking(storage, settings, conflicts_store, base, timeout_s
                     # 1) normaler Merge des frischen Remote-Stands
                     local_doc = sync.build_local_doc(storage, settings, conflicts_store)
                     merged = sync.merge(local_doc, remote_doc, settings.get("last_pull_at") or "")
-                    sync.apply_merged_doc(merged, storage, settings, conflicts_store)
+                    sync_journal.apply_merged_doc_journaled(
+                        merged, storage, settings, conflicts_store,
+                        os.path.join(base, sync_journal.JOURNAL_FILENAME))
                     settings.set("last_pull_at", now)
                     # 2) Watermark setzen + lokal strippen
                     sync.compact_local(storage, settings, conflicts_store, now)
@@ -402,6 +437,15 @@ def main():
 
     reservation_store = ReservationStore(os.path.join(base, "reservations.json"),
                                          lock=data_lock)
+
+    # M6: Ein unvollständig gebliebener Sync-Apply eines vorherigen Laufs
+    # (Crash zwischen den vier Store-Writes) wird jetzt idempotent nachgeholt —
+    # bevor irgendein Sync-Thread startet, hier noch single-threaded (kein
+    # data_lock nötig). Kein Journal → No-op.
+    from src import sync_journal
+    sync_journal.recover_pending_apply(
+        os.path.join(base, sync_journal.JOURNAL_FILENAME),
+        storage, settings, conflicts_store)
 
     root = tk.Tk()
     _apply_ui_scaling(root, settings.get("ui_scale"))

--- a/src/reservations.py
+++ b/src/reservations.py
@@ -105,6 +105,9 @@ class ReservationStore:
         tmp = self.filepath + ".tmp"
         with open(tmp, "w", encoding="utf-8") as f:
             json.dump(self._data, f, indent=2, ensure_ascii=False)
+            # N1: fsync vor os.replace (Durability bei Crash/Stromausfall).
+            f.flush()
+            os.fsync(f.fileno())
         try:
             os.replace(tmp, self.filepath)
         except OSError:

--- a/src/reservations.py
+++ b/src/reservations.py
@@ -14,6 +14,7 @@ erhalten, bis der Reconcile die zugehörigen Events entfernt hat.
 
 import datetime
 import json
+import logging
 import os
 import threading
 
@@ -54,7 +55,13 @@ class ReservationStore:
                 self._data = json.load(f)
         except (json.JSONDecodeError, ValueError):
             stamp = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
-            os.replace(self.filepath, f"{self.filepath}.corrupt-{stamp}")
+            target = f"{self.filepath}.corrupt-{stamp}"
+            os.replace(self.filepath, target)
+            logging.getLogger(__name__).warning(
+                "%s korrupt (JSON nicht parsebar) — nach %s in Quarantäne "
+                "verschoben, starte leer",
+                os.path.basename(self.filepath), os.path.basename(target),
+            )
             self._data = {}
             return
         self._migrate_legacy_reservations()

--- a/src/settings.py
+++ b/src/settings.py
@@ -273,6 +273,9 @@ class Settings:
         tmp = self.filepath + ".tmp"
         with open(tmp, "w", encoding="utf-8") as f:
             json.dump(payload, f, indent=2, ensure_ascii=False)
+            # N1: fsync vor os.replace (Durability bei Crash/Stromausfall).
+            f.flush()
+            os.fsync(f.fileno())
         try:
             os.replace(tmp, self.filepath)
         except OSError:

--- a/src/settings.py
+++ b/src/settings.py
@@ -200,15 +200,14 @@ class Settings:
             with open(self.filepath, "r", encoding="utf-8") as f:
                 loaded = json.load(f)
         except (json.JSONDecodeError, ValueError):
+            self._quarantine_corrupt("JSON nicht parsebar")
             self._data = dict(DEFAULTS)
             return
 
         log = logging.getLogger(__name__)
         if not isinstance(loaded, dict):
-            log.warning(
-                "settings.json hat unerwartetes Toplevel-Format (%s), "
-                "verwerfe Inhalt und verwende Defaults",
-                type(loaded).__name__,
+            self._quarantine_corrupt(
+                f"unerwartetes Toplevel-Format ({type(loaded).__name__})"
             )
             self._data = dict(DEFAULTS)
             return
@@ -241,6 +240,29 @@ class Settings:
                 continue
             self._data[key] = coerced
         # Unbekannte Keys aus loaded werden ignoriert (nicht in _data übernommen).
+
+    def _quarantine_corrupt(self, reason):
+        """Verschiebt ein korruptes settings.json nach `.corrupt-<stamp>`
+        (wie storage/reservations/conflicts_store) und loggt das Ereignis,
+        statt es kommentarlos zu verwerfen (Audit M4/N4). Defaults setzt der
+        Aufrufer. Der Rename ist wie in `_save_to_disk` gegen `OSError`
+        abgesichert — schlägt er fehl, bleibt die Datei liegen und der Boot
+        läuft trotzdem mit Defaults weiter, statt zu crashen."""
+        stamp = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
+        target = f"{self.filepath}.corrupt-{stamp}"
+        log = logging.getLogger(__name__)
+        try:
+            os.replace(self.filepath, target)
+        except OSError:
+            log.warning(
+                "settings.json korrupt (%s); Quarantäne-Rename fehlgeschlagen "
+                "— verwende Defaults", reason, exc_info=True,
+            )
+            return
+        log.warning(
+            "settings.json korrupt (%s) — nach %s in Quarantäne verschoben, "
+            "verwende Defaults", reason, os.path.basename(target),
+        )
 
     def _save_to_disk(self):
         # Atomic write: temp file + replace, damit ein Crash mid-write

--- a/src/settings.py
+++ b/src/settings.py
@@ -350,7 +350,23 @@ class Settings:
                     continue
                 if not isinstance(payload, dict) or "value" not in payload:
                     continue
-                self._data[key] = payload["value"]
+                value = payload["value"]
+                # Remote-Wert typprüfen wie beim lokalen _load (N5): ein
+                # korrumpiertes/böswilliges Sync-Doc darf z.B. hourly_rate
+                # nicht auf einen String setzen. Nicht castbar → überspringen
+                # (lokaler Wert bleibt), statt Garbage zu übernehmen.
+                if key in DEFAULTS:
+                    coerced = _coerce(value, DEFAULTS[key])
+                    if coerced is _COERCE_FAILED:
+                        logging.getLogger(__name__).warning(
+                            "Sync: Remote-Wert für %r (%r, Typ %s) ist nicht in "
+                            "Typ %s castbar — übersprungen",
+                            key, value, type(value).__name__,
+                            type(DEFAULTS[key]).__name__,
+                        )
+                        continue
+                    value = coerced
+                self._data[key] = value
                 self._synced_meta[key] = {
                     "modified_at": str(payload.get("modified_at", "")),
                     "device_id": str(payload.get("device_id", "")),

--- a/src/storage.py
+++ b/src/storage.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+import logging
 import os
 import threading
 
@@ -46,7 +47,13 @@ class Storage:
                 self._data = json.load(f)
         except (json.JSONDecodeError, ValueError):
             stamp = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
-            os.replace(self.filepath, f"{self.filepath}.corrupt-{stamp}")
+            target = f"{self.filepath}.corrupt-{stamp}"
+            os.replace(self.filepath, target)
+            logging.getLogger(__name__).warning(
+                "%s korrupt (JSON nicht parsebar) — nach %s in Quarantäne "
+                "verschoben, starte leer",
+                os.path.basename(self.filepath), os.path.basename(target),
+            )
             self._data = {}
             return
         self._migrate_legacy_entries()

--- a/src/storage.py
+++ b/src/storage.py
@@ -103,6 +103,10 @@ class Storage:
         tmp = self.filepath + ".tmp"
         with open(tmp, "w", encoding="utf-8") as f:
             json.dump(self._data, f, indent=2, ensure_ascii=False)
+            # N1: fsync vor os.replace — sonst kann das Rename durabel sein, die
+            # Datenblöcke aber noch im OS-Cache (Stromausfall → leere/halbe Datei).
+            f.flush()
+            os.fsync(f.fileno())
         try:
             os.replace(tmp, self.filepath)
         except OSError:

--- a/src/sync.py
+++ b/src/sync.py
@@ -102,6 +102,13 @@ def _merge_one(local, remote, last_pull_at, equal_fn=_values_equal_entry, kind="
     local_changed = local["modified_at"] > last_pull_at
     remote_changed = remote["modified_at"] > last_pull_at
 
+    # N2 (LWW-Wanduhr-Abhängigkeit — bewusst festgehalten): `modified_at` ist eine
+    # Wanduhr-Zeit (_utc_now_iso, Sekunden-Auflösung, KEINE Millisekunden). Der
+    # Vergleich ist ein String-Vergleich der ISO-Timestamps. Das LWW-Ergebnis
+    # hängt damit an halbwegs synchronen Geräte-Uhren; eine stark falsch gehende
+    # Uhr kann Änderungen dauerhaft gewinnen/verlieren lassen. Bei exakt gleicher
+    # Sekunde bevorzugt `>=` deterministisch die REMOTE-Seite (arbiträr, aber
+    # stabil) — akzeptierter Trade-off für ein Ein-Nutzer-Multi-Device-Tool.
     winner = remote if remote["modified_at"] >= local["modified_at"] else local
 
     if local_changed and remote_changed:

--- a/src/sync.py
+++ b/src/sync.py
@@ -1,12 +1,14 @@
 """Sync-Engine: pure Funktionen ohne I/O. Drive-Calls leben in src/drive.py.
 
-Doc-Struktur (Sync-File und Zwischenformate):
+Doc-Struktur (Sync-File und Zwischenformate), Stand SCHEMA_VERSION = 4:
 {
-  "schema_version": 1,
-  "entries":   {date: {start, end, pause, modified_at, device_id, deleted}},
+  "schema_version": 4,
+  "entries":   {date: {slots: [{start, end, pause, kategorie}],
+                       modified_at, device_id, deleted}},
   "settings":  {key:  {value, modified_at, device_id}},
   "conflicts": [{id, kind, key, candidates, detected_at,
-                 resolved, resolution, resolved_at, resolved_by}]
+                 resolved, resolution, resolved_at, resolved_by}],
+  "meta":      {gc_watermark}
 }
 """
 

--- a/src/sync.py
+++ b/src/sync.py
@@ -22,6 +22,11 @@ import uuid
 # stiller Datenverlust im Multi-Device-Sync (Issue #48). settings.py ist
 # stdlib-only und importiert sync.py nicht (kein Zyklus, CI-import-sicher).
 from src.settings import SYNCED_SETTING_KEYS
+# _REQUIRED_ENTRY_KEYS ist der Pflichtfeld-Vertrag, den storage.apply_merge
+# erzwingt — hier als Single Source of Truth importieren (nicht duplizieren),
+# damit validate_remote_doc nie gegen einen anderen Feldsatz prüft als der
+# Store später schreibt. storage.py importiert sync.py nicht (kein Zyklus).
+from src.storage import _REQUIRED_ENTRY_KEYS
 
 
 SCHEMA_VERSION = 4
@@ -321,6 +326,67 @@ def migrate_doc_to_current(remote_doc):
             "deleted": bool(entry.get("deleted", False)),
         }
     return {**remote_doc, "schema_version": SCHEMA_VERSION, "entries": migrated}
+
+
+def validate_remote_doc(doc):
+    """Prüft ein (bereits auf SCHEMA_VERSION migriertes) Remote-Doc auf die
+    strukturellen Invarianten, die `merge`/`apply_merged_doc` voraussetzen —
+    BEVOR ein `KeyError`/`ValueError` mitten im Merge landet (Audit M5).
+
+    Der Merge greift an mehreren Stellen ungeprüft zu: `entry["modified_at"]`
+    beim LWW-Vergleich (`_merge_one`), `conflict["id"]` bei der Union-by-ID,
+    und `storage.apply_merge` wirft `ValueError`, wenn einem Eintrag eines der
+    Pflichtfelder (`slots`/`modified_at`/`device_id`/`deleted`) fehlt. Ein
+    defektes/manipuliertes Remote-Doc landet sonst im generischen
+    `except Exception` als „unerwarteter Fehler".
+
+    Liefert `(True, "")` oder `(False, grund)`. Ein invalides Doc behandelt der
+    Aufrufer wie korruptes JSON: Remote-File quarantänen und leer weitermergen
+    (lokaler Stand wird zur neuen Remote-Wahrheit)."""
+    if not isinstance(doc, dict):
+        return False, "Doc ist kein Objekt"
+
+    entries = doc.get("entries", {})
+    if not isinstance(entries, dict):
+        return False, "entries ist kein Objekt"
+    for date, entry in entries.items():
+        if not isinstance(entry, dict):
+            return False, f"entry {date!r} ist kein Objekt"
+        missing = _REQUIRED_ENTRY_KEYS - entry.keys()
+        if missing:
+            return False, f"entry {date!r} fehlen Felder {sorted(missing)}"
+        if not isinstance(entry.get("modified_at"), str):
+            return False, f"entry {date!r}: modified_at ist kein String"
+        if not isinstance(entry.get("slots"), list):
+            return False, f"entry {date!r}: slots ist keine Liste"
+
+    settings = doc.get("settings", {})
+    if not isinstance(settings, dict):
+        return False, "settings ist kein Objekt"
+    for skey, payload in settings.items():
+        if not isinstance(payload, dict):
+            return False, f"setting {skey!r} ist kein Objekt"
+        if "value" not in payload:
+            return False, f"setting {skey!r} ohne value"
+        if not isinstance(payload.get("modified_at"), str):
+            return False, f"setting {skey!r}: modified_at ist kein String"
+
+    conflicts = doc.get("conflicts", [])
+    if not isinstance(conflicts, list):
+        return False, "conflicts ist keine Liste"
+    for c in conflicts:
+        if not isinstance(c, dict):
+            return False, "conflict ist kein Objekt"
+        if not isinstance(c.get("id"), str) or not c.get("id"):
+            return False, "conflict ohne gültige id"
+        if c.get("kind") not in ("entry", "setting"):
+            return False, "conflict mit ungültigem kind"
+        if "key" not in c:
+            return False, "conflict ohne key"
+        if not isinstance(c.get("candidates"), list):
+            return False, "conflict ohne candidates-Liste"
+
+    return True, ""
 
 
 def _remote_is_newer(remote_doc):

--- a/src/sync_journal.py
+++ b/src/sync_journal.py
@@ -1,0 +1,103 @@
+"""Crash-Recovery für `sync.apply_merged_doc` (Audit M6).
+
+`apply_merged_doc` schreibt das Merge-Ergebnis in **vier** separate Stores
+nacheinander (storage, settings-synced, conflicts, gc_watermark). Jeder einzelne
+Write ist atomar (`.tmp` + `os.replace`), die **Sequenz** ist es nicht: stürzt der
+Prozess zwischen zwei Writes ab (Stromausfall, Kill), bleiben die Stores
+inkonsistent — z. B. Storage-Tombstones gestrippt, aber das gc_watermark noch alt.
+
+Dieses Modul klammert die vier Writes in ein **Write-Ahead-Journal**:
+
+1. Der komplette `merged_doc` wird zuerst atomar + `fsync` in eine Journal-Datei
+   geschrieben (durable, bevor irgendein Store angefasst wird).
+2. `sync.apply_merged_doc` schreibt die vier Stores.
+3. Das Journal wird gelöscht.
+
+Existiert beim App-Start noch ein Journal, war der letzte Apply unvollständig →
+er wird **idempotent** wiederholt. Das ist gefahrlos, weil alle vier Store-Ops
+Full-Replace sind (`storage.apply_merge`/`conflicts_store.save_all` ersetzen den
+kompletten Stand, `settings.apply_synced`/`set` sind für gleiche Eingabe
+idempotent) — die Wiederholung reproduziert exakt denselben Endzustand.
+
+Damit ist der Apply effektiv atomar: entweder das Journal ist weg (vollständig
+angewandt) oder es existiert (wird beim nächsten Start vollständig nachgeholt).
+"""
+
+import json
+import logging
+import os
+import tempfile
+
+from src import sync
+
+JOURNAL_FILENAME = "sync-apply.journal"
+
+
+def _atomic_write_json(path, obj):
+    """Schreibt `obj` als JSON atomar + durable (fsync vor replace). Ohne den
+    fsync könnte das Rename durabel sein, der Inhalt aber noch im OS-Cache —
+    dann wäre das Journal beim Recovery leer/kurz (der Fall, gegen den es
+    schützt)."""
+    directory = os.path.dirname(path) or "."
+    fd, tmp = tempfile.mkstemp(dir=directory, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(obj, f, ensure_ascii=False)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, path)
+    except BaseException:
+        if os.path.exists(tmp):
+            try:
+                os.remove(tmp)
+            except OSError:
+                pass
+        raise
+
+
+def apply_merged_doc_journaled(merged_doc, storage, settings, conflicts_store,
+                               journal_path):
+    """Wie `sync.apply_merged_doc`, aber crash-sicher über ein Journal (M6):
+    merged_doc erst durable auf Platte, dann die vier Store-Writes, dann Journal
+    löschen. Stürzt der Prozess dazwischen ab, holt `recover_pending_apply` den
+    Apply beim nächsten Start nach."""
+    _atomic_write_json(journal_path, merged_doc)
+    sync.apply_merged_doc(merged_doc, storage, settings, conflicts_store)
+    try:
+        os.remove(journal_path)
+    except FileNotFoundError:
+        pass
+
+
+def recover_pending_apply(journal_path, storage, settings, conflicts_store):
+    """Beim App-Start (vor dem Start der Sync-Threads, single-threaded → kein
+    Lock nötig) aufrufen: existiert ein Journal, war der letzte Apply
+    unvollständig → idempotent wiederholen.
+
+    Liefert True, wenn ein Journal nachgeholt wurde, sonst False."""
+    log = logging.getLogger(__name__)
+    if not os.path.exists(journal_path):
+        return False
+    try:
+        with open(journal_path, "r", encoding="utf-8") as f:
+            merged_doc = json.load(f)
+    except (json.JSONDecodeError, ValueError, OSError):
+        # Unlesbares Journal: dank atomic-write sollte das nicht vorkommen (ein
+        # halb geschriebenes .tmp wird nie zu journal_path). Falls doch, ist der
+        # sichere Zustand der Vor-Apply-Stand (Stores unverändert) — verwerfen.
+        log.warning("Sync-Apply-Journal unlesbar — verworfen (Stores im "
+                    "Vor-Apply-Zustand)", exc_info=True)
+        _remove_quietly(journal_path)
+        return False
+
+    log.warning("Unvollständiger Sync-Apply gefunden — hole ihn nach (M6-Recovery)")
+    sync.apply_merged_doc(merged_doc, storage, settings, conflicts_store)
+    _remove_quietly(journal_path)
+    return True
+
+
+def _remove_quietly(path):
+    try:
+        os.remove(path)
+    except OSError:
+        pass

--- a/src/theme.py
+++ b/src/theme.py
@@ -110,10 +110,8 @@ HOLIDAY_BG = "#0f3a2a"
 HOLIDAY_BG_HOVER = "#15523a"
 HOLIDAY_ACCENT = "#4ade80"  # gleicher Grünton wie STATUS_OK
 
-# Reservation cell colors ("geplant"-Look — violetter Akzent, abgesetzt von
+# Reservation cell accent ("geplant"-Look — violetter Akzent, abgesetzt von
 # der roten Ist-Zeit-Zelle und der grünen Feiertagszelle)
-RESERVATION_BG = "#2a2150"
-RESERVATION_BG_HOVER = "#352a66"
 RESERVATION_ACCENT = "#a78bfa"
 
 # Rahmenfarbe für den heutigen Tag — blau, klar abgesetzt von rotem Eintrag,
@@ -252,16 +250,6 @@ def dark_combo(parent, textvariable, values, width=8, **kw):
     return ttk.Combobox(
         parent, textvariable=textvariable, values=values,
         width=width, font=FONT, style="Dark.TCombobox", state="readonly", **kw,
-    )
-
-
-def dark_combo_editable(parent, textvariable, values, width=14, **kw):
-    """Wie dark_combo, aber editierbar (state="normal") — Freitext plus
-    Vorschlagsliste. Für die Kategorie-Auswahl je Slot, deren Werte aus
-    settings['categories'] kommen, aber auch frei eingetippt werden dürfen."""
-    return ttk.Combobox(
-        parent, textvariable=textvariable, values=values,
-        width=width, font=FONT, style="Dark.TCombobox", state="normal", **kw,
     )
 
 

--- a/src/time_utils.py
+++ b/src/time_utils.py
@@ -155,7 +155,13 @@ def validate_slots(slots, with_pause=True):
     with_pause=False (Reservierungen): das Pause-Feld wird ignoriert (als 0
     behandelt). Eine leere Liste ist gültig (ok, "")."""
     for s in slots:
-        pause = int(s.get("pause", 0)) if with_pause else 0
+        if with_pause:
+            try:
+                pause = int(s.get("pause", 0))
+            except (TypeError, ValueError):
+                return False, "Pause muss eine ganze Zahl (Minuten) sein."
+        else:
+            pause = 0
         ok, msg = validate_entry(s.get("start"), s.get("end"), pause_minutes=pause)
         if not ok:
             return False, msg

--- a/src/tray.py
+++ b/src/tray.py
@@ -245,7 +245,9 @@ class _PystrayBackend:
             try:
                 self._icon.stop()
             except Exception:
-                pass
+                # N13: Stop ist best-effort (Icon evtl. schon weg), aber nicht spurlos.
+                logging.getLogger(__name__).debug(
+                    "Tray-Icon stop() fehlgeschlagen", exc_info=True)
             self._icon = None
 
 

--- a/src/ui.py
+++ b/src/ui.py
@@ -637,6 +637,16 @@ class App:
         except Exception:
             logging.getLogger(__name__).exception(
                 "Neustart für UI-Skalierung fehlgeschlagen")
+            # N18: Popen ist fehlgeschlagen, der oben freigegebene Single-
+            # Instance-Guard würde sonst für den Rest der Session fehlen
+            # (ein manueller Zweitstart bliebe unbemerkt). Guard neu binden.
+            if self._single_instance is not None:
+                from src import single_instance
+                self._single_instance = single_instance.acquire(
+                    self.base_path, show_requested=False)
+                if self._single_instance is not None:
+                    self._single_instance.serve(
+                        lambda: self._marshal_to_ui(self._restore_from_tray))
             themed_showinfo(
                 self.root,
                 "Neustart nötig",

--- a/src/update_banner.py
+++ b/src/update_banner.py
@@ -79,6 +79,12 @@ class UpdateBanner:
         self._on_resize()
 
     def _open_download(self, release):
+        # M9 (bewusste Design-Grenze): Die App verifiziert das Update NICHT per
+        # Hash/Signatur — sie lädt und startet aber auch nichts selbst, sondern
+        # öffnet nur die Release-URL im Browser. Vertrauensanker ist damit TLS +
+        # GitHub (der Nutzer lädt/installiert manuell). Ein späterer In-App-
+        # Auto-Download OHNE Verifikation wäre eine echte Lücke — dann hier
+        # Signatur-/Hash-Prüfung ergänzen.
         url = pick_asset_url(
             release.assets, platform.system(), release.version,
         ) or release.html_url

--- a/tests/test_background_tasks.py
+++ b/tests/test_background_tasks.py
@@ -45,6 +45,25 @@ def test_run_without_on_done_still_executes_fn():
     assert ran.wait(timeout=5)
 
 
+def test_run_swallows_and_logs_fn_exception(caplog):
+    # N19: wirft fn() unerwartet, darf der Worker nicht still sterben —
+    # der Fehler wird geloggt und on_done feuert NICHT (kein halber Zustand).
+    import logging
+    entered = threading.Event()
+    on_done_called = threading.Event()
+
+    def boom():
+        entered.set()
+        raise RuntimeError("kaputt")
+
+    with caplog.at_level(logging.ERROR):
+        _runner().run(boom, on_done=lambda _r: on_done_called.set())
+        assert entered.wait(timeout=5)          # fn lief
+        assert not on_done_called.wait(timeout=0.5)  # on_done NICHT gefeuert
+
+    assert any("Hintergrund-Task fehlgeschlagen" in r.message for r in caplog.records)
+
+
 def test_check_update_skips_when_not_due(monkeypatch):
     import src.background_tasks as bg
     monkeypatch.setattr(bg, "should_check_today", lambda v: False)

--- a/tests/test_conflicts_store.py
+++ b/tests/test_conflicts_store.py
@@ -1,3 +1,4 @@
+import logging
 
 import pytest
 
@@ -23,13 +24,16 @@ def test_save_and_persist(tmp_path):
                               "resolved": False}]
 
 
-def test_corrupt_file_is_quarantined(tmp_path):
+def test_corrupt_file_is_quarantined(tmp_path, caplog):
     path = tmp_path / "conflicts.json"
     path.write_text("not json{{{", encoding="utf-8")
-    store = ConflictsStore(str(path))
+    with caplog.at_level(logging.WARNING):
+        store = ConflictsStore(str(path))
     assert store.get_all() == []
     quarantined = list(tmp_path.glob("conflicts.json.corrupt-*"))
     assert len(quarantined) == 1
+    # N4: Quarantäne wird jetzt geloggt, nicht mehr stumm.
+    assert any("Quarantäne" in r.message for r in caplog.records)
 
 
 def test_count_unresolved(tmp_conflicts):

--- a/tests/test_reservations.py
+++ b/tests/test_reservations.py
@@ -1,3 +1,4 @@
+import logging
 from unittest import mock
 
 import pytest
@@ -130,12 +131,15 @@ def test_apply_reconciled_rejects_missing_keys(store):
     assert store.get_all_raw() == {}
 
 
-def test_corrupt_json_is_quarantined_and_starts_empty(tmp_path):
+def test_corrupt_json_is_quarantined_and_starts_empty(tmp_path, caplog):
     path = tmp_path / "res.json"
     path.write_text("{not valid", encoding="utf-8")
-    store = ReservationStore(str(path))
+    with caplog.at_level(logging.WARNING):
+        store = ReservationStore(str(path))
     assert store.get_all() == {}
     assert len(list(tmp_path.glob("res.json.corrupt-*"))) == 1
+    # N4: Quarantäne wird jetzt geloggt, nicht mehr stumm.
+    assert any("Quarantäne" in r.message for r in caplog.records)
 
 
 def test_save_failure_keeps_original_intact(tmp_path):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -37,6 +37,49 @@ def test_corrupted_file(tmp_path):
     assert s.get("recipient") == ""
     assert s.get("default_pause") == 30
 
+
+def test_corrupt_json_is_quarantined(tmp_path):
+    # M4: korruptes settings.json wird nach .corrupt-<stamp> in Quarantäne
+    # verschoben (wie die anderen drei Stores), nicht kommentarlos verworfen.
+    path = tmp_path / "settings.json"
+    path.write_text("not json{{{", encoding="utf-8")
+
+    s = Settings(str(path))
+
+    assert s.get("default_pause") == 30
+    quarantined = list(tmp_path.glob("settings.json.corrupt-*"))
+    assert len(quarantined) == 1
+    assert quarantined[0].read_text(encoding="utf-8") == "not json{{{"
+    # Original ist weg → frisches Save legt es sauber neu an.
+    assert not path.exists()
+
+
+def test_non_dict_toplevel_is_quarantined(tmp_path):
+    # Gültiges JSON, aber falsches Toplevel (Liste) ist ebenso korrupt.
+    path = tmp_path / "settings.json"
+    path.write_text("[1, 2, 3]", encoding="utf-8")
+
+    s = Settings(str(path))
+
+    assert s.get("recipient") == ""
+    quarantined = list(tmp_path.glob("settings.json.corrupt-*"))
+    assert len(quarantined) == 1
+    assert quarantined[0].read_text(encoding="utf-8") == "[1, 2, 3]"
+
+
+def test_quarantine_rename_failure_falls_back_to_defaults(tmp_path):
+    # Schlägt der Quarantäne-Rename fehl (z.B. Windows-Filelock), darf der
+    # Boot nicht crashen — Defaults greifen, die Datei bleibt liegen.
+    path = tmp_path / "settings.json"
+    path.write_text("not json{{{", encoding="utf-8")
+
+    with patch("src.settings.os.replace", side_effect=OSError("locked")):
+        s = Settings(str(path))
+
+    assert s.get("default_pause") == 30
+    assert path.exists()
+    assert list(tmp_path.glob("settings.json.corrupt-*")) == []
+
 def test_recipient_default(tmp_settings):
     assert tmp_settings.get("recipient") == ""
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -391,6 +391,33 @@ def test_apply_synced_overwrites_value_and_meta(tmp_path):
     assert s.get_synced_doc()["recipient"]["device_id"] == "other-dev"
 
 
+def test_apply_synced_skips_uncoercible_value(tmp_path):
+    """N5: ein Remote-Wert, der nicht in den erwarteten Typ castbar ist
+    (hier: hourly_rate als nicht-numerischer String), wird verworfen — der
+    lokale Wert bleibt, statt Garbage zu übernehmen."""
+    path = str(tmp_path / "settings.json")
+    s = Settings(path)
+    s.apply_synced({
+        "hourly_rate": {"value": "not-a-number", "modified_at": "2026-05-14T10:00:00Z",
+                        "device_id": "other-dev"},
+    })
+    assert s.get("hourly_rate") == 0.0            # Default unverändert
+    assert "hourly_rate" not in s.get_synced_doc()  # Meta nicht gestempelt
+
+
+def test_apply_synced_coerces_numeric_string(tmp_path):
+    """N5-Gegentest: ein castbarer Wert (Zahl als String) wird übernommen und
+    in den Zieltyp gecastet — Sync bleibt tolerant gegenüber JSON-Zahlformaten."""
+    path = str(tmp_path / "settings.json")
+    s = Settings(path)
+    s.apply_synced({
+        "hourly_rate": {"value": "15", "modified_at": "2026-05-14T10:00:00Z",
+                        "device_id": "other-dev"},
+    })
+    assert s.get("hourly_rate") == 15.0
+    assert isinstance(s.get("hourly_rate"), float)
+
+
 def test_get_synced_doc_empty_when_nothing_set(tmp_settings):
     assert tmp_settings.get_synced_doc() == {}
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from unittest import mock
 
@@ -67,16 +68,19 @@ def test_save_with_pause(tmp_storage):
     assert tmp_storage.get("2026-03-23") == {"slots": [_slot("08:00", "16:30", 30)]}
 
 
-def test_corrupt_json_is_quarantined_and_starts_empty(tmp_path):
+def test_corrupt_json_is_quarantined_and_starts_empty(tmp_path, caplog):
     path = tmp_path / "test.json"
     path.write_text("{not valid json", encoding="utf-8")
 
-    storage = Storage(str(path))
+    with caplog.at_level(logging.WARNING):
+        storage = Storage(str(path))
 
     assert storage.get_all() == {}
     quarantined = list(tmp_path.glob("test.json.corrupt-*"))
     assert len(quarantined) == 1
     assert quarantined[0].read_text(encoding="utf-8") == "{not valid json"
+    # N4: Quarantäne wird jetzt geloggt, nicht mehr stumm.
+    assert any("Quarantäne" in r.message for r in caplog.records)
 
 
 def test_save_failure_keeps_original_file_intact(tmp_path):

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -68,6 +68,19 @@ def test_save_with_pause(tmp_storage):
     assert tmp_storage.get("2026-03-23") == {"slots": [_slot("08:00", "16:30", 30)]}
 
 
+def test_save_fsyncs_before_replace(tmp_path, monkeypatch):
+    # N1: _save_to_disk muss den Temp-File fsyncen, bevor os.replace ihn sichtbar
+    # macht (Durability). Wir prüfen, dass fsync tatsächlich aufgerufen wird.
+    import src.storage as storage_mod
+    fsync_calls = []
+    monkeypatch.setattr(storage_mod.os, "fsync", lambda fd: fsync_calls.append(fd))
+    s = Storage(str(tmp_path / "z.json"))
+
+    s.save("2026-05-14", [_slot("08:00", "16:00")])
+
+    assert fsync_calls, "os.fsync wurde beim Speichern nicht aufgerufen"
+
+
 def test_corrupt_json_is_quarantined_and_starts_empty(tmp_path, caplog):
     path = tmp_path / "test.json"
     path.write_text("{not valid json", encoding="utf-8")

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -5,7 +5,10 @@ import pytest
 from src.conflicts_store import ConflictsStore
 from src.settings import Settings
 from src.storage import Storage
-from src.sync import _merge_one, apply_merged_doc, build_local_doc, merge, resolve_conflict
+from src.sync import (
+    _merge_one, apply_merged_doc, build_local_doc, merge, resolve_conflict,
+    validate_remote_doc,
+)
 
 
 def _e(start, end, pause, modified_at, device_id="d", deleted=False):
@@ -406,6 +409,111 @@ def test_main_pull_returns_doc_when_valid_json():
     raw = _json.dumps({"schema_version": 1, "entries": {"D": {}}, "settings": {}, "conflicts": []})
     doc = _parse_remote_or_quarantine(raw.encode(), "file-1", lambda fid: None)
     assert "D" in doc["entries"]
+
+
+# --- validate_remote_doc (Audit M5) ---
+
+def _valid_remote_doc():
+    return {
+        "schema_version": 4,
+        "entries": {"2026-05-14": _e("08:00", "16:00", 30, "2026-05-14T10:00:00Z")},
+        "settings": {"recipient": {"value": "a@b.de", "modified_at": "2026-05-14T10:00:00Z",
+                                   "device_id": "d"}},
+        "conflicts": [],
+        "meta": {"gc_watermark": ""},
+    }
+
+
+def test_validate_accepts_valid_doc():
+    ok, reason = validate_remote_doc(_valid_remote_doc())
+    assert ok is True
+    assert reason == ""
+
+
+def test_validate_accepts_empty_doc():
+    ok, _ = validate_remote_doc({"entries": {}, "settings": {}, "conflicts": []})
+    assert ok is True
+
+
+def test_validate_rejects_non_dict():
+    ok, reason = validate_remote_doc(["not", "a", "doc"])
+    assert ok is False
+
+
+def test_validate_rejects_entry_missing_modified_at():
+    # Genau der Fall, der merge()/_merge_one mit KeyError abstürzen ließ.
+    doc = _valid_remote_doc()
+    del doc["entries"]["2026-05-14"]["modified_at"]
+    ok, reason = validate_remote_doc(doc)
+    assert ok is False
+    assert "modified_at" in reason or "Felder" in reason
+
+
+def test_validate_rejects_entry_missing_required_key():
+    doc = _valid_remote_doc()
+    del doc["entries"]["2026-05-14"]["device_id"]  # apply_merge würde ValueError werfen
+    ok, reason = validate_remote_doc(doc)
+    assert ok is False
+
+
+def test_validate_rejects_entry_modified_at_not_string():
+    doc = _valid_remote_doc()
+    doc["entries"]["2026-05-14"]["modified_at"] = 12345
+    ok, _ = validate_remote_doc(doc)
+    assert ok is False
+
+
+def test_validate_rejects_setting_missing_value():
+    doc = _valid_remote_doc()
+    del doc["settings"]["recipient"]["value"]
+    ok, reason = validate_remote_doc(doc)
+    assert ok is False
+    assert "value" in reason
+
+
+def test_validate_rejects_setting_missing_modified_at():
+    doc = _valid_remote_doc()
+    del doc["settings"]["recipient"]["modified_at"]
+    ok, _ = validate_remote_doc(doc)
+    assert ok is False
+
+
+def test_validate_rejects_conflict_without_id():
+    doc = _valid_remote_doc()
+    doc["conflicts"] = [{"kind": "entry", "key": "2026-05-14", "candidates": []}]
+    ok, reason = validate_remote_doc(doc)
+    assert ok is False
+    assert "id" in reason
+
+
+def test_validate_rejects_conflict_bad_kind():
+    doc = _valid_remote_doc()
+    doc["conflicts"] = [{"id": "c1", "kind": "bogus", "key": "x", "candidates": []}]
+    ok, _ = validate_remote_doc(doc)
+    assert ok is False
+
+
+def test_validate_rejects_conflicts_not_a_list():
+    doc = _valid_remote_doc()
+    doc["conflicts"] = {"nope": True}
+    ok, _ = validate_remote_doc(doc)
+    assert ok is False
+
+
+def test_invalid_remote_doc_would_crash_merge_but_validate_catches_it():
+    # Regression-Beleg: ohne Validierung wirft merge() KeyError, sobald BEIDE
+    # Seiten denselben Tag haben (nur-Remote short-circuitet vor dem Zugriff).
+    doc = _valid_remote_doc()
+    del doc["entries"]["2026-05-14"]["modified_at"]
+    local = {
+        "schema_version": 4,
+        "entries": {"2026-05-14": _e("07:00", "15:00", 0, "2026-05-14T09:00:00Z")},
+        "settings": {}, "conflicts": [],
+    }
+    with pytest.raises(KeyError):
+        merge(local, doc, "")
+    ok, _ = validate_remote_doc(doc)
+    assert ok is False
 
 
 def test_resolve_nonexistent_conflict_raises(tmp_path):

--- a/tests/test_sync_journal.py
+++ b/tests/test_sync_journal.py
@@ -1,0 +1,105 @@
+import json
+import os
+
+import pytest
+
+from src import sync_journal
+from src.conflicts_store import ConflictsStore
+from src.settings import Settings
+from src.storage import Storage
+
+
+def _stores(tmp_path):
+    storage = Storage(str(tmp_path / "zeiterfassung.json"), device_id="A")
+    settings = Settings(str(tmp_path / "settings.json"))
+    conflicts = ConflictsStore(str(tmp_path / "conflicts.json"))
+    return storage, settings, conflicts
+
+
+def _merged_doc():
+    return {
+        "schema_version": 4,
+        "entries": {
+            "2026-05-14": {
+                "slots": [{"start": "08:00", "end": "16:00", "pause": 30, "kategorie": ""}],
+                "modified_at": "2026-05-14T10:00:00Z", "device_id": "A", "deleted": False,
+            }
+        },
+        "settings": {
+            "recipient": {"value": "a@b.de", "modified_at": "2026-05-14T10:00:00Z",
+                          "device_id": "A"},
+        },
+        "conflicts": [{"id": "c1", "kind": "entry", "key": "2026-05-14",
+                       "candidates": [], "resolved": True, "resolution": None,
+                       "resolved_at": "2026-05-14T10:00:00Z", "resolved_by": "A"}],
+        "meta": {"gc_watermark": "2026-05-10T00:00:00Z"},
+    }
+
+
+def test_journaled_apply_writes_all_stores_and_removes_journal(tmp_path):
+    storage, settings, conflicts = _stores(tmp_path)
+    journal = str(tmp_path / sync_journal.JOURNAL_FILENAME)
+
+    sync_journal.apply_merged_doc_journaled(_merged_doc(), storage, settings, conflicts, journal)
+
+    assert not os.path.exists(journal)          # Journal nach Erfolg gelöscht
+    assert "2026-05-14" in storage.get_all_raw()
+    assert settings.get("recipient") == "a@b.de"
+    assert settings.get("gc_watermark") == "2026-05-10T00:00:00Z"
+    assert conflicts.get_all() == _merged_doc()["conflicts"]
+
+
+def test_recover_is_noop_without_journal(tmp_path):
+    storage, settings, conflicts = _stores(tmp_path)
+    journal = str(tmp_path / sync_journal.JOURNAL_FILENAME)
+    assert sync_journal.recover_pending_apply(journal, storage, settings, conflicts) is False
+
+
+def test_recover_applies_leftover_journal(tmp_path):
+    storage, settings, conflicts = _stores(tmp_path)
+    journal = tmp_path / sync_journal.JOURNAL_FILENAME
+    journal.write_text(json.dumps(_merged_doc()), encoding="utf-8")
+
+    recovered = sync_journal.recover_pending_apply(str(journal), storage, settings, conflicts)
+
+    assert recovered is True
+    assert "2026-05-14" in storage.get_all_raw()
+    assert settings.get("gc_watermark") == "2026-05-10T00:00:00Z"
+    assert not journal.exists()               # Journal nach Recovery gelöscht
+
+
+def test_crash_during_apply_leaves_journal_then_recovers(tmp_path, monkeypatch):
+    # Crash mitten in apply_merged_doc: der dritte Write (conflicts) wirft.
+    storage, settings, conflicts = _stores(tmp_path)
+    journal = str(tmp_path / sync_journal.JOURNAL_FILENAME)
+
+    def boom(*_a, **_k):
+        raise RuntimeError("simulierter Crash vor dem letzten Write")
+    monkeypatch.setattr(conflicts, "save_all", boom)
+
+    with pytest.raises(RuntimeError):
+        sync_journal.apply_merged_doc_journaled(_merged_doc(), storage, settings, conflicts, journal)
+
+    assert os.path.exists(journal)                 # Journal überlebt den Crash
+    assert settings.get("gc_watermark") == ""      # Write 4 kam nicht mehr dran (inkonsistent)
+
+    # „Neustart": frische Stores lesen den partiellen Disk-Stand, Recovery holt nach.
+    storage2, settings2, conflicts2 = _stores(tmp_path)
+    assert settings2.get("gc_watermark") == ""     # partieller Stand auf Platte
+    recovered = sync_journal.recover_pending_apply(journal, storage2, settings2, conflicts2)
+
+    assert recovered is True
+    assert settings2.get("gc_watermark") == "2026-05-10T00:00:00Z"  # jetzt konsistent
+    assert conflicts2.get_all() == _merged_doc()["conflicts"]
+    assert not os.path.exists(journal)
+
+
+def test_recover_discards_unreadable_journal(tmp_path):
+    storage, settings, conflicts = _stores(tmp_path)
+    journal = tmp_path / sync_journal.JOURNAL_FILENAME
+    journal.write_text("not json{{{", encoding="utf-8")
+
+    recovered = sync_journal.recover_pending_apply(str(journal), storage, settings, conflicts)
+
+    assert recovered is False
+    assert not journal.exists()               # kaputtes Journal verworfen

--- a/tests/test_time_calc.py
+++ b/tests/test_time_calc.py
@@ -109,6 +109,20 @@ def test_validate_slots_without_pause_ignores_pause():
     assert ok is True
 
 
+def test_validate_slots_rejects_non_numeric_pause():
+    # N7: nicht-numerische Pause darf keinen ValueError durchreichen, sondern
+    # eine saubere Validierungsmeldung liefern.
+    ok, msg = validate_slots([_s("08:00", "16:00", "abc")])
+    assert ok is False
+    assert "Pause" in msg
+
+
+def test_validate_slots_non_numeric_pause_ignored_without_pause():
+    # with_pause=False: die kaputte Pause wird gar nicht erst geparst.
+    ok, _ = validate_slots([_s("08:00", "16:00", "abc")], with_pause=False)
+    assert ok is True
+
+
 def test_validate_period_from_after_to_is_invalid():
     import datetime
     from src.time_utils import validate_period


### PR DESCRIPTION
Aggregierter PR über mehrere Data-/Sync-Layer-Punkte plus Robustheits-Kleinfixes aus dem Audit-Sammelissue #131.

## Store-Robustheit
- **M4** — korruptes `settings.json` → `.corrupt-<stamp>`-Quarantäne + Log statt still verwerfen (neuer `_quarantine_corrupt`-Helfer, deckt JSON-Fehler **und** non-dict-Toplevel; Rename wie `_save_to_disk` gegen `OSError` abgesichert).
- **N4** — `storage`/`reservations`/`conflicts_store` loggen ihr `.corrupt-<stamp>`-Quarantäne-Event jetzt (WARNING), spiegelt M4.
- **N3** — veralteter Modul-Docstring in `sync.py` auf `SCHEMA_VERSION = 4` (Slot-Struktur + `meta.gc_watermark`).
- **N5** — `settings.apply_synced` prüft Remote-Werte per `_coerce` gegen den DEFAULTS-Typ (kein `hourly_rate="foo"` mehr aus dem Sync).
- **N7** — `validate_slots` fängt nicht-numerische Pause ab (unabgefangener `ValueError` → saubere `(False, msg)`).
- **N1** — `fsync` (`f.flush()` + `os.fsync(fileno())`) vor `os.replace` in allen vier Stores → bei Stromausfall kann nicht das Rename durabel sein, die Datenblöcke aber nicht.

## Sync-Robustheit
- **M5** — neue pure `sync.validate_remote_doc(doc)` prüft die Merge-Invarianten (Pflichtfelder, `modified_at`-Typ, Conflict-`id`/`kind`) **nach** der Migration. Alle drei Sync-Flows (Pull/Push/Kompaktierung) behandeln ein invalides Remote-Doc wie korruptes JSON — Pull quarantänt das Drive-File, Push/Kompaktierung mergen leer weiter (lokaler Stand wird neue Remote-Wahrheit), statt mit `KeyError`/`ValueError` im generischen `except` zu landen. `_REQUIRED_ENTRY_KEYS` aus `storage.py` als Single Source of Truth importiert.
- **M6** — `apply_merged_doc` schrieb vier Stores nacheinander (einzeln atomar, Sequenz nicht → Crash dazwischen = inkonsistente Stores). Neues Modul `sync_journal`: Write-Ahead-Journal (`sync-apply.journal`, `fsync`-durable) klammert die vier Writes; beim Start holt `recover_pending_apply` ein übriggebliebenes Journal idempotent nach (alle vier Ops sind Full-Replace). Die drei Sync-Apply-Stellen laufen über `apply_merged_doc_journaled`, Boot-Recovery vor dem Start der Sync-Threads.
- **N2** — Wanduhr-Abhängigkeit des LWW-Merges (Sekunden-Auflösung + `>=`-Tie-Break bevorzugt Remote) direkt am Vergleich in `sync._merge_one` dokumentiert.

## Robustheit / Logging / Cleanup
- **N19** — `BackgroundTaskRunner.run` klammert `fn()` in `try/except`: wirft der Task unerwartet, loggt der Worker und `on_done` feuert **nicht** (kein halber Zustand, kein hängendes Status-Label).
- **N18** — scheitert `Popen` in `restart_for_scaling`, re-akquiriert der `except`-Zweig den Single-Instance-Guard (`acquire` + `serve`) statt ungeschützt weiterzulaufen; Fehler geloggt.
- **N13** — stumme `except Exception: pass` außerhalb des Sendepfads loggen jetzt auf `debug(..., exc_info=True)` (`mail.py`, `tray.py`); der bewusst stille Fall in `main.py` (Logging-Setup selbst gescheitert) trägt einen erklärenden Kommentar statt nacktem `pass`.
- **N16** — toter Code in `theme.py` entfernt (`RESERVATION_BG`/`_HOVER`, `dark_combo_editable`; das genutzte `RESERVATION_ACCENT` bleibt).

## Doku-Grenzen (nur Kommentare)
- **N15** — `OAUTHLIB_RELAX_TOKEN_SCOPE=1` als bewusste Sicherheits-Lockerung in `main.py` festgehalten (warum nötig, über `discard_token_for_scope_upgrade` abgesichert).
- **M9** — Update-Design-Grenze in `update_banner.py::_open_download` dokumentiert: keine Hash-/Signaturprüfung, aber die App lädt/startet nichts selbst (öffnet nur die Release-URL im Browser, Vertrauensanker TLS + GitHub); markiert explizit, dass ein späterer In-App-Auto-Download ohne Verifikation eine echte Lücke wäre.

## Verifikation
- Volle Suite **798 passed / 3 skipped**; `ruff check .` sauber; `pyright` 0/0.
- +26 Tests: Store-Quarantäne/Log, `apply_synced`-Coercion, `validate_slots`-Pause (M4/N3–N7); `fsync`-vor-`replace` (N1); `validate_remote_doc` inkl. Regressionsbeleg, dass `merge()` ohne Validierung `KeyError` wirft (M5); `sync_journal` inkl. simuliertem Crash + Recovery über frische Stores (M6); Worker-Exception-Auffangnetz (N19). Keine Test-Löschung.
- `src/CLAUDE.md` + Root-`CLAUDE.md` um `sync_journal`/`validate_remote_doc` ergänzt.

Bezug: #131 (M4, M5, M6, M9, N1, N2, N3, N4, N5, N7, N13, N15, N16, N18, N19).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
