### PR TITLE
ci/test(audit): Test-Infra N22/N24/N25 (#131)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,13 +4,23 @@ on: [push, pull_request]
 
 jobs:
   test:
+    # Audit N25: über alle unterstützten Python-Versionen testen (README: 3.10+),
+    # nicht nur 3.10. fail-fast=false, damit ein Ausreißer die anderen nicht
+    # abbricht. macOS/Windows verifizieren die Plattform (unten, je 3.10) —
+    # hier geht es um die Sprachversion.
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.10', '3.11', '3.12', '3.13']
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.10'
-      - run: pip install pytest "holidays==0.99" google-api-python-client google-auth google-auth-oauthlib
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: requirements-test.txt
+      - run: pip install -r requirements-test.txt
       - run: pytest tests/
 
   coverage:
@@ -23,7 +33,9 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
-      - run: pip install pytest pytest-cov "holidays==0.99" google-api-python-client google-auth google-auth-oauthlib
+          cache: pip
+          cache-dependency-path: requirements-test.txt
+      - run: pip install -r requirements-test.txt pytest-cov==7.1.0
       - run: pytest --cov=src --cov-report=term-missing tests/
 
   test-macos:
@@ -33,7 +45,9 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
-      - run: pip install pytest "holidays==0.99" google-api-python-client google-auth google-auth-oauthlib pyobjc-framework-Cocoa
+          cache: pip
+          cache-dependency-path: requirements-test.txt
+      - run: pip install -r requirements-test.txt pyobjc-framework-Cocoa==12.2.1
       - run: pytest tests/
 
   test-windows:
@@ -43,7 +57,9 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
-      - run: pip install pytest "holidays==0.99" google-api-python-client google-auth google-auth-oauthlib
+          cache: pip
+          cache-dependency-path: requirements-test.txt
+      - run: pip install -r requirements-test.txt
       - run: pytest tests/
 
   lint:
@@ -53,6 +69,8 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
+          cache: pip
+          cache-dependency-path: requirements-test.txt
       - run: pip install ruff==0.15.10
       - run: ruff check .
 
@@ -63,11 +81,14 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
-      # Gleiche Minimal-Deps wie der test-Job, damit unsere eigenen Typen
-      # (google-*, holidays, pytest) auflösen. Die plattform-optionalen
-      # Lazy-Imports (xhtml2pdf/Pillow/pystray/pyobjc) sind an der Import-Zeile
-      # per `# pyright: ignore[reportMissingImports]` entschärft — kein
-      # requirements.txt nötig (pycairo/pyobjc wären hier ohnehin nicht baubar).
-      # pyright pinnen: neuere Versionen ziehen strengere Checks nach.
-      - run: pip install pyright==1.1.411 pytest "holidays==0.99" google-api-python-client google-auth google-auth-oauthlib
+          cache: pip
+          cache-dependency-path: requirements-test.txt
+      # Gleiche Minimal-Deps wie der test-Job (aus requirements-test.txt), damit
+      # unsere eigenen Typen (google-*, holidays, pytest) auflösen. Die
+      # plattform-optionalen Lazy-Imports (xhtml2pdf/Pillow/pystray/pyobjc) sind
+      # an der Import-Zeile per `# pyright: ignore[reportMissingImports]`
+      # entschärft — kein requirements.txt nötig (pycairo/pyobjc wären hier
+      # ohnehin nicht baubar). pyright pinnen: neuere Versionen ziehen strengere
+      # Checks nach.
+      - run: pip install -r requirements-test.txt pyright==1.1.411
       - run: pyright

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,19 @@ jobs:
       - run: pip install pytest "holidays==0.99" google-api-python-client google-auth google-auth-oauthlib
       - run: pytest tests/
 
+  coverage:
+    # Coverage-Report (Audit N24) — reines Reporting, KEIN fail_under-Gate
+    # (Config in pyproject.toml, [tool.coverage]). Ein Lauf auf ubuntu/3.10
+    # reicht; die Zahlen sind plattformunabhängig.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.10'
+      - run: pip install pytest pytest-cov "holidays==0.99" google-api-python-client google-auth google-auth-oauthlib
+      - run: pytest --cov=src --cov-report=term-missing tests/
+
   test-macos:
     runs-on: macos-latest
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -249,9 +249,16 @@ nach dem Widget-Aufbau bleibt Aufgabe des Dialogs.
 
 ## Tests / CI
 
-`.github/workflows/test.yml` installiert gezielt nur die Pakete, die die Tests brauchen (`pytest`, `holidays==0.99`, `google-api-python-client`, `google-auth`, `google-auth-oauthlib`), **nicht** `requirements.txt`. Grund: `pycairo` (transitive Dep von `xhtml2pdf`) braucht Cairo-Systemheader auf Ubuntu und bricht sonst den CI-Build. Der Import von `xhtml2pdf` in `src/report.py::generate_pdf` ist lazy, daher laufen die Report-Tests ohne die Lib. `holidays` und die Google-Libs sind pure Python ohne C-Deps und problemlos installierbar — letztere sind nötig, weil Tests `src.ui` importieren (z.B. `tests/test_ui_delete.py`), dessen Importkette die Google-Wrapper zieht. Ein zweiter Job läuft `ruff check .` (Lint).
+`.github/workflows/test.yml` installiert gezielt nur die Pakete, die die Tests brauchen — gepinnt in **`requirements-test.txt`** (`pytest`, `holidays`, `google-api-python-client`, `google-auth`, `google-auth-oauthlib`), **nicht** `requirements.txt`. Grund: `pycairo` (transitive Dep von `xhtml2pdf`) braucht Cairo-Systemheader auf Ubuntu und bricht sonst den CI-Build. Der Import von `xhtml2pdf` in `src/report.py::generate_pdf` ist lazy, daher laufen die Report-Tests ohne die Lib. `holidays` und die Google-Libs sind pure Python ohne C-Deps und problemlos installierbar — letztere sind nötig, weil Tests `src.ui` importieren (z.B. `tests/test_ui_delete.py`), dessen Importkette die Google-Wrapper zieht.
 
-Lokal: `pytest` aus dem Repo-Root. Alle Tests müssen vor dem PR-Merge grün sein.
+Die Test-Deps sind **exakt gepinnt** (Audit N25) — beim Bump gegen Python 3.10 gegenchecken (alle rein-Python, daher auf jedem Matrix-Python installierbar). Jobs (alle mit `cache: pip` auf `requirements-test.txt`):
+
+- **test** — Matrix über **Python 3.10–3.13** (README: „3.10+"), `fail-fast: false`.
+- **coverage** — `pytest --cov=src` (ubuntu/3.10); Reporting, **kein** `fail_under`-Gate (Config: `pyproject.toml [tool.coverage]`, Audit N24).
+- **test-macos** / **test-windows** — Plattform-Verifikation (je 3.10; macOS zieht zusätzlich `pyobjc-framework-Cocoa`).
+- **lint** — `ruff check .`. **typecheck** — `pyright` (gepinnt `1.1.411`).
+
+Lokal: `pytest` aus dem Repo-Root (Coverage: `pytest --cov=src --cov-report=term-missing`). Alle Tests müssen vor dem PR-Merge grün sein.
 
 ## Struktur
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,24 @@ select = ["E4", "E7", "E9", "F"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 
+# Coverage-Reporting (Audit N24). Aktiv nur, wenn explizit mit `--cov`
+# aufgerufen (der coverage-CI-Job bzw. lokal `pytest --cov=src`); ein normaler
+# `pytest`-Lauf bleibt unverändert schnell.
+[tool.coverage.run]
+source = ["src"]
+branch = true
+
+[tool.coverage.report]
+show_missing = true
+# BEWUSST kein fail_under-Gate: Coverage ist hier Reporting, kein harter
+# CI-Blocker. Die UI/Tk-Schicht ist absichtlich nur über extrahierte
+# Pure-Functions getestet (vgl. Audit M16) — ein Schwellwert-Gate färbte den
+# Build sonst dauerhaft rot. Der Report zeigt Lücken, erzwingt sie aber nicht.
+exclude_also = [
+    "if TYPE_CHECKING:",
+    "raise NotImplementedError",
+]
+
 [tool.pyright]
 # Wird sowohl von der Pyright-CLI als auch von Pylance (VS Code) gelesen —
 # eine einzige Quelle. Bewusst KEINE separate pyrightconfig.json, die wuerde

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,14 @@
+# Gepinnte Test-/CI-Abhängigkeiten (Audit N25) — known-good, für die Jobs in
+# .github/workflows/test.yml. NICHT die App-Laufzeit-Deps (die stehen in
+# requirements.txt). Alle rein-Python (keine C-Extensions), daher auf jedem
+# Matrix-Python (3.10–3.13) installierbar; ermöglicht zugleich pip-Caching.
+#
+# Die Google-Libs sind nötig, weil Tests src.ui importieren (Importkette zieht
+# die Google-Wrapper); holidays für die Feiertags-Tests. pyobjc (macOS-Job) und
+# pyright/ruff/pytest-cov (typecheck/lint/coverage-Jobs) werden im jeweiligen
+# Job zusätzlich installiert.
+pytest==9.0.3
+holidays==0.99
+google-api-python-client==2.196.0
+google-auth==2.55.0
+google-auth-oauthlib==1.4.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,41 @@
+"""Gemeinsame Test-Helfer (Audit N22).
+
+Vorher war die Ist-Zeit-Slot-Factory (`_slot`) 4× dupliziert (test_report/
+test_storage/test_sync/test_weekly_limit) und der xhtml2pdf-Fake (`FakePisa`)
+4× in test_report. Beide leben jetzt zentral hier.
+
+Die Slot-Factory wird von den Aufrufern weiterhin auf ihren lokalen Namen
+`_slot` aliast (`from tests.conftest import ist_slot as _slot`), damit die
+vielen bestehenden Call-Sites unverändert bleiben. Reservierungs-Slots
+(kategorie/gcal_event_id) und Sync-Einträge (modified_at/device_id) sind je
+nur in einer Datei und bleiben dort lokal.
+"""
+from unittest.mock import MagicMock
+
+
+def ist_slot(start, end, pause=0, kategorie=""):
+    """Ein Ist-Zeit-Slot {start, end, pause, kategorie} für Storage-/Sync-/
+    Report-/Weekly-Limit-Tests."""
+    return {"start": start, "end": end, "pause": pause, "kategorie": kategorie}
+
+
+def make_fake_xhtml2pdf(captured):
+    """Fake für den lazy `xhtml2pdf`-Import in `report.generate_pdf` (die CI hat
+    die Lib nicht). Liefert ein Mock-Modul, dessen `pisa.CreatePDF` das
+    gerenderte HTML unter `captured['html']` ablegt und Erfolg (err=0) meldet.
+
+    Nutzung:
+        captured = {}
+        with patch.dict("sys.modules", {"xhtml2pdf": make_fake_xhtml2pdf(captured)}):
+            report.generate_pdf(...)
+        assert "…" in captured["html"]
+    """
+    class _FakePisa:
+        @staticmethod
+        def CreatePDF(html_str, dest):
+            captured["html"] = html_str
+            return MagicMock(err=0)
+
+    fake_mod = MagicMock()
+    fake_mod.pisa = _FakePisa
+    return fake_mod

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -9,8 +9,8 @@ def _e(start, end, pause=0, kategorie=""):
     return {"slots": [{"start": start, "end": end, "pause": pause, "kategorie": kategorie}]}
 
 
-def _slot(start, end, pause=0, kategorie=""):
-    return {"start": start, "end": end, "pause": pause, "kategorie": kategorie}
+# geteilte Ist-Zeit-Factory + xhtml2pdf-Fake (Audit N22)
+from tests.conftest import ist_slot as _slot, make_fake_xhtml2pdf
 
 
 def test_empty_entries():
@@ -294,16 +294,7 @@ def test_pdf_name_is_escaped():
     entries = {"2026-03-23": _e("08:00", "16:00")}
     captured_html = {}
 
-    class FakePisa:
-        @staticmethod
-        def CreatePDF(html_str, dest):
-            captured_html["html"] = html_str
-            return MagicMock(err=0)
-
-    fake_xhtml2pdf = MagicMock()
-    fake_xhtml2pdf.pisa = FakePisa
-
-    with patch.dict("sys.modules", {"xhtml2pdf": fake_xhtml2pdf}):
+    with patch.dict("sys.modules", {"xhtml2pdf": make_fake_xhtml2pdf(captured_html)}):
         report_mod.generate_pdf(
             datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries, name="Müller & Co")
 
@@ -318,16 +309,7 @@ def test_pdf_category_filter_applied():
                                          {"start": "13:00", "end": "17:00", "pause": 0, "kategorie": "HO"}]}}
     captured_html = {}
 
-    class FakePisa:
-        @staticmethod
-        def CreatePDF(html_str, dest):
-            captured_html["html"] = html_str
-            return MagicMock(err=0)
-
-    fake_xhtml2pdf = MagicMock()
-    fake_xhtml2pdf.pisa = FakePisa
-
-    with patch.dict("sys.modules", {"xhtml2pdf": fake_xhtml2pdf}):
+    with patch.dict("sys.modules", {"xhtml2pdf": make_fake_xhtml2pdf(captured_html)}):
         report_mod.generate_pdf(
             datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries, categories={"Büro"})
 
@@ -365,16 +347,7 @@ def test_pdf_category_breakdown_false_hides_summary():
     entries = {"2026-03-23": _e("08:00", "16:00", 0, "Büro")}
     captured_html = {}
 
-    class FakePisa:
-        @staticmethod
-        def CreatePDF(html_str, dest):
-            captured_html["html"] = html_str
-            return MagicMock(err=0)
-
-    fake_xhtml2pdf = MagicMock()
-    fake_xhtml2pdf.pisa = FakePisa
-
-    with patch.dict("sys.modules", {"xhtml2pdf": fake_xhtml2pdf}):
+    with patch.dict("sys.modules", {"xhtml2pdf": make_fake_xhtml2pdf(captured_html)}):
         report_mod.generate_pdf(
             datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries,
             category_breakdown=False)
@@ -394,16 +367,7 @@ def test_pdf_table_defines_explicit_column_widths():
     entries = {"2026-03-23": _e("08:00", "16:00")}
     captured_html = {}
 
-    class FakePisa:
-        @staticmethod
-        def CreatePDF(html_str, dest):
-            captured_html["html"] = html_str
-            return MagicMock(err=0)
-
-    fake_xhtml2pdf = MagicMock()
-    fake_xhtml2pdf.pisa = FakePisa
-
-    with patch.dict("sys.modules", {"xhtml2pdf": fake_xhtml2pdf}):
+    with patch.dict("sys.modules", {"xhtml2pdf": make_fake_xhtml2pdf(captured_html)}):
         report_mod.generate_pdf(datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), entries)
 
     html = captured_html["html"]

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -11,8 +11,7 @@ def tmp_storage(tmp_path):
     return Storage(str(tmp_path / "test.json"), device_id="test-device")
 
 
-def _slot(start, end, pause=0, kategorie=""):
-    return {"start": start, "end": end, "pause": pause, "kategorie": kategorie}
+from tests.conftest import ist_slot as _slot  # geteilte Ist-Zeit-Factory (Audit N22)
 
 
 def test_load_empty(tmp_storage):

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -19,8 +19,7 @@ def _e(start, end, pause, modified_at, device_id="d", deleted=False):
     }
 
 
-def _slot(start, end, pause=0, kategorie=""):
-    return {"start": start, "end": end, "pause": pause, "kategorie": kategorie}
+from tests.conftest import ist_slot as _slot  # geteilte Ist-Zeit-Factory (Audit N22)
 
 
 def test_merge_one_local_only_keeps_local():

--- a/tests/test_weekly_limit.py
+++ b/tests/test_weekly_limit.py
@@ -21,8 +21,7 @@ def _entry(slots):
     return {"slots": slots}
 
 
-def _slot(start, end, pause=0, kategorie=""):
-    return {"start": start, "end": end, "pause": pause, "kategorie": kategorie}
+from tests.conftest import ist_slot as _slot  # geteilte Ist-Zeit-Factory (Audit N22)
 
 
 def test_is_limit_active_false_when_disabled():


### PR DESCRIPTION
Dritte Runde aus dem Audit-Tracking-Issue #131 — die Test/CI-Infra-Punkte. Je ein Commit pro Finding, kein Produktivcode-Verhalten geändert.

## Findings

- **N22** — kein `tests/conftest.py`, Helfer dupliziert. Neu `tests/conftest.py` mit:
  - `ist_slot(...)` — die Ist-Zeit-Slot-Factory, vorher 4× identisch in `test_report`/`test_storage`/`test_sync`/`test_weekly_limit`. Die Aufrufer aliasen sie weiter auf ihren lokalen Namen `_slot` (`from tests.conftest import ist_slot as _slot`), sodass die ~93 Call-Sites unverändert bleiben.
  - `make_fake_xhtml2pdf(captured)` — der xhtml2pdf-Fake, vorher 4× in `test_report`.
  - Reservierungs-Slots / Sync-Einträge sind je nur in einer Datei und bleiben lokal.

- **N24** — kein Coverage-Reporting. `[tool.coverage]` in `pyproject.toml` (source=src, branch, show_missing) + neuer `coverage`-CI-Job (`pytest --cov=src --cov-report=term-missing`). **Bewusst kein `fail_under`-Gate** — Coverage ist Reporting, die Tk-Schicht ist absichtlich nur über Pure-Functions getestet (vgl. M16). Lokal: Datenschicht hoch (report 100 %, storage 96 %, sync 89 %, settings 92 %), Tk/UI erwartbar niedrig, gesamt ~51 %.

- **N25** — CI lief nur auf Python 3.10, ohne pip-Cache, mit ungepinnten Test-Deps.
  - **Matrix** Python **3.10–3.13** auf dem ubuntu `test`-Job (`fail-fast: false`); macOS/Windows bleiben bei 3.10 (Plattform-Verifikation).
  - **`requirements-test.txt`** mit exakt gepinnten known-good Test-Deps, von allen Jobs via `-r` installiert (DRY + reproduzierbar; alle rein-Python → auf jedem Matrix-Python installierbar).
  - **pip-Cache** (`cache: pip` + `cache-dependency-path: requirements-test.txt`) an allen Jobs.
  - `CLAUDE.md` „Tests / CI" nachgezogen.

## Verifikation

- `pytest`: **804 passed, 3 skipped** (lokal Python 3.14 mit den gepinnten Versionen → die niedrigeren Matrix-Pythons erwartbar grün)
- `ruff check .`: **All checks passed**
- `test.yml` als YAML validiert; `requirements-test.txt` löst auf.

## Hinweise

- Basiert auf `master`, unabhängig von PR #144 (Runde 1) und PR #146 (Runde 2). Berührt weitgehend andere Dateien; die einzige Überlappung mit #146 ist `CLAUDE.md` (verschiedene Abschnitte) — ggf. trivialer Rebase.
- Die Matrix-Erweiterung sollte beim ersten CI-Lauf beobachtet werden (holidays==0.99 & Google-Libs auf 3.13); alle sind rein-Python und lokal auf 3.14 grün, ein Ausreißer ließe sich per Trim einzelner Matrix-Einträge entschärfen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
