### PR TITLE
fix(audit): Sammel-Cleanup M2a/M11/M12/N20/N29 (#131)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,10 @@ line-length = 100
 # Kuratierter Default: pyflakes (F, echte Bugs wie unused/undefined) plus die
 # semantisch relevanten pycodestyle-Gruppen E4/E7/E9. Bewusst OHNE Whitespace-/
 # Zeilenlängen-Regeln (E1/E2/E3/E501) — das ist Formatter-Sache, kein Gate.
-select = ["E4", "E7", "E9", "F"]
+# B (flake8-bugbear): billiges Bug-Netz für Callback-/Threading-Code — fängt
+# u.a. zip() ohne strict=, verschluckte Exception-Ketten (raise ohne from) und
+# ungenutzte Loop-Variablen (Audit N29).
+select = ["E4", "E7", "E9", "F", "B"]
 
 [tool.ruff.lint.per-file-ignores]
 # Test-Dateien gruppieren Imports bewusst vor den zugehörigen Test-Blöcken

--- a/src/dialogs/category_dialog.py
+++ b/src/dialogs/category_dialog.py
@@ -205,7 +205,7 @@ def open_category_dialog(parent, settings, on_change=None):
             row=0, column=1, padx=6)
         tk.Label(daygrid, text="Ende", font=FONT, bg=BG, fg=TEXT_MUTED).grid(
             row=0, column=2, padx=6)
-        for i, (key, lbl) in enumerate(zip(WEEKDAY_KEYS, DAYS_DE), start=1):
+        for i, (key, lbl) in enumerate(zip(WEEKDAY_KEYS, DAYS_DE, strict=False), start=1):
             tk.Label(daygrid, text=lbl, font=FONT, bg=BG, fg=TEXT,
                      width=4, anchor="w").grid(row=i, column=0, padx=(2, 8),
                                                pady=1, sticky="w")
@@ -267,7 +267,7 @@ def open_category_dialog(parent, settings, on_change=None):
         # 7-Tage-Grid — Sichtbarkeit via _apply_mode
         day_vars = {}
         day_frame = tk.Frame(container, bg=BG)
-        for i, (key, lbl) in enumerate(zip(WEEKDAY_KEYS, DAYS_DE)):
+        for i, (key, lbl) in enumerate(zip(WEEKDAY_KEYS, DAYS_DE, strict=False)):
             d = (defaults["days"] or {}).get(key) or {}
             sv = tk.StringVar(value=d.get("start") or STANDARD)
             ev = tk.StringVar(value=d.get("end") or STANDARD)

--- a/src/dialogs/entry_dialog.py
+++ b/src/dialogs/entry_dialog.py
@@ -11,7 +11,7 @@ from src.theme import (
     primary_button, secondary_button,
     set_primary_button_enabled, themed_askyesno, themed_showinfo,
 )
-from src.time_utils import format_iso_weekday_date, get_week_label, validate_slots
+from src.time_utils import format_date, format_iso_weekday_date, get_week_label, validate_slots
 from src.weekly_limit import check_week_limit
 
 # Kategorie am Slot: "" = keine Kategorie. Das Dropdown ist readonly (Anlegen/
@@ -76,7 +76,7 @@ def open_entry_dialog(parent, date_str, storage, settings, on_change,
         if state:
             feiertage = get_holidays(state, day.year)
             if day in feiertage:
-                date_de = day.strftime("%d.%m.%Y")
+                date_de = format_date(day)
                 confirm = themed_askyesno(
                     parent, "Feiertag",
                     f"Der {date_de} ist {feiertage[day]} (Feiertag).\n\n"

--- a/src/dialogs/export_dialog.py
+++ b/src/dialogs/export_dialog.py
@@ -2,7 +2,7 @@ import tkinter as tk
 from tkinter import filedialog, messagebox
 
 from src.report import default_pdf_filename
-from src.time_utils import validate_period
+from src.time_utils import format_date, validate_period
 from src.dialogs.period_picker import build_period_picker
 from src.dialogs.export_task import perform_export_pdf
 from src.theme import (
@@ -82,8 +82,8 @@ def open_export_dialog(parent, storage, settings, runner):
             if pdf_bytes is None:
                 themed_showinfo(
                     dialog, "Keine Einträge",
-                    f"Keine Einträge für {date_from.strftime('%d.%m.%Y')} – "
-                    f"{date_to.strftime('%d.%m.%Y')} vorhanden.",
+                    f"Keine Einträge für {format_date(date_from)} – "
+                    f"{format_date(date_to)} vorhanden.",
                 )
                 return
 

--- a/src/dialogs/import_dialog.py
+++ b/src/dialogs/import_dialog.py
@@ -17,7 +17,7 @@ from src.share import (
     diff_share_against_local,
     parse_share_doc,
 )
-from src.time_utils import format_iso_date
+from src.time_utils import format_date, format_iso_date
 from src.theme import (
     BG, CELL_BG, FONT, FONT_SMALL, TEXT, TEXT_MUTED,
     apply_combobox_style, attach_unfocus_on_click, center_dialog_on_parent,
@@ -159,8 +159,8 @@ class _ImportSummaryDialog:
         tk.Label(
             self.top,
             text=f"Voller Bereich der Datei: "
-                 f"{self.file_min.strftime('%d.%m.%Y')} bis "
-                 f"{self.file_max.strftime('%d.%m.%Y')}",
+                 f"{format_date(self.file_min)} bis "
+                 f"{format_date(self.file_max)}",
             font=FONT_SMALL, bg=BG, fg=TEXT_MUTED,
         ).grid(row=row, column=0, columnspan=6, padx=10, pady=(0, 8), sticky="w")
         row += 1

--- a/src/dialogs/send_dialog.py
+++ b/src/dialogs/send_dialog.py
@@ -15,7 +15,7 @@ from src.theme import (
     set_button_text, set_primary_button_enabled,
     themed_showerror, themed_showinfo,
 )
-from src.time_utils import validate_period
+from src.time_utils import format_date, validate_period
 
 
 def show_missing_credentials_dialog(parent, base_path):
@@ -112,11 +112,11 @@ def open_send_dialog(parent, storage, settings, base_path, runner):
         if html is None:
             themed_showinfo(
                 dialog, "Keine Einträge",
-                f"Keine Einträge für {date_from.strftime('%d.%m.%Y')} – {date_to.strftime('%d.%m.%Y')} vorhanden.",
+                f"Keine Einträge für {format_date(date_from)} – {format_date(date_to)} vorhanden.",
             )
             return
 
-        label = f"{date_from.strftime('%d.%m.%Y')} – {date_to.strftime('%d.%m.%Y')}"
+        label = f"{format_date(date_from)} – {format_date(date_to)}"
         subject = (
             settings.get("mail_subject")
             .replace("{zeitraum}", label)

--- a/src/dialogs/settings_dialog/dialog.py
+++ b/src/dialogs/settings_dialog/dialog.py
@@ -74,7 +74,7 @@ def open_settings_dialog(parent, settings, base_path, on_change, *,
     tabs = {"work": work.frame, "mail": mail.frame, "google": google.frame, "app": app.frame}
 
     def save_settings():
-        for key, lbl in zip(WEEKDAY_KEYS, DAYS_DE):
+        for key, lbl in zip(WEEKDAY_KEYS, DAYS_DE, strict=False):
             ok, msg = validate_entry(work.start_vars[key].get(), work.end_vars[key].get())
             if not ok:
                 notebook.select(tabs["work"])

--- a/src/dialogs/settings_dialog/tab_work.py
+++ b/src/dialogs/settings_dialog/tab_work.py
@@ -30,7 +30,7 @@ class WorkTab:
 
         start_vars = {}
         end_vars = {}
-        for i, (key, lbl) in enumerate(zip(WEEKDAY_KEYS, DAYS_DE), start=1):
+        for i, (key, lbl) in enumerate(zip(WEEKDAY_KEYS, DAYS_DE, strict=False), start=1):
             tk.Label(times_frame, text=lbl, font=FONT, bg=BG, fg=TEXT, width=3, anchor="w").grid(
                 row=i, column=0, padx=(0, 8), pady=2)
             start_vars[key] = tk.StringVar(value=settings.get(f"default_start_{key}"))

--- a/src/drive.py
+++ b/src/drive.py
@@ -23,10 +23,6 @@ class DriveNetworkError(Exception):
     """Netzwerkproblem oder Drive-API nicht erreichbar."""
 
 
-class DriveConflictError(Exception):
-    """ETag-Mismatch beim Upload — Remote wurde inzwischen verändert."""
-
-
 try:
     from google.auth.exceptions import RefreshError, TransportError
     from google.auth.transport.requests import Request
@@ -169,7 +165,7 @@ def download(service, file_id):
     return buf.getvalue(), str(meta.get("version", ""))
 
 
-def upload(service, content_bytes, file_id=None, expected_etag=None):
+def upload(service, content_bytes, file_id=None):
     """Uploadet `content_bytes` als Sync-Datei.
 
     - file_id=None  → neues File in appDataFolder anlegen
@@ -177,10 +173,11 @@ def upload(service, content_bytes, file_id=None, expected_etag=None):
 
     Drive API v3 kennt kein `etag`-Feld mehr und unterstützt kein
     granulares If-Match auf Datei-Updates ohne HTTP-Header-Tricks, die
-    googleapiclient nicht sauber freilegt. Die `expected_etag`-Signatur
-    bleibt aus Kompatibilitätsgründen erhalten, wird aber ignoriert.
-    Konflikt-Erkennung passiert pro-Eintrag über `modified_at` im
-    Sync-Doc-Merge, nicht auf File-Ebene.
+    googleapiclient nicht sauber freilegt. Es gibt daher bewusst KEIN
+    File-level Optimistic Locking hier — Konflikt-Erkennung passiert
+    stattdessen im Push-Flow (`main.py::_run_push_blocking`) doc-level über
+    `sync._remote_is_newer` und pro-Eintrag über `modified_at` im
+    Sync-Doc-Merge (Audit M2).
 
     Liefert (file_id, new_version_token).
     """
@@ -201,11 +198,4 @@ def upload(service, content_bytes, file_id=None, expected_etag=None):
         ).execute()
         return resp["id"], str(resp.get("version", ""))
     except HttpError as e:
-        # googleapiclient's HttpError trägt e.resp (httplib2.Response) — der
-        # Fallback oben aliased HttpError auf Exception, daher kennt Pylance
-        # das Attribut nicht statisch. getattr() umgeht das sauber.
-        resp_obj = getattr(e, "resp", None)
-        status = getattr(resp_obj, "status", None) if resp_obj is not None else None
-        if status == 412:
-            raise DriveConflictError(str(e)) from e
         raise _http_error_to_drive_error(e) from e

--- a/src/grid_renderer.py
+++ b/src/grid_renderer.py
@@ -164,26 +164,25 @@ class GridRenderer:
                           iso_year: int, current_week: int):
         """Pre-warm: rendert alle 4 (view × show_weekend)-Kombinationen einmal
         in den versteckten Backbuffer und merkt die maximale reqwidth intern
-        (self._fixed_width). show_weekend wird über _data temporär mutiert
-        (kein Disk-Save) und wiederhergestellt; _suppress_geometry verhindert
-        den Resize während der Messung. Läuft vor mainloop()."""
-        saved_weekend = self._settings.get("show_weekend")
+        (self._fixed_width). show_weekend wird über settings.override_in_memory
+        temporär verstellt (kein Disk-Save, danach wiederhergestellt);
+        _suppress_geometry verhindert den Resize während der Messung. Läuft vor
+        mainloop()."""
         max_w = 0
         self._suppress_geometry = True
         try:
             for view in ("month", "week"):
                 for weekend in (True, False):
-                    self._settings._data["show_weekend"] = weekend
-                    self._last_refresh_view = None
-                    self._last_refresh_columns = None
-                    self.refresh(view, year, month, iso_year, current_week)
-                    self._root.update_idletasks()
-                    w = self._root.winfo_reqwidth()
-                    if w > max_w:
-                        max_w = w
+                    with self._settings.override_in_memory("show_weekend", weekend):
+                        self._last_refresh_view = None
+                        self._last_refresh_columns = None
+                        self.refresh(view, year, month, iso_year, current_week)
+                        self._root.update_idletasks()
+                        w = self._root.winfo_reqwidth()
+                        if w > max_w:
+                            max_w = w
         finally:
             self._suppress_geometry = False
-            self._settings._data["show_weekend"] = saved_weekend
             self._last_refresh_view = None
             self._last_refresh_columns = None
         self._fixed_width = max_w
@@ -256,7 +255,7 @@ class GridRenderer:
         return f"{slot['start']}-{slot['end']}{kat}"
 
     @staticmethod
-    def _build_tooltip_text(entry, reservation, holiday_name):
+    def _build_tooltip_text(entry, reservation, holiday_name, has_conflict=False):
         """Baut den kombinierten Hover-Tooltip aus den vorhandenen Einheiten.
 
         Reine Funktion (Tk-frei, testbar): entscheidet, WELCHE Blöcke der
@@ -269,6 +268,12 @@ class GridRenderer:
         Der Feiertag kommt nur in den kombinierten Tooltip, wenn ohnehin ein
         Eintrag oder eine Reservierung vorhanden ist (sonst zeigt die Holiday-
         Zelle ihren Namen selbst).
+
+        has_conflict: ist der Tag ein ungelöster Sync-Konflikt, wird der
+        Konflikt-Hinweis in DENSELBEN Tooltip gefaltet (Audit M11) — früher
+        hängte der Konflikt-Zweig einen ZWEITEN attach_tooltip an dieselbe
+        Zelle, was den 'genau EIN Tooltip pro Zelle'-Invariant verletzte und
+        die Arbeitszeit-Details verdeckte.
         """
         parts = []
         if entry and entry.get("slots"):
@@ -284,6 +289,8 @@ class GridRenderer:
                     for s in reservation.get("slots", [])))
         if holiday_name and (reservation is not None or entry):
             parts.append(f"Feiertag: {holiday_name}")
+        if has_conflict:
+            parts.append("Konflikt — bitte auflösen")
         return "\n".join(parts)
 
     def _add_reservation_marker(self, cell):
@@ -400,16 +407,18 @@ class GridRenderer:
         # Reservierung ist ein reiner Overlay-Marker (Eck-Punkt) — sie ändert
         # den Zelltyp nicht. Genau EIN attach_tooltip pro Zelle (Mehrfachaufruf
         # erzeugt überlappende Tooltips); deshalb alle relevanten Infos
-        # (Arbeitszeit-Slots, Reservierung, Feiertag) in einen kombinierten
-        # Tooltip (Textaufbau in _build_tooltip_text). Ein Feiertag-OHNE-
-        # Eintrag/-Reservierung zeigt seinen Namen weiterhin als Zelltext
+        # (Arbeitszeit-Slots, Reservierung, Feiertag, Konflikt-Hinweis) in einen
+        # kombinierten Tooltip (Textaufbau in _build_tooltip_text). Ein Feiertag-
+        # OHNE-Eintrag/-Reservierung zeigt seinen Namen weiterhin als Zelltext
         # (Holiday-Zelle) bzw. eigenen Tooltip (name_tooltip) und kommt hier
         # NICHT rein.
+        has_conflict = bool(conflict_dates and date_str in conflict_dates)
         if reservation is not None:
             self._add_reservation_marker(cell)
         tip_text = self._build_tooltip_text(
             entry, reservation,
-            holidays_map[day_date] if is_holiday else None)
+            holidays_map[day_date] if is_holiday else None,
+            has_conflict=has_conflict)
         if tip_text:
             attach_tooltip(cell, tip_text)
 
@@ -427,9 +436,11 @@ class GridRenderer:
         if day_date == datetime.date.today():
             cell.configure(highlightbackground=TODAY_ACCENT, highlightthickness=2)
 
-        if conflict_dates and date_str in conflict_dates:
+        # Der Konflikt-Hinweis steckt bereits im kombinierten Tooltip oben
+        # (has_conflict → _build_tooltip_text, Audit M11); hier nur noch der
+        # orange Rand als visuelle Markierung, KEIN zweiter attach_tooltip.
+        if has_conflict:
             cell.configure(highlightbackground="orange", highlightthickness=2)
-            attach_tooltip(cell, "Konflikt — bitte auflösen")
 
         return cell
 

--- a/src/main.py
+++ b/src/main.py
@@ -233,7 +233,7 @@ def _run_push_blocking(storage, settings, conflicts_store, base, timeout_seconds
                         os.path.join(base, sync_journal.JOURNAL_FILENAME))
                     doc = sync.build_local_doc(storage, settings, conflicts_store)
                     content = json.dumps(doc, ensure_ascii=False).encode("utf-8")
-                new_id, new_etag = drive.upload(service, content, file_id, expected_etag="")
+                new_id, new_etag = drive.upload(service, content, file_id)
                 settings.set_many({
                     "last_pull_at": sync._utc_now_iso(),
                     "drive_etag": new_etag,
@@ -330,7 +330,7 @@ def _run_compaction_blocking(storage, settings, conflicts_store, base, timeout_s
                     # 3) kompaktiertes Doc für den Upload snapshotten
                     doc = sync.build_local_doc(storage, settings, conflicts_store)
                     payload = json.dumps(doc, ensure_ascii=False).encode("utf-8")
-                new_id, new_etag = drive.upload(service, payload, file_id, expected_etag="")
+                new_id, new_etag = drive.upload(service, payload, file_id)
                 settings.set("drive_etag", new_etag)
                 result.update({"ok": True})
             except Exception as e:

--- a/src/report.py
+++ b/src/report.py
@@ -3,7 +3,7 @@ import html
 import io
 from collections import OrderedDict
 
-from src.time_utils import DAYS_DE, calculate_hours, get_week_label
+from src.time_utils import DAYS_DE, calculate_hours, format_date, get_week_label
 
 
 def _esc(text):
@@ -170,7 +170,7 @@ def _week_block(iso_year, iso_week, week_entries, style):
     for idx, (date_str, entry) in enumerate(week_entries):
         dt = datetime.date.fromisoformat(date_str)
         weekday = DAYS_DE[dt.weekday()]
-        day_fmt = dt.strftime("%d.%m.%Y")
+        day_fmt = format_date(dt)
         row_bg = s["row_a"] if idx % 2 == 0 else s["row_b"]
         td = s["td_base"]
         slots = entry["slots"]
@@ -223,7 +223,7 @@ def _build_table(groups, style):
 
     th_cells = "".join(
         f'<th style="{s["th_cell"]}{f"width:{w};" if w else ""}">{label}</th>'
-        for label, w in zip(COLUMN_LABELS, s["col_widths"])
+        for label, w in zip(COLUMN_LABELS, s["col_widths"], strict=False)
     )
 
     table = (
@@ -296,7 +296,7 @@ def generate_report(date_from, date_to, all_entries, greeting="", content="",
     if not range_entries:
         return None, 0
 
-    label = f"{date_from.strftime('%d.%m.%Y')} – {date_to.strftime('%d.%m.%Y')}"
+    label = f"{format_date(date_from)} – {format_date(date_to)}"
     groups = _group_by_week(range_entries)
     table, total = _build_table(groups, HTML_STYLE)
     category_summary = (
@@ -342,7 +342,7 @@ def generate_pdf(date_from, date_to, all_entries, name="", categories=None,
     if not range_entries:
         return None
 
-    label = f"{date_from.strftime('%d.%m.%Y')} – {date_to.strftime('%d.%m.%Y')}"
+    label = f"{format_date(date_from)} – {format_date(date_to)}"
     groups = _group_by_week(range_entries)
     table, _ = _build_table(groups, PDF_STYLE)
     category_summary = (

--- a/src/reservations.py
+++ b/src/reservations.py
@@ -81,7 +81,7 @@ class ReservationStore:
             if mtime is not None
             else _utc_now_iso()
         )
-        for date, entry in list(self._data.items()):
+        for _date, entry in list(self._data.items()):
             if not isinstance(entry, dict):
                 continue
             if "slots" in entry:

--- a/src/settings.py
+++ b/src/settings.py
@@ -1,3 +1,4 @@
+import contextlib
 import datetime
 import json
 import logging
@@ -300,6 +301,29 @@ class Settings:
         with self._lock:
             self._data.update(updates)
             self._save_to_disk()
+
+    @contextlib.contextmanager
+    def override_in_memory(self, key, value):
+        """Überschreibt `key` NUR im Speicher (kein Disk-Save) für die Dauer
+        des with-Blocks und stellt den vorherigen Zustand danach wieder her.
+
+        Für transiente Mess-/Pre-Warm-Szenarien (GridRenderer.measure_max_width
+        variiert show_weekend, um die maximale Fensterbreite zu proben), die
+        einen Setting kurzzeitig verstellen müssen, ohne settings.json zu
+        schreiben. Nicht für persistente Änderungen — dafür set()/set_many().
+        Kapselt den früher direkten Zugriff auf `_data` von außen (Audit M12)."""
+        with self._lock:
+            had_key = key in self._data
+            previous = self._data.get(key)
+            self._data[key] = value
+        try:
+            yield
+        finally:
+            with self._lock:
+                if had_key:
+                    self._data[key] = previous
+                else:
+                    self._data.pop(key, None)
 
     def set_synced(self, key, value):
         """Setzt einen whitelisted Sync-Key und stempelt Per-Field-Metadaten.

--- a/src/share.py
+++ b/src/share.py
@@ -53,7 +53,8 @@ def _validate_time(date_str, label, value):
     try:
         datetime.time.fromisoformat(value)
     except ValueError:
-        raise ShareValidationError(f"Eintrag {date_str}: ungültige {label} {value!r}")
+        raise ShareValidationError(
+            f"Eintrag {date_str}: ungültige {label} {value!r}") from None
 
 
 def _validate_date_key(date_str):
@@ -62,7 +63,7 @@ def _validate_date_key(date_str):
     try:
         datetime.date.fromisoformat(date_str)
     except ValueError:
-        raise ShareValidationError(f"Ungültiges Datum: {date_str!r}")
+        raise ShareValidationError(f"Ungültiges Datum: {date_str!r}") from None
 
 
 def _check_keys(date_str, entry, expected_keys, label="Eintrag"):
@@ -159,7 +160,7 @@ def parse_share_doc(raw_bytes):
     try:
         doc = json.loads(raw_bytes)
     except (ValueError, TypeError) as e:
-        raise ShareValidationError(f"Datei ist kein gültiges JSON: {e}")
+        raise ShareValidationError(f"Datei ist kein gültiges JSON: {e}") from e
 
     if not isinstance(doc, dict):
         raise ShareValidationError("Datei-Inhalt ist kein JSON-Objekt.")

--- a/src/storage.py
+++ b/src/storage.py
@@ -74,7 +74,7 @@ class Storage:
             if mtime is not None
             else _utc_now_iso()
         )
-        for date, entry in list(self._data.items()):
+        for _date, entry in list(self._data.items()):
             if not isinstance(entry, dict):
                 continue
             # 1. Sync-Metadaten für ganz alte Einträge nachrüsten.

--- a/src/time_utils.py
+++ b/src/time_utils.py
@@ -68,14 +68,25 @@ def get_week_dates(iso_year, iso_week):
     return [monday + datetime.timedelta(days=i) for i in range(7)]
 
 
+def format_date(d):
+    """date/datetime → 'TT.MM.JJJJ' für die Anzeige (deutsches UI-Format).
+
+    Objekt-Pendant zu format_iso_date (das einen ISO-String erwartet):
+    zentralisiert das über Dialoge und Report verstreute
+    `d.strftime('%d.%m.%Y')` (Audit N20). ISO bleibt die Speicher-/interne
+    Quelle — dies ist reine Anzeige-Formatierung.
+    """
+    return d.strftime("%d.%m.%Y")
+
+
 def get_week_label(iso_year, iso_week):
     """Return display label like 'KW 14 · 30.03. – 05.04.2026'."""
     dates = get_week_dates(iso_year, iso_week)
     monday = dates[0]
     sunday = dates[6]
     if monday.year != sunday.year:
-        return f"KW {iso_week} · {monday.strftime('%d.%m.%Y')} – {sunday.strftime('%d.%m.%Y')}"
-    return f"KW {iso_week} · {monday.strftime('%d.%m.')} – {sunday.strftime('%d.%m.%Y')}"
+        return f"KW {iso_week} · {format_date(monday)} – {format_date(sunday)}"
+    return f"KW {iso_week} · {monday.strftime('%d.%m.')} – {format_date(sunday)}"
 
 
 def week_spans_months(iso_year, iso_week):
@@ -93,7 +104,7 @@ def format_iso_date(iso, fallback="—"):
     if not iso or len(iso) < 10:
         return fallback
     try:
-        return datetime.date.fromisoformat(iso[:10]).strftime("%d.%m.%Y")
+        return format_date(datetime.date.fromisoformat(iso[:10]))
     except ValueError:
         return iso[:10]
 
@@ -109,7 +120,7 @@ def format_iso_weekday_date(iso, fallback="—"):
         day = datetime.date.fromisoformat(iso[:10])
     except ValueError:
         return iso[:10]
-    return f"{WEEKDAYS_DE_FULL[day.weekday()]} - {day.strftime('%d.%m.%Y')}"
+    return f"{WEEKDAYS_DE_FULL[day.weekday()]} - {format_date(day)}"
 
 
 def format_iso_datetime(iso, fallback="—"):
@@ -142,7 +153,7 @@ def slots_overlap(slots):
             continue
         intervals.append((start[0] * 60 + start[1], end[0] * 60 + end[1]))
     intervals.sort()
-    for (_prev_start, prev_end), (next_start, _next_end) in zip(intervals, intervals[1:]):
+    for (_prev_start, prev_end), (next_start, _next_end) in zip(intervals, intervals[1:], strict=False):
         if next_start < prev_end:
             return True
     return False

--- a/tests/test_drive.py
+++ b/tests/test_drive.py
@@ -1,14 +1,13 @@
 import pytest
 from unittest import mock
 
-from src.drive import DriveAuthError, DriveConflictError, DriveNetworkError
+from src.drive import DriveAuthError, DriveNetworkError
 from src.drive import SYNC_SCOPES, get_drive_service
 
 
 def test_exceptions_are_distinct():
     assert not issubclass(DriveAuthError, DriveNetworkError)
     assert not issubclass(DriveNetworkError, DriveAuthError)
-    assert not issubclass(DriveConflictError, DriveAuthError)
 
 
 def test_sync_scopes_includes_gmail_send_and_drive_appdata():
@@ -117,7 +116,7 @@ def test_download_returns_content_and_version():
 def test_upload_new_file_when_file_id_none():
     service = mock.MagicMock()
     service.files().create().execute.return_value = {"id": "new-id", "version": 1}
-    file_id, version = upload(service, b'{"x":1}', file_id=None, expected_etag="")
+    file_id, version = upload(service, b'{"x":1}', file_id=None)
     assert file_id == "new-id"
     assert version == "1"
 
@@ -125,20 +124,9 @@ def test_upload_new_file_when_file_id_none():
 def test_upload_existing_file_uses_update():
     service = mock.MagicMock()
     service.files().update().execute.return_value = {"id": "file-123", "version": 2}
-    file_id, version = upload(service, b'{"x":2}', file_id="file-123", expected_etag="")
+    file_id, version = upload(service, b'{"x":2}', file_id="file-123")
     assert file_id == "file-123"
     assert version == "2"
-
-
-def test_upload_412_response_raises_drive_conflict_error():
-    """Drive API v3 schickt normalerweise kein 412, aber die 412→DriveConflictError-
-    Mappung bleibt als defensiver Pfad bestehen."""
-    from googleapiclient.errors import HttpError
-    service = mock.MagicMock()
-    resp = mock.MagicMock(status=412, reason="Precondition Failed")
-    service.files().update().execute.side_effect = HttpError(resp, b"")
-    with pytest.raises(DriveConflictError):
-        upload(service, b'{"x":1}', file_id="file-1", expected_etag="")
 
 
 def test_find_sync_file_403_raises_drive_auth_error():
@@ -179,7 +167,7 @@ def test_upload_403_raises_drive_auth_error():
     resp = mock.MagicMock(status=403, reason="Forbidden")
     service.files().update().execute.side_effect = HttpError(resp, b"")
     with pytest.raises(DriveAuthError):
-        upload(service, b'{"x":1}', file_id="file-1", expected_etag="")
+        upload(service, b'{"x":1}', file_id="file-1")
 
 
 from src.drive import reconnect

--- a/tests/test_grid_renderer.py
+++ b/tests/test_grid_renderer.py
@@ -71,6 +71,27 @@ def test_tooltip_text_holiday_only_with_entry_or_reservation():
     assert GridRenderer._build_tooltip_text(None, None, "Neujahr") == ""
 
 
+def test_tooltip_text_folds_conflict_into_combined():
+    # M11: der Konflikt-Hinweis gehört in DENSELBEN Tooltip wie die
+    # Arbeitszeit-Details — nicht als zweiter attach_tooltip an dieselbe Zelle.
+    entry = {"slots": [{"start": "09:30", "end": "16:00", "kategorie": "Office"}]}
+    assert GridRenderer._build_tooltip_text(entry, None, None, has_conflict=True) == (
+        "Arbeitszeit:\n09:30-16:00  Office\nKonflikt — bitte auflösen")
+
+
+def test_tooltip_text_conflict_only_when_no_other_units():
+    # Konfliktzelle ohne Ist-Zeit/Reservierung: der Tooltip zeigt allein den
+    # Konflikt-Hinweis (früher der separate attach_tooltip-Pfad).
+    assert GridRenderer._build_tooltip_text(None, None, None, has_conflict=True) == (
+        "Konflikt — bitte auflösen")
+
+
+def test_tooltip_text_no_conflict_is_unchanged():
+    entry = {"slots": [{"start": "09:30", "end": "16:00"}]}
+    assert GridRenderer._build_tooltip_text(entry, None, None, has_conflict=False) == (
+        "Arbeitszeit:\n09:30-16:00")
+
+
 def test_truncate_clips_long_text():
     assert GridRenderer._truncate("Donnerstag", 5) == "Donn…"
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -751,3 +751,48 @@ def test_reminder_defaults_present_and_device_local():
     assert DEFAULTS["reminder_minutes_before"] == 15
     assert "reminders_enabled" not in SYNCED_SETTING_KEYS
     assert "reminder_minutes_before" not in SYNCED_SETTING_KEYS
+
+
+# --- override_in_memory (Audit M12) ---
+
+
+def test_override_in_memory_sets_value_during_block(tmp_settings):
+    tmp_settings.set("show_weekend", True)
+    with tmp_settings.override_in_memory("show_weekend", False):
+        assert tmp_settings.get("show_weekend") is False
+
+
+def test_override_in_memory_restores_previous_after_block(tmp_settings):
+    tmp_settings.set("show_weekend", True)
+    with tmp_settings.override_in_memory("show_weekend", False):
+        pass
+    assert tmp_settings.get("show_weekend") is True
+
+
+def test_override_in_memory_does_not_persist_to_disk(tmp_path):
+    """Kern der M12-Kapselung: der temporäre Override darf settings.json NICHT
+    anfassen — ein paralleler Reader (frischer Settings-Reload) sieht den alten
+    Wert, auch während der with-Block läuft."""
+    path = str(tmp_path / "settings.json")
+    s1 = Settings(path)
+    s1.set("show_weekend", True)
+    with s1.override_in_memory("show_weekend", False):
+        s2 = Settings(path)
+        assert s2.get("show_weekend") is True  # Disk unverändert
+
+
+def test_override_in_memory_restores_even_on_exception(tmp_settings):
+    tmp_settings.set("show_weekend", True)
+    with pytest.raises(RuntimeError):
+        with tmp_settings.override_in_memory("show_weekend", False):
+            raise RuntimeError("boom")
+    assert tmp_settings.get("show_weekend") is True
+
+
+def test_override_in_memory_removes_key_absent_before(tmp_settings):
+    """War der Key vorher nicht in _data (nur via DEFAULTS sichtbar), wird er
+    nach dem Block wieder entfernt statt auf dem Override-Wert kleben zu bleiben."""
+    assert "some_transient_key" not in tmp_settings._data
+    with tmp_settings.override_in_memory("some_transient_key", 42):
+        assert tmp_settings.get("some_transient_key") == 42
+    assert "some_transient_key" not in tmp_settings._data

--- a/tests/test_time_utils.py
+++ b/tests/test_time_utils.py
@@ -1,6 +1,17 @@
+import datetime
+
 from src.time_utils import (
-    format_iso_date, format_iso_datetime, format_iso_weekday_date,
+    format_date, format_iso_date, format_iso_datetime, format_iso_weekday_date,
 )
+
+
+def test_format_date_from_date_object():
+    assert format_date(datetime.date(2026, 6, 2)) == "02.06.2026"
+
+
+def test_format_date_from_datetime_object():
+    # Nimmt auch datetime (Zeitanteil wird ignoriert) — deutsches TT.MM.JJJJ.
+    assert format_date(datetime.datetime(2026, 12, 5, 14, 30)) == "05.12.2026"
 
 
 def test_format_iso_date_from_timestamp():


### PR DESCRIPTION
Sammel-PR für fünf kleine, lokalisierte Follow-ups aus dem Audit-Tracking-Issue #131. Alle headless verifizierbar (pytest/ruff), keine plattformspezifischen Pfade.

## Findings

- **M2a** (`drive.py`) — `DriveConflictError` + der ignorierte `expected_etag`-Parameter waren toter Code: Drive API v3 sendet auf File-Updates kein 412, und die Exception wurde nirgends in Produktivcode gefangen (nur in historischen Specs). Ein 412 fällt jetzt sauber auf `DriveNetworkError` zurück. Die echte Konflikterkennung bleibt doc-level in `main.py::_run_push_blocking` (`_remote_is_newer`) und ist als solche im `upload()`-Docstring dokumentiert.
  - **M2b bleibt offen:** File-level Optimistic Locking / Post-Merge-Version-Recheck bzw. Retry-on-conflict ist eine Design-Entscheidung und *nicht* Teil dieses PRs. Das TOCTOU-Fenster zwischen `download` und `upload` besteht weiter (durch LWW-Merge pro Eintrag praktisch entschärft).

- **M11** (`grid_renderer.py`) — Konfliktzellen hängten einen **zweiten** `attach_tooltip` an dieselbe Zelle und verletzten den „genau EIN Tooltip pro Zelle"-Invariant (die Arbeitszeit-Details wurden dadurch verdeckt). Der Konflikt-Hinweis wird jetzt via `has_conflict` in den kombinierten Tooltip (`_build_tooltip_text`) gefaltet; der orange Rand bleibt.

- **M12** (`settings.py` / `grid_renderer.py`) — `measure_max_width` griff für die Breiten-Messung direkt in `Settings._data`. Neuer Kontextmanager `Settings.override_in_memory` (in-memory-only, kein Disk-Save, restauriert auch bei Exception) kapselt das.

- **N20** (`time_utils.py` + 4 Dialoge + `report.py`) — das über 6 Dateien verstreute `d.strftime('%d.%m.%Y')` hinter dem neuen Helfer `time_utils.format_date` konsolidiert (Objekt-Pendant zu `format_iso_date`).

- **N29** (`pyproject.toml`) — Ruff-Regel **B** (flake8-bugbear) aktiviert und die 11 Funde gefixt: 6× `zip(strict=False)` (verhaltenserhaltend), 2× ungenutzte Loop-Variable → `_`-Präfix, 3× `raise ... from None/err` in `share.py`.

## Nicht enthalten (aus dem Scoping)

- **N27** (pyinstaller aus `requirements.txt`) ist durch die M17-Pinning-Entscheidung **überholt** — CLAUDE.md hält pyinstaller bewusst dort. Vorschlag: im Issue als superseded abhaken.

## Verifikation

- `pytest`: **813 passed, 3 skipped**
- `ruff check .`: **All checks passed** (mit aktivierter B-Regel)
- Neue Tests: `override_in_memory` (5), Tooltip-Konflikt-Fold (3), `format_date` (2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
