### PR TITLE
ci: manueller Build-Workflow (build.yml) ohne Release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,126 @@
+name: Build
+
+# Manueller Test-Build eines beliebigen Branches OHNE Release (kein Tag, kein
+# Upload zu GitHub-Releases, kein Auto-Update-Effekt). Baut wie `build.py` die
+# reine App (PyInstaller-Ausgabe, ohne Installer-Pack-Schritt) und lädt sie als
+# Workflow-Artefakt hoch. Zweck: einen Branch in CI-identischer Umgebung
+# (Python 3.10 + gepinnte requirements.txt) bauen, ohne eine lokale venv zu
+# pflegen, die zur CI divergieren kann. Der Installer/Pack-Schritt (Inno Setup /
+# create-dmg / appimagetool) entfällt bewusst — `build.py` überspringt ihn
+# automatisch, wenn das jeweilige Pack-Tool fehlt, und lässt die reine
+# PyInstaller-Ausgabe stehen.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch/Tag/SHA zum Bauen (leer = Branch, aus dem der Lauf startet)"
+        type: string
+        required: false
+        default: ""
+      windows:
+        description: "Windows bauen (.exe)"
+        type: boolean
+        default: true
+      macos:
+        description: "macOS bauen (.app)"
+        type: boolean
+        default: false
+      linux:
+        description: "Linux bauen (Binary)"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  build-windows:
+    if: ${{ inputs.windows }}
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: pip install -r requirements.txt pip-licenses==5.5.5
+      # Kein Inno Setup installiert → build.py überspringt den Installer-Schritt
+      # und lässt die reine dist/Zeiterfassung.exe (onefile) stehen.
+      - name: Build (PyInstaller, ohne Installer)
+        run: python build.py
+      - name: dist auflisten
+        shell: bash
+        run: ls -la dist/
+      - uses: actions/upload-artifact@v7
+        with:
+          name: zeiterfassung-windows-exe
+          path: dist/Zeiterfassung.exe
+          if-no-files-found: error
+          retention-days: 14
+
+  build-macos:
+    if: ${{ inputs.macos }}
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: pip install -r requirements.txt pip-licenses==5.5.5
+      # Kein create-dmg installiert → build.py überspringt den DMG-Schritt und
+      # lässt das reine dist/Zeiterfassung.app (onedir-Bundle) stehen.
+      - name: Build (PyInstaller, ohne DMG)
+        run: python build.py
+      - name: dist auflisten
+        run: ls -la dist/
+      # Das .app-Bundle enthält Symlinks und Exec-Bits — ein nackter
+      # upload-artifact-Zip würde beides zerstören. tar bewahrt sie.
+      - name: App-Bundle packen (tar, bewahrt Symlinks/Exec-Bits)
+        run: tar -czf dist/Zeiterfassung-macos-app.tar.gz -C dist Zeiterfassung.app
+      - uses: actions/upload-artifact@v7
+        with:
+          name: zeiterfassung-macos-app
+          path: dist/Zeiterfassung-macos-app.tar.gz
+          if-no-files-found: error
+          retention-days: 14
+
+  build-linux:
+    if: ${{ inputs.linux }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.10'
+      # libcairo2-dev + pkg-config: pycairo (transitiv über xhtml2pdf) braucht die
+      # Cairo-Header beim pip-Build (sonst bricht die Installation). libfuse2 und
+      # appimagetool entfallen bewusst — kein AppImage-Pack.
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libcairo2-dev pkg-config
+      - name: Install Python dependencies
+        run: pip install -r requirements.txt pip-licenses==5.5.5
+      # Kein appimagetool installiert → build.py überspringt den AppImage-Schritt
+      # und lässt das reine dist/Zeiterfassung (onefile-Binary) stehen.
+      - name: Build (PyInstaller, ohne AppImage)
+        run: python build.py
+      - name: dist auflisten
+        run: ls -la dist/
+      # Exec-Bit bewahren (upload-artifact-Zip würde es verlieren).
+      - name: Binary packen (tar, bewahrt Exec-Bit)
+        run: tar -czf dist/Zeiterfassung-linux.tar.gz -C dist Zeiterfassung
+      - uses: actions/upload-artifact@v7
+        with:
+          name: zeiterfassung-linux-bin
+          path: dist/Zeiterfassung-linux.tar.gz
+          if-no-files-found: error
+          retention-days: 14

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,41 @@ python build.py
 
 Fehlt das Pack-Tool lokal, überspringt `build.py` den Pack-Schritt mit Warnung — der PyInstaller-Build läuft trotzdem durch. Das ist für Local-Dev gewollt.
 
+## Manueller CI-Build ohne Release (`build.yml`)
+
+Für einen reinen Test-Build eines Branches — **ohne** Tag, Release oder
+Auto-Update-Effekt — gibt es den Workflow **Build** (`.github/workflows/build.yml`):
+Actions → **Build** → „Run workflow". Er baut in **CI-identischer Umgebung**
+(Python 3.10 + gepinnte `requirements.txt`), sodass man einen Stand verifizieren
+kann, ohne eine lokale venv zu pflegen, die zur CI divergiert (Vorbild für das
+Divergenz-Problem: der lokale Frozen-Build scheiterte auf Python 3.13/3.14 an
+fehlenden gebündelten Datendateien — die CI auf 3.10 spiegelt die echte
+Release-Umgebung).
+
+- **Inputs:** `windows`/`macos`/`linux` als Häkchen (mindestens eins, maximal
+  alle; Default nur Windows) + optionaler `ref` (Branch/Tag/SHA; leer = der
+  Branch, aus dem der Lauf startet).
+- **Ausgabe = reine App** (kein Installer): `build.py` läuft ohne Inno Setup /
+  create-dmg / appimagetool, überspringt also den Pack-Schritt und lädt die
+  nackte PyInstaller-Ausgabe als **Workflow-Artefakt** hoch — Windows
+  `Zeiterfassung.exe`, macOS `Zeiterfassung.app` und Linux-Binary als `.tar.gz`
+  (tar bewahrt Symlinks/Exec-Bits, die ein Zip zerstören würde). `retention-days: 14`.
+- **Kanal-Stempel:** kein `ZEIT_RELEASE`/`ZEIT_PRERELEASE` → `build.py` stempelt
+  `CHANNEL=dev` + Commit-SHA; der In-App-Titel zeigt damit den exakt gebauten Commit.
+- **Abgrenzung zum (Pre-)Release:** `build.yml` erzeugt **keinen** Tag und
+  **kein** GitHub-Release. Wer testbare, installierbare Artefakte (Setup.exe/DMG/
+  AppImage) oder einen plattformübergreifenden Vorab-Stand für andere Nutzer will,
+  nimmt weiter den **Pre-Release** aus `release.yml` (s. „Release-Prozess").
+
+**Default-Branch-Eigenheit:** `workflow_dispatch` ist erst dispatchbar, wenn
+`build.yml` auf dem **Default-Branch** (`master`) liegt — vorher liefert
+`gh workflow run build.yml …` ein `HTTP 404: workflow not found on the default
+branch`, und der „Run workflow"-Knopf fehlt. Solange der Workflow nur auf einem
+Feature-Branch existiert, lässt er sich ausschließlich aus diesem Branch heraus
+starten (in der Actions-UI den Branch im „Run workflow"-Dropdown wählen). Der
+`ref`-Input entfaltet seinen Nutzen — einen *beliebigen* Branch bauen, der
+`build.yml` selbst nicht trägt — daher erst nach dem Merge nach `master`.
+
 ## Abhängigkeiten & Pinning
 
 Die **direkten** Abhängigkeiten in `requirements.txt` sind exakt (`==`) auf


### PR DESCRIPTION
Eigenständiger `workflow_dispatch`-Build **ohne Release**, herausgelöst aus den Build-Jobs von `release.yml` (aber ohne Tag/Publish). Baut einen wählbaren Branch in **CI-identischer Umgebung** (Python 3.10 + gepinnte `requirements.txt`) und lädt die reine PyInstaller-App als **Workflow-Artefakt** hoch — so lässt sich ein Stand auf Windows/macOS/Linux verifizieren, ohne eine lokale venv zu pflegen, die zur CI divergieren kann.

## Motivation
Der lokale Frozen-Build scheiterte auf Python 3.13/3.14 an fehlenden gebündelten Datendateien (`drive.v3.json`, CA-Certs) → Sync/Feiertage im Artefakt kaputt. Die CI auf 3.10 spiegelt die echte Release-Umgebung; ein Test-Build dort ist verlässlich, ohne dass man erst ein echtes (Pre-)Release anlegen muss.

## Was der Workflow tut
- **Inputs:** `windows`/`macos`/`linux` als Häkchen (mind. eins, max. alle; Default nur Windows) + optionaler `ref` (Branch/Tag/SHA; leer = der Branch, aus dem der Lauf startet).
- **Ausgabe = reine App** (kein Installer): `build.py` läuft ohne Inno Setup / create-dmg / appimagetool, überspringt den Pack-Schritt und lädt die nackte PyInstaller-Ausgabe hoch — Windows `Zeiterfassung.exe`, macOS `Zeiterfassung.app` und Linux-Binary als `.tar.gz` (tar bewahrt Symlinks/Exec-Bits). `retention-days: 14`.
- **Kanal-Stempel:** kein `ZEIT_RELEASE`/`ZEIT_PRERELEASE` → `build.py` stempelt `CHANNEL=dev` + Commit-SHA (In-App-Titel zeigt den exakt gebauten Commit).
- **Abgrenzung:** erzeugt **keinen** Tag und **kein** GitHub-Release. Für installierbare Artefakte / plattformübergreifende Vorab-Stände bleibt der Pre-Release aus `release.yml` zuständig.
- `permissions: contents: read` (kein Release-Write).

## Verifikation
Live getestet im Fork: [Run 28819284828](https://github.com/Xveyn/Zeiterfassung/actions/runs/28819284828) — `build-windows` grün (checkout → setup-python 3.10 → `pip install -r requirements.txt` → `python build.py` → Artefakt `Zeiterfassung.exe`, ~52 MB), macOS/Linux korrekt übersprungen.

## Doku
Neue Sektion in `CLAUDE.md` („Manueller CI-Build ohne Release (`build.yml`)") inkl. der `workflow_dispatch`-Default-Branch-Eigenheit (dispatchbar erst, wenn `build.yml` auf `master` liegt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
