### PR TITLE
fix(ui): Fensterbreite ratcht bei lohnabhängigem Footer statt zu springen

### DIFF
--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -54,7 +54,13 @@ Rendering der Monats-/Wochenansicht inkl. Double-Buffer und Fenster-Geometrie.
   `refresh()`, beim Wechsel der Footer-Reservierungsbreite (Stundenlohn zur Laufzeit
   gesetzt/entfernt — `_update_footer` reserviert 16 vs. 40 Zeichen, s.u.) **und** extern vom
   `UpdateBanner` (als `on_resize`), dessen Ein-/Ausblenden die nötige Höhe ändert, ohne
-  View/Spalten zu wechseln. `resizable(False, False)` bleibt.
+  View/Spalten zu wechseln. `resizable(False, False)` bleibt. Die **Breite ratcht**:
+  `_fixed_width` wächst mit der breitesten je angeforderten reqwidth mit, schrumpft aber nie
+  wieder — startet die App ohne Lohn (schmaler Footer, `measure_max_width` pinnt schmal) und
+  der Nutzer trägt später einen Lohn ein, wächst das Fenster einmalig auf die breite Variante
+  und bleibt dort. Ohne Ratchet spränge es bei jedem Lohn-Ein/Aus zwischen schmal und breit
+  (Test: `tests/test_grid_geometry.py`). Die Höhe ratcht bewusst nicht (Banner braucht beide
+  Richtungen).
 - `_fmt_slot_line` ist `@staticmethod`; `App._delete_day` ruft es als
   `GridRenderer._fmt_slot_line(...)` (bleibt in App, nutzt aber den Renderer-Static).
 

--- a/src/grid_renderer.py
+++ b/src/grid_renderer.py
@@ -143,10 +143,21 @@ class GridRenderer:
         unter dem fixen Fenster über (#92). Das Fenster bleibt
         resizable(False, False); gewachsen/geschrumpft wird nur kontrolliert
         hier. Während der Vorab-Messung (measure_max_width) unterdrückt
-        _suppress_geometry den Resize."""
+        _suppress_geometry den Resize.
+
+        Die Breite **ratcht**: _fixed_width wächst mit der breitesten je
+        angeforderten reqwidth mit, schrumpft aber nie wieder. Grund: der Footer
+        ist ohne Stundenlohn schmal (width=16) und mit Lohn breit (width=40,
+        s. _update_footer). Startet die App ohne Lohn, pinnt measure_max_width
+        die schmale Breite; trägt der Nutzer später einen Lohn ein, wächst das
+        Fenster hier einmalig auf die breite Variante. Ohne Ratchet würde es beim
+        Entfernen des Lohns wieder zurückschrumpfen und bei jedem Lohn-Ein/Aus
+        zwischen schmal und breit springen. Die Höhe ratcht bewusst NICHT (das
+        Update-Banner braucht sie in beide Richtungen)."""
         self._root.update_idletasks()
         if not self._suppress_geometry:
             width = max(self._fixed_width or 0, self._root.winfo_reqwidth())
+            self._fixed_width = width
             self._root.geometry(f"{width}x{self._root.winfo_reqheight()}")
 
     def measure_max_width(self, view_mode: str, year: int, month: int,

--- a/tests/test_grid_geometry.py
+++ b/tests/test_grid_geometry.py
@@ -1,0 +1,55 @@
+"""repin_geometry: die fixe Fensterbreite ratcht (waechst mit, schrumpft nie).
+
+Hintergrund: ohne Stundenlohn ist der Footer schmal, mit Lohn breit
+(_update_footer, width 16 vs 40). Startet die App ohne Lohn, pinnt
+measure_max_width die schmale Breite. Traegt der Nutzer spaeter einen Lohn ein,
+wird der Footer breit und repin_geometry waechst das Fenster. Entfernt er ihn
+wieder, darf das Fenster NICHT zurueckschrumpfen — sonst springt die Breite bei
+jedem Lohn-Ein/Aus. Tk-frei ueber ein gemocktes root."""
+
+from unittest.mock import MagicMock
+
+from src.grid_renderer import GridRenderer
+
+
+def _renderer_with_root(reqwidth, reqheight=400):
+    root = MagicMock()
+    root.winfo_reqwidth.return_value = reqwidth
+    root.winfo_reqheight.return_value = reqheight
+    settings = MagicMock(get=lambda k, d=None: d)
+    r = GridRenderer(
+        root=root, storage=object(), settings=settings,
+        reservation_store=None, conflicts_store=None,
+        on_cell_click=lambda d: None, on_cell_right_click=lambda d: None,
+        reservations_active=lambda: False,
+    )
+    return r, root
+
+
+def test_repin_grows_and_pins_wide_footer():
+    r, root = _renderer_with_root(reqwidth=721)
+    r._fixed_width = 552  # measure_max_width hat schmal gepinnt (Start ohne Lohn)
+    r.repin_geometry()
+    assert r._fixed_width == 721
+    root.geometry.assert_called_once_with("721x400")
+
+
+def test_repin_does_not_shrink_below_widest_seen():
+    r, root = _renderer_with_root(reqwidth=721)
+    r._fixed_width = 552
+    r.repin_geometry()  # Lohn gesetzt -> breit (721)
+
+    # Lohn wieder entfernt: reqwidth faellt zurueck auf schmal, Fenster bleibt breit
+    root.winfo_reqwidth.return_value = 482
+    r.repin_geometry()
+    assert r._fixed_width == 721
+    assert root.geometry.call_args_list[-1].args[0] == "721x400"
+
+
+def test_repin_suppressed_during_measure_leaves_geometry_untouched():
+    r, root = _renderer_with_root(reqwidth=721)
+    r._fixed_width = 552
+    r._suppress_geometry = True
+    r.repin_geometry()
+    root.geometry.assert_not_called()
+    assert r._fixed_width == 552  # kein Ratchet waehrend der Vorab-Messung


### PR DESCRIPTION
## Problem

Trägt man einen Stundenlohn ein, ändert das Hauptfenster die Breite. Ohne Lohn ist der Footer schmal (`_update_footer` → `width=16`), mit Lohn breit (`width=40`, „Gesamt: Xh — Y € brutto"). `measure_max_width` pinnt `_fixed_width` mit dem beim **Start** gesetzten Lohn:

- Start **ohne** Lohn → `_fixed_width = 552px` (schmal).
- Lohn eintragen → Footer breit → `repin_geometry` wächst auf 721px.
- Lohn entfernen → schrumpft **zurück** auf 552px.

`repin_geometry` nutzte `max(_fixed_width, reqwidth)`, schrieb `_fixed_width` aber nicht fort → das Fenster sprang bei jedem Lohn-Ein/Aus zwischen schmal und breit.

## Fix

`repin_geometry` **ratcht** `_fixed_width` jetzt hoch (breiteste je angeforderte reqwidth), schrumpft aber nie mehr:

- Ohne Lohn bleibt das Fenster schmal.
- Beim ersten Lohn-Eintrag wächst es **einmalig** und bleibt dann stabil.
- Die Höhe ratcht bewusst **nicht** (Update-Banner braucht beide Richtungen).

Verifiziert mit der echten App: `552 → 721 → 721 → 721` über Lohn setzen/entfernen/setzen.

## Tests

Neu `tests/test_grid_geometry.py` (Tk-frei über gemocktes `root`): Grow, No-Shrink-below-widest-seen, Suppress-during-measure. Gesamt-Suite lokal grün (775 passed, 3 skipped), `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
