### PR TITLE
refactor(audit): 2. Cleanup-Runde N17/N8/M14/N21/N14 (#131)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,6 +175,25 @@ Installierte App und Benutzerdaten liegen je nach Plattform:
 
 `--noconsole` unterdrückt stderr. Fehler aus dem Sendepfad (Gmail, PDF-Erzeugung) **müssen** per `messagebox.showerror` mit `traceback.format_exc()` angezeigt werden — sonst klickt der Nutzer auf „Senden", nichts passiert, und es gibt keine Spur.
 
+### Bekannt-themed / unerwartet-nativ (bewusste Zweiteilung, Audit N14)
+
+Für Fehlerdialoge gilt eine bewusste Aufteilung:
+
+- **Bekannte, erwartete Fehler** (Validierung, „Keine Einträge", „Ungültiger
+  Zeitraum", ein gehandhabter Speicher-`OSError`) → die **themed** Drop-ins
+  aus `theme.py` (`themed_showerror`/`themed_showinfo`/…). Kurze, kuratierte
+  Meldung, konsistentes Dark-Theme.
+- **Unerwartete Fehler** (die generischen `except`-Zweige, die
+  `traceback.format_exc()` bzw. ein `result["tb"]` mitzeigen) →
+  **rohes `tkinter.messagebox.showerror`**. Bewusst nativ und nicht themed:
+  ein themed Dialog baut selbst Tk-Toplevels/Widgets auf und könnte im bereits
+  gestörten Zustand seinerseits scheitern und damit genau die Fehlermeldung
+  verschlucken, die er zeigen soll. Der native Dialog ist die robuste
+  Fallback-Schicht (siehe auch die `messagebox.showerror`-Pflicht oben).
+
+Neue Fehlerpfade dieser Konvention folgen: kuratierte Meldung → themed;
+Traceback-/Catch-all-Ausgabe → nativ.
+
 ## UTF-8 im Mail-Pipeline
 
 Damit Umlaute/ß nicht als Mojibake ankommen, gelten drei Pflichten:

--- a/src/conflicts_store.py
+++ b/src/conflicts_store.py
@@ -1,22 +1,31 @@
+from __future__ import annotations
+
 import datetime
 import json
 import logging
 import os
 import threading
+from typing import Any
+
+# Ein Konflikt-Record, wie er in conflicts.json / im Sync-Doc liegt
+# (id, kind, key, candidates, detected_at, resolved, resolution, …). Die
+# Felder sind heterogen (str/bool/list), daher Any als Wert (Audit N8).
+Conflict = dict[str, Any]
 
 
 class ConflictsStore:
     """JSON-Persistenz für die lokale Konflikt-Liste. Spiegelt die conflicts-Liste
     aus dem Sync-File, damit der ConflictsDialog ohne Netz funktioniert."""
 
-    def __init__(self, filepath="conflicts.json", lock=None):
+    def __init__(self, filepath: str = "conflicts.json",
+                 lock: threading.RLock | None = None) -> None:
         self.filepath = filepath
         # Geteilter Daten-Lock (Audit H1/H2) — siehe storage.py.
         self._lock = lock if lock is not None else threading.RLock()
-        self._conflicts = []
+        self._conflicts: list[Conflict] = []
         self._load()
 
-    def _load(self):
+    def _load(self) -> None:
         if not os.path.exists(self.filepath):
             return
         try:
@@ -35,7 +44,7 @@ class ConflictsStore:
         if isinstance(data, list):
             self._conflicts = data
 
-    def _save_to_disk(self):
+    def _save_to_disk(self) -> None:
         tmp = self.filepath + ".tmp"
         with open(tmp, "w", encoding="utf-8") as f:
             json.dump(self._conflicts, f, indent=2, ensure_ascii=False)
@@ -49,15 +58,15 @@ class ConflictsStore:
                 os.remove(tmp)
             raise
 
-    def get_all(self):
+    def get_all(self) -> list[Conflict]:
         with self._lock:
             return list(self._conflicts)
 
-    def save_all(self, conflicts):
+    def save_all(self, conflicts: list[Conflict]) -> None:
         with self._lock:
             self._conflicts = list(conflicts)
             self._save_to_disk()
 
-    def count_unresolved(self):
+    def count_unresolved(self) -> int:
         with self._lock:
             return sum(1 for c in self._conflicts if not c.get("resolved"))

--- a/src/dialogs/date_row.py
+++ b/src/dialogs/date_row.py
@@ -1,0 +1,102 @@
+"""Gemeinsames Tag/Monat/Jahr-Datums-Zeilen-Widget (Audit M14).
+
+Früher dreifach implementiert (period_picker, import_dialog, tab_work) mit
+divergierender Robustheit: nur `import_dialog` fing den `ValueError` beim
+Tag-Clamp ab — `period_picker` und `tab_work` crashten, sobald ein Feld einen
+nicht-numerischen Wert trug. Diese eine Implementierung ist durchgängig robust.
+
+`build_date_row` liefert ein selbst-enthaltenes Frame (Label + drei
+`dark_combo`-Felder für Tag/Monat/Jahr), das der Aufrufer via grid/pack
+platziert. Die reine Kernlogik `max_day_for` ist Tk-frei und getestet.
+"""
+from __future__ import annotations
+
+import calendar
+import datetime
+import tkinter as tk
+from typing import Callable
+
+from src.theme import BG, FONT, TEXT, dark_combo
+
+
+def max_day_for(month_value: str, year_value: str) -> int:
+    """Monatslänge (28–31) für die (String-)Combobox-Werte von Monat und Jahr.
+
+    Bei nicht-numerischem oder ungültigem Monat/Jahr ist der Fallback 31 — der
+    Tag-Combobox wird dann nicht künstlich beschnitten. Kapselt genau den
+    Robustheits-Kern, den vorher nur `import_dialog` hatte (Audit M14)."""
+    try:
+        return calendar.monthrange(int(year_value), int(month_value))[1]
+    except (ValueError, KeyError):
+        return 31
+
+
+class DateRow:
+    """Handle auf eine gebaute Datumszeile: das Frame plus die drei Tk-Vars.
+
+    Der Aufrufer platziert `frame` (grid/pack) und liest Tag/Monat/Jahr über
+    `vars` bzw. die Einzel-Attribute."""
+
+    def __init__(self, frame: tk.Frame, day_var: tk.StringVar,
+                 month_var: tk.StringVar, year_var: tk.StringVar) -> None:
+        self.frame = frame
+        self.day_var = day_var
+        self.month_var = month_var
+        self.year_var = year_var
+
+    @property
+    def vars(self) -> tuple[tk.StringVar, tk.StringVar, tk.StringVar]:
+        return self.day_var, self.month_var, self.year_var
+
+
+def build_date_row(parent: tk.Misc, label_text: str, default_date: datetime.date, *,
+                   on_change: Callable[[], None] | None = None,
+                   year_from: int = 2020, year_to_offset: int = 2,
+                   label_width: int = 0) -> DateRow:
+    """Baut eine Tag/Monat/Jahr-Zeile in ein eigenes Frame und liefert das Handle.
+
+    - on_change: optionaler Callback bei jeder Benutzer-Änderung an Tag, Monat
+      oder Jahr (Vorschau aktualisieren / Zähler neu berechnen). Wird beim
+      initialen Aufbau NICHT gefeuert.
+    - year_from / year_to_offset: Jahresbereich `range(year_from,
+      heute.Jahr + year_to_offset)`.
+    - label_width: feste Label-Breite in Zeichen (0 = natürlich) — für
+      Spaltenausrichtung mehrerer Zeilen untereinander.
+    """
+    frame = tk.Frame(parent, bg=BG)
+    tk.Label(frame, text=label_text, font=FONT, bg=BG, fg=TEXT,
+             width=label_width, anchor="w").pack(side=tk.LEFT, padx=(0, 5))
+
+    today = datetime.date.today()
+    month_values = [str(m) for m in range(1, 13)]
+    year_values = [str(y) for y in range(year_from, today.year + year_to_offset)]
+
+    day_var = tk.StringVar(value=str(default_date.day))
+    start_max_day = calendar.monthrange(default_date.year, default_date.month)[1]
+    day_cb = dark_combo(frame, day_var, [str(d) for d in range(1, start_max_day + 1)], width=3)
+    day_cb.pack(side=tk.LEFT, padx=2)
+    tk.Label(frame, text=".", font=FONT, bg=BG, fg=TEXT).pack(side=tk.LEFT)
+    month_var = tk.StringVar(value=str(default_date.month))
+    dark_combo(frame, month_var, month_values, width=3).pack(side=tk.LEFT, padx=2)
+    tk.Label(frame, text=".", font=FONT, bg=BG, fg=TEXT).pack(side=tk.LEFT)
+    year_var = tk.StringVar(value=str(default_date.year))
+    dark_combo(frame, year_var, year_values, width=5).pack(side=tk.LEFT, padx=(2, 10))
+
+    def _on_write(*_a) -> None:
+        md = max_day_for(month_var.get(), year_var.get())
+        day_cb["values"] = [str(d) for d in range(1, md + 1)]
+        # Tag-Clamp defensiv: der Tag-Combobox kann während der Eingabe einen
+        # nicht-numerischen Zwischenwert tragen (Audit M14 — vorher crashten
+        # period_picker/tab_work hier).
+        try:
+            if int(day_var.get()) > md:
+                day_var.set(str(md))
+        except ValueError:
+            pass
+        if on_change is not None:
+            on_change()
+
+    day_var.trace_add("write", _on_write)
+    month_var.trace_add("write", _on_write)
+    year_var.trace_add("write", _on_write)
+    return DateRow(frame, day_var, month_var, year_var)

--- a/src/dialogs/import_dialog.py
+++ b/src/dialogs/import_dialog.py
@@ -2,13 +2,13 @@
 (Arbeitszeiten/Reservierungen) ein Abschnitt mit Master-Schalter, Zeitraum-
 Filter und Konflikt-Modi, optional Pro-Tag-Modal, atomarer Apply."""
 
-import calendar
 import datetime
 import logging
 import tkinter as tk
 import traceback
 from tkinter import filedialog, messagebox
 
+from src.dialogs.date_row import build_date_row
 from src.share import (
     ShareValidationError,
     apply_import,
@@ -21,7 +21,7 @@ from src.time_utils import format_iso_date
 from src.theme import (
     BG, CELL_BG, FONT, FONT_SMALL, TEXT, TEXT_MUTED,
     apply_combobox_style, attach_unfocus_on_click, center_dialog_on_parent,
-    create_dialog, dark_combo, primary_button, secondary_button,
+    create_dialog, primary_button, secondary_button,
     themed_showerror, themed_showinfo,
 )
 
@@ -149,11 +149,16 @@ class _ImportSummaryDialog:
         ).grid(row=row, column=0, columnspan=6, padx=10, pady=(4, 0), sticky="w")
         row += 1
 
-        self.from_day, self.from_month, self.from_year = self._build_date_row(
-            row, "Von:", self.file_min)
+        # Von/Bis über das gemeinsame Datums-Zeilen-Widget (Audit M14).
+        from_row = build_date_row(self.top, "Von:", self.file_min,
+                                  on_change=self._recompute_counts, label_width=4)
+        from_row.frame.grid(row=row, column=0, columnspan=6, sticky="w", padx=10, pady=4)
+        self.from_day, self.from_month, self.from_year = from_row.vars
         row += 1
-        self.to_day, self.to_month, self.to_year = self._build_date_row(
-            row, "Bis:", self.file_max)
+        to_row = build_date_row(self.top, "Bis:", self.file_max,
+                                on_change=self._recompute_counts, label_width=4)
+        to_row.frame.grid(row=row, column=0, columnspan=6, sticky="w", padx=10, pady=4)
+        self.to_day, self.to_month, self.to_year = to_row.vars
         row += 1
 
         tk.Label(
@@ -217,51 +222,6 @@ class _ImportSummaryDialog:
         secondary_button(btn_frame, "Abbrechen", self.top.destroy).pack(side=tk.LEFT, padx=5)
 
         self._on_toggle_section()  # ruft intern bereits _recompute_counts()
-
-    def _build_date_row(self, row, label_text, default_date):
-        tk.Label(self.top, text=label_text, font=FONT, bg=BG, fg=TEXT).grid(
-            row=row, column=0, padx=(10, 5), pady=4, sticky="w")
-
-        day_var = tk.StringVar(value=str(default_date.day))
-        max_day = calendar.monthrange(default_date.year, default_date.month)[1]
-        day_cb = dark_combo(self.top, day_var,
-                            [str(d) for d in range(1, max_day + 1)], width=3)
-        day_cb.grid(row=row, column=1, padx=2, pady=4)
-
-        tk.Label(self.top, text=".", font=FONT, bg=BG, fg=TEXT).grid(row=row, column=2)
-
-        month_var = tk.StringVar(value=str(default_date.month))
-        dark_combo(self.top, month_var,
-                   [str(m) for m in range(1, 13)], width=3).grid(
-            row=row, column=3, padx=2, pady=4)
-
-        tk.Label(self.top, text=".", font=FONT, bg=BG, fg=TEXT).grid(row=row, column=4)
-
-        year_var = tk.StringVar(value=str(default_date.year))
-        years = [str(y) for y in range(2020, datetime.date.today().year + 2)]
-        dark_combo(self.top, year_var, years, width=5).grid(
-            row=row, column=5, padx=(2, 10), pady=4)
-
-        def _on_change(*_):
-            try:
-                m = int(month_var.get())
-                y = int(year_var.get())
-                max_day = calendar.monthrange(y, m)[1]
-            except (ValueError, KeyError):
-                max_day = 31
-            day_cb["values"] = [str(d) for d in range(1, max_day + 1)]
-            try:
-                if int(day_var.get()) > max_day:
-                    day_var.set(str(max_day))
-            except ValueError:
-                pass
-            self._recompute_counts()
-
-        day_var.trace_add("write", _on_change)
-        month_var.trace_add("write", _on_change)
-        year_var.trace_add("write", _on_change)
-
-        return day_var, month_var, year_var
 
     def _get_range(self):
         try:

--- a/src/dialogs/period_picker.py
+++ b/src/dialogs/period_picker.py
@@ -2,8 +2,9 @@ import calendar
 import datetime
 import tkinter as tk
 
+from src.dialogs.date_row import build_date_row
 from src.report import total_hours
-from src.theme import BG, CELL_BG, FONT, TEXT, dark_combo
+from src.theme import BG, CELL_BG, FONT, TEXT
 
 
 def selected_category_filter(selected_map):
@@ -71,39 +72,20 @@ def build_period_picker(parent, storage, settings, on_change=None):
 
     today = datetime.date.today()
     from_default = _default_from_date(today)
-    month_values = [str(m) for m in range(1, 13)]
-    year_values = [str(y) for y in range(2020, today.year + 2)]
 
-    def update_day_values(day_cb, day_var, month_var, year_var):
-        try:
-            m = int(month_var.get())
-            y = int(year_var.get())
-            max_day = calendar.monthrange(y, m)[1]
-        except (ValueError, KeyError):
-            max_day = 31
-        day_cb["values"] = [str(d) for d in range(1, max_day + 1)]
-        if int(day_var.get()) > max_day:
-            day_var.set(str(max_day))
-
-    def build_date_row(row, label_text, default_date):
-        tk.Label(frame, text=label_text, font=FONT, bg=BG, fg=TEXT).grid(
-            row=row, column=0, padx=(10, 5), pady=8, sticky="w")
-        day_var = tk.StringVar(value=str(default_date.day))
-        max_day = calendar.monthrange(default_date.year, default_date.month)[1]
-        day_cb = dark_combo(frame, day_var, [str(d) for d in range(1, max_day + 1)], width=3)
-        day_cb.grid(row=row, column=1, padx=2, pady=8)
-        tk.Label(frame, text=".", font=FONT, bg=BG, fg=TEXT).grid(row=row, column=2)
-        month_var = tk.StringVar(value=str(default_date.month))
-        dark_combo(frame, month_var, month_values, width=3).grid(row=row, column=3, padx=2, pady=8)
-        tk.Label(frame, text=".", font=FONT, bg=BG, fg=TEXT).grid(row=row, column=4)
-        year_var = tk.StringVar(value=str(default_date.year))
-        dark_combo(frame, year_var, year_values, width=5).grid(row=row, column=5, padx=(2, 10), pady=8)
-        month_var.trace_add("write", lambda *_: update_day_values(day_cb, day_var, month_var, year_var))
-        year_var.trace_add("write", lambda *_: update_day_values(day_cb, day_var, month_var, year_var))
-        return day_var, month_var, year_var
-
-    from_vars = build_date_row(0, "Von:", from_default)
-    to_vars = build_date_row(1, "Bis:", today)
+    # Von/Bis über das gemeinsame Datums-Zeilen-Widget (Audit M14). Der
+    # on_change-Callback (Tag-Clamp + Vorschau) ist late-bound auf das weiter
+    # unten definierte _changed; er feuert erst bei Benutzer-Interaktion, also
+    # ist _changed dann längst gebunden. label_width=4 hält "Von:"/"Bis:"
+    # untereinander bündig.
+    from_row = build_date_row(frame, "Von:", from_default,
+                              on_change=lambda: _changed(), label_width=4)
+    to_row = build_date_row(frame, "Bis:", today,
+                            on_change=lambda: _changed(), label_width=4)
+    from_row.frame.grid(row=0, column=0, columnspan=6, sticky="w", padx=(10, 0), pady=8)
+    to_row.frame.grid(row=1, column=0, columnspan=6, sticky="w", padx=(10, 0), pady=8)
+    from_vars = from_row.vars
+    to_vars = to_row.vars
 
     # Kategorien aus Bestand UND Settings-Pickliste ("" = ohne Kategorie). Alle
     # default ausgewählt. Bewusst NICHT auf den Zeitraum eingeschränkt (vgl.
@@ -159,13 +141,13 @@ def build_period_picker(parent, storage, settings, on_change=None):
 
     def _changed(*_):
         # Benutzer-Änderung an Datum oder Kategorie: Vorschau aktualisieren und
-        # den Aufrufer benachrichtigen (Export-Button (de)aktivieren).
+        # den Aufrufer benachrichtigen (Export-Button (de)aktivieren). Die
+        # Datumszeilen rufen dies über ihren on_change (siehe build_date_row);
+        # die Kategorie-Checkboxen über command=_changed.
         _update_total()
         if on_change is not None:
             on_change()
 
-    for _v in (*from_vars, *to_vars):
-        _v.trace_add("write", _changed)
     _update_total()
 
     return frame, handle

--- a/src/dialogs/settings_dialog/tab_work.py
+++ b/src/dialogs/settings_dialog/tab_work.py
@@ -1,10 +1,10 @@
 """Tab „Arbeitszeit": Standardzeiten, Pause, Werkstudenten-Limit, Kategorien."""
 
-import calendar
 import datetime
 import tkinter as tk
 
 from src.dialogs.category_dialog import open_category_dialog
+from src.dialogs.date_row import build_date_row
 from src.dialogs.settings_dialog._shared import label, subheader
 from src.settings import WEEKDAY_KEYS
 from src.theme import (
@@ -56,47 +56,21 @@ class WorkTab:
             activebackground=BG, activeforeground=TEXT, cursor="hand2",
         ).pack(anchor="w")
 
-        def _wsl_date_row(parent_frame, label_text, default_date):
-            row = tk.Frame(parent_frame, bg=BG)
-            row.pack(anchor="w", pady=(4, 0))
-            tk.Label(row, text=label_text, font=FONT, bg=BG, fg=TEXT).pack(
-                side=tk.LEFT, padx=(0, 5))
-            month_values = [str(m) for m in range(1, 13)]
-            year_values = [str(y) for y in range(2020, datetime.date.today().year + 3)]
-            day_var = tk.StringVar(value=str(default_date.day))
-            max_day = calendar.monthrange(default_date.year, default_date.month)[1]
-            day_cb = dark_combo(row, day_var, [str(d) for d in range(1, max_day + 1)], width=3)
-            day_cb.pack(side=tk.LEFT, padx=2)
-            tk.Label(row, text=".", font=FONT, bg=BG, fg=TEXT).pack(side=tk.LEFT)
-            month_var = tk.StringVar(value=str(default_date.month))
-            dark_combo(row, month_var, month_values, width=3).pack(side=tk.LEFT, padx=2)
-            tk.Label(row, text=".", font=FONT, bg=BG, fg=TEXT).pack(side=tk.LEFT)
-            year_var = tk.StringVar(value=str(default_date.year))
-            dark_combo(row, year_var, year_values, width=5).pack(side=tk.LEFT, padx=2)
-
-            def _update_days(*_a):
-                try:
-                    m = int(month_var.get())
-                    y = int(year_var.get())
-                    md = calendar.monthrange(y, m)[1]
-                except (ValueError, KeyError):
-                    md = 31
-                day_cb["values"] = [str(d) for d in range(1, md + 1)]
-                if int(day_var.get()) > md:
-                    day_var.set(str(md))
-
-            month_var.trace_add("write", _update_days)
-            year_var.trace_add("write", _update_days)
-            return day_var, month_var, year_var
-
         wsl_start_default = (
             datetime.date.fromisoformat(settings.get("werkstudent_limit_start"))
             if settings.get("werkstudent_limit_start") else datetime.date.today())
         wsl_end_default = (
             datetime.date.fromisoformat(settings.get("werkstudent_limit_end"))
             if settings.get("werkstudent_limit_end") else datetime.date.today())
-        wsl_start_vars = _wsl_date_row(wsl_frame, "Zeitraum von:", wsl_start_default)
-        wsl_end_vars = _wsl_date_row(wsl_frame, "bis:", wsl_end_default)
+        # Gemeinsames Datums-Zeilen-Widget (Audit M14); Werkstudenten-Limit
+        # erlaubt Zeiträume etwas weiter in die Zukunft (year_to_offset=3).
+        wsl_start_row = build_date_row(wsl_frame, "Zeitraum von:", wsl_start_default,
+                                       year_to_offset=3)
+        wsl_start_row.frame.pack(anchor="w", pady=(4, 0))
+        wsl_start_vars = wsl_start_row.vars
+        wsl_end_row = build_date_row(wsl_frame, "bis:", wsl_end_default, year_to_offset=3)
+        wsl_end_row.frame.pack(anchor="w", pady=(4, 0))
+        wsl_end_vars = wsl_end_row.vars
 
         wsl_hours_row = tk.Frame(wsl_frame, bg=BG)
         wsl_hours_row.pack(anchor="w", pady=(4, 0))

--- a/src/main.py
+++ b/src/main.py
@@ -28,6 +28,7 @@ from src.reservations import ReservationStore
 from src.settings import Settings, clamp_ui_scale
 from src.storage import Storage
 from src.theme import init_fonts
+from src.time_utils import utc_now_iso
 from src.ui import App
 from src.version import VERSION
 
@@ -74,7 +75,7 @@ def _lock_ctx(lock):
     return lock if lock is not None else contextlib.nullcontext()
 
 
-def _run_pull_in_background(storage, settings, conflicts_store, base, ui_callback,
+def run_pull_in_background(storage, settings, conflicts_store, base, ui_callback,
                             data_lock=None, sync_guard=None):
     """Pull läuft in einem Thread; UI-Update über ui_callback (root.after).
 
@@ -113,7 +114,7 @@ def _run_pull_in_background(storage, settings, conflicts_store, base, ui_callbac
                         logging.getLogger(__name__).warning(
                             "Quarantine rename failed for %s", fid, exc_info=True)
                 remote_doc = _parse_remote_or_quarantine(content, file_id, _quarantine)
-            if sync._remote_is_newer(remote_doc):
+            if sync.remote_is_newer(remote_doc):
                 # Neueres (zukünftiges) Schema: NICHT mergen/pushen — Pull sauber
                 # abbrechen, last_pull_at/etag unverändert lassen.
                 ui_callback(ok=False, error=sync.NEWER_REMOTE_VERSION_MSG, tb="")
@@ -143,7 +144,7 @@ def _run_pull_in_background(storage, settings, conflicts_store, base, ui_callbac
                     merged, storage, settings, conflicts_store,
                     os.path.join(base, sync_journal.JOURNAL_FILENAME))
                 settings.set_many({
-                    "last_pull_at": sync._utc_now_iso(),
+                    "last_pull_at": utc_now_iso(),
                     "drive_etag": etag,
                 })
             ui_callback(ok=True, error=None, tb="")
@@ -156,7 +157,7 @@ def _run_pull_in_background(storage, settings, conflicts_store, base, ui_callbac
             sync_guard.release()
 
 
-def _run_push_blocking(storage, settings, conflicts_store, base, timeout_seconds=5,
+def run_push_blocking(storage, settings, conflicts_store, base, timeout_seconds=5,
                        data_lock=None, sync_guard=None, guard_timeout=0):
     """Synchroner Push mit Timeout. Fehler werden geloggt, nicht angezeigt
     (App schließt gerade).
@@ -202,7 +203,7 @@ def _run_push_blocking(storage, settings, conflicts_store, base, timeout_seconds
                         remote_doc = json.loads(remote_bytes)
                     except (json.JSONDecodeError, ValueError):
                         remote_doc = {"schema_version": 1, "entries": {}, "settings": {}, "conflicts": []}
-                    if sync._remote_is_newer(remote_doc):
+                    if sync.remote_is_newer(remote_doc):
                         # Neueres Gerät hat das Remote-Doc fortgeschrieben: nicht
                         # mergen/überschreiben — Push abbrechen, neuere Daten bleiben.
                         result["ok"] = False
@@ -235,7 +236,7 @@ def _run_push_blocking(storage, settings, conflicts_store, base, timeout_seconds
                     content = json.dumps(doc, ensure_ascii=False).encode("utf-8")
                 new_id, new_etag = drive.upload(service, content, file_id, expected_etag="")
                 settings.set_many({
-                    "last_pull_at": sync._utc_now_iso(),
+                    "last_pull_at": utc_now_iso(),
                     "drive_etag": new_etag,
                 })
                 result["ok"] = True
@@ -270,7 +271,7 @@ def _run_compaction_blocking(storage, settings, conflicts_store, base, timeout_s
     sync_guard: non-blocking — läuft ein Sync, kommt {"skipped": True} zurück
     (der Settings-Dialog zeigt dann einen Hinweis). Release im finally des
     inneren _do-Threads. data_lock: klammert Merge/Apply/Kompaktierung atomar;
-    der Upload läuft ungelockt (Invarianten wie _run_push_blocking)."""
+    der Upload läuft ungelockt (Invarianten wie run_push_blocking)."""
     import json
     from src import drive, sync, sync_journal
 
@@ -297,7 +298,7 @@ def _run_compaction_blocking(storage, settings, conflicts_store, base, timeout_s
                         remote_doc = {"schema_version": 1}
                     # Neueres Schema (>v3) auf dem FRISCH gepullten Doc: nicht
                     # mergen/überschreiben — Kompaktierung abbrechen.
-                    if sync._remote_is_newer(remote_doc):
+                    if sync.remote_is_newer(remote_doc):
                         result.update({"ok": False, "reason": "newer_version"})
                         return
                 else:
@@ -314,7 +315,7 @@ def _run_compaction_blocking(storage, settings, conflicts_store, base, timeout_s
                     logging.getLogger(__name__).warning(
                         "Remote-Sync-Doc ungültig (%s) — ignoriert, lokaler Stand gewinnt", reason)
                     remote_doc = {"schema_version": 1, "entries": {}, "settings": {}, "conflicts": []}
-                now = sync._utc_now_iso()
+                now = utc_now_iso()
                 # Merge + Apply + Watermark/Strippung + Upload-Snapshot atomar
                 # (Audit H1); der Upload danach läuft bewusst ungelockt.
                 with _lock_ctx(data_lock):
@@ -486,7 +487,7 @@ def main():
                     pass
             root.after(0, apply)
         threading.Thread(
-            target=_run_pull_in_background,
+            target=run_pull_in_background,
             args=(storage, settings, conflicts_store, base, _on_sync_done),
             kwargs={"data_lock": data_lock, "sync_guard": sync_guard},
             daemon=True,

--- a/src/reservations.py
+++ b/src/reservations.py
@@ -18,10 +18,7 @@ import logging
 import os
 import threading
 
-
-def _utc_now_iso():
-    # Z-Suffix statt +00:00 — konsistent zu storage.py / sync.py.
-    return datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+from src.time_utils import utc_now_iso
 
 
 _REQUIRED_RESERVATION_KEYS = frozenset({"slots", "modified_at", "deleted"})
@@ -79,7 +76,7 @@ class ReservationStore:
             datetime.datetime.fromtimestamp(mtime, datetime.timezone.utc)
             .strftime("%Y-%m-%dT%H:%M:%SZ")
             if mtime is not None
-            else _utc_now_iso()
+            else utc_now_iso()
         )
         for date, entry in list(self._data.items()):
             if not isinstance(entry, dict):
@@ -163,7 +160,7 @@ class ReservationStore:
                 new_slots.append(ns)
             self._data[date_str] = {
                 "slots": new_slots,
-                "modified_at": _utc_now_iso(),
+                "modified_at": utc_now_iso(),
                 "deleted": False,
             }
             self._save_to_disk()
@@ -176,7 +173,7 @@ class ReservationStore:
                 return
             self._data[date_str] = {
                 "slots": [],
-                "modified_at": _utc_now_iso(),
+                "modified_at": utc_now_iso(),
                 "deleted": True,
             }
             self._save_to_disk()

--- a/src/reservations.py
+++ b/src/reservations.py
@@ -12,19 +12,27 @@ Eine gelöschte Reservierung bleibt als Tombstone (deleted=True, slots=[])
 erhalten, bis der Reconcile die zugehörigen Events entfernt hat.
 """
 
+from __future__ import annotations
+
 import datetime
 import json
 import logging
 import os
 import threading
+from typing import Any
 
 from src.time_utils import utc_now_iso
 
+# JSON-getragene Records (Audit N8): ein Slot {start, end, kategorie,
+# gcal_event_id}; ein Reservierungs-Record {slots, modified_at, deleted};
+# der Store hält {ISO-Datum: Reservation}. Werte sind heterogen → Any.
+Slot = dict[str, Any]
+Reservation = dict[str, Any]
 
 _REQUIRED_RESERVATION_KEYS = frozenset({"slots", "modified_at", "deleted"})
 
 
-def _normalize_slot(slot):
+def _normalize_slot(slot: Slot) -> Slot:
     """Vervollständigt einen Reservierungs-Slot auf
     {start, end, kategorie, gcal_event_id}. Fehlende `kategorie` → "",
     fehlende `gcal_event_id` → None."""
@@ -37,14 +45,15 @@ def _normalize_slot(slot):
 
 
 class ReservationStore:
-    def __init__(self, filepath="reservations.json", lock=None):
+    def __init__(self, filepath: str = "reservations.json",
+                 lock: threading.RLock | None = None) -> None:
         self.filepath = filepath
         # Geteilter Daten-Lock (Audit H1/H2) — siehe storage.py.
         self._lock = lock if lock is not None else threading.RLock()
-        self._data = {}
+        self._data: dict[str, Reservation] = {}
         self._load()
 
-    def _load(self):
+    def _load(self) -> None:
         if not os.path.exists(self.filepath):
             return
         try:
@@ -63,7 +72,7 @@ class ReservationStore:
             return
         self._migrate_legacy_reservations()
 
-    def _migrate_legacy_reservations(self):
+    def _migrate_legacy_reservations(self) -> None:
         """Wrappt alte Ein-Reservierung-Tage in eine Slot-Liste. Idempotent:
         Einträge mit `slots` bleiben unangetastet. modified_at/deleted werden
         nur gesetzt, falls sie fehlen (alte Dateien tragen sie i.d.R. bereits);
@@ -98,7 +107,7 @@ class ReservationStore:
             entry.setdefault("modified_at", fallback_modified_at)
             entry.setdefault("deleted", False)
 
-    def _save_to_disk(self):
+    def _save_to_disk(self) -> None:
         tmp = self.filepath + ".tmp"
         with open(tmp, "w", encoding="utf-8") as f:
             json.dump(self._data, f, indent=2, ensure_ascii=False)
@@ -113,14 +122,14 @@ class ReservationStore:
             raise
 
     @staticmethod
-    def _user_shape(entry):
+    def _user_shape(entry: Reservation) -> dict[str, Any]:
         """User-Shape: Slots ohne das interne Feld gcal_event_id."""
         return {"slots": [
             {"start": s.get("start"), "end": s.get("end"), "kategorie": s.get("kategorie", "")}
             for s in entry.get("slots", [])
         ]}
 
-    def get_all(self):
+    def get_all(self) -> dict[str, dict[str, Any]]:
         """{date: {slots: [...]}} ohne Tombstones — für die UI."""
         with self._lock:
             return {
@@ -129,20 +138,20 @@ class ReservationStore:
                 if not entry.get("deleted")
             }
 
-    def get_all_raw(self):
+    def get_all_raw(self) -> dict[str, Reservation]:
         """Komplette Objekte inkl. Metadaten, gcal_event_id und Tombstones —
         für den Reconcile."""
         with self._lock:
             return dict(self._data)
 
-    def get(self, date_str):
+    def get(self, date_str: str) -> dict[str, Any] | None:
         with self._lock:
             entry = self._data.get(date_str)
             if entry is None or entry.get("deleted"):
                 return None
             return self._user_shape(entry)
 
-    def save(self, date_str, slots):
+    def save(self, date_str: str, slots: list[Slot]) -> None:
         """Legt die Reservierungs-Slots eines Tages an oder überschreibt sie.
 
         Dialog-Edits liefern Slots OHNE gcal_event_id. Damit der Reconcile die
@@ -165,7 +174,7 @@ class ReservationStore:
             }
             self._save_to_disk()
 
-    def delete(self, date_str):
+    def delete(self, date_str: str) -> None:
         """Tombstone schreiben (slots=[]). Der Reconcile entfernt die
         zugehörigen Kalender-Events über den vollständigen Event-Pull (AP7)."""
         with self._lock:
@@ -178,7 +187,7 @@ class ReservationStore:
             }
             self._save_to_disk()
 
-    def apply_reconciled(self, reconciled):
+    def apply_reconciled(self, reconciled: dict[str, Reservation]) -> None:
         """Ersetzt den kompletten Stand durch das Reconcile-Ergebnis.
         Wirft ValueError, wenn ein Eintrag Pflichtfelder vermissen lässt —
         analog zu Storage.apply_merge."""

--- a/src/reservations_sync.py
+++ b/src/reservations_sync.py
@@ -9,11 +9,8 @@ pull → merge → push und schreibt neue event_ids pro Slot zurück.
 """
 
 import contextlib
-import datetime
 
-
-def _utc_now_iso():
-    return datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+from src.time_utils import utc_now_iso
 
 
 def _slot_from_event(ev):
@@ -210,5 +207,5 @@ def reconcile_reservations(service, calendar_id, store, settings, data_lock=None
                 merged[date] = entry
 
         store.apply_reconciled(merged)
-        settings.set("last_calendar_sync_at", _utc_now_iso())
+        settings.set("last_calendar_sync_at", utc_now_iso())
     return {"imported_dates": imported_dates}

--- a/src/settings.py
+++ b/src/settings.py
@@ -1,8 +1,11 @@
+from __future__ import annotations
+
 import datetime
 import json
 import logging
 import os
 import threading
+from typing import Any
 
 from src.time_utils import utc_now_iso
 
@@ -70,7 +73,7 @@ DEFAULTS = {
 _COERCE_FAILED = object()
 
 
-def _coerce(value, default):
+def _coerce(value: Any, default: Any) -> Any:
     """Versuche `value` in den Typ von `default` zu casten.
 
     Liefert den gecasteten Wert oder `_COERCE_FAILED`. bool ist Subklasse
@@ -94,7 +97,7 @@ def _coerce(value, default):
     return _COERCE_FAILED
 
 
-def _migrate_legacy_default_times(loaded):
+def _migrate_legacy_default_times(loaded: dict[str, Any]) -> None:
     """Spiegelt alte globale default_start/default_end auf Per-Tag-Keys.
 
     Modifiziert `loaded` in-place. Per-Tag-Keys haben Priorität — wenn ein
@@ -126,7 +129,7 @@ def _migrate_legacy_default_times(loaded):
 # holidays_de.code_for_state_label, nicht hier.
 
 
-def parse_hourly_rate(raw):
+def parse_hourly_rate(raw: str | None) -> float:
     """Parst die Stundensatz-Eingabe (String) zu float. Leer/nur Whitespace oder
     ungültig → 0.0 (bewusst tolerant: der Dialog soll bei Tippfehlern nicht
     blocken). Komma-Dezimal wird nicht unterstützt (float() wirft → 0.0)."""
@@ -139,7 +142,7 @@ def parse_hourly_rate(raw):
         return 0.0
 
 
-def parse_reminder_minutes(raw):
+def parse_reminder_minutes(raw: Any) -> int | None:
     """Parst die 'Minuten vor Ende'-Eingabe zu int in [0, 120]. Ungültig
     (nicht-numerisch, negativ, > 120, Kommazahl) -> None. Der Dialog nutzt None
     als Fehlersignal (anders als parse_hourly_rate, das tolerant auf 0.0 fällt —
@@ -153,7 +156,7 @@ def parse_reminder_minutes(raw):
     return None
 
 
-def split_synced_updates(updates):
+def split_synced_updates(updates: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]]:
     """Partitioniert ein updates-Dict in (synced, plain) anhand
     SYNCED_SETTING_KEYS. synced reist per Drive-Sync mit (set_synced), plain
     bleibt gerätelokal (set_many)."""
@@ -162,14 +165,14 @@ def split_synced_updates(updates):
     return synced, plain
 
 
-def resolve_calendar_id(cal_map, selected_label, current_id):
+def resolve_calendar_id(cal_map: dict[str, str], selected_label: str, current_id: str) -> str:
     """Mappt den im Dialog gewählten Kalender-Klarnamen über cal_map zurück auf
     die Kalender-ID. Unbekanntes Label → bisheriger Wert, ersatzweise
     "primary" (nie leer, damit der gcal-Abgleich einen gültigen Kalender hat)."""
     return cal_map.get(selected_label, current_id or "primary")
 
 
-def clamp_ui_scale(value):
+def clamp_ui_scale(value: Any) -> float:
     """Normalisiert den UI-Skalierungsfaktor defensiv: castet zu float und
     klemmt auf [0.75, 2.0]. Nicht-castbare Werte (None, Müll-String) → 1.0
     (Default). Schützt das tk-scaling vor korrupten settings.json-Werten und
@@ -182,16 +185,18 @@ def clamp_ui_scale(value):
 
 
 class Settings:
-    def __init__(self, filepath="settings.json", lock=None):
+    def __init__(self, filepath: str = "settings.json",
+                 lock: threading.RLock | None = None) -> None:
         self.filepath = filepath
         # Geteilter Daten-Lock (Audit H1/H2) — siehe storage.py.
         self._lock = lock if lock is not None else threading.RLock()
-        self._data = dict(DEFAULTS)
-        self._synced_meta = {}   # {key: {"modified_at": ..., "device_id": ...}}
+        self._data: dict[str, Any] = dict(DEFAULTS)
+        # {key: {"modified_at": ..., "device_id": ...}}
+        self._synced_meta: dict[str, dict[str, str]] = {}
         self.device_id_for_sync = ""  # wird von main.py auf settings.device_id gesetzt
         self._load()
 
-    def _load(self):
+    def _load(self) -> None:
         if not os.path.exists(self.filepath):
             return
         try:
@@ -239,7 +244,7 @@ class Settings:
             self._data[key] = coerced
         # Unbekannte Keys aus loaded werden ignoriert (nicht in _data übernommen).
 
-    def _quarantine_corrupt(self, reason):
+    def _quarantine_corrupt(self, reason: str) -> None:
         """Verschiebt ein korruptes settings.json nach `.corrupt-<stamp>`
         (wie storage/reservations/conflicts_store) und loggt das Ereignis,
         statt es kommentarlos zu verwerfen (Audit M4/N4). Defaults setzt der
@@ -262,7 +267,7 @@ class Settings:
             "verwende Defaults", reason, os.path.basename(target),
         )
 
-    def _save_to_disk(self):
+    def _save_to_disk(self) -> None:
         # Atomic write: temp file + replace, damit ein Crash mid-write
         # kein halb geschriebenes settings.json hinterlässt.
         payload = dict(self._data)
@@ -281,14 +286,14 @@ class Settings:
                 os.remove(tmp)
             raise
 
-    def get(self, key):
+    def get(self, key: str) -> Any:
         with self._lock:
             return self._data.get(key, DEFAULTS.get(key))
 
-    def set(self, key, value):
+    def set(self, key: str, value: Any) -> None:
         self.set_many({key: value})
 
-    def set_many(self, updates):
+    def set_many(self, updates: dict[str, Any]) -> None:
         """Mehrere Werte setzen, einmal auf Platte schreiben.
 
         Leeres Dict ist No-op (kein Disk-Roundtrip).
@@ -299,7 +304,7 @@ class Settings:
             self._data.update(updates)
             self._save_to_disk()
 
-    def set_synced(self, key, value):
+    def set_synced(self, key: str, value: Any) -> None:
         """Setzt einen whitelisted Sync-Key und stempelt Per-Field-Metadaten.
         Außerhalb der Whitelist verhält sich wie ein normales set()."""
         if key not in SYNCED_SETTING_KEYS:
@@ -313,7 +318,7 @@ class Settings:
             }
             self._save_to_disk()
 
-    def apply_updates(self, updates):
+    def apply_updates(self, updates: dict[str, Any]) -> None:
         """Routet ein updates-Dict aus dem Settings-Dialog auf den korrekten
         Persistenz-Pfad: Keys in SYNCED_SETTING_KEYS über set_synced (je ein
         Per-Field-Stempel + Disk-Write), der Rest in einem set_many. Single
@@ -324,7 +329,7 @@ class Settings:
         if plain:
             self.set_many(plain)
 
-    def get_synced_doc(self):
+    def get_synced_doc(self) -> dict[str, dict[str, Any]]:
         """{key: {value, modified_at, device_id}} — Eingabe für den Sync-Merge.
         Nur Keys mit vorhandener Metadaten-Spur werden zurückgegeben."""
         with self._lock:
@@ -340,7 +345,7 @@ class Settings:
                 }
             return doc
 
-    def apply_synced(self, synced_doc):
+    def apply_synced(self, synced_doc: dict[str, Any]) -> None:
         """Übernimmt das Merge-Ergebnis: schreibt value in _data und Meta in
         _synced_meta. Schreibt einmal auf Platte."""
         if not synced_doc:

--- a/src/settings.py
+++ b/src/settings.py
@@ -4,6 +4,8 @@ import logging
 import os
 import threading
 
+from src.time_utils import utc_now_iso
+
 WEEKDAY_KEYS = ("mon", "tue", "wed", "thu", "fri", "sat", "sun")  # Index = datetime.weekday()
 
 SYNCED_SETTING_KEYS = (
@@ -115,10 +117,6 @@ def _migrate_legacy_default_times(loaded):
             loaded[f"default_start_{day}"] = legacy_start
         if legacy_end is not None and f"default_end_{day}" not in loaded:
             loaded[f"default_end_{day}"] = legacy_end
-
-
-def _utc_now_iso():
-    return datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 # --- Reine Helfer für den Settings-Dialog-Save-Pfad (ohne Tk, headless testbar,
@@ -310,7 +308,7 @@ class Settings:
         with self._lock:
             self._data[key] = value
             self._synced_meta[key] = {
-                "modified_at": _utc_now_iso(),
+                "modified_at": utc_now_iso(),
                 "device_id": self.device_id_for_sync,
             }
             self._save_to_disk()

--- a/src/share.py
+++ b/src/share.py
@@ -20,6 +20,8 @@ import datetime
 import json
 import re
 
+from src.time_utils import utc_now_iso
+
 
 SCHEMA_VERSION = 3
 KIND = "zeiterfassung-share"
@@ -33,10 +35,6 @@ _LEGACY_RESERVATION_KEYS = frozenset({"start", "end"})
 # v3-Slot-Keys:
 _ENTRY_SLOT_KEYS = frozenset({"start", "end", "pause", "kategorie"})
 _RESERVATION_SLOT_KEYS = frozenset({"start", "end", "kategorie"})
-
-
-def _utc_now_iso():
-    return datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 class ShareValidationError(Exception):
@@ -244,7 +242,7 @@ def build_share_doc(storage, sender_email, *, reservation_store=None,
     doc = {
         "schema_version": SCHEMA_VERSION,
         "kind": KIND,
-        "exported_at": _utc_now_iso(),
+        "exported_at": utc_now_iso(),
         "exported_by": sender_email or "",
     }
     if include_entries:

--- a/src/storage.py
+++ b/src/storage.py
@@ -4,13 +4,9 @@ import logging
 import os
 import threading
 
+from src.time_utils import utc_now_iso
 
-def _utc_now_iso():
-    # Z-Suffix statt +00:00 — kompatibel zu JS/Drive-Konventionen
-    return datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-
-
-_REQUIRED_ENTRY_KEYS = frozenset({"slots", "modified_at", "device_id", "deleted"})
+REQUIRED_ENTRY_KEYS = frozenset({"slots", "modified_at", "device_id", "deleted"})
 
 
 def _normalize_slot(slot):
@@ -72,7 +68,7 @@ class Storage:
             datetime.datetime.fromtimestamp(mtime, datetime.timezone.utc)
             .strftime("%Y-%m-%dT%H:%M:%SZ")
             if mtime is not None
-            else _utc_now_iso()
+            else utc_now_iso()
         )
         for date, entry in list(self._data.items()):
             if not isinstance(entry, dict):
@@ -146,7 +142,7 @@ class Storage:
         with self._lock:
             self._data[date_str] = {
                 "slots": [_normalize_slot(s) for s in slots],
-                "modified_at": _utc_now_iso(),
+                "modified_at": utc_now_iso(),
                 "device_id": self.device_id,
                 "deleted": False,
             }
@@ -160,7 +156,7 @@ class Storage:
             # Delete gegen ein veraltetes Save eines anderen Geräts durchsetzen kann.
             self._data[date_str] = {
                 "slots": [],
-                "modified_at": _utc_now_iso(),
+                "modified_at": utc_now_iso(),
                 "device_id": self.device_id,
                 "deleted": True,
             }
@@ -172,7 +168,7 @@ class Storage:
         Wirft ValueError, wenn ein Eintrag Pflichtfelder vermissen lässt."""
         with self._lock:
             for date, entry in merged_entries.items():
-                missing = _REQUIRED_ENTRY_KEYS - entry.keys()
+                missing = REQUIRED_ENTRY_KEYS - entry.keys()
                 if missing:
                     raise ValueError(
                         f"apply_merge: entry {date!r} missing keys {sorted(missing)}"
@@ -192,7 +188,7 @@ class Storage:
         if not updates:
             return
         with self._lock:
-            now = _utc_now_iso()
+            now = utc_now_iso()
             for date_str, payload in updates.items():
                 self._data[date_str] = {
                     "slots": [_normalize_slot(s) for s in payload.get("slots", [])],

--- a/src/storage.py
+++ b/src/storage.py
@@ -1,15 +1,24 @@
+from __future__ import annotations
+
 import datetime
 import json
 import logging
 import os
 import threading
+from typing import Any
 
 from src.time_utils import utc_now_iso
+
+# JSON-getragene Records (Audit N8): ein Slot {start, end, pause, kategorie};
+# ein Entry {slots, modified_at, device_id, deleted}; der Store hält
+# {ISO-Datum: Entry}. Werte sind heterogen (str/int/bool/list) → Any.
+Slot = dict[str, Any]
+Entry = dict[str, Any]
 
 REQUIRED_ENTRY_KEYS = frozenset({"slots", "modified_at", "device_id", "deleted"})
 
 
-def _normalize_slot(slot):
+def _normalize_slot(slot: Slot) -> Slot:
     """Vervollständigt einen Ist-Zeit-Slot auf {start, end, pause, kategorie}.
 
     Fehlende `pause` → 0, fehlende `kategorie` → "" (= keine Kategorie,
@@ -24,7 +33,8 @@ def _normalize_slot(slot):
 
 
 class Storage:
-    def __init__(self, filepath="zeiterfassung.json", device_id="", lock=None):
+    def __init__(self, filepath: str = "zeiterfassung.json", device_id: str = "",
+                 lock: threading.RLock | None = None) -> None:
         self.filepath = filepath
         self.device_id = device_id
         # Geteilter Daten-Lock (Audit H1/H2): main() injiziert EINEN RLock in
@@ -32,10 +42,10 @@ class Storage:
         # _load()/Migration laufen vor dem Teilen (single-threaded Boot) —
         # bewusst ungelockt.
         self._lock = lock if lock is not None else threading.RLock()
-        self._data = {}
+        self._data: dict[str, Entry] = {}
         self._load()
 
-    def _load(self):
+    def _load(self) -> None:
         if not os.path.exists(self.filepath):
             return
         try:
@@ -54,7 +64,7 @@ class Storage:
             return
         self._migrate_legacy_entries()
 
-    def _migrate_legacy_entries(self):
+    def _migrate_legacy_entries(self) -> None:
         """Rüstet Sync-Metadaten nach UND wrappt alte Ein-Eintrag-Tage in eine
         Slot-Liste. Idempotent: Einträge mit `slots` bleiben unangetastet,
         Einträge mit `modified_at` behalten ihre Metadaten.
@@ -95,7 +105,7 @@ class Storage:
                 entry.setdefault("device_id", self.device_id)
                 entry.setdefault("deleted", False)
 
-    def _save_to_disk(self):
+    def _save_to_disk(self) -> None:
         tmp = self.filepath + ".tmp"
         with open(tmp, "w", encoding="utf-8") as f:
             json.dump(self._data, f, indent=2, ensure_ascii=False)
@@ -111,12 +121,12 @@ class Storage:
             raise
 
     @staticmethod
-    def _user_shape(entry):
+    def _user_shape(entry: Entry) -> dict[str, Any]:
         """Reduziert ein Roh-Entry auf {slots: [...]} für UI-Caller.
         Liefert frische Kopien, damit Caller den internen Stand nicht mutieren."""
         return {"slots": [dict(s) for s in entry.get("slots", [])]}
 
-    def get_all(self):
+    def get_all(self) -> dict[str, dict[str, Any]]:
         """Liefert {date: {slots: [...]}} ohne Tombstones."""
         with self._lock:
             return {
@@ -125,20 +135,20 @@ class Storage:
                 if not entry.get("deleted")
             }
 
-    def get_all_raw(self):
+    def get_all_raw(self) -> dict[str, Entry]:
         """Liefert die kompletten Eintragsobjekte inkl. Metadaten und Tombstones.
         Nur für den Sync-Pfad."""
         with self._lock:
             return dict(self._data)
 
-    def get(self, date_str):
+    def get(self, date_str: str) -> dict[str, Any] | None:
         with self._lock:
             entry = self._data.get(date_str)
             if entry is None or entry.get("deleted"):
                 return None
             return self._user_shape(entry)
 
-    def save(self, date_str, slots):
+    def save(self, date_str: str, slots: list[Slot]) -> None:
         with self._lock:
             self._data[date_str] = {
                 "slots": [_normalize_slot(s) for s in slots],
@@ -148,7 +158,7 @@ class Storage:
             }
             self._save_to_disk()
 
-    def delete(self, date_str):
+    def delete(self, date_str: str) -> None:
         with self._lock:
             if date_str not in self._data:
                 return
@@ -162,7 +172,7 @@ class Storage:
             }
             self._save_to_disk()
 
-    def apply_merge(self, merged_entries):
+    def apply_merge(self, merged_entries: dict[str, Entry]) -> None:
         """Ersetzt den kompletten Storage-Stand durch das Merge-Ergebnis.
         merged_entries: {date: {slots, modified_at, device_id, deleted}}.
         Wirft ValueError, wenn ein Eintrag Pflichtfelder vermissen lässt."""
@@ -176,7 +186,7 @@ class Storage:
             self._data = dict(merged_entries)
             self._save_to_disk()
 
-    def save_many(self, updates):
+    def save_many(self, updates: dict[str, dict[str, Any]]) -> None:
         """Mehrere Einträge in einem einzigen Disk-Write speichern.
 
         updates: {date_str: {"slots": [...]}}. Jeder Eintrag bekommt

--- a/src/sync.py
+++ b/src/sync.py
@@ -13,7 +13,6 @@ Doc-Struktur (Sync-File und Zwischenformate), Stand SCHEMA_VERSION = 4:
 """
 
 import contextlib
-import datetime
 import uuid
 
 # SYNCED_SETTING_KEYS lebt als Single Source of Truth in settings.py — hier nur
@@ -22,11 +21,12 @@ import uuid
 # stiller Datenverlust im Multi-Device-Sync (Issue #48). settings.py ist
 # stdlib-only und importiert sync.py nicht (kein Zyklus, CI-import-sicher).
 from src.settings import SYNCED_SETTING_KEYS
-# _REQUIRED_ENTRY_KEYS ist der Pflichtfeld-Vertrag, den storage.apply_merge
+from src.time_utils import utc_now_iso
+# REQUIRED_ENTRY_KEYS ist der Pflichtfeld-Vertrag, den storage.apply_merge
 # erzwingt — hier als Single Source of Truth importieren (nicht duplizieren),
 # damit validate_remote_doc nie gegen einen anderen Feldsatz prüft als der
 # Store später schreibt. storage.py importiert sync.py nicht (kein Zyklus).
-from src.storage import _REQUIRED_ENTRY_KEYS
+from src.storage import REQUIRED_ENTRY_KEYS
 
 
 SCHEMA_VERSION = 4
@@ -51,10 +51,6 @@ def _is_settled_entry(entry, watermark):
 def _is_settled_conflict(conflict, watermark):
     resolved_at = conflict.get("resolved_at") or ""
     return bool(conflict.get("resolved")) and resolved_at != "" and resolved_at < watermark
-
-
-def _utc_now_iso():
-    return datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 def _slots_signature(entry):
@@ -103,7 +99,7 @@ def _merge_one(local, remote, last_pull_at, equal_fn=_values_equal_entry, kind="
     remote_changed = remote["modified_at"] > last_pull_at
 
     # N2 (LWW-Wanduhr-Abhängigkeit — bewusst festgehalten): `modified_at` ist eine
-    # Wanduhr-Zeit (_utc_now_iso, Sekunden-Auflösung, KEINE Millisekunden). Der
+    # Wanduhr-Zeit (utc_now_iso, Sekunden-Auflösung, KEINE Millisekunden). Der
     # Vergleich ist ein String-Vergleich der ISO-Timestamps. Das LWW-Ergebnis
     # hängt damit an halbwegs synchronen Geräte-Uhren; eine stark falsch gehende
     # Uhr kann Änderungen dauerhaft gewinnen/verlieren lassen. Bei exakt gleicher
@@ -117,7 +113,7 @@ def _merge_one(local, remote, last_pull_at, equal_fn=_values_equal_entry, kind="
             "kind": kind,
             "key": key,
             "candidates": [_strip_for_candidate(local), _strip_for_candidate(remote)],
-            "detected_at": _utc_now_iso(),
+            "detected_at": utc_now_iso(),
             "resolved": False,
             "resolution": None,
             "resolved_at": None,
@@ -359,7 +355,7 @@ def validate_remote_doc(doc):
     for date, entry in entries.items():
         if not isinstance(entry, dict):
             return False, f"entry {date!r} ist kein Objekt"
-        missing = _REQUIRED_ENTRY_KEYS - entry.keys()
+        missing = REQUIRED_ENTRY_KEYS - entry.keys()
         if missing:
             return False, f"entry {date!r} fehlen Felder {sorted(missing)}"
         if not isinstance(entry.get("modified_at"), str):
@@ -396,7 +392,7 @@ def validate_remote_doc(doc):
     return True, ""
 
 
-def _remote_is_newer(remote_doc):
+def remote_is_newer(remote_doc):
     """True, wenn das Remote-Doc von einer NEUEREN App-Version stammt
     (schema_version > der hier verstandenen SCHEMA_VERSION).
 
@@ -431,7 +427,7 @@ def resolve_conflict(conflict_id, chosen_value, conflicts_store, storage, settin
         if target is None:
             raise KeyError(f"Konflikt {conflict_id!r} nicht gefunden")
 
-        now = _utc_now_iso()
+        now = utc_now_iso()
         target["resolved"] = True
         target["resolution"] = dict(chosen_value)
         target["resolved_at"] = now

--- a/src/sync.py
+++ b/src/sync.py
@@ -12,8 +12,11 @@ Doc-Struktur (Sync-File und Zwischenformate), Stand SCHEMA_VERSION = 4:
 }
 """
 
+from __future__ import annotations
+
 import contextlib
 import uuid
+from typing import TYPE_CHECKING, Any, Callable
 
 # SYNCED_SETTING_KEYS lebt als Single Source of Truth in settings.py — hier nur
 # importieren, NICHT erneut definieren. Eine zweite (divergierende) Definition
@@ -28,6 +31,20 @@ from src.time_utils import utc_now_iso
 # Store später schreibt. storage.py importiert sync.py nicht (kein Zyklus).
 from src.storage import REQUIRED_ENTRY_KEYS
 
+if TYPE_CHECKING:
+    import threading
+
+    from src.conflicts_store import ConflictsStore
+    from src.settings import Settings
+    from src.storage import Storage
+
+# JSON-getragene Sync-Strukturen (Audit N8). Doc = ein komplettes Sync-Doc
+# ({schema_version, entries, settings, conflicts, meta}); Entry = ein
+# Eintrag-Record; Conflict = ein Konflikt-Record. Werte heterogen → Any.
+Doc = dict[str, Any]
+Entry = dict[str, Any]
+Conflict = dict[str, Any]
+
 
 SCHEMA_VERSION = 4
 
@@ -40,20 +57,20 @@ NEWER_REMOTE_VERSION_MSG = (
 )
 
 
-def _watermark_of(doc):
+def _watermark_of(doc: Doc) -> str:
     return ((doc.get("meta") or {}).get("gc_watermark") or "")
 
 
-def _is_settled_entry(entry, watermark):
+def _is_settled_entry(entry: Entry, watermark: str) -> bool:
     return bool(entry.get("deleted")) and (entry.get("modified_at") or "") < watermark
 
 
-def _is_settled_conflict(conflict, watermark):
+def _is_settled_conflict(conflict: Conflict, watermark: str) -> bool:
     resolved_at = conflict.get("resolved_at") or ""
     return bool(conflict.get("resolved")) and resolved_at != "" and resolved_at < watermark
 
 
-def _slots_signature(entry):
+def _slots_signature(entry: Entry) -> list[tuple[Any, ...]]:
     """Reihenfolge-normalisierte Signatur der Slot-Liste eines Eintrags,
     für den Gleichheitsvergleich im Merge. Sortiert nach den Slot-Feldern,
     damit eine reine Umordnung der Slots NICHT als Änderung zählt."""
@@ -63,16 +80,19 @@ def _slots_signature(entry):
     )
 
 
-def _values_equal_entry(a, b):
+def _values_equal_entry(a: Entry, b: Entry) -> bool:
     return (_slots_signature(a) == _slots_signature(b)
             and bool(a.get("deleted")) == bool(b.get("deleted")))
 
 
-def _values_equal_setting(a, b):
+def _values_equal_setting(a: dict[str, Any], b: dict[str, Any]) -> bool:
     return a.get("value") == b.get("value")
 
 
-def _merge_one(local, remote, last_pull_at, equal_fn=_values_equal_entry, kind="entry", key=None):
+def _merge_one(local: dict[str, Any] | None, remote: dict[str, Any] | None,
+               last_pull_at: str, equal_fn: Callable[[Any, Any], bool] = _values_equal_entry,
+               kind: str = "entry", key: str | None = None
+               ) -> tuple[dict[str, Any] | None, Conflict | None]:
     """LWW-Merge eines einzelnen Werts.
 
     Returns: (winner_dict, conflict_or_none)
@@ -123,12 +143,12 @@ def _merge_one(local, remote, last_pull_at, equal_fn=_values_equal_entry, kind="
     return (winner, None)
 
 
-def _strip_for_candidate(item):
+def _strip_for_candidate(item: dict[str, Any]) -> dict[str, Any]:
     """Reduziert ein Entry/Setting auf das, was im conflict.candidates landen soll."""
     return {k: v for k, v in item.items()}
 
 
-def _merge_conflict_pair(a, b):
+def _merge_conflict_pair(a: Conflict, b: Conflict) -> Conflict:
     """LWW auf resolved_at, resolved beats unresolved."""
     if a.get("resolved") and not b.get("resolved"):
         return a
@@ -139,7 +159,7 @@ def _merge_conflict_pair(a, b):
     return a  # beide unresolved — ID-Match heißt dasselbe Detection-Event
 
 
-def _equivalent_unresolved_exists(existing, new_conflict):
+def _equivalent_unresolved_exists(existing: list[Conflict], new_conflict: Conflict) -> bool:
     """Dedupe: existiert bereits ein unresolved Konflikt mit gleichem
     (kind, key, Kandidaten-Set)?"""
     if new_conflict.get("resolved"):
@@ -155,12 +175,12 @@ def _equivalent_unresolved_exists(existing, new_conflict):
     return False
 
 
-def _candidate_signatures(candidates):
+def _candidate_signatures(candidates: list[dict[str, Any]]) -> tuple[tuple[Any, Any], ...]:
     """Sortiertes Tuple aus (modified_at, device_id) — als Set-Vergleichsbasis."""
     return tuple(sorted((c.get("modified_at"), c.get("device_id")) for c in candidates))
 
 
-def merge(local, remote, last_pull_at):
+def merge(local: Doc, remote: Doc, last_pull_at: str) -> Doc:
     merged = {
         "schema_version": SCHEMA_VERSION,
         "entries": {},
@@ -261,7 +281,8 @@ def merge(local, remote, last_pull_at):
     return merged
 
 
-def build_local_doc(storage, settings, conflicts_store):
+def build_local_doc(storage: Storage, settings: Settings,
+                    conflicts_store: ConflictsStore) -> Doc:
     """Erzeugt das Sync-Doc-Format aus den lokalen Stores."""
     return {
         "schema_version": SCHEMA_VERSION,
@@ -272,7 +293,8 @@ def build_local_doc(storage, settings, conflicts_store):
     }
 
 
-def apply_merged_doc(merged_doc, storage, settings, conflicts_store):
+def apply_merged_doc(merged_doc: Doc, storage: Storage, settings: Settings,
+                     conflicts_store: ConflictsStore) -> None:
     """Schreibt das Merge-Ergebnis zurück in die lokalen Stores."""
     storage.apply_merge(merged_doc.get("entries", {}))
     settings.apply_synced(merged_doc.get("settings", {}))
@@ -280,7 +302,8 @@ def apply_merged_doc(merged_doc, storage, settings, conflicts_store):
     settings.set("gc_watermark", (merged_doc.get("meta") or {}).get("gc_watermark") or "")
 
 
-def compact_local(storage, settings, conflicts_store, now):
+def compact_local(storage: Storage, settings: Settings,
+                  conflicts_store: ConflictsStore, now: str) -> None:
     """Schreibt das gc_watermark lokal und strippt settled Tombstones aus
     Storage und ConflictsStore. Ein lokaler Schreibvorgang pro Store
     (Wiederverwendung von storage.apply_merge — Required-Key-Validator +
@@ -296,7 +319,7 @@ def compact_local(storage, settings, conflicts_store, now):
     ])
 
 
-def migrate_doc_to_current(remote_doc):
+def migrate_doc_to_current(remote_doc: Doc) -> Doc:
     """Migriert ein älteres Sync-Doc auf das aktuelle Schema (v4): flache Einträge
     (start/end/pause) werden in eine Slot-Liste gewrappt. Idempotent — Einträge mit
     `slots` bleiben unangetastet; Tombstones bekommen eine leere Slot-Liste.
@@ -331,7 +354,7 @@ def migrate_doc_to_current(remote_doc):
     return {**remote_doc, "schema_version": SCHEMA_VERSION, "entries": migrated}
 
 
-def validate_remote_doc(doc):
+def validate_remote_doc(doc: Any) -> tuple[bool, str]:
     """Prüft ein (bereits auf SCHEMA_VERSION migriertes) Remote-Doc auf die
     strukturellen Invarianten, die `merge`/`apply_merged_doc` voraussetzen —
     BEVOR ein `KeyError`/`ValueError` mitten im Merge landet (Audit M5).
@@ -392,7 +415,7 @@ def validate_remote_doc(doc):
     return True, ""
 
 
-def remote_is_newer(remote_doc):
+def remote_is_newer(remote_doc: Doc) -> bool:
     """True, wenn das Remote-Doc von einer NEUEREN App-Version stammt
     (schema_version > der hier verstandenen SCHEMA_VERSION).
 
@@ -404,8 +427,9 @@ def remote_is_newer(remote_doc):
     return (remote_doc.get("schema_version") or 1) > SCHEMA_VERSION
 
 
-def resolve_conflict(conflict_id, chosen_value, conflicts_store, storage, settings, device_id,
-                      data_lock=None):
+def resolve_conflict(conflict_id: str, chosen_value: dict[str, Any],
+                     conflicts_store: ConflictsStore, storage: Storage, settings: Settings,
+                     device_id: str, data_lock: threading.RLock | None = None) -> None:
     """User hat einen Konflikt aufgelöst. chosen_value enthält den gewählten
     (oder manuell editierten) Wert. Für entries: {slots: [...]} (und
     optional deleted). Für settings: {value}.

--- a/src/sync_orchestrator.py
+++ b/src/sync_orchestrator.py
@@ -2,7 +2,7 @@
 Pull-Callbacks, Status-Label, Quit-Push und die Fehler-Aufbereitung.
 
 `import tkinter`/`messagebox` auf Modulebene ist unkritisch (stdlib, kein
-Display zum Import nötig). `_run_push_blocking` wird LAZY in den Methoden aus
+Display zum Import nötig). `run_push_blocking` wird LAZY in den Methoden aus
 `src.main` importiert — sonst Circular-Import (src.main → src.ui →
 src.sync_orchestrator).
 """
@@ -17,7 +17,7 @@ from src.theme import set_icon_button_enabled, themed_showinfo
 from src.time_utils import format_iso_date
 
 
-def _classify_sync_error(error):
+def classify_sync_error(error):
     """Kategorisiert einen Google-Sync/Reconcile-Fehler als 'auth', 'network'
     oder 'unknown'. `error` kann eine Exception oder ein String sein (der
     Push-/Reconcile-Pfad liefert str(e), der Pull-Pfad das Exception-Objekt).
@@ -44,7 +44,7 @@ def _friendly_sync_message(error, tb=""):
     if str(error) == NEWER_REMOTE_VERSION_MSG:
         return ("Update erforderlich", NEWER_REMOTE_VERSION_MSG, True)
 
-    kind = _classify_sync_error(error)
+    kind = classify_sync_error(error)
 
     if kind == "auth":
         return (
@@ -140,8 +140,8 @@ class SyncOrchestrator:
         return 0
 
     def _push(self, guard_timeout=0, timeout_seconds=15):
-        from src.main import _run_push_blocking
-        return _run_push_blocking(
+        from src.main import run_push_blocking
+        return run_push_blocking(
             self._storage, self._settings, self._conflicts_store,
             self._base_path, timeout_seconds=timeout_seconds,
             data_lock=self._data_lock, sync_guard=self._sync_guard,

--- a/src/theme.py
+++ b/src/theme.py
@@ -1030,7 +1030,13 @@ def themed_showwarning(parent, title: str, message: str) -> None:
 
 
 def themed_showerror(parent, title: str, message: str) -> None:
-    """Modaler Fehler-Dialog im App-Theme. Drop-in für `messagebox.showerror`."""
+    """Modaler Fehler-Dialog im App-Theme. Drop-in für `messagebox.showerror`.
+
+    Für **bekannte, erwartete** Fehler (Validierung, „Keine Einträge" …). Für
+    **unerwartete** Fehler mit Traceback bleibt bewusst das rohe
+    `messagebox.showerror` — ein themed Toplevel könnte im gestörten Zustand
+    selbst scheitern und die Meldung verschlucken. Konvention siehe
+    CLAUDE.md, „UI-Fehler sichtbar machen" (Audit N14)."""
     _themed_ok_dialog(parent, title, message)
 
 

--- a/src/time_utils.py
+++ b/src/time_utils.py
@@ -11,6 +11,19 @@ MONTHS_DE = [
 ]
 
 
+def utc_now_iso():
+    """Aktueller UTC-Zeitstempel als ISO-String 'YYYY-MM-DDTHH:MM:SSZ'.
+
+    Z-Suffix statt +00:00 (JS/Drive-Konvention), Sekunden-Auflösung, kein
+    Millisekunden-Anteil. Single Source of Truth für alle Sync-/Persistenz-
+    Timestamps — war früher 6× privat als `_utc_now_iso` in
+    storage/reservations/reservations_sync/settings/share/sync dupliziert
+    (Audit N17). An dieser Sekunden-Auflösung + Wanduhr-Abhängigkeit hängt das
+    LWW-Tie-Break im Sync (vgl. sync.py), daher nicht ohne Bedacht ändern.
+    """
+    return datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
 def parse_time(time_str):
     """Parse HH:MM string. Returns (hours, minutes) or None if invalid."""
     try:

--- a/src/ui.py
+++ b/src/ui.py
@@ -18,7 +18,7 @@ from src.version import VERSION, version_label
 from src.background_tasks import BackgroundTaskRunner
 from src.weekly_limit import format_limit_warnings
 from src.grid_renderer import GridRenderer
-from src.sync_orchestrator import _classify_sync_error, SyncOrchestrator
+from src.sync_orchestrator import classify_sync_error, SyncOrchestrator
 from src.update_banner import UpdateBanner
 from src.reminder_scheduler import ReminderScheduler
 from src.dialogs.entry_dialog import open_entry_dialog
@@ -192,7 +192,7 @@ class App:
     def _on_reconcile_done(self, result):
         if not result.get("ok"):
             error = result.get("error", "?")
-            if _classify_sync_error(error) == "auth":
+            if classify_sync_error(error) == "auth":
                 themed_showinfo(
                     self.root,
                     "Google-Verbindung abgelaufen",

--- a/src/ui.py
+++ b/src/ui.py
@@ -69,54 +69,15 @@ class App:
         self.root.configure(bg=BG)
         apply_dark_titlebar(self.root)
 
-        # Set unique AppUserModelID so Windows shows our icon in taskbar.
-        # Die AUMID bleibt bewusst die stabile, namespaced ID — Windows knüpft
-        # Taskbar-Pins und Fenster-Gruppierung daran; ein Wechsel würde
-        # bestehende Pins beim Update lösen. Den lesbaren Absender-Namen für
-        # Toast-Benachrichtigungen (inkl. dynamischer Version) registrieren wir
-        # separat als DisplayName unter dem AUMID-Registry-Key — den greift
-        # Windows für die Toast-Attribution, ohne die AUMID selbst zu ändern.
-        app_aumid = "margenheld.zeiterfassung"
-        try:
-            ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(app_aumid)
-        except Exception:
-            pass
-        try:
-            import winreg
-            with winreg.CreateKeyEx(
-                winreg.HKEY_CURRENT_USER,
-                rf"Software\Classes\AppUserModelId\{app_aumid}",
-            ) as _aumid_key:
-                winreg.SetValueEx(
-                    _aumid_key, "DisplayName", 0, winreg.REG_SZ,
-                    f"Zeiterfassung v{VERSION}",
-                )
-        except Exception:
-            pass
-
-        # Set window/taskbar icon
-        ico_path = os.path.join(base_path, "assets", "margenheld-icon.ico")
-        png_path = os.path.join(base_path, "assets", "margenheld-icon.png")
-        if platform.system() == "Windows" and os.path.exists(ico_path):
-            # default=ico_path → `wm iconbitmap -default` setzt das
-            # App-weite Default-Icon im Tk-Interpreter. Muss auf root
-            # gesetzt werden, damit künftige Toplevels (Settings, Entry,
-            # …) das Icon erben statt das Tk-Default-Feder-Icon zu zeigen.
-            self.root.iconbitmap(default=ico_path)
-        if os.path.exists(png_path):
-            icon = tk.PhotoImage(file=png_path)
-            self.root.iconphoto(True, icon)
-            self._icon_ref = icon
+        # Win32-Fenster-/Taskbar-Identität nur unter Windows (Audit N21) — die
+        # AUMID-/DisplayName-Registry-Schritte sind auf macOS/Linux ohnehin
+        # No-ops (ctypes.windll/winreg fehlen), das Gate macht das explizit.
+        if platform.system() == "Windows":
+            self._setup_windows_app_identity()
+        self._setup_window_icon(base_path)
 
         self.root.resizable(False, False)
-
-        today = datetime.date.today()
-        self.year = today.year
-        self.month = today.month
-        self.view_mode = "month"  # "month" or "week"
-        iso = today.isocalendar()
-        self.iso_year = iso[0]
-        self.current_week = iso[1]
+        self._init_view_state()
 
         self._tray = None
         self._bg = BackgroundTaskRunner(
@@ -180,6 +141,61 @@ class App:
         self._bg.check_update(on_result=self._update_banner.handle_check_result)
         self._bg.reconcile_on_start(on_ok=self._on_reconcile_start_done)
         self.root.protocol("WM_DELETE_WINDOW", self._on_close)
+
+    def _setup_windows_app_identity(self):
+        """Setzt die AppUserModelID und registriert den Toast-DisplayName
+        (Windows-only, aus __init__ extrahiert — Audit N21).
+
+        Die AUMID bleibt bewusst die stabile, namespaced ID — Windows knüpft
+        Taskbar-Pins und Fenster-Gruppierung daran; ein Wechsel würde
+        bestehende Pins beim Update lösen. Den lesbaren Absender-Namen für
+        Toast-Benachrichtigungen (inkl. dynamischer Version) registrieren wir
+        separat als DisplayName unter dem AUMID-Registry-Key — den greift
+        Windows für die Toast-Attribution, ohne die AUMID selbst zu ändern.
+        Jeder Schritt ist einzeln gegen Fehler abgesichert."""
+        app_aumid = "margenheld.zeiterfassung"
+        try:
+            ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(app_aumid)
+        except Exception:
+            pass
+        try:
+            import winreg
+            with winreg.CreateKeyEx(
+                winreg.HKEY_CURRENT_USER,
+                rf"Software\Classes\AppUserModelId\{app_aumid}",
+            ) as _aumid_key:
+                winreg.SetValueEx(
+                    _aumid_key, "DisplayName", 0, winreg.REG_SZ,
+                    f"Zeiterfassung v{VERSION}",
+                )
+        except Exception:
+            pass
+
+    def _setup_window_icon(self, base_path):
+        """Setzt App-/Taskbar-Icon (aus __init__ extrahiert — Audit N21).
+
+        Unter Windows das .ico als Tk-Default (`wm iconbitmap -default`), damit
+        künftige Toplevels (Settings, Entry, …) es erben statt des Tk-Default-
+        Feder-Icons; zusätzlich das .png als iconphoto auf allen Plattformen."""
+        ico_path = os.path.join(base_path, "assets", "margenheld-icon.ico")
+        png_path = os.path.join(base_path, "assets", "margenheld-icon.png")
+        if platform.system() == "Windows" and os.path.exists(ico_path):
+            self.root.iconbitmap(default=ico_path)
+        if os.path.exists(png_path):
+            icon = tk.PhotoImage(file=png_path)
+            self.root.iconphoto(True, icon)
+            self._icon_ref = icon
+
+    def _init_view_state(self):
+        """Initialer Kalender-View-Zustand aus dem heutigen Datum (aus __init__
+        extrahiert — Audit N21): Jahr/Monat + Monatsansicht, ISO-Jahr/-Woche."""
+        today = datetime.date.today()
+        self.year = today.year
+        self.month = today.month
+        self.view_mode = "month"  # "month" or "week"
+        iso = today.isocalendar()
+        self.iso_year = iso[0]
+        self.current_week = iso[1]
 
     def _reservations_active(self):
         """True, wenn Reservierungen angezeigt/bearbeitet werden dürfen: ein

--- a/tests/test_date_row.py
+++ b/tests/test_date_row.py
@@ -1,0 +1,36 @@
+"""Pure Kernlogik des gemeinsamen Datums-Zeilen-Widgets (Audit M14).
+
+Nur `max_day_for` ist Tk-frei testbar; der Widget-Aufbau (build_date_row)
+braucht ein Tk-Display und wird — wie der Rest der Tk-Schicht — nicht headless
+getestet."""
+
+from src.dialogs.date_row import max_day_for
+
+
+def test_max_day_for_leap_february():
+    assert max_day_for("2", "2024") == 29
+
+
+def test_max_day_for_common_february():
+    assert max_day_for("2", "2023") == 28
+
+
+def test_max_day_for_30_day_month():
+    assert max_day_for("4", "2024") == 30
+
+
+def test_max_day_for_31_day_month():
+    assert max_day_for("1", "2024") == 31
+
+
+def test_max_day_for_non_numeric_falls_back_to_31():
+    # Robustheits-Kern: der Combobox kann während der Eingabe einen
+    # nicht-numerischen Zwischenwert tragen — vorher crashten period_picker
+    # und tab_work hier (Audit M14).
+    assert max_day_for("abc", "2024") == 31
+    assert max_day_for("2", "") == 31
+
+
+def test_max_day_for_out_of_range_month_falls_back_to_31():
+    assert max_day_for("13", "2024") == 31
+    assert max_day_for("0", "2024") == 31

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -788,16 +788,16 @@ def test_merge_different_slots_conflict_candidates_carry_slots():
 # --- Forward-Compat (>v4 abweisen) + Absorb/Migration älterer Docs (v1/v2) ---
 
 from src.sync import (
-    NEWER_REMOTE_VERSION_MSG, SCHEMA_VERSION, _remote_is_newer, migrate_doc_to_current,
+    NEWER_REMOTE_VERSION_MSG, SCHEMA_VERSION, remote_is_newer, migrate_doc_to_current,
 )
 
 
-def test_remote_is_newer():
-    assert _remote_is_newer({"schema_version": SCHEMA_VERSION + 1, "entries": {}}) is True
-    assert _remote_is_newer({"schema_version": 99, "entries": {}}) is True
-    assert _remote_is_newer({"schema_version": SCHEMA_VERSION, "entries": {}}) is False
-    assert _remote_is_newer({"schema_version": 2, "entries": {}}) is False  # älter → absorb
-    assert _remote_is_newer({"entries": {}}) is False
+def testremote_is_newer():
+    assert remote_is_newer({"schema_version": SCHEMA_VERSION + 1, "entries": {}}) is True
+    assert remote_is_newer({"schema_version": 99, "entries": {}}) is True
+    assert remote_is_newer({"schema_version": SCHEMA_VERSION, "entries": {}}) is False
+    assert remote_is_newer({"schema_version": 2, "entries": {}}) is False  # älter → absorb
+    assert remote_is_newer({"entries": {}}) is False
 
 
 def test_migrate_doc_to_current_wraps_flat_entries():
@@ -873,7 +873,7 @@ def test_run_pull_aborts_on_newer_remote(tmp_path, monkeypatch):
     def cb(ok, error, tb=""):
         received["ok"] = ok
         received["error"] = error
-    main._run_pull_in_background(storage, settings, conflicts, str(tmp_path), cb)
+    main.run_pull_in_background(storage, settings, conflicts, str(tmp_path), cb)
     assert received["ok"] is False
     assert str(received["error"]) == NEWER_REMOTE_VERSION_MSG
     assert storage.get_all_raw() == {}
@@ -894,7 +894,7 @@ def test_run_pull_absorbs_v2_remote(tmp_path, monkeypatch):
     def cb(ok, error, tb=""):
         received["ok"] = ok
         received["error"] = error
-    main._run_pull_in_background(storage, settings, conflicts, str(tmp_path), cb)
+    main.run_pull_in_background(storage, settings, conflicts, str(tmp_path), cb)
     assert received["ok"] is True
     assert storage.get_all_raw()["2026-06-20"]["slots"] == [
         {"start": "08:00", "end": "16:00", "pause": 30, "kategorie": ""}]
@@ -913,7 +913,7 @@ def test_run_push_aborts_on_newer_remote(tmp_path, monkeypatch):
     upload_calls = []
     monkeypatch.setattr(drive, "upload",
                         lambda *a, **k: (upload_calls.append(a), ("id", "etag"))[1])
-    res = main._run_push_blocking(storage, settings, conflicts, str(tmp_path))
+    res = main.run_push_blocking(storage, settings, conflicts, str(tmp_path))
     assert res.get("ok") is False
     assert str(res.get("error")) == NEWER_REMOTE_VERSION_MSG
     assert upload_calls == []
@@ -937,7 +937,7 @@ def test_run_push_absorbs_v2_remote_before_upload(tmp_path, monkeypatch):
         uploaded["doc"] = _json.loads(content)
         return ("file-1", "etag-new")
     monkeypatch.setattr(drive, "upload", _fake_upload)
-    res = main._run_push_blocking(storage, settings, conflicts, str(tmp_path))
+    res = main.run_push_blocking(storage, settings, conflicts, str(tmp_path))
     assert res.get("ok") is True
     assert uploaded["doc"]["schema_version"] == 4
     assert set(uploaded["doc"]["entries"]) == {"2026-06-09", "2026-06-20"}

--- a/tests/test_sync_orchestrator.py
+++ b/tests/test_sync_orchestrator.py
@@ -206,7 +206,7 @@ def test_push_passes_lock_guard_and_timeouts(monkeypatch):
         captured["timeout_seconds"] = timeout_seconds
         return {"ok": True}
 
-    monkeypatch.setattr("src.main._run_push_blocking", fake)
+    monkeypatch.setattr("src.main.run_push_blocking", fake)
     lock, guard = object(), object()
     orch, _ = _orch(sync_enabled=True, data_lock=lock, sync_guard=guard)
     orch._push()
@@ -224,7 +224,7 @@ def test_push_on_quit_uses_guard_timeout(monkeypatch):
         captured["timeout_seconds"] = timeout_seconds
         return {"ok": True}
 
-    monkeypatch.setattr("src.main._run_push_blocking", fake)
+    monkeypatch.setattr("src.main.run_push_blocking", fake)
     orch, _ = _orch(sync_enabled=True)
     orch.push_on_quit()
     assert captured["guard_timeout"] == 5
@@ -235,7 +235,7 @@ def test_push_on_quit_skipped_logs_no_dialog(monkeypatch):
     import src.sync_orchestrator as so
     errors = []
     monkeypatch.setattr(so, "_show_sync_error", lambda *a, **k: errors.append(a))
-    monkeypatch.setattr("src.main._run_push_blocking",
+    monkeypatch.setattr("src.main.run_push_blocking",
                         lambda *a, **k: {"ok": False, "skipped": True})
     orch, _ = _orch(sync_enabled=True)
     orch.push_on_quit()

--- a/tests/test_sync_threading.py
+++ b/tests/test_sync_threading.py
@@ -54,7 +54,7 @@ def test_pull_skipped_when_guard_held(tmp_path):
     calls = []
     assert guard.acquire(blocking=False)
     try:
-        main._run_pull_in_background(
+        main.run_pull_in_background(
             storage, settings, conflicts, str(tmp_path),
             lambda **kw: calls.append(kw), data_lock=lock, sync_guard=guard)
     finally:
@@ -80,7 +80,7 @@ def test_pull_holds_data_lock_during_apply_and_releases_guard(tmp_path, monkeypa
 
     monkeypatch.setattr(sync, "apply_merged_doc", spy)
     calls = []
-    main._run_pull_in_background(
+    main.run_pull_in_background(
         storage, settings, conflicts, str(tmp_path),
         lambda **kw: calls.append(kw), data_lock=lock, sync_guard=guard)
     assert held == [True]                    # Apply lief unter dem Daten-Lock
@@ -97,7 +97,7 @@ def test_pull_without_lock_and_guard_still_works(tmp_path, monkeypatch):
     storage, settings, conflicts = _stores(tmp_path, lock)
     _mock_drive_empty(monkeypatch)
     calls = []
-    main._run_pull_in_background(
+    main.run_pull_in_background(
         storage, settings, conflicts, str(tmp_path),
         lambda **kw: calls.append(kw))
     assert calls and calls[0]["ok"] is True
@@ -110,7 +110,7 @@ def test_push_skipped_when_guard_held(tmp_path):
     guard = threading.Lock()
     assert guard.acquire(blocking=False)
     try:
-        res = main._run_push_blocking(
+        res = main.run_push_blocking(
             storage, settings, conflicts, str(tmp_path),
             data_lock=lock, sync_guard=guard)
     finally:
@@ -132,7 +132,7 @@ def test_push_holds_data_lock_during_apply(tmp_path, monkeypatch):
         return orig(merged, storage_, settings_, conflicts_)
 
     monkeypatch.setattr(sync, "apply_merged_doc", spy)
-    res = main._run_push_blocking(
+    res = main.run_push_blocking(
         storage, settings, conflicts, str(tmp_path),
         data_lock=lock, sync_guard=None)
     assert res.get("ok") is True
@@ -155,7 +155,7 @@ def test_push_uploads_without_holding_data_lock(tmp_path, monkeypatch):
         return ("file-1", "etag-1")
 
     monkeypatch.setattr(drive, "upload", fake_upload)
-    res = main._run_push_blocking(
+    res = main.run_push_blocking(
         storage, settings, conflicts, str(tmp_path),
         data_lock=lock, sync_guard=None)
     assert res.get("ok") is True
@@ -168,7 +168,7 @@ def test_push_guard_released_after_run(tmp_path, monkeypatch):
     storage, settings, conflicts = _stores(tmp_path, lock)
     _mock_drive_empty(monkeypatch)
     guard = threading.Lock()
-    res = main._run_push_blocking(
+    res = main.run_push_blocking(
         storage, settings, conflicts, str(tmp_path),
         data_lock=lock, sync_guard=guard)
     assert res.get("ok") is True
@@ -189,7 +189,7 @@ def test_push_guard_timeout_waits_for_running_sync(tmp_path, monkeypatch):
     out = {}
 
     def run_push():
-        out["res"] = main._run_push_blocking(
+        out["res"] = main.run_push_blocking(
             storage, settings, conflicts, str(tmp_path),
             timeout_seconds=30, data_lock=lock, sync_guard=guard,
             guard_timeout=30)

--- a/tests/test_ui_sync_errors.py
+++ b/tests/test_ui_sync_errors.py
@@ -1,12 +1,12 @@
 """Tests für die Klassifizierung von Drive-Sync-Fehlern im UI.
 
 Hintergrund: Im manuellen Sync-/Push-/Reconcile-Pfad kommt der Fehler als
-String (str(e)) bei _classify_sync_error an — die Exception-Typinfo ist dann
+String (str(e)) bei classify_sync_error an — die Exception-Typinfo ist dann
 weg. Ein 403 'insufficient authentication scopes' muss trotzdem als 'auth'
 (Re-Consent nötig) erkannt werden, nicht als 'unknown' (roher Traceback) oder
 'network' ('Keine Internetverbindung').
 """
-from src.sync_orchestrator import _classify_sync_error, _friendly_sync_message
+from src.sync_orchestrator import classify_sync_error, _friendly_sync_message
 from src.drive import DriveAuthError, DriveNetworkError
 from src.sync import NEWER_REMOTE_VERSION_MSG
 
@@ -16,23 +16,23 @@ def test_classify_403_scope_string_is_auth():
         "<HttpError 403 ... returned \"Request had insufficient authentication "
         "scopes.\". Details: 'reason': 'insufficientPermissions'>"
     )
-    assert _classify_sync_error(text) == "auth"
+    assert classify_sync_error(text) == "auth"
 
 
 def test_classify_invalid_grant_string_is_auth():
-    assert _classify_sync_error("... invalid_grant: Token has been expired ...") == "auth"
+    assert classify_sync_error("... invalid_grant: Token has been expired ...") == "auth"
 
 
 def test_classify_drive_auth_error_instance_is_auth():
-    assert _classify_sync_error(DriveAuthError("insufficientPermissions")) == "auth"
+    assert classify_sync_error(DriveAuthError("insufficientPermissions")) == "auth"
 
 
 def test_classify_network_error_instance_is_network():
-    assert _classify_sync_error(DriveNetworkError("connection reset")) == "network"
+    assert classify_sync_error(DriveNetworkError("connection reset")) == "network"
 
 
 def test_classify_plain_error_is_unknown():
-    assert _classify_sync_error("ValueError: kaputt") == "unknown"
+    assert classify_sync_error("ValueError: kaputt") == "unknown"
 
 
 def test_newer_remote_version_is_friendly_known():


### PR DESCRIPTION
Zweite Aufräum-Runde aus dem Audit-Tracking-Issue #131 — fünf Refactor-/Doku-Findings, je ein eigener Commit für die Review.

## Findings

- **N17** — private, modulübergreifend genutzte Namen öffentlich gemacht: `sync.remote_is_newer`, `sync_orchestrator.classify_sync_error`, `main.run_push_blocking`/`run_pull_in_background`, `storage.REQUIRED_ENTRY_KEYS`. Das 6× duplizierte private `_utc_now_iso` zu **einem** öffentlichen `time_utils.utc_now_iso()` entdoppelt (Single Source of Truth; die Sekunden-Auflösung, an der das LWW-Tie-Break hängt, ist im Docstring festgehalten). Rein modul-intern-private, nur von Tests referenzierte Namen (`_friendly_sync_message`, `_show_sync_error`) bleiben privat.

- **N8** — umfassende Typannotationen für die Datenschicht (`storage`/`settings`/`conflicts_store`/`reservations`/`sync`): Parameter, Rückgaben, Instanz-Attribute. `from __future__ import annotations` überall; lokale Aliase (`Slot`/`Entry`/`Reservation`/`Conflict`/`Doc = dict[str, Any]`); sync.py nutzt einen `TYPE_CHECKING`-Block für die Store-Klassen. **Pyright: 0 errors** über alle fünf Module.

- **M14** — das dreifach implementierte Tag/Monat/Jahr-Datums-Zeilen-Widget (period_picker, import_dialog, tab_work) mit **divergierender Robustheit** (nur import_dialog fing den `ValueError` beim Tag-Clamp — die anderen crashten) zu **einem** gemeinsamen `src/dialogs/date_row.py` vereinheitlicht. Reine Kernlogik `max_day_for` Tk-frei getestet. Layout via Screenshot gegen den period_picker verifiziert (Von/Bis bündig, Kategorie-Zeile ausgerichtet).

- **N21** — `App.__init__` (~120 Zeilen) entzerrt: `_setup_windows_app_identity()` (jetzt hinter `platform.system() == "Windows"` gegatet statt stiller No-op), `_setup_window_icon()`, `_init_view_state()`. End-to-end verifiziert — App-Konstruktor headless gebaut, Hauptfenster rendert korrekt.

- **N14** — die bewusste Zweiteilung „bekannte Fehler → themed / unerwartete Traceback-Fehler → natives `messagebox.showerror`" dokumentiert (CLAUDE.md + `themed_showerror`-Docstring). Der native Fallback ist Absicht (ein themed Toplevel könnte im gestörten Zustand selbst scheitern). Reine Doku.

## Verifikation

- `ruff check .`: **All checks passed**
- `pyright` (Datenschicht + geänderte Module): **0 errors, 0 warnings**
- `pytest`: **810 passed, 3 skipped**
- Neue Tests: `max_day_for` (6). Der Tk-Widget-Aufbau bleibt — wie der Rest der UI-Schicht — headless ungetestet; M14/N21 wurden stattdessen per Screenshot des real gerenderten Fensters verifiziert.

## Hinweise

- Basiert auf `master`; unabhängig von PR #144 (Runde 1). Beide berühren teils dieselben Dateien (time_utils/settings/import_dialog) in verschiedenen Regionen — beim Zusammenführen ggf. ein trivialer Rebase nötig.
- Tk-Layout (M14) und Konstruktor (N21) sind auf der Windows-Dev-Maschine verifiziert; für macOS/Linux bleibt die übliche Pre-Release-Empfehlung.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
